### PR TITLE
ci(win): ship ay-spawn-hidden.exe in the win32 release zip

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -127,12 +127,19 @@ jobs:
           mkdir -p artifacts
           cp rs/target/${{ matrix.target }}/release/agent-yes${{ matrix.ext }} artifacts/${{ matrix.artifact }}${{ matrix.ext }}
           chmod +x artifacts/${{ matrix.artifact }}${{ matrix.ext }} || true
+          # Windows also ships the ay-spawn-hidden launcher (a second [[bin]]).
+          # `ay serve install` interposes it so pm2/oxmgr don't flash a console
+          # window on each daemon (re)start. It rides along in the same zip and
+          # extracts beside the main binary in rustBinary.ts getBinDir().
+          if [ "${{ matrix.ext }}" = ".exe" ]; then
+            cp rs/target/${{ matrix.target }}/release/ay-spawn-hidden.exe artifacts/ay-spawn-hidden.exe
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: artifacts/${{ matrix.artifact }}${{ matrix.ext }}
+          path: artifacts/
           if-no-files-found: error
 
   # Create a combined artifact with all binaries


### PR DESCRIPTION
Completes the Windows console-flash fix: the daemon interposes `ay-spawn-hidden` (#160), but bunx/npm installs only get the launcher if it ships in the release. `cargo build --release` already produces it (a second `[[bin]]`), so this copies it into the win32 artifact and uploads the whole `artifacts/` dir → it extracts beside `agent-yes-win32-x64.exe` in the download cache, where `rustBinary.ts` `findSpawnHiddenLauncher()` (getBinDir) finds it.

No-op for other platforms (copy gated on the `.exe` ext); dev/cargo installs already have the launcher beside `agent-yes`.

Follow-up to #156/#160 — the workflow change the default OAuth token couldn't push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)