### PR TITLE
feat(send): send a slash-command body verbatim (no [from] prefix)

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -855,6 +855,28 @@ describe("subcommands.isExitRequest", () => {
   });
 });
 
+describe("subcommands.isSlashCommand", () => {
+  it("matches a body that starts with a slash command (so it is sent unprefixed)", async () => {
+    const { isSlashCommand } = await loadModule();
+    for (const s of ["/compact", "/clear", "/model sonnet", "/resume\nmore text"]) {
+      expect(isSlashCommand(s)).toBe(true);
+    }
+  });
+  it("does NOT match plain prose, or a slash not at column 0", async () => {
+    const { isSlashCommand } = await loadModule();
+    for (const s of [
+      "please run /compact",
+      " /compact", // leading space — the CLI won't parse it as a command either
+      "//two slashes... wait, no letter after first slash",
+      "/ ",
+      "hello",
+      "",
+    ]) {
+      expect(isSlashCommand(s)).toBe(false);
+    }
+  });
+});
+
 describe("subcommands.writeToIpc reliable delivery", () => {
   const itUnix = process.platform === "linux" || process.platform === "darwin";
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2413,10 +2413,15 @@ async function cmdSend(rest: string[]): Promise<number> {
   }
 
   // When an agent sends, prefix one line so the recipient knows who pinged it
-  // and exactly how to reply (to a resolvable pid — the sender's own).
-  const prefix = sender.agent
-    ? `[from ${sender.agent.cli} #${sender.agent.pid} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${sender.agent.pid} "..."]\n`
-    : "";
+  // and exactly how to reply (to a resolvable pid — the sender's own). BUT a
+  // slash command is only recognized when `/` is the very first character of the
+  // submitted message; the prefix would bump it to line 2 and the CLI would type
+  // the command as plain text. So skip the prefix for a command body and send it
+  // verbatim — attribution is dropped for the command, but it actually runs.
+  const prefix =
+    sender.agent && !isSlashCommand(body)
+      ? `[from ${sender.agent.cli} #${sender.agent.pid} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${sender.agent.pid} "..."]\n`
+      : "";
 
   const fullBody = prefix + body;
   if (fullBody && trailing) {
@@ -2852,6 +2857,14 @@ async function cmdStop(rest: string[]): Promise<number> {
 export function isExitRequest(body: string): boolean {
   const t = body.trim().toLowerCase();
   return t === "exit" || t === "/exit";
+}
+
+/** A body that the CLI will parse as a slash command — `/` as the very first
+ * character (claude requires column 0, no leading whitespace, then a letter).
+ * Such a body must be sent verbatim: any prefix line bumps the `/` off column 0
+ * and the CLI types the command as plain text instead of running it. */
+export function isSlashCommand(body: string): boolean {
+  return /^\/[A-Za-z]/.test(body);
 }
 
 /**


### PR DESCRIPTION
## Problem

`ay send` from one agent to another prepends a `[from <cli> #<pid> @ <cwd> — reply: ay send <pid> "..."]` line so the recipient knows who pinged it. But a **slash command is only recognized when `/` is the very first character** of the submitted message — the prefix bumps it to line 2, so `ay send <pid> /compact` gets typed as plain text and the command never runs.

## Fix

Skip the `[from …]` prefix when the body is a slash command and send it **verbatim**.

- New predicate `isSlashCommand(body)`: `/^\/[A-Za-z]/` — `/` at column 0 followed by a letter (mirrors the CLI's own recognition; a leading space or `//` is not a command).
- Attribution is intentionally dropped for command sends — a command is a control action, not a conversational ping.
- `/exit` was already special-cased upstream (routed to a graceful shutdown). This covers `/compact`, `/clear`, `/model`, `/resume`, `/context`, etc.

## Tests

`isSlashCommand` unit tests (matches `/compact`, `/model sonnet`, `/resume\n…`; rejects `please run /compact`, ` /compact`, `//…`, `/ `, prose, empty). Full `subcommands.spec.ts` green (93 passed) on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)