### PR TITLE
feat(console): show last-active (stdout) time in the left panel

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -204,11 +204,16 @@ export function badgesFor(e) {
   return (e.badges || []).map((id) => ({ id, ...(BADGE_META[id] || { label: id, title: id }) }));
 }
 
-// Human age of an agent ("12s" / "5m" / "3h"). `now` is injectable so tests
-// don't depend on the wall clock; the browser calls age(e) and gets Date.now().
+// Time since the agent was last active ("12s" / "5m" / "3h") — measured from
+// its last stdout write (last_active_at, the log file's mtime), so a long-lived
+// but quiet agent reads as stale rather than "new". Falls back to started_at
+// when the server hasn't stamped a last-active time (e.g. freshly spawned, no
+// log yet). `now` is injectable so tests don't depend on the wall clock; the
+// browser calls age(e) and gets Date.now().
 export function age(e, now = Date.now()) {
-  if (!e.started_at) return "";
-  const s = Math.max(0, (now - e.started_at) / 1000);
+  const at = e.last_active_at ?? e.started_at;
+  if (!at) return "";
+  const s = Math.max(0, (now - at) / 1000);
   if (s < 60) return Math.floor(s) + "s";
   if (s < 3600) return Math.floor(s / 60) + "m";
   return Math.floor(s / 3600) + "h";

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -314,6 +314,14 @@ describe("age", () => {
   it("clamps a future start time to 0s instead of going negative", () => {
     expect(age(agent({ started_at: now + 10_000 }), now)).toBe("0s");
   });
+  it("prefers last_active_at (last stdout) over started_at when present", () => {
+    expect(
+      age(agent({ started_at: now - 3 * 3_600_000, last_active_at: now - 5_000 }), now),
+    ).toBe("5s");
+  });
+  it("falls back to started_at when last_active_at is absent", () => {
+    expect(age(agent({ started_at: now - 5 * 60_000, last_active_at: undefined }), now)).toBe("5m");
+  });
 });
 
 describe("matches", () => {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1165,8 +1165,18 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // dot and the CLI agree.
     const question =
       status !== "exited" && !r.unresponsive ? await logNeedsInput(r.log_file, r.cli) : null;
+    // Last-active time: the log file's mtime, i.e. when the agent last wrote
+    // output (stdout). The console's left panel shows the age off this instead
+    // of started_at, so a long-lived-but-quiet agent reads as stale, not "new".
+    // Falls back to started_at when there's no log yet (freshly spawned).
+    const lastActiveAt = r.log_file
+      ? await stat(r.log_file)
+          .then((s) => s.mtimeMs)
+          .catch(() => r.started_at)
+      : r.started_at;
     return {
       ...r,
+      last_active_at: lastActiveAt,
       // Precedence: exited stays exited; the Rust supervisor's unresponsive flag is
       // an authoritative wedge signal (`stuck`); then a blocked menu (`needs_input`);
       // else the base live status — so the console's dot matches `ay ls`. (A dead


### PR DESCRIPTION
## What

The agent-yes.com console left panel showed each agent's age measured from **create time** (`started_at`). A long-lived but quiet agent therefore read as "new". This changes the age chip to measure from **last active** — the agent's last stdout write.

## How

- `ay serve` now stamps every `/api/ls` (and `/api/ls/subscribe`) record with `last_active_at` = the log file's mtime (falling back to `started_at` when there's no log yet, e.g. a freshly spawned agent).
- The console's `age(e)` prefers `last_active_at`, falling back to `started_at`.
- Sorting by "created" still keys off `started_at` — only the displayed age chip changed.

## Verify

- `bun test tests/ui-logic/console-logic.spec.ts` → 96 pass (added 2 cases for the new field).
- Ran `ay serve --http` locally and confirmed `/api/ls` emits `last_active_at`, distinct from `started_at` (e.g. ~200s later for an active agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)