### PR TITLE
feat(landing): autofocus the "Open the console" CTA on load

### DIFF
--- a/lab/ui/landing.html
+++ b/lab/ui/landing.html
@@ -214,7 +214,7 @@
           spawn agents from anywhere.
         </p>
         <div class="cta">
-          <a class="btn" href="/w/">Open the console →</a>
+          <a class="btn" href="/w/" autofocus>Open the console →</a>
           <a class="btn ghost" href="https://github.com/snomiao/agent-yes">Star on GitHub</a>
         </div>
         <div class="install">
@@ -273,5 +273,15 @@ powershell -c "irm https://agent-yes.com/setup.ps1 | iex"</code></pre>
         </div>
       </footer>
     </div>
+    <script>
+      // Focus the "Open the console" CTA on load so keyboard/Enter users land
+      // straight on it. `autofocus` on <a> isn't honored everywhere, so back it
+      // up here — but skip on touch devices where focusing scroll-jumps the page.
+      (function () {
+        if (matchMedia("(hover: none)").matches) return;
+        var cta = document.querySelector(".hero .cta a.btn");
+        if (cta) cta.focus({ preventScroll: true });
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## What

Make the homepage default-focus the **Open the console** button so keyboard/Enter users land straight on the primary action.

## Changes
- Add `autofocus` to the `/w/` CTA anchor in `lab/ui/landing.html`.
- JS fallback focuses the same anchor on load (`autofocus` on `<a>` isn't honored in every browser), using `focus({ preventScroll: true })`.
- Skipped on touch devices (`hover: none`) to avoid a focus-induced scroll jump.

## Verify
Served `lab/ui/landing.html` locally and drove it in Chrome — `document.activeElement` on load is `A | Open the console → | href=/w/`. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)