### PR TITLE
fix(serve): resolve ay binary for /api/restart so it works under the daemon

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1642,7 +1642,18 @@ export async function cmdServe(rest: string[]): Promise<number> {
         const record = await resolveOne(keyword, defaultOpts({ all: true }));
         const args = ["restart", String(record.pid)];
         if (body.fresh) args.push("--fresh");
-        const child = Bun.spawn(["agent-yes", ...args], {
+        // Resolve `ay` to an absolute command — same as the /api/spawn path below.
+        // The detached daemon (oxmgr/launchd/pm2) usually has a PATH WITHOUT
+        // ~/.bun/bin and ~/.cargo/bin, so a bare "agent-yes"/"ay" fails with
+        // "Executable not found in $PATH" — the exact error the console surfaced on
+        // restart. Prefer PATH; fall back to re-running THIS process's own ay entry
+        // (process.argv[1]) — always present, since the daemon is itself an `ay serve`.
+        const ayBin = Bun.which("ay") ?? process.argv[1];
+        const ayCmd =
+          process.platform === "win32" && ayBin.toLowerCase().endsWith(".exe")
+            ? [ayBin]
+            : [process.execPath, ayBin];
+        const child = Bun.spawn([...ayCmd, ...args], {
           cwd: record.cwd,
           detached: true,
           stdio: ["ignore", "ignore", "ignore"],


### PR DESCRIPTION
Fixes restart failing with 'Executable not found in $PATH: agent-yes'. POST /api/restart spawned the bare 'agent-yes' command, but the detached ay serve daemon (oxmgr/launchd/pm2) runs with a PATH lacking ~/.bun/bin and ~/.cargo/bin. Now resolves the launcher like /api/spawn does (Bun.which('ay') ?? process.argv[1], run via process.execPath). Verified E2E on a throwaway serve: /api/restart went from 404 'Executable not found' to {ok:true} with a real pid swap (35629 -> 45695). Host-side fix; takes effect when the ay serve daemon is updated + restarted.

Generated with Claude Code