### PR TITLE
feat(cli): fork-by-default when an agent spawns a nested agent non-interactively

### DIFF
--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -106,6 +106,52 @@ if (config.useRust) {
       console.log(`[rust] Args: ${rustArgs.join(" ")}`);
     }
 
+    // Nested + non-tty (e.g. an agent ran this via its Bash tool): detach the
+    // agent so we don't block the parent's tool call for the whole session, then
+    // print how to drive it and exit. `--attach`/AGENT_YES_ATTACH=1 opts out.
+    const attach = config.attach || process.env.AGENT_YES_ATTACH === "1";
+    const { shouldForkNested, buildSpawnTutorial, waitForFifo } = await import("./forkNested.ts");
+    if (
+      shouldForkNested({
+        isTTY: Boolean(process.stdout.isTTY),
+        ayPid: process.env.AGENT_YES_PID,
+        attach,
+      })
+    ) {
+      const forked = spawn(rustBinary, rustArgs, {
+        detached: true,
+        stdio: "ignore",
+        env: process.env,
+        cwd: process.cwd(),
+      });
+      const forkedPid = forked.pid;
+      if (!forkedPid) {
+        console.error("Failed to spawn agent: no pid.");
+        process.exit(1);
+      }
+      // Race a fast startup failure against FIFO registration so we never print a
+      // success tutorial for a dead pid. The wrapper keeps its own per-pid log, so
+      // real output stays reachable via `ay tail` even with stdio ignored. Store a
+      // pre-formatted message (not a union) — the callbacks run async, so control-flow
+      // analysis can't narrow a union here anyway.
+      let deathMsg: string | null = null;
+      forked.on("error", (err) => {
+        deathMsg ??= `Failed to spawn agent: ${err.message}`;
+      });
+      forked.on("exit", (code, signal) => {
+        deathMsg ??= `Agent exited immediately (${signal ?? `code ${code}`}). See: ay tail ${forkedPid}`;
+      });
+      const registered = await waitForFifo(forkedPid, 2000, () => deathMsg !== null);
+      if (deathMsg) {
+        console.error(deathMsg);
+        process.exit(1);
+      }
+      forked.unref();
+      console.log(buildSpawnTutorial(config.cli || "agent", forkedPid));
+      if (!registered) console.log(`(note: still registering — give ay send/tail a moment)`);
+      process.exit(0);
+    }
+
     const child = spawn(rustBinary, rustArgs, {
       stdio: "inherit",
       env: process.env,

--- a/ts/forkNested.spec.ts
+++ b/ts/forkNested.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildSpawnTutorial, shouldForkNested } from "./forkNested";
+
+describe("shouldForkNested", () => {
+  it("forks when nested (AGENT_YES_PID set) and stdout is not a TTY", () => {
+    expect(shouldForkNested({ isTTY: false, ayPid: "1234", attach: false })).toBe(true);
+  });
+
+  it("does NOT fork on an interactive TTY (a human running it directly)", () => {
+    expect(shouldForkNested({ isTTY: true, ayPid: "1234", attach: false })).toBe(false);
+  });
+
+  it("does NOT fork when not nested — a human piping output has no AGENT_YES_PID", () => {
+    expect(shouldForkNested({ isTTY: false, ayPid: undefined, attach: false })).toBe(false);
+    expect(shouldForkNested({ isTTY: false, ayPid: "", attach: false })).toBe(false);
+    expect(shouldForkNested({ isTTY: false, ayPid: "   ", attach: false })).toBe(false);
+  });
+
+  it("does NOT fork when attach opts out, regardless of context", () => {
+    expect(shouldForkNested({ isTTY: false, ayPid: "1234", attach: true })).toBe(false);
+  });
+});
+
+describe("buildSpawnTutorial", () => {
+  it("names the cli + pid and lists the drive commands with that pid", () => {
+    const out = buildSpawnTutorial("claude", 4242);
+    expect(out).toContain("Spawned claude agent as pid 4242");
+    expect(out).toContain("ay tail 4242");
+    expect(out).toContain("ay send 4242");
+    expect(out).toContain("ay ls");
+    expect(out).toContain("ay result get 4242");
+    expect(out).toContain("ay exit 4242");
+  });
+});

--- a/ts/forkNested.ts
+++ b/ts/forkNested.ts
@@ -1,0 +1,64 @@
+import { existsSync } from "fs";
+import path from "path";
+import { agentYesHome } from "./agentYesHome.ts";
+
+/**
+ * Should a nested agent-run detach (fork) instead of blocking the caller?
+ *
+ * A claude/codex agent that runs `ay <cli> -- <task>` inside its Bash tool would
+ * otherwise block that Bash call for the whole (possibly very long) session and
+ * time out. When we detect that context we spawn the agent detached, print a
+ * tutorial, and return immediately so the parent stays responsive.
+ *
+ * The context is: we are NESTED inside another agent (`AGENT_YES_PID` is injected
+ * into an agent's environment by its wrapper — a human shell never has it) AND
+ * stdout is not a TTY (captured/piped, e.g. a tool's Bash). A human piping output
+ * (`ay claude | cat`) has no `AGENT_YES_PID`, so they still block as before.
+ * `attach` (the `--attach` flag or `AGENT_YES_ATTACH=1`) forces foreground.
+ */
+export function shouldForkNested(opts: {
+  isTTY: boolean;
+  ayPid: string | undefined;
+  attach: boolean;
+}): boolean {
+  if (opts.attach) return false;
+  if (opts.isTTY) return false;
+  return Boolean(opts.ayPid && opts.ayPid.trim());
+}
+
+/** The tutorial printed to the parent agent after a detached spawn, telling it
+ *  exactly how to drive the agent it just started. */
+export function buildSpawnTutorial(cli: string, pid: number): string {
+  return [
+    `Spawned ${cli} agent as pid ${pid} (detached — this shell returned immediately).`,
+    `It runs in the background; drive it with:`,
+    `  ay tail ${pid}          # watch its output (live)`,
+    `  ay send ${pid} "..."    # send it a message / instruction`,
+    `  ay send ${pid} /compact # send a slash command`,
+    `  ay ls                   # list running agents`,
+    `  ay result get ${pid}    # read its final result when done`,
+    `  ay exit ${pid}          # stop it`,
+  ].join("\n");
+}
+
+/**
+ * Poll for the spawned wrapper's stdin FIFO to appear, so the tutorial's
+ * `ay send`/`ay tail` work the instant we print them (the wrapper registers its
+ * FIFO a moment after spawn). Resolves true once registered, false on timeout or
+ * if `aborted()` reports the child already died (so a startup failure fails fast
+ * instead of waiting out the whole window).
+ */
+export async function waitForFifo(
+  pid: number,
+  timeoutMs = 2000,
+  aborted?: () => boolean,
+): Promise<boolean> {
+  const fifo = path.join(agentYesHome(), "fifo", `${pid}.stdin`);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (aborted?.()) return false;
+    if (existsSync(fifo)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return existsSync(fifo);
+}

--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -439,4 +439,22 @@ describe("CLI argument parsing", () => {
     expect(afterCli.useStdinAppend).toBe(true);
     expect(afterCli.cliArgs).toContain("--no-stdpush");
   });
+
+  it("consumes --attach as an agent-yes flag before the CLI positional", () => {
+    const result = parseCliArgs(["node", "/path/to/ay", "--attach", "claude", "--", "task"]);
+    expect(result.attach).toBe(true);
+  });
+
+  it("defaults attach to false so fork-by-default stays enabled", () => {
+    const result = parseCliArgs(["node", "/path/to/ay", "claude"]);
+    expect(result.attach).toBe(false);
+  });
+
+  it("does NOT treat --attach after -- as an agent-yes flag (passthrough safety)", () => {
+    // Everything after `--` is prompt / CLI passthrough, never an agent-yes flag —
+    // so `ay claude -- --attach` sends --attach to the CLI and still forks.
+    const result = parseCliArgs(["node", "/path/to/ay", "claude", "--", "--attach"]);
+    expect(result.attach).toBe(false);
+    expect(result.prompt).toContain("--attach");
+  });
 });

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -30,6 +30,13 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
       description: "re-spawn Claude with --continue if it crashes, only works for claude yet",
       alias: "r",
     })
+    .option("attach", {
+      type: "boolean",
+      default: false,
+      description:
+        "Run the agent in the foreground even when nested inside another agent (disables fork-by-default; also AGENT_YES_ATTACH=1).",
+      alias: "foreground",
+    })
     .option("logFile", {
       type: "string",
       description: "Rendered log file to write to.",
@@ -307,6 +314,7 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
     ),
     queue: parsedArgv.queue,
     robust: parsedArgv.robust,
+    attach: parsedArgv.attach,
     logFile: parsedArgv.logFile,
     verbose: parsedArgv.verbose,
     resume: parsedArgv.continue, // Note: intentional use resume here to avoid preserved keyword (continue)


### PR DESCRIPTION
## Problem

When an agent (claude/codex) runs `ay <cli> -- <task>` inside its Bash tool, the child runs in the **foreground and blocks the parent's tool call** for the whole (possibly very long) session — so the tool call times out and the parent can't do anything else.

## Fix

Detect that context and spawn the agent **detached**, print a tutorial on how to drive it, and exit 0 immediately.

**Detection** (`shouldForkNested`): `!stdout.isTTY` **and** `AGENT_YES_PID` is set (injected into an agent's env by its wrapper — a human shell never has it). Precisely targets "nested inside an agent, output captured".
- A human piping output (`ay claude | cat`) has no `AGENT_YES_PID` → still blocks (no surprise).
- `ay serve` scrubs `AGENT_YES_PID` before spawning → its `/api/spawn` agents are roots, unaffected.
- Opt out: `--attach` / `--foreground`, or `AGENT_YES_ATTACH=1`.

## Planned with codex, hardened per its review

- **No bogus tutorial for a dead pid**: race `child.on('error'|'exit')` against FIFO registration; on fast failure/exit, report the error with a non-zero exit instead of a "spawned" message.
- **Registration race**: wait for the wrapper's stdin FIFO so `ay send`/`ay tail` work the instant the tutorial prints.
- **Output still reachable**: detached child uses `stdio:'ignore'`, but the wrapper writes its own per-pid log → `ay tail`/`ay cat` show output.
- **Passthrough safety**: `--attach` is only consumed before `--`, so `ay claude -- --attach` forwards `--attach` to the CLI (unit-tested).

## Tutorial printed

```
Spawned claude agent as pid 28725 (detached — this shell returned immediately).
It runs in the background; drive it with:
  ay tail 28725     # watch its output
  ay send 28725 ".."  # send a message
  ay ls             # list agents
  ay result get 28725 # read final result
  ay exit 28725     # stop it
```

## Verification

- Unit: `shouldForkNested` (nested→fork; TTY / non-nested / attach → no fork) + `buildSpawnTutorial`; parseCliArgs `--attach` consume-before-`--` + passthrough-after-`--`.
- Live (fake CLI): nested+non-tty → forks, returns immediately, detached agent alive, FIFO registered, `ay cat`/`ay ls` work; `--attach`, `AGENT_YES_ATTACH=1`, and non-nested all stay foreground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)