### PR TITLE
perf(ts): shorten exitAgent kill timeout 5s→2s, heartbeat poll 800ms→100ms

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -896,7 +896,12 @@ export default async function agentYes({
       // Silently ignore heartbeat errors to avoid disrupting main flow
       logger.debug(`heartbeat|error: ${error}`);
     }
-  }, 800); // Run every 800ms
+  }, 100); // Run every 100ms — cheap when unchanged (see the rendered === lastHeartbeatRendered
+  // guard above): most ticks bail after one xtermProxy.tail(12) + string compare. A short
+  // interval matters for two things this heartbeat drives: no-EOL ready/fatal detection
+  // (CSI-redrawn output never fires the newline-driven consoleResponder path) and auto-retry
+  // backoff timing precision (AUTO_RETRY_MIN_IDLE_MS gating). Previously 800ms; still coarser
+  // than Rust's HEARTBEAT_INTERVAL_MS=50 (rs/src/context.rs) since Rust's per-tick cost is lower.
 
   // Clear heartbeat on exit
   const cleanupHeartbeat = () => clearInterval(heartbeatInterval);
@@ -1312,14 +1317,18 @@ export default async function agentYes({
     await Promise.race([
       pendingExitCode.promise.then(() => (exited = true)), // resolve when shell exits
 
-      // if shell doesn't exit in 5 seconds, kill it
+      // if shell doesn't exit in 2 seconds, kill it. Rust's equivalent (rs/src/context.rs)
+      // doesn't wait for the child's own exit at all — it sends the exit command(s) and tears
+      // down immediately. 2s keeps a real grace window for a CLI to actually process `/exit`
+      // (flush session state, close connections) while still bounding the worst case — down
+      // from a previous 5s that mostly just delayed force-killing CLIs that never respond.
       new Promise<void>((resolve) =>
         setTimeout(() => {
           if (exited) return; // if shell already exited, do nothing
           shell.kill(); // kill the shell process if it doesn't exit in time
           resolve();
-        }, 5000),
-      ), // 5 seconds timeout
+        }, 2000),
+      ), // 2 seconds timeout
     ]);
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #153 — ships the two production-behavior tunings that were flagged there but left for a deliberate decision.

- **`exitAgent()` kill timeout: 5000ms → 2000ms** (`ts/index.ts`). This wait only matters for CLIs that don't respond to the exit command (idle-timeout/fatal/restart paths) — Rust's equivalent doesn't wait for the child's own exit at all. 2s keeps a real grace window for a genuine CLI's `/exit` handling (flush state, close connections) while bounding the worst case much tighter than 5s.
- **No-EOL fallback heartbeat: 800ms → 100ms poll** (`ts/index.ts`). The heartbeat's own `rendered === lastHeartbeatRendered` guard makes most ticks cheap (bail after one `xtermProxy.tail(12)` + string compare) when the screen hasn't changed, so tightening the interval isn't a blind CPU trade. It also drives the auto-retry backoff timer's firing precision (`AUTO_RETRY_MIN_IDLE_MS` gating from #150), not just no-EOL ready/fatal detection — so this has real production value beyond faster tests. Still coarser than Rust's `HEARTBEAT_INTERVAL_MS = 50`.

## Test plan
- [x] `bunx vitest run` — 650 passed, 1 skipped, 0 failed, including every shared-e2e `[ts]`/`[rs]` parity assertion
- [x] Pre-push hook's full coverage gate passed locally