### PR TITLE
feat: nested-agent auto-detach, rapid-Ctrl-C panic gesture, slash-command send fix

### DIFF
--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -41,6 +41,14 @@ const RETRY_MAX_DELAY_SECS: u64 = 256; // cap per-retry backoff: 8,16,32,…,256
 /// submit a mangled line. Deliberately short — this only debounces against
 /// active typing, not a real excuse to delay recovery.
 const RETRY_MIN_IDLE_MS: u64 = 5_000;
+
+// Rapid-Ctrl-C panic gesture: a human escape hatch for an agent wedged on a
+// silent stall that ignores forwarded Ctrl-C. Pressing Ctrl-C this many times
+// within the window is read as "get me out": the first completed gesture
+// Esc-cancels the in-flight request; a second while still stuck forces a restart
+// (exit 75 → a --robust parent resumes with --continue).
+const PANIC_CTRL_C_COUNT: usize = 5;
+const PANIC_CTRL_C_WINDOW_SECS: u64 = 2;
 const RETRY_GIVE_UP_SECS: u64 = 8 * 3600; // stop after 8h (claude's usage window is ~5h)
 
 /// What the no-output watchdog should do this tick. Pure decision so it can be
@@ -75,6 +83,31 @@ fn decide_stall_action(
         None => StallAction::SendEsc,
         Some(elapsed) if elapsed >= esc_grace_secs => StallAction::ForceRestart,
         Some(_) => StallAction::Wait,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PanicAction {
+    /// Gesture incomplete: fewer than `threshold` presses in the window.
+    None,
+    /// Gesture complete, first time this stall: Esc-cancel the request.
+    Esc,
+    /// Gesture complete again while an Esc is still in flight (output hasn't
+    /// resumed): escalate to a forced restart.
+    ForceKill,
+}
+
+/// Decide the rapid-Ctrl-C panic action. `recent` is the number of Ctrl-C
+/// presses inside the trailing window; `esc_in_flight` is true once this gesture
+/// already sent an Esc that output hasn't recovered from yet.
+fn decide_panic_action(recent: usize, threshold: usize, esc_in_flight: bool) -> PanicAction {
+    if recent < threshold {
+        return PanicAction::None;
+    }
+    if esc_in_flight {
+        PanicAction::ForceKill
+    } else {
+        PanicAction::Esc
     }
 }
 
@@ -181,6 +214,14 @@ pub struct AgentContext {
     stall_esc_sent_at: Option<Instant>,
     pub stall_force_restart: bool,
 
+    // Rapid-Ctrl-C panic gesture (human escape hatch, see PANIC_CTRL_C_COUNT).
+    // `ctrl_c_times` holds recent Ctrl-C Instants trimmed to the trailing window;
+    // `panic_esc_sent_at` arms once the gesture Esc-cancels a wedged request and
+    // clears the moment visible output resumes, so a repeat gesture escalates to
+    // a forced restart rather than re-sending Esc.
+    ctrl_c_times: Vec<Instant>,
+    panic_esc_sent_at: Option<Instant>,
+
     // Our own pid — needed to update this agent's pid_store record (the
     // unresponsive flag) from inside the loop.
     pid: u32,
@@ -244,6 +285,8 @@ impl AgentContext {
             auto_retry_next_at: None,
             stall_esc_sent_at: None,
             stall_force_restart: false,
+            ctrl_c_times: Vec::new(),
+            panic_esc_sent_at: None,
             last_idle_scan_at: None,
             stdout_drop_count: 0,
             log_writer: LogWriter::new(pid, &cwd),
@@ -567,11 +610,56 @@ impl AgentContext {
                             exit_code = 130;
                             break;
                         } else {
-                            // Forward Ctrl+C to agent — a live TUI redraws (e.g.
-                            // an interrupt prompt), so treat it as a liveness poke.
-                            send_ctrl_c(&writer)?;
-                            self.idle_waiter.ping();
-                            self.mark_stdin_sent();
+                            // Record the press(es) and check the rapid-Ctrl-C
+                            // panic gesture — a human escape hatch for an agent
+                            // wedged on a silent stall that ignores forwarded
+                            // Ctrl-C. Count every 0x03 in the chunk: a fast burst
+                            // can arrive coalesced in a single read, and one
+                            // timestamp per chunk would never reach the threshold.
+                            let now = Instant::now();
+                            let presses = data.iter().filter(|&&b| b == 0x03).count().max(1);
+                            for _ in 0..presses {
+                                self.ctrl_c_times.push(now);
+                            }
+                            let window = Duration::from_secs(PANIC_CTRL_C_WINDOW_SECS);
+                            self.ctrl_c_times
+                                .retain(|t| now.duration_since(*t) <= window);
+                            match decide_panic_action(
+                                self.ctrl_c_times.len(),
+                                PANIC_CTRL_C_COUNT,
+                                self.panic_esc_sent_at.is_some(),
+                            ) {
+                                PanicAction::None => {
+                                    // Forward Ctrl+C to agent — a live TUI redraws
+                                    // (e.g. an interrupt prompt), so treat it as a
+                                    // liveness poke.
+                                    send_ctrl_c(&writer)?;
+                                    self.idle_waiter.ping();
+                                    self.mark_stdin_sent();
+                                }
+                                PanicAction::Esc => {
+                                    warn!(
+                                        "Panic gesture: {}x Ctrl-C in {}s — sending Esc to \
+                                         cancel a wedged request (repeat to force restart)",
+                                        PANIC_CTRL_C_COUNT, PANIC_CTRL_C_WINDOW_SECS
+                                    );
+                                    // send_esc (NOT send_text) so we don't reset the
+                                    // idle timer; mirrors the no-output watchdog. If
+                                    // output resumes, handle_output disarms this.
+                                    send_esc(&writer)?;
+                                    self.panic_esc_sent_at = Some(now);
+                                    self.ctrl_c_times.clear();
+                                }
+                                PanicAction::ForceKill => {
+                                    warn!(
+                                        "Panic gesture repeated while still stuck — forcing \
+                                         restart (a --robust run resumes with --continue)"
+                                    );
+                                    // Picked up next heartbeat → exit 75 → restart.
+                                    self.stall_force_restart = true;
+                                    self.ctrl_c_times.clear();
+                                }
+                            }
                         }
                     }
                     // Check for Ctrl+Y (toggle auto-yes)
@@ -812,6 +900,9 @@ impl AgentContext {
         let stripped = strip_ansi_escapes::strip_str(output);
         if !stripped.trim().is_empty() {
             self.idle_waiter.ping();
+            // Output resumed → a panic-Esc unstuck the stream. Disarm so the next
+            // gesture starts fresh at Esc rather than jumping to force-restart.
+            self.panic_esc_sent_at = None;
         }
 
         // Check patterns
@@ -1367,6 +1458,30 @@ mod tests {
             decide_stall_action(300, false, 9999, None, 30),
             StallAction::Clear
         );
+    }
+
+    #[test]
+    fn test_panic_below_threshold_is_none() {
+        // 4 presses in the window → gesture incomplete, forward as normal.
+        assert_eq!(decide_panic_action(4, 5, false), PanicAction::None);
+    }
+
+    #[test]
+    fn test_panic_at_threshold_sends_esc() {
+        // 5th press completes the gesture, no Esc yet → Esc-cancel.
+        assert_eq!(decide_panic_action(5, 5, false), PanicAction::Esc);
+    }
+
+    #[test]
+    fn test_panic_repeat_while_esc_in_flight_force_kills() {
+        // Gesture repeats while a prior Esc hasn't recovered → force restart.
+        assert_eq!(decide_panic_action(5, 5, true), PanicAction::ForceKill);
+    }
+
+    #[test]
+    fn test_panic_below_threshold_ignores_esc_state() {
+        // An armed Esc doesn't lower the bar: still need a full gesture.
+        assert_eq!(decide_panic_action(4, 5, true), PanicAction::None);
     }
 
     #[test]

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -106,6 +106,52 @@ if (config.useRust) {
       console.log(`[rust] Args: ${rustArgs.join(" ")}`);
     }
 
+    // Nested + non-tty (e.g. an agent ran this via its Bash tool): detach the
+    // agent so we don't block the parent's tool call for the whole session, then
+    // print how to drive it and exit. `--attach`/AGENT_YES_ATTACH=1 opts out.
+    const attach = config.attach || process.env.AGENT_YES_ATTACH === "1";
+    const { shouldForkNested, buildSpawnTutorial, waitForFifo } = await import("./forkNested.ts");
+    if (
+      shouldForkNested({
+        isTTY: Boolean(process.stdout.isTTY),
+        ayPid: process.env.AGENT_YES_PID,
+        attach,
+      })
+    ) {
+      const forked = spawn(rustBinary, rustArgs, {
+        detached: true,
+        stdio: "ignore",
+        env: process.env,
+        cwd: process.cwd(),
+      });
+      const forkedPid = forked.pid;
+      if (!forkedPid) {
+        console.error("Failed to spawn agent: no pid.");
+        process.exit(1);
+      }
+      // Race a fast startup failure against FIFO registration so we never print a
+      // success tutorial for a dead pid. The wrapper keeps its own per-pid log, so
+      // real output stays reachable via `ay tail` even with stdio ignored. Store a
+      // pre-formatted message (not a union) — the callbacks run async, so control-flow
+      // analysis can't narrow a union here anyway.
+      let deathMsg: string | null = null;
+      forked.on("error", (err) => {
+        deathMsg ??= `Failed to spawn agent: ${err.message}`;
+      });
+      forked.on("exit", (code, signal) => {
+        deathMsg ??= `Agent exited immediately (${signal ?? `code ${code}`}). See: ay tail ${forkedPid}`;
+      });
+      const registered = await waitForFifo(forkedPid, 2000, () => deathMsg !== null);
+      if (deathMsg) {
+        console.error(deathMsg);
+        process.exit(1);
+      }
+      forked.unref();
+      console.log(buildSpawnTutorial(config.cli || "agent", forkedPid));
+      if (!registered) console.log(`(note: still registering — give ay send/tail a moment)`);
+      process.exit(0);
+    }
+
     const child = spawn(rustBinary, rustArgs, {
       stdio: "inherit",
       env: process.env,

--- a/ts/forkNested.spec.ts
+++ b/ts/forkNested.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildSpawnTutorial, shouldForkNested } from "./forkNested";
+
+describe("shouldForkNested", () => {
+  it("forks when nested (AGENT_YES_PID set) and stdout is not a TTY", () => {
+    expect(shouldForkNested({ isTTY: false, ayPid: "1234", attach: false })).toBe(true);
+  });
+
+  it("does NOT fork on an interactive TTY (a human running it directly)", () => {
+    expect(shouldForkNested({ isTTY: true, ayPid: "1234", attach: false })).toBe(false);
+  });
+
+  it("does NOT fork when not nested — a human piping output has no AGENT_YES_PID", () => {
+    expect(shouldForkNested({ isTTY: false, ayPid: undefined, attach: false })).toBe(false);
+    expect(shouldForkNested({ isTTY: false, ayPid: "", attach: false })).toBe(false);
+    expect(shouldForkNested({ isTTY: false, ayPid: "   ", attach: false })).toBe(false);
+  });
+
+  it("does NOT fork when attach opts out, regardless of context", () => {
+    expect(shouldForkNested({ isTTY: false, ayPid: "1234", attach: true })).toBe(false);
+  });
+});
+
+describe("buildSpawnTutorial", () => {
+  it("names the cli + pid and lists the drive commands with that pid", () => {
+    const out = buildSpawnTutorial("claude", 4242);
+    expect(out).toContain("Spawned claude agent as pid 4242");
+    expect(out).toContain("ay tail 4242");
+    expect(out).toContain("ay send 4242");
+    expect(out).toContain("ay ls");
+    expect(out).toContain("ay result get 4242");
+    expect(out).toContain("ay exit 4242");
+  });
+});

--- a/ts/forkNested.ts
+++ b/ts/forkNested.ts
@@ -1,0 +1,64 @@
+import { existsSync } from "fs";
+import path from "path";
+import { agentYesHome } from "./agentYesHome.ts";
+
+/**
+ * Should a nested agent-run detach (fork) instead of blocking the caller?
+ *
+ * A claude/codex agent that runs `ay <cli> -- <task>` inside its Bash tool would
+ * otherwise block that Bash call for the whole (possibly very long) session and
+ * time out. When we detect that context we spawn the agent detached, print a
+ * tutorial, and return immediately so the parent stays responsive.
+ *
+ * The context is: we are NESTED inside another agent (`AGENT_YES_PID` is injected
+ * into an agent's environment by its wrapper — a human shell never has it) AND
+ * stdout is not a TTY (captured/piped, e.g. a tool's Bash). A human piping output
+ * (`ay claude | cat`) has no `AGENT_YES_PID`, so they still block as before.
+ * `attach` (the `--attach` flag or `AGENT_YES_ATTACH=1`) forces foreground.
+ */
+export function shouldForkNested(opts: {
+  isTTY: boolean;
+  ayPid: string | undefined;
+  attach: boolean;
+}): boolean {
+  if (opts.attach) return false;
+  if (opts.isTTY) return false;
+  return Boolean(opts.ayPid && opts.ayPid.trim());
+}
+
+/** The tutorial printed to the parent agent after a detached spawn, telling it
+ *  exactly how to drive the agent it just started. */
+export function buildSpawnTutorial(cli: string, pid: number): string {
+  return [
+    `Spawned ${cli} agent as pid ${pid} (detached — this shell returned immediately).`,
+    `It runs in the background; drive it with:`,
+    `  ay tail ${pid}          # watch its output (live)`,
+    `  ay send ${pid} "..."    # send it a message / instruction`,
+    `  ay send ${pid} /compact # send a slash command`,
+    `  ay ls                   # list running agents`,
+    `  ay result get ${pid}    # read its final result when done`,
+    `  ay exit ${pid}          # stop it`,
+  ].join("\n");
+}
+
+/**
+ * Poll for the spawned wrapper's stdin FIFO to appear, so the tutorial's
+ * `ay send`/`ay tail` work the instant we print them (the wrapper registers its
+ * FIFO a moment after spawn). Resolves true once registered, false on timeout or
+ * if `aborted()` reports the child already died (so a startup failure fails fast
+ * instead of waiting out the whole window).
+ */
+export async function waitForFifo(
+  pid: number,
+  timeoutMs = 2000,
+  aborted?: () => boolean,
+): Promise<boolean> {
+  const fifo = path.join(agentYesHome(), "fifo", `${pid}.stdin`);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (aborted?.()) return false;
+    if (existsSync(fifo)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return existsSync(fifo);
+}

--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -439,4 +439,22 @@ describe("CLI argument parsing", () => {
     expect(afterCli.useStdinAppend).toBe(true);
     expect(afterCli.cliArgs).toContain("--no-stdpush");
   });
+
+  it("consumes --attach as an agent-yes flag before the CLI positional", () => {
+    const result = parseCliArgs(["node", "/path/to/ay", "--attach", "claude", "--", "task"]);
+    expect(result.attach).toBe(true);
+  });
+
+  it("defaults attach to false so fork-by-default stays enabled", () => {
+    const result = parseCliArgs(["node", "/path/to/ay", "claude"]);
+    expect(result.attach).toBe(false);
+  });
+
+  it("does NOT treat --attach after -- as an agent-yes flag (passthrough safety)", () => {
+    // Everything after `--` is prompt / CLI passthrough, never an agent-yes flag —
+    // so `ay claude -- --attach` sends --attach to the CLI and still forks.
+    const result = parseCliArgs(["node", "/path/to/ay", "claude", "--", "--attach"]);
+    expect(result.attach).toBe(false);
+    expect(result.prompt).toContain("--attach");
+  });
 });

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -30,6 +30,13 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
       description: "re-spawn Claude with --continue if it crashes, only works for claude yet",
       alias: "r",
     })
+    .option("attach", {
+      type: "boolean",
+      default: false,
+      description:
+        "Run the agent in the foreground even when nested inside another agent (disables fork-by-default; also AGENT_YES_ATTACH=1).",
+      alias: "foreground",
+    })
     .option("logFile", {
       type: "string",
       description: "Rendered log file to write to.",
@@ -307,6 +314,7 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
     ),
     queue: parsedArgv.queue,
     robust: parsedArgv.robust,
+    attach: parsedArgv.attach,
     logFile: parsedArgv.logFile,
     verbose: parsedArgv.verbose,
     resume: parsedArgv.continue, // Note: intentional use resume here to avoid preserved keyword (continue)

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -964,6 +964,28 @@ describe("subcommands.isExitRequest", () => {
   });
 });
 
+describe("subcommands.isSlashCommand", () => {
+  it("matches a body that starts with a slash command (so it is sent unprefixed)", async () => {
+    const { isSlashCommand } = await loadModule();
+    for (const s of ["/compact", "/clear", "/model sonnet", "/resume\nmore text"]) {
+      expect(isSlashCommand(s)).toBe(true);
+    }
+  });
+  it("does NOT match plain prose, or a slash not at column 0", async () => {
+    const { isSlashCommand } = await loadModule();
+    for (const s of [
+      "please run /compact",
+      " /compact", // leading space — the CLI won't parse it as a command either
+      "//two slashes... wait, no letter after first slash",
+      "/ ",
+      "hello",
+      "",
+    ]) {
+      expect(isSlashCommand(s)).toBe(false);
+    }
+  });
+});
+
 describe("subcommands.writeToIpc reliable delivery", () => {
   const itUnix = process.platform === "linux" || process.platform === "darwin";
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2476,10 +2476,15 @@ async function cmdSend(rest: string[]): Promise<number> {
   }
 
   // When an agent sends, prefix one line so the recipient knows who pinged it
-  // and exactly how to reply (to a resolvable pid — the sender's own).
-  const prefix = sender.agent
-    ? `[from ${sender.agent.cli} #${sender.agent.pid} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${sender.agent.pid} "..."]\n`
-    : "";
+  // and exactly how to reply (to a resolvable pid — the sender's own). BUT a
+  // slash command is only recognized when `/` is the very first character of the
+  // submitted message; the prefix would bump it to line 2 and the CLI would type
+  // the command as plain text. So skip the prefix for a command body and send it
+  // verbatim — attribution is dropped for the command, but it actually runs.
+  const prefix =
+    sender.agent && !isSlashCommand(body)
+      ? `[from ${sender.agent.cli} #${sender.agent.pid} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${sender.agent.pid} "..."]\n`
+      : "";
 
   const fullBody = prefix + body;
   if (fullBody && trailing) {
@@ -2915,6 +2920,14 @@ async function cmdStop(rest: string[]): Promise<number> {
 export function isExitRequest(body: string): boolean {
   const t = body.trim().toLowerCase();
   return t === "exit" || t === "/exit";
+}
+
+/** A body that the CLI will parse as a slash command — `/` as the very first
+ * character (claude requires column 0, no leading whitespace, then a letter).
+ * Such a body must be sent verbatim: any prefix line bumps the `/` off column 0
+ * and the CLI types the command as plain text instead of running it. */
+export function isSlashCommand(body: string): boolean {
+  return /^\/[A-Za-z]/.test(body);
 }
 
 /**


### PR DESCRIPTION
## Summary
Three small, independently-tested pieces of in-progress work:

- **Nested-agent auto-detach** (`ts/forkNested.ts`, `ts/cli.ts`, `--attach` flag in `parseCliArgs.ts`): `ay <cli>` run inside another agent's Bash tool (non-TTY + `AGENT_YES_PID` set) now spawns detached and prints a drive-it tutorial instead of blocking that Bash call for the whole session. `--attach`/`AGENT_YES_ATTACH=1` opts back into blocking foreground. Live-smoke-tested end to end.
- **Rapid-Ctrl-C panic gesture** (`rs/src/context.rs`): a human escape hatch for an agent wedged on a silent stall that ignores forwarded Ctrl-C. 5 presses in 2s Esc-cancels the in-flight request; a repeat while still stuck forces a restart (a `--robust` parent resumes with `--continue`).
- **`ay send`**: skip the `[from ...]` attribution prefix when the body is a slash command (`isSlashCommand`), since the prefix bumps the leading `/` off column 0 and the CLI types it as plain text instead of running it.

## Test plan
- [x] `cargo test --manifest-path rs/Cargo.toml` — 247 unit + 10 integration tests pass
- [x] `bunx vitest run --coverage.enabled=false` — 622 + 15 (shared-e2e ts-vs-rs parity) = 637 tests pass
- [x] Live smoke test: `ay claude -- "..."` from inside an agent's Bash tool returns immediately with the tutorial; the spawned agent ran correctly and was drivable via `ay tail`/`ay exit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)