### PR TITLE
feat(console): add /kill and /restart slash commands to the Cmd+K palette

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -630,6 +630,10 @@
       .omni-spawn .omni-title {
         color: var(--green);
       }
+      /* Destructive slash command (/kill) — red title, matching the ⋯-menu Force-kill. */
+      .omni-spawn.danger .omni-title {
+        color: var(--red);
+      }
       .omni-empty {
         padding: 14px;
         color: var(--muted);
@@ -2819,8 +2823,10 @@
       //   Force — escalation a stuck agent can't ignore: a real SIGKILL of its process
       //           GROUP, server-side via POST /api/kill. Use when /exit does nothing.
       const GRACEFUL_EXIT = { claude: "/exit", codex: "/exit", gemini: "/quit" };
-      async function stopAgent(force) {
-        const e = sel ? entries.find((x) => x._key === sel) : null;
+      // `ent` targets a specific agent (the Cmd+K /kill · /restart commands pass the
+      // omnibox anchor); the ⋯-menu buttons omit it and act on the selected agent.
+      async function stopAgent(force, ent) {
+        const e = ent || (sel ? entries.find((x) => x._key === sel) : null);
         if (!e) return;
         const who = `pid ${e.pid} ${cliLabel(e) || ident(e) || ""}`.trim();
         const tx = txFor(e),
@@ -2843,8 +2849,8 @@
       // Restart — stop (if live) + relaunch resuming the session, server-side via
       // POST /api/restart (the `ay restart` flow). The server runs it detached, so
       // it's decoupled from this agent's lifecycle — no prompt typed into the agent.
-      async function restartAgent() {
-        const e = sel ? entries.find((x) => x._key === sel) : null;
+      async function restartAgent(ent) {
+        const e = ent || (sel ? entries.find((x) => x._key === sel) : null);
         if (!e) return;
         const who = `pid ${e.pid} ${cliLabel(e) || ident(e) || ""}`.trim();
         if (!confirm(`Restart ${who}?\nStops it (if live) and relaunches resuming the session.`))
@@ -3889,6 +3895,42 @@
         return cur && cur.cwd && cur.git && cur.git.branch ? cur : null;
       }
 
+      // Slash commands that act on the OPEN agent (the omnibox anchor), mirroring the
+      // ⋯-menu recovery buttons. Typing "/" in the omnibox lists them; "/k" / "/r"
+      // narrows. Each runs the very same handler the dropdown button does, so the
+      // confirm prompt and server call are identical — /kill = Force-kill (SIGKILL),
+      // /restart = Restart (resume).
+      const OMNI_COMMANDS = [
+        {
+          cmd: "/restart",
+          icon: "↻",
+          title: "Restart (resume)",
+          desc: "stops it (if live) and relaunches resuming the session",
+          run: (e) => restartAgent(e),
+        },
+        {
+          cmd: "/kill",
+          icon: "✕",
+          title: "Force-kill (SIGKILL)",
+          desc: "terminates the process immediately",
+          danger: true,
+          run: (e) => stopAgent(true, e),
+        },
+      ];
+      // Build the command rows for a "/…"-prefixed query, targeting the anchor agent.
+      // Empty when nothing is open (a command with no agent to act on is a no-op) so
+      // the omnibox falls through to its normal search/spawn behaviour.
+      function omniCommandRows(q) {
+        const target = omniAnchor();
+        if (!target) return [];
+        const term = q.slice(1).toLowerCase(); // text after the leading "/"
+        return OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(term)).map((c) => ({
+          kind: "cmd",
+          cmd: c,
+          target,
+        }));
+      }
+
       // Which agent the highlighted candidate should preview in the background: an
       // agent row → that agent; the spawn row / an empty list → the launch-time
       // agent (so the backdrop shows the spawn target's cwd).
@@ -3975,6 +4017,16 @@
                   <div class="omni-sub">⏎ to choose a working dir &nbsp;·&nbsp; prompt: ${esc(q || "(empty)")}</div>
                 </div></div>`;
             }
+            if (r.kind === "cmd") {
+              const t = r.target;
+              const dz = r.cmd.danger ? " danger" : "";
+              return `<div class="omni-row omni-spawn${dz}${sc}" data-i="${i}">
+                <span class="dot ${esc(t.status)}"></span>
+                <div class="omni-main">
+                  <div class="omni-title">${r.cmd.icon} ${esc(r.cmd.title)} <span style="opacity:.55">${esc(r.cmd.cmd)}</span></div>
+                  <div class="omni-sub">pid ${esc(String(t.pid))} ${esc(cliLabel(t) || ident(t) || "")} &nbsp;·&nbsp; ${esc(r.cmd.desc)}</div>
+                </div></div>`;
+            }
             const e = r.entry;
             const snip = r.snippet ? `<div class="omni-snip">…${r.snippet}…</div>` : "";
             return `<div class="omni-row${sc}" data-i="${i}">
@@ -3993,6 +4045,18 @@
 
       function runOmni() {
         const q = $("omni-input").value.trim();
+        // A "/…" query is a slash command against the open agent, not a search —
+        // show the matching command rows and skip the agent/spawn/tail machinery.
+        if (q.startsWith("/")) {
+          const cmds = omniCommandRows(q);
+          if (cmds.length) {
+            if (omniTailTimer) clearTimeout(omniTailTimer);
+            omniRows = cmds;
+            omniIdx = 0;
+            renderOmni();
+            return;
+          }
+        }
         const toks = q.split(/\s+/).filter(Boolean);
         // Tier 1 — instant title/identity match, ranked title-first then by recency.
         const hits = entries
@@ -4085,6 +4149,13 @@
         const q = $("omni-input").value.trim();
         const row = omniRows[omniIdx];
         const anchor = omniAnchor();
+        // A slash command runs its ⋯-menu handler against the pinned target. Handled
+        // before the spawn fallthrough so ⌘⏎ on a "/kill" row can't spawn instead.
+        if (row && row.kind === "cmd") {
+          closeOmni(false);
+          await row.cmd.run(row.target);
+          return;
+        }
         // ⌘⏎ always = spawn-here (the fast default), regardless of the selected row.
         if (forceSpawn || (row && row.kind === "spawn")) {
           closeOmni(false); // committing — keep the bg as-is, spawnAndSelect takes over

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -240,6 +240,59 @@ describe("console DOM behaviour", () => {
     }
   });
 
+  it("Cmd+K /restart and /kill fire the open agent's recovery endpoints", async () => {
+    // The slash commands mirror the ⋯-menu Restart / Force-kill buttons: they act
+    // on the agent that was open when the palette launched (the anchor), and hit
+    // the very same POST /api/restart · /api/kill with a STRING keyword=pid.
+    const { ctx, page } = await openConsole(browser, url);
+    const posts: { path: string; body: any }[] = [];
+    page.on("request", (r) => {
+      const u = new URL(r.url());
+      if (r.method() === "POST" && (u.pathname === "/api/kill" || u.pathname === "/api/restart")) {
+        try {
+          posts.push({ path: u.pathname, body: r.postDataJSON() });
+        } catch {}
+      }
+    });
+    // The commands reuse the ⋯-menu confirm() gate — auto-accept it.
+    page.on("dialog", (d) => d.accept());
+    try {
+      // Open agent 101, then launch the palette so 101 is the anchor.
+      await page.click('.list .row[data-key="local#101"]');
+      await expect.poll(() => page.locator(".row.sel").getAttribute("data-key")).toBe("local#101");
+      await page.keyboard.press("Control+k");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
+
+      // "/" lists the commands; both /restart and /kill are offered.
+      await page.fill("#omni-input", "/");
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(2);
+      const menu = (await page.locator("#omni-results").innerText()).toLowerCase();
+      expect(menu).toContain("restart");
+      expect(menu).toContain("kill");
+
+      // "/restart" narrows to one row; ⏎ fires POST /api/restart for pid 101.
+      await page.fill("#omni-input", "/restart");
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(1);
+      await page.keyboard.press("Enter");
+      await expect.poll(() => posts.filter((x) => x.path === "/api/restart").length).toBe(1);
+      const restart = posts.find((x) => x.path === "/api/restart")!;
+      expect(restart.body.keyword).toBe("101");
+      expect(typeof restart.body.keyword).toBe("string");
+
+      // Re-open and run "/kill" → POST /api/kill for the same agent.
+      await page.keyboard.press("Control+k");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
+      await page.fill("#omni-input", "/kill");
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(1);
+      await page.keyboard.press("Enter");
+      await expect.poll(() => posts.filter((x) => x.path === "/api/kill").length).toBe(1);
+      const kill = posts.find((x) => x.path === "/api/kill")!;
+      expect(kill.body.keyword).toBe("101");
+    } finally {
+      await ctx.close();
+    }
+  });
+
   it("key bar + composer apply sticky Ctrl/Alt and never leak the modifier", async () => {
     const { ctx, page } = await openConsole(
       browser,

--- a/tests/ui-dom/server.ts
+++ b/tests/ui-dom/server.ts
@@ -14,6 +14,8 @@
  *   GET  /api/tail/:pid?raw=1   → SSE; one JSON-encoded chunk then keep-alive
  *   POST /api/resize/:pid       → ok
  *   POST /api/send              → ok
+ *   POST /api/kill              → { ok: true }  (Cmd+K /kill, ⋯ Force-kill)
+ *   POST /api/restart           → { ok: true }  (Cmd+K /restart, ⋯ Restart)
  */
 import http from "http";
 import { readFileSync } from "fs";
@@ -102,6 +104,13 @@ export async function startServer(): Promise<{ url: string; close: () => void }>
     if (req.method === "POST" && (p.startsWith("/api/resize/") || p === "/api/send")) {
       res.writeHead(200, { "Content-Type": "text/plain" });
       return res.end("ok");
+    }
+    // Recovery endpoints (Cmd+K /kill · /restart, and the ⋯-menu buttons). Ack ok
+    // so restartAgent()'s success path runs; the test asserts the target from the
+    // captured request body.
+    if (req.method === "POST" && (p === "/api/kill" || p === "/api/restart")) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({ ok: true }));
     }
 
     res.writeHead(404);


### PR DESCRIPTION
## What

Typing `/` in the Cmd+K omnibox now lists two recovery commands that act on the **open agent** (the palette anchor), mirroring the ⋯-menu buttons in the terminal header:

| Command | Action | Endpoint |
|---|---|---|
| `/restart` | Restart (resume) | `POST /api/restart` |
| `/kill` | Force-kill (SIGKILL) | `POST /api/kill` |

`/` shows both; `/r` / `/k` narrows. Each runs the **exact same handler** the dropdown button does — including the `confirm()` gate — so the behaviour is identical to clicking the dots menu.

## How

- `stopAgent`/`restartAgent` gained an optional explicit-target arg so a command can pin the anchor agent (`omniReturnSel`) rather than the live, preview-drifting `sel`.
- `runOmni` short-circuits on a `/…` query to render command rows (skipping the agent/spawn/tail search machinery); `omniActivate` handles the command row before the spawn fallthrough so ⌘⏎ can't spawn instead.
- `/kill` gets the red danger accent, matching the ⋯-menu Force-kill.

## Test

Added a hermetic DOM test (`tests/ui-dom/console-dom.test.ts`) driving the real `index.html`: opens an agent, launches the palette, and asserts `/restart` and `/kill` fire `POST /api/restart` · `/api/kill` with a string `keyword=pid`. The stub server acks both endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)