### PR TITLE
feat(win): wire the daemon to spawn via ay-spawn-hidden (no console flash)

### DIFF
--- a/ts/rustBinary.ts
+++ b/ts/rustBinary.ts
@@ -102,6 +102,36 @@ export function findRustBinary(verbose = false): string | undefined {
 }
 
 /**
+ * Locate the `ay-spawn-hidden` launcher (Windows-only). Returns undefined off
+ * Windows, or when the launcher isn't present — older installs, or a release
+ * that predates it. Callers MUST fall back to spawning the program directly.
+ *
+ * The launcher is a second `[[bin]]` built alongside `agent-yes`, so it sits
+ * next to the Rust binary in every install shape: the cargo `target/` build
+ * dir, the downloaded release bin dir (getBinDir), and `~/.cargo/bin` on PATH.
+ */
+export function findSpawnHiddenLauncher(): string | undefined {
+  if (process.platform !== "win32") return undefined;
+
+  const dir = import.meta.dirname ?? import.meta.dir;
+  const searchPaths = [
+    // 1. Dev build, right next to the target/release agent-yes.exe
+    path.resolve(dir, "../rs/target/release/ay-spawn-hidden.exe"),
+    path.resolve(dir, "../rs/target/debug/ay-spawn-hidden.exe"),
+    // 2. npm package bin / version-scoped download cache (getBinDir), where the
+    //    win32 release zip extracts it beside agent-yes-win32-x64.exe.
+    path.join(getBinDir(), "ay-spawn-hidden.exe"),
+    // 3. cargo-installed (`bun run build:rs`) → on PATH.
+    Bun.which("ay-spawn-hidden") ?? "",
+  ];
+
+  for (const p of searchPaths) {
+    if (p && existsSync(p)) return p;
+  }
+  return undefined;
+}
+
+/**
  * Get GitHub release download URL for the binary
  */
 export function getDownloadUrl(version = "latest"): string {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -20,6 +20,7 @@ import {
   type CommonOpts,
 } from "./subcommands.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
+import { findSpawnHiddenLauncher } from "./rustBinary.ts";
 import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
@@ -172,12 +173,15 @@ function loginShellEnv(): Record<string, string> | null {
     // Delimiters fence off the env dump from any banner/prompt noise the rc files
     // print to stdout; `env -0` is NUL-separated so values with newlines survive.
     const delim = "_AY_SHELL_ENV_DELIM_";
-    const res = Bun.spawnSync([shell, "-ilc", `printf %s "${delim}"; env -0; printf %s "${delim}"`], {
-      stdin: "ignore",
-      stderr: "ignore",
-      timeout: 5_000,
-      env: process.env as Record<string, string>,
-    });
+    const res = Bun.spawnSync(
+      [shell, "-ilc", `printf %s "${delim}"; env -0; printf %s "${delim}"`],
+      {
+        stdin: "ignore",
+        stderr: "ignore",
+        timeout: 5_000,
+        env: process.env as Record<string, string>,
+      },
+    );
     const out = res.stdout?.toString() ?? "";
     const start = out.indexOf(delim);
     const end = out.lastIndexOf(delim);
@@ -507,6 +511,17 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
     // args after `--`. Both auto-restart on crash by default (pm2) / via the
     // explicit flag (oxmgr).
     const serveArgv = ayServeArgv(effArgs);
+    // On Windows, interpose the window-less launcher so the manager (pm2/oxmgr)
+    // doesn't flash a console window on each (re)start. `ay-spawn-hidden` is a
+    // GUI-subsystem shim that starts the real `ay serve …` with CREATE_NO_WINDOW
+    // and mirrors its lifetime/exit-code, so the manager still tracks it exactly.
+    // Resolves to undefined off Windows or when the launcher isn't installed
+    // (older builds / a release predating it) → fall back to the raw command.
+    const spawnHidden = findSpawnHiddenLauncher();
+    // The command the manager launches: unchanged normally, or the launcher
+    // followed by the real argv when interposing. Split into program + args for
+    // pm2 (which takes `<program> … -- <args>`); oxmgr takes the joined string.
+    const managedArgv = spawnHidden ? [spawnHidden, ...serveArgv] : serveArgv;
     // WebRTC daemons get an oxmgr health watchdog: the native WebRTC stack can
     // freeze the JS event loop (host answers nobody, no in-process timer can
     // recover it), so an EXTERNAL probe of the serve heartbeat is the only thing
@@ -530,7 +545,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
         ? [
             mgr.bin,
             "start",
-            serveArgv.join(" "),
+            managedArgv.join(" "),
             "--name",
             DAEMON_NAME,
             "--restart",
@@ -546,7 +561,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
         : [
             mgr.bin,
             "start",
-            serveArgv[0]!,
+            managedArgv[0]!,
             "--name",
             DAEMON_NAME,
             "--interpreter",
@@ -559,7 +574,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
             "--exp-backoff-restart-delay",
             "200",
             "--",
-            ...serveArgv.slice(1),
+            ...managedArgv.slice(1),
           ];
     const proc = Bun.spawn(startArgv, { stdio: ["ignore", "inherit", "inherit"] });
     const code = await proc.exited;


### PR DESCRIPTION
Wires `ay serve install`'s daemon-spawn path to interpose the `ay-spawn-hidden` launcher (landed in #156) so pm2/oxmgr don't flash a console window on each (re)start of the managed `ay serve …` process on Windows.

This is the consumer that #156 explicitly deferred ("No consumer yet — oxmgr wiring is a follow-up").

## What changed
- **`ts/rustBinary.ts`** — `findSpawnHiddenLauncher()` resolves the launcher across every install shape: `rs/target/{release,debug}` (dev), `getBinDir()` (npm package bin / version-scoped download cache), and `~/.cargo/bin` on PATH. Returns `undefined` off Windows or when the launcher is absent (older installs) → callers fall back to the raw command. **No-op on non-Windows.**
- **`ts/serve.ts`** — when resolved, the managed command becomes `ay-spawn-hidden <ay serve …>` for both the pm2 branch (program + `-- args`) and the oxmgr branch (joined string). Falls back to the direct command otherwise.

## Why it's lifetime-safe
`ay-spawn-hidden` is a GUI-subsystem shim: the manager allocates no console for *it*, and it starts the real child with `CREATE_NO_WINDOW`. It `WaitForSingleObject`s the child and exits with its exact code, and holds the child in a `KILL_ON_JOB_CLOSE` Job Object — so the manager still tracks the PID exactly and a stop/restart tears the child down with the launcher (no orphans).

## Verified on this Windows box
Rolled the live daemon forward with `ay serve install`:
- pm2 now manages `ay-spawn-hidden.exe … ay.exe serve --webrtc` → real child `ay.exe serve --webrtc`, healthcheck green.
- `pm2 restart` killed the old child (confirmed gone — no orphan) and respawned a fresh launcher→child; healthcheck green after.

## Follow-up (not in this PR)
Shipping `ay-spawn-hidden.exe` in the **win32 release zip** needs a `.github/workflows/rust-build.yml` change that this token can't push (no `workflow` scope). Until that lands, bunx/npm installs fall back to the raw command; dev/cargo installs already have the launcher beside `agent-yes`. The workflow diff is ready to apply.

## Stacking
Based on \`feat/ay-spawn-hidden\` (#156). Rebase onto main once #156 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)