### PR TITLE
feat(console): add "active" order-by (sort by last active)

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -344,7 +344,7 @@ function agentForestNodes(list) {
 // flat entry list BEFORE layeredRows builds the room/peer/agent tree (which keeps
 // the given order for siblings and first-seen order for room/peer groups). So
 // sorting reorders roots and siblings without breaking the nesting.
-export const SORT_MODES = ["state", "created", "identity"];
+export const SORT_MODES = ["state", "active", "created", "identity"];
 
 // Attention-first state ranking: someone scanning the fleet wants the agents that
 // need them (needs_input) up top, then the wedged ones (stuck), then live work,
@@ -371,19 +371,29 @@ function gitWeight(e) {
   return (g.changed || 0) + (g.ahead || 0) + (g.behind || 0) + (g.dirty ? 0.5 : 0);
 }
 
+// Last-active instant for an entry: its last stdout write (last_active_at),
+// falling back to started_at when the server hasn't stamped one yet.
+function lastActive(e) {
+  return e.last_active_at ?? e.started_at ?? 0;
+}
+
 // Return a NEW array sorted for display per `mode` (default "state"):
 //   - "state":    attention-first state, then git busyness, then newest.
+//   - "active":   most recently active first (last_active_at desc).
 //   - "created":  newest first (started_at desc).
 //   - "identity": user@host:owner/repo/branch (alphabetical).
 // Every comparator falls back to newest-first so order is total & deterministic.
 export function sortEntries(entries, mode = "state") {
   const byNewest = (a, b) => (b.started_at || 0) - (a.started_at || 0);
+  const byActive = (a, b) => lastActive(b) - lastActive(a) || byNewest(a, b);
   const cmp =
-    mode === "created"
-      ? byNewest
-      : mode === "identity"
-        ? (a, b) => fullIdent(a).localeCompare(fullIdent(b)) || byNewest(a, b)
-        : (a, b) => stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
+    mode === "active"
+      ? byActive
+      : mode === "created"
+        ? byNewest
+        : mode === "identity"
+          ? (a, b) => fullIdent(a).localeCompare(fullIdent(b)) || byNewest(a, b)
+          : (a, b) => stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
   return entries.slice().sort(cmp);
 }
 

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -729,7 +729,7 @@ describe("sortEntries", () => {
   const keys = (arr, k = "_k") => arr.map((e) => e[k]);
 
   it("SORT_MODES is the documented cycle", () => {
-    expect(SORT_MODES).toEqual(["state", "created", "identity"]);
+    expect(SORT_MODES).toEqual(["state", "active", "created", "identity"]);
   });
 
   it("returns a new array and does not mutate the input", () => {
@@ -777,6 +777,23 @@ describe("sortEntries", () => {
       a({ _k: "mid", started_at: 500 }),
     ];
     expect(keys(sortEntries(list, "created"))).toEqual(["new", "mid", "old"]);
+  });
+
+  it("active mode: most recently active (last_active_at) first", () => {
+    const list = [
+      a({ _k: "old", started_at: 900, last_active_at: 100 }),
+      a({ _k: "fresh", started_at: 100, last_active_at: 900 }),
+      a({ _k: "mid", started_at: 500, last_active_at: 500 }),
+    ];
+    expect(keys(sortEntries(list, "active"))).toEqual(["fresh", "mid", "old"]);
+  });
+
+  it("active mode: falls back to started_at when last_active_at is absent", () => {
+    const list = [
+      a({ _k: "old", started_at: 100 }),
+      a({ _k: "new", started_at: 900 }),
+    ];
+    expect(keys(sortEntries(list, "active"))).toEqual(["new", "old"]);
   });
 
   it("identity mode: alphabetical by full identity (user@host:owner/repo/branch)", () => {


### PR DESCRIPTION
Follow-up to #163. Adds a new **"active"** mode to the left-panel sort cycle (⇅), between `state` and `created`. It orders agents by `last_active_at` (last stdout write) descending, so the agents that just produced output float to the top. Falls back to `started_at` when the server hasn't stamped a last-active time.

The sort button auto-picks up the new mode (it just cycles `SORT_MODES` and shows `⇅ <mode>`), so no other UI wiring was needed.

## Verify
- `bun test tests/ui-logic/console-logic.spec.ts` → 98 pass (added 2 cases for the new mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)