### PR TITLE
feat(notify): push subagent status edges to the parent (ay notify / ay notifyd)

### DIFF
--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -124,11 +124,30 @@ parent addresses its own inbox with no argument.
   is O(1) (no full inbox parse) — a full scan only self-heals a missing/corrupt
   counter. This keeps the lock-hold window tiny.
 
-- **The pid-reuse guard survives a synthetic exited.** The child's `started_at`
-  is carried in the router's per-child state, so a synthetic `exited` for a
-  vanished/reaped child still stamps `child_started_at`; reconcile seeds a child
-  only on a positive identity match (missing/zero start time → don't seed → allow
-  a re-emit rather than risk suppressing a recycled pid's first edge).
+- **The pid-reuse guard survives a synthetic exited.** BOTH the child's and the
+  parent's `started_at` are carried in the router's per-child state, so a
+  synthetic `exited` for a vanished/reaped child still stamps `child_started_at`
+  AND `parent_started_at` (never 0, which would bypass the reader's parent guard).
+  Reconcile seeds a child only on a positive identity match (missing/zero start →
+  don't seed → allow a re-emit rather than risk suppressing a recycled pid's edge).
+
+- **Hot-path pid-reuse guard.** `stepRouter` applies the same identity check
+  per-tick: if an observed pid's start time differs from the tracked one, the old
+  child is closed out with a synthetic `exited` and the new child rebuilds fresh
+  state — so a recycled pid mid-run doesn't inherit the old child's emitted-edge
+  memory and get its first edge suppressed.
+
+- **The lock heartbeats while held.** The lock owner's `ts` is refreshed on a
+  timer for the whole time the lock is held, so a long critical section (a big GC
+  rewrite) never crosses `staleMs` and gets stolen out from under a live holder.
+  The daemon singleton lock shares the same torn-owner grace, so two concurrent
+  daemon starts can't both win.
+
+- **Residual (documented): `stop` identity vs OS start time.** `status`/`stop`
+  compare our recorded `started_at`, not the OS's real process start time (non-
+  portable to read), so a pid recycled onto an unrelated process within the tight
+  `OWNER_TTL` window could be briefly trusted. Heartbeat freshness + a few-tick
+  TTL bound it to seconds; a real OS start-time cross-check is deferred.
 
 - **`notifyd stop` re-verifies identity before signalling.** It re-reads the
   owner (`pid` + `started_at`) immediately before `SIGTERM`, so a pid recycled

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -141,6 +141,33 @@ parent addresses its own inbox with no argument.
   state — so a recycled pid mid-run doesn't inherit the old child's emitted-edge
   memory and get its first edge suppressed.
 
+- **Three liveness signals, kept separate (so a watcher lapse ≠ a child death).**
+  - _child liveness_ = `isPidAlive(child.pid)` from the registry — the sole truth
+    for whether a child process is alive.
+  - _watcher presence_ = a fresh + alive heartbeat — governs ONLY the emission
+    scope (which parents' inboxes get written) and the daemon's lifetime.
+  - _daemon liveness_ = `owner.json` (`{pid, started_at, ts}`).
+
+  The load-bearing consequence: a tracked child that drops out of a tick's
+  observations gets a synthetic `exited` **only if its pid is actually dead**. A
+  child that's merely unobserved because its parent's watcher lapsed (so it left
+  the observed scope) is **carried forward untouched** — never false-exited while
+  still running. If such a carried-forward child dies and its pid is reused during
+  the lapse, the old child's `exited` is recovered (with its identity) the moment
+  the watcher returns and the hot-path guard sees the new start time — delayed,
+  never dropped.
+
+- **The daemon heartbeats its owner on a background timer**, not once per loop, so
+  a slow tick (many watched children, slow log I/O) can't let the heartbeat cross
+  `OWNER_TTL` and have another `watch` steal the lock as "stale" → double daemon.
+  `started_at` is captured once at acquire; the heartbeat updates only `ts`, so
+  `stop`'s identity re-check never sees it move.
+
+- **Append is at-least-once even under a transient FS/lock blip.** An append that
+  fails is retried a few times; if it still fails, that edge's "emitted" mark is
+  rolled back in the router state so the next tick re-emits it (a duplicate is
+  acceptable; a drop is not) — scoped to the one child, no cross-parent churn.
+
 - **The lock heartbeats while held.** The lock owner's `ts` is refreshed on a
   timer for the whole time the lock is held, so a long critical section (a big GC
   rewrite) never crosses `staleMs` and gets stolen out from under a live holder.

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -247,9 +247,6 @@ with a documented mitigation, tracked in a single follow-up issue.
   subprocess's own liveness.** A crashed watch stops refreshing, so its heartbeat
   goes stale within the TTL and is dropped — but carrying the watch subprocess's
   pid/token in the heartbeat for a strict check is a follow-up.
-
-## Known limitation
-
 - **An inbox nobody acks can grow unbounded.** Rotation only evicts events at or
   below the minimum consumer cursor (at-least-once). So a parent that runs
   `ay notify watch` WITHOUT `--ack` (the default, at-least-once) and never

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -72,9 +72,13 @@ parent addresses its own inbox with no argument.
 - **Consumer-side opt-in via a watcher registry — nothing happens unless a parent
   watches.** `ay notify watch` writes a **heartbeat** (`notify/watchers/<pid>.json`,
   refreshed every poll, TTL 15s) and the daemon:
-  - **scopes** its work to children whose parent has a live heartbeat — so an
-    unrelated agent that never watches gets **no inbox** (the scope matches the
-    "nothing happens unless you watch" promise);
+  - **scopes** its work to children whose parent has a live heartbeat — where
+    "live" means the heartbeat is fresh AND the watcher process is actually alive
+    (a crashed `watch` whose heartbeat lingers for the TTL does NOT keep the
+    daemon writing to a dead parent's inbox) — so an unrelated agent that never
+    watches gets **no inbox** (the scope matches the "nothing happens unless you
+    watch" promise). The daemon takes the parent's `started_at` from the watcher's
+    own heartbeat (authoritative, never 0), not a registry lookup that could miss;
   - **stays alive** while any heartbeat is live, self-exiting only after a grace
     window with none.
 
@@ -164,10 +168,13 @@ parent addresses its own inbox with no argument.
   (`notify/cursors/<host>/<parent>/<consumer>.json`) so it survives parent
   restarts. `--unread` reads `seq > cursor`.
 
-- **At-least-once by default.** `ay notify watch` does **not** advance the cursor
-  unless you pass `--ack` (or use `ay notify read --ack`). A consumer that
-  crashes mid-handling (a Monitor torn down at session end) re-reads the edge on
-  restart instead of dropping it.
+- **At-least-once by default; ack is monotonic.** `ay notify watch` does **not**
+  advance the cursor unless you pass `--ack` (or use `ay notify read --ack`). A
+  consumer that crashes mid-handling (a Monitor torn down at session end) re-reads
+  the edge on restart instead of dropping it. When `--ack` IS set, the cursor
+  advances to the high-water of what was shown and **never regresses** — an empty
+  poll doesn't lower it — so a restarted `watch --ack` resumes past what it
+  already delivered, not from a stale cursor.
 
 - **Startup reconcile.** On start the daemon seeds the router's memory from each
   inbox's already-written edges, so a restart does not re-emit a baseline the

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -210,6 +210,13 @@ parent addresses its own inbox with no argument.
   poll doesn't lower it — so a restarted `watch --ack` resumes past what it
   already delivered, not from a stale cursor.
 
+  Monitor-loop guidance: with the default (no `--ack`), a restarted `watch`
+  **replays** everything above the persisted cursor (unread), which is what you
+  want for a durable, restart-safe consumer that re-processes idempotently. If
+  your Monitor is NOT idempotent (must see each edge once), pass `--ack` so the
+  cursor advances as edges are shown — or track the high-water in-process and
+  filter — accepting that a crash between "shown" and "handled" drops that edge.
+
 - **Startup reconcile.** On start the daemon seeds the router's memory from each
   inbox's already-written edges, so a restart does not re-emit a baseline the
   parent already saw — while still emitting the current terminal state
@@ -265,7 +272,11 @@ with a documented mitigation, tracked in a single follow-up issue.
   parent exits (then GC removes the whole inbox). This is a deliberate trade
   (never drop an unacked edge) for the human-in-the-loop scale this targets; a
   future safeguard could warn or apply an emergency hard cap that drops the
-  oldest unacked events with a logged notice.
+  oldest unacked events with a logged notice. `gcInboxes` already logs a warning
+  when it can't trim an oversize inbox. **Manual cleanup:** an operator can delete
+  `$AGENT_YES_HOME/notify/inbox/<host>/<parent>.ndjson` (and its `.seq` +
+  `cursors/<host>/<parent>/`) for a parent that is done; the whole inbox is GC'd
+  automatically once that parent is dead and unreferenced.
 
 ## Not done — drafted for later
 

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -111,6 +111,29 @@ parent addresses its own inbox with no argument.
   And it never evicts an event above the **minimum consumer cursor** (unacked) —
   only already-acked events are trimmed.
 
+- **The per-inbox lock steals on HOLDER LIVENESS, not wait time.** The lock dir
+  carries an `owner` file (`{pid, ts}`); a contender steals only when the holder
+  is dead or its heartbeat is stale — never merely because it waited a while, so
+  a live holder mid-critical-section (a big GC rewrite, a slow disk) is never
+  robbed into a seq-duplicating double-entry. A torn/empty owner (the
+  mkdir→writeFile window of a holder mid-acquire) is respected for a short grace,
+  so a just-created lock can't be stolen out from under its creator.
+
+- **`appendEvent` trusts the sidecar seq counter.** The counter is written under
+  the lock on every append and stays valid across a GC rewrite, so the hot path
+  is O(1) (no full inbox parse) — a full scan only self-heals a missing/corrupt
+  counter. This keeps the lock-hold window tiny.
+
+- **The pid-reuse guard survives a synthetic exited.** The child's `started_at`
+  is carried in the router's per-child state, so a synthetic `exited` for a
+  vanished/reaped child still stamps `child_started_at`; reconcile seeds a child
+  only on a positive identity match (missing/zero start time → don't seed → allow
+  a re-emit rather than risk suppressing a recycled pid's first edge).
+
+- **`notifyd stop` re-verifies identity before signalling.** It re-reads the
+  owner (`pid` + `started_at`) immediately before `SIGTERM`, so a pid recycled
+  between the status read and the kill is never signalled.
+
 - **Enrichment is concurrent.** A burst of N edges enriches (tail + git head) in
   parallel; only the inbox appends stay serial (for unambiguous seq allocation),
   so N git timeouts don't serialize.

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -258,6 +258,12 @@ with a documented mitigation, tracked in a single follow-up issue.
   subprocess's own liveness.** A crashed watch stops refreshing, so its heartbeat
   goes stale within the TTL and is dropped — but carrying the watch subprocess's
   pid/token in the heartbeat for a strict check is a follow-up.
+- **No postmortem inbox inspection after the parent exits.** `ay notify
+  read/watch` fail closed when the parent isn't a live registry record (started_at
+  can't be resolved) — deliberately, so a recycled parent pid can't read another
+  session's inbox. The trade-off is that you can't inspect a parent's inbox after
+  that parent has exited. A read-only "postmortem" mode (inspect without
+  registering as a watcher, identity-checked by started_at) is a follow-up.
 - **Event-loop-block false steal.** The daemon heartbeats its lock owner on a
   single-threaded JS timer. If the daemon loop ever blocked SYNCHRONOUSLY longer
   than `OWNER_TTL` (30s), the heartbeat would stall and another `watch` could

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -251,6 +251,13 @@ with a documented mitigation, tracked in a single follow-up issue.
   subprocess's own liveness.** A crashed watch stops refreshing, so its heartbeat
   goes stale within the TTL and is dropped — but carrying the watch subprocess's
   pid/token in the heartbeat for a strict check is a follow-up.
+- **Event-loop-block false steal.** The daemon heartbeats its lock owner on a
+  single-threaded JS timer. If the daemon loop ever blocked SYNCHRONOUSLY longer
+  than `OWNER_TTL` (30s), the heartbeat would stall and another `watch` could
+  steal the singleton lock → a second daemon. The loop is all `await`s and never
+  blocks for seconds, and `OWNER_TTL` is set well above any realistic sync block,
+  so this is a theoretical window; fully closing it needs a worker-isolated
+  heartbeat (follow-up).
 - **An inbox nobody acks can grow unbounded.** Rotation only evicts events at or
   below the minimum consumer cursor (at-least-once). So a parent that runs
   `ay notify watch` WITHOUT `--ack` (the default, at-least-once) and never

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -73,9 +73,12 @@ parent addresses its own inbox with no argument.
   watches.** `ay notify watch` writes a **heartbeat** (`notify/watchers/<pid>.json`,
   refreshed every poll, TTL 15s) and the daemon:
   - **scopes** its work to children whose parent has a live heartbeat — where
-    "live" means the heartbeat is fresh AND the watcher process is actually alive
-    (a crashed `watch` whose heartbeat lingers for the TTL does NOT keep the
-    daemon writing to a dead parent's inbox) — so an unrelated agent that never
+    "live" means the heartbeat is fresh (refreshed within the TTL) AND the parent
+    agent's pid is alive. A crashed `watch` stops refreshing, so its heartbeat
+    goes stale within the TTL and is dropped; a dead parent is dropped
+    immediately. (The heartbeat proves parent-liveness + freshness, not the watch
+    subprocess's own pid — carrying the watch pid/token in the heartbeat for a
+    strict check is a documented follow-up.) So an unrelated agent that never
     watches gets **no inbox** (the scope matches the "nothing happens unless you
     watch" promise). The daemon takes the parent's `started_at` from the watcher's
     own heartbeat (authoritative, never 0), not a registry lookup that could miss;

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -69,11 +69,35 @@ parent addresses its own inbox with no argument.
   spinner/elapsed-seconds cosmetic redraw does not double-fire. `exited` fires
   once. `idle` fires once per idle episode; returning to work resets it.
 
-- **Consumer-side opt-in — nothing happens unless a parent watches.** The daemon
-  is started on demand (`ay notify watch --ensure-daemon`, default on) and
-  self-exits after a grace window with nothing to watch. If no parent ever
+- **Consumer-side opt-in via a watcher registry — nothing happens unless a parent
+  watches.** `ay notify watch` writes a **heartbeat** (`notify/watchers/<pid>.json`,
+  refreshed every poll, TTL 15s) and the daemon:
+  - **scopes** its work to children whose parent has a live heartbeat — so an
+    unrelated agent that never watches gets **no inbox** (the scope matches the
+    "nothing happens unless you watch" promise);
+  - **stays alive** while any heartbeat is live, self-exiting only after a grace
+    window with none.
+
+  `ay notify watch` also **re-ensures the daemon every poll**, so a parent that
+  watches BEFORE spawning children (or across a fan-out gap where the daemon
+  self-exited) always has a running, correctly-scoped daemon. If no parent ever
   watches, the daemon never runs and **no files are created** — fully backward
   compatible. Monitor-on-HEAD keeps working, now strictly dominated by this.
+
+- **Singleton lock with liveness-based steal.** The daemon holds an mkdir lock
+  recording its owner pid (`notify/notifyd.lock/owner.json`). A stale lock left by
+  a crashed daemon is detected (owner pid dead / torn) and **stolen**, so the
+  daemon can never permanently deadlock; a lock held by a **live** owner is
+  respected (no double daemon). The parent `notify/` dir is created first so a
+  clean install can't misread an `ENOENT` as "held".
+
+- **pid-reuse guard.** Every event stamps `parent_started_at`; the reader drops
+  events whose `parent_started_at` disagrees with its own record's start time, so
+  a recycled pid never reads a prior incarnation's edges.
+
+- **Rotation preserves at-least-once.** GC rotation of an oversized live inbox
+  never evicts an event above the **minimum consumer cursor** (unacked) — only
+  already-acked events are trimmed.
 
 - **Append-only inbox + monotonic seq + separate cursor.** Each parent has
   `notify/inbox/<host>/<parent>.ndjson`; every event carries a per-inbox `seq`

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -1,0 +1,128 @@
+# Subagent → parent notifications: `ay notify` + `ay notifyd`
+
+Context (real incident, 2026-07): a parent agent fanned out sub-agents that
+committed their work but then **sat at an idle `❯` prompt without exiting**
+(`claude-yes` does not exit on idle by default). Claude Code's built-in
+background-task notification only fires on process **EXIT** — so the parent
+never learned the children went idle and left two of them parked **16 minutes**.
+The stop-gap was Monitor-on-HEAD polling, which catches a *commit* but is blind
+to a child that finished **without** committing (an investigation, a failure, a
+question).
+
+`ay ls --watch` already streams state transitions — but it is **pull**: the
+parent must run the watch loop. The whole point of this pain is that the parent
+is **not** watching. This feature adds a **push** layer on top of the existing
+`needs_input` / `deriveLiveState` / `ay ls --watch` machinery: qualifying edges
+accumulate in a per-parent **append-only inbox** the parent drains on its own
+schedule, with a persisted cursor so a restarted parent reads only unread edges.
+
+## What a parent runs
+
+One command in its Monitor loop:
+
+```bash
+ay notify watch --unread          # tail my inbox; ensures the daemon is up
+```
+
+It streams, for every child this agent spawned, three edges — each with a
+payload so the parent can act without tailing:
+
+- **`needs_input`** — the child is blocked on a question (the compact question
+  text is included). Highest priority: the task is stuck until answered.
+- **`idle`** — the child has been **continuously idle** for the confirm window
+  (default 30s): hands-free / probably done. Catches the "finished without
+  committing" case HEAD-polling can't see.
+- **`exited`** — the child process ended (the inverse of today's EXIT-only
+  signal).
+
+Other verbs:
+
+```bash
+ay notify read [--parent <pid>] [--since <seq>] [--unread] [--ack] [--json]
+ay notify cursor get|set <seq> [--parent <pid>] [--consumer <name>]
+ay notifyd run|start|status|stop
+```
+
+`--parent` defaults to `$AGENT_YES_PID` — the agent's own wrapper pid — so a
+parent addresses its own inbox with no argument.
+
+## Design decisions (frozen with codex + the two agents who hit the pain)
+
+- **Detection lives in the query layer, not the run loop (Option 2).** A single
+  host daemon (`ay notifyd`) polls `deriveLiveState` across all agents and runs
+  the pure debounce router. Rust is the default runtime and `needs_input` is only
+  classified in the TS query layer, so pushing detection into the child run loop
+  would either miss Rust children or duplicate the hardest classifier in both
+  runtimes — the wrong ownership boundary. The query layer is runtime-agnostic,
+  so one implementation covers both. _Rejected:_ child-supervisor push.
+
+- **The load-bearing idle guard: `idle` is a `deriveLiveState` state, not a bare
+  no-output timer.** `idle` already means "idle prompt visible AND no working
+  spinner", so a long, silent tool call (a 2-minute test run) is classified
+  `active` and never produces a false idle edge. Without this the feature would
+  be a notification storm and get switched off. The router emits an idle edge
+  only after the state has been **continuously** idle for `idleConfirmMs`, once
+  per idle episode (edge, not level).
+
+- **Edge, not level, with per-episode debounce.** `needs_input` fires on entry
+  and re-fires only when the **compact** (chrome-stripped) question changes — a
+  spinner/elapsed-seconds cosmetic redraw does not double-fire. `exited` fires
+  once. `idle` fires once per idle episode; returning to work resets it.
+
+- **Consumer-side opt-in — nothing happens unless a parent watches.** The daemon
+  is started on demand (`ay notify watch --ensure-daemon`, default on) and
+  self-exits after a grace window with nothing to watch. If no parent ever
+  watches, the daemon never runs and **no files are created** — fully backward
+  compatible. Monitor-on-HEAD keeps working, now strictly dominated by this.
+
+- **Append-only inbox + monotonic seq + separate cursor.** Each parent has
+  `notify/inbox/<host>/<parent>.ndjson`; every event carries a per-inbox `seq`
+  (the authoritative watermark; `ts` is display-only, since clocks skew). A
+  consumer's cursor lives in a separate file
+  (`notify/cursors/<host>/<parent>/<consumer>.json`) so it survives parent
+  restarts. `--unread` reads `seq > cursor`.
+
+- **At-least-once by default.** `ay notify watch` does **not** advance the cursor
+  unless you pass `--ack` (or use `ay notify read --ack`). A consumer that
+  crashes mid-handling (a Monitor torn down at session end) re-reads the edge on
+  restart instead of dropping it.
+
+- **Startup reconcile.** On start the daemon seeds the router's memory from each
+  inbox's already-written edges, so a restart does not re-emit a baseline the
+  parent already saw — while still emitting the current terminal state
+  (`needs_input`/`idle`/`exited`) for a child that was already parked when the
+  daemon came up.
+
+- **pid-reuse & cross-host safety.** Inboxes are namespaced by host; events carry
+  the child pid/wrapper. (Cross-host *delivery* is out of scope — the daemon only
+  sees the local registry.)
+
+- **Retention.** GC deletes an inbox (+ counter + cursors) once its parent is
+  dead and no live child references it; oversized live inboxes rotate to the
+  newest events.
+
+## Module layout
+
+- `ts/notifyRouter.ts` — **pure** debounce/edge state machine (`stepRouter`).
+  The heart; unit-tested (`notifyRouter.spec.ts`), incl. the P1 idle-prompt
+  regression fixture.
+- `ts/notifyInbox.ts` — **pure** path math + NDJSON (de)serialization + seq /
+  cursor / retention helpers (`notifyInbox.spec.ts`).
+- `ts/notifyStore.ts` — fs side: locked append, inbox/cursor read-write, GC.
+- `ts/notifyDaemon.ts` — the poll loop, startup reconcile, payload enrichment
+  (tail + git head), daemon lifecycle.
+- `ts/subcommands.ts` — `ay notify` / `ay notifyd` CLI.
+
+## Not done — drafted for later
+
+- **Producer-side `--notify-parent` / `--no-notify-parent` spawn flag** for
+  per-child suppression or force-on. Not needed for v1: the daemon-not-running
+  default already IS opt-in, and plumbing a flag through both runtimes' spawn
+  paths is a separate change. Reconciles the earlier `ay spawn-notify` idea.
+- **`stuck` edge.** A wedged child (alive, busy marker, long-silent) is a
+  distinct signal from idle; surface it once the `stuck` state is load-bearing.
+- **Cross-host fan-in.** Deliver a remote child's edge to a parent on another
+  host. Needs the remote-notify transport designed first.
+- **Native runtime push.** The runtime could push an edge the instant a menu
+  appears instead of the daemon noticing on the next poll — a latency
+  optimization, not a capability gap.

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -195,8 +195,12 @@ parent addresses its own inbox with no argument.
   `notify/inbox/<host>/<parent>.ndjson`; every event carries a per-inbox `seq`
   (the authoritative watermark; `ts` is display-only, since clocks skew). A
   consumer's cursor lives in a separate file
-  (`notify/cursors/<host>/<parent>/<consumer>.json`) so it survives parent
-  restarts. `--unread` reads `seq > cursor`.
+  (`notify/cursors/<host>/<parent>/<consumer>.json`). `--unread` reads
+  `seq > cursor`. NOTE: inbox and cursor are keyed by the parent's WRAPPER PID, so
+  the cursor persists across a restart of the `ay notify watch` **subprocess**
+  within the same parent-agent session — NOT across a restart of the parent agent
+  itself, which gets a new pid (and thus a fresh inbox). A truly stable parent
+  identity across pid changes is a follow-up (issue #169).
 
 - **At-least-once by default; ack is monotonic.** `ay notify watch` does **not**
   advance the cursor unless you pass `--ack` (or use `ay notify read --ack`). A

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -232,6 +232,22 @@ parent addresses its own inbox with no argument.
   (tail + git head), daemon lifecycle.
 - `ts/subcommands.ts` — `ay notify` / `ay notifyd` CLI.
 
+## Known limitations (v1 — tracked as follow-ups)
+
+These are deliberately out of v1 scope; each is a bounded, low-probability edge
+with a documented mitigation, tracked in a single follow-up issue.
+
+- **`notifyd stop` trusts the owner file's identity, not the OS process start
+  time.** A pid recycled onto an unrelated process WITHIN the tight `OWNER_TTL`
+  window (a few ticks) could be briefly trusted and signalled. Reading the real
+  OS start time is non-portable (`/proc/<pid>/stat` on Linux vs `ps -o lstart` /
+  `proc_pidinfo` on macOS); heartbeat freshness + a few-tick TTL bound the window
+  to seconds. A strict OS start-time cross-check is a follow-up.
+- **The watcher heartbeat proves parent-liveness, not the `ay notify watch`
+  subprocess's own liveness.** A crashed watch stops refreshing, so its heartbeat
+  goes stale within the TTL and is dropped — but carrying the watch subprocess's
+  pid/token in the heartbeat for a strict check is a follow-up.
+
 ## Known limitation
 
 - **An inbox nobody acks can grow unbounded.** Rotation only evicts events at or

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -84,20 +84,36 @@ parent addresses its own inbox with no argument.
   watches, the daemon never runs and **no files are created** — fully backward
   compatible. Monitor-on-HEAD keeps working, now strictly dominated by this.
 
-- **Singleton lock with liveness-based steal.** The daemon holds an mkdir lock
-  recording its owner pid (`notify/notifyd.lock/owner.json`). A stale lock left by
-  a crashed daemon is detected (owner pid dead / torn) and **stolen**, so the
-  daemon can never permanently deadlock; a lock held by a **live** owner is
-  respected (no double daemon). The parent `notify/` dir is created first so a
-  clean install can't misread an `ENOENT` as "held".
+- **Singleton lock with liveness-based steal; ownership proven only by mkdir.**
+  The daemon holds an mkdir lock whose `owner.json` records `{pid, started_at,
+  ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
+  removes the dir; ownership is then re-proven by the next `mkdir(recursive:false)`
+  (the atomic, exclusive create), so two would-be stealers can never both enter.
+  A lock held by a **live** owner is respected. The parent `notify/` dir is
+  created first so a clean install can't misread `ENOENT` as "held".
 
-- **pid-reuse guard.** Every event stamps `parent_started_at`; the reader drops
-  events whose `parent_started_at` disagrees with its own record's start time, so
-  a recycled pid never reads a prior incarnation's edges.
+- **`owner.json` is the single source of truth for `status`/`stop`.** A running
+  daemon refreshes `ts` every tick; `notifyd status`/`stop` trust the owner pid
+  only if it's alive AND its heartbeat is fresh — so a recycled pid (not
+  refreshing this file) is never trusted or sent a wrong `SIGTERM`.
 
-- **Rotation preserves at-least-once.** GC rotation of an oversized live inbox
-  never evicts an event above the **minimum consumer cursor** (unacked) — only
-  already-acked events are trimmed.
+- **pid-reuse guards on BOTH read and reconcile.** Every event stamps
+  `parent_started_at` and `child_started_at`. The reader drops events whose
+  `parent_started_at` disagrees with its own record. The daemon's startup
+  reconcile seeds a child's emitted-edge memory ONLY if that pid is still in the
+  registry with the SAME `child_started_at` — so a new child recycling a pid never
+  inherits the old child's `exitedEmitted`/`idleEmitted` (which would suppress its
+  first notification).
+
+- **GC read+compute+write all under the inbox lock.** Rotation reads the inbox,
+  computes the keep-set, and rewrites — all inside the same lock `appendEvent`
+  takes, so a concurrent append can't be lost between a stale read and the write.
+  And it never evicts an event above the **minimum consumer cursor** (unacked) —
+  only already-acked events are trimmed.
+
+- **Enrichment is concurrent.** A burst of N edges enriches (tail + git head) in
+  parallel; only the inbox appends stay serial (for unambiguous seq allocation),
+  so N git timeouts don't serialize.
 
 - **Append-only inbox + monotonic seq + separate cursor.** Each parent has
   `notify/inbox/<host>/<parent>.ndjson`; every event carries a per-inbox `seq`

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -202,6 +202,17 @@ parent addresses its own inbox with no argument.
   (tail + git head), daemon lifecycle.
 - `ts/subcommands.ts` — `ay notify` / `ay notifyd` CLI.
 
+## Known limitation
+
+- **An inbox nobody acks can grow unbounded.** Rotation only evicts events at or
+  below the minimum consumer cursor (at-least-once). So a parent that runs
+  `ay notify watch` WITHOUT `--ack` (the default, at-least-once) and never
+  otherwise advances its cursor will accumulate events past `capBytes` until the
+  parent exits (then GC removes the whole inbox). This is a deliberate trade
+  (never drop an unacked edge) for the human-in-the-loop scale this targets; a
+  future safeguard could warn or apply an emergency hard cap that drops the
+  oldest unacked events with a logged notice.
+
 ## Not done — drafted for later
 
 - **Producer-side `--notify-parent` / `--no-notify-parent` spawn flag** for

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -20,8 +20,9 @@ use std::env;
 /// Management subcommands handled by the TypeScript CLI, not this runner.
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
-    "ls", "list", "ps", "status", "result", "read", "cat", "tail", "head", "send", "spawn",
-    "attach", "stop", "exit", "restart", "note", "serve", "schedule", "remote", "reap", "help",
+    "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
+    "send", "spawn", "attach", "stop", "exit", "restart", "note", "serve", "schedule", "remote",
+    "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -204,6 +204,22 @@ describe("startup reconcile pid-reuse guard", () => {
     expect(seeded.get(555)?.parent_started_at).toBe(42);
   });
 
+  it("does NOT inherit exitedEmitted when the pid was reused after an exit (identity-aware)", async () => {
+    // Old child (pid 555, started 1000) exited; then pid 555 is reused by a NEW
+    // child (started 2000) whose latest edge is idle. On reconcile the new child
+    // matches liveStarted=2000, and its exitedEmitted must be FALSE (its own exit
+    // still fires later), not inherited from the old incarnation's exit.
+    await appendEvent(1, exitedEv(555, 1000)); // old child exited
+    await appendEvent(1, {
+      ...exitedEv(555, 2000),
+      edge: "idle",
+      state: "idle",
+    }); // new child's later idle
+    const cs = (await reconcileFromInboxes(host, new Map([[555, 2000]]), new Set([1]))).get(555)!;
+    expect(cs.started_at).toBe(2000);
+    expect(cs.exitedEmitted).toBe(false);
+  });
+
   it("does NOT seed the idle emitted flag — a restart RE-CONFIRMS idle (never suppress)", async () => {
     const idleEv: Omit<NotifyEvent, "seq"> = {
       ts: 1,

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -171,7 +171,7 @@ describe("startup reconcile pid-reuse guard", () => {
 
   it("seeds a child still live with the SAME start time (no re-emit) + copies identity", async () => {
     await appendEvent(1, { ...exitedEv(555, 1000), parent_started_at: 42 });
-    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]));
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]), new Set([1]));
     expect(seeded.get(555)?.exitedEmitted).toBe(true);
     // I2: identity copied into the seeded state so the hot-path guard can fire.
     expect(seeded.get(555)?.started_at).toBe(1000);
@@ -182,13 +182,13 @@ describe("startup reconcile pid-reuse guard", () => {
     await appendEvent(1, exitedEv(555, 1000));
     // pid 555 now belongs to a NEW child (started_at 2000) → must not inherit
     // the old child's exitedEmitted, else its own exit would be suppressed.
-    const seeded = await reconcileFromInboxes(host, new Map([[555, 2000]]));
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 2000]]), new Set([1]));
     expect(seeded.has(555)).toBe(false);
   });
 
   it("does NOT seed a reaped child absent from the registry", async () => {
     await appendEvent(1, exitedEv(555, 1000));
-    const seeded = await reconcileFromInboxes(host, new Map());
+    const seeded = await reconcileFromInboxes(host, new Map(), new Set([1]));
     expect(seeded.has(555)).toBe(false);
   });
 
@@ -196,7 +196,16 @@ describe("startup reconcile pid-reuse guard", () => {
     // A pre-C2 / synthetic event without a start time can't be identity-checked,
     // so it must not seed (better a duplicate edge than a suppressed one).
     await appendEvent(1, { ...exitedEv(555, 1000), child_started_at: 0 });
-    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]));
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]), new Set([1]));
     expect(seeded.has(555)).toBe(false);
+  });
+
+  it("does NOT seed an inbox whose parent is NOT currently watched (I1)", async () => {
+    // Parent 1's inbox exists, but no one is watching parent 1 now → the daemon
+    // must not hold its state (else it could later write a synthetic exited into
+    // an unwatched inbox, violating "nothing happens unless you watch").
+    await appendEvent(1, exitedEv(555, 1000));
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]), new Set()); // none watched
+    expect(seeded.size).toBe(0);
   });
 });

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -169,10 +169,13 @@ describe("startup reconcile pid-reuse guard", () => {
     question: null,
   });
 
-  it("seeds a child still live with the SAME start time (no re-emit)", async () => {
-    await appendEvent(1, exitedEv(555, 1000));
+  it("seeds a child still live with the SAME start time (no re-emit) + copies identity", async () => {
+    await appendEvent(1, { ...exitedEv(555, 1000), parent_started_at: 42 });
     const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]));
     expect(seeded.get(555)?.exitedEmitted).toBe(true);
+    // I2: identity copied into the seeded state so the hot-path guard can fire.
+    expect(seeded.get(555)?.started_at).toBe(1000);
+    expect(seeded.get(555)?.parent_started_at).toBe(42);
   });
 
   it("does NOT seed a pid whose live start time differs (reused pid emits fresh)", async () => {

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -35,8 +35,11 @@ describe("notifyd singleton lock", () => {
 
   it("steals a stale lock whose owner is dead (no permanent deadlock)", async () => {
     await mkdir(daemonLockDir(), { recursive: true });
-    await writeFile(daemonLockOwnerPath(), JSON.stringify({ pid: 424242, started_at: 1 }));
-    // 424242 reported dead → steal.
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: 424242, started_at: 1, ts: Date.now() }),
+    );
+    // 424242 reported dead → steal (dead pid, no wait needed).
     expect(await acquireDaemonLock(() => false)).toBe(true);
     const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
     expect(owner.pid).toBe(process.pid);
@@ -63,10 +66,16 @@ describe("notifyd singleton lock", () => {
     expect(await acquireDaemonLock((pid) => pid === 424242)).toBe(true);
   });
 
-  it("steals a lock with a torn/missing owner file (treated as stale)", async () => {
+  it("eventually steals a torn owner, but only AFTER the grace (no double daemon)", async () => {
+    // A torn owner is also the mkdir→writeOwner window of a concurrent daemon
+    // start, so it is respected within the grace (~1s) and stolen only past it —
+    // the same invariant as the per-inbox lock (the steal decision itself is
+    // unit-tested via shouldStealLock in notifyStore.spec).
     await mkdir(daemonLockDir(), { recursive: true });
     await writeFile(daemonLockOwnerPath(), "{ not json");
+    const t0 = Date.now();
     expect(await acquireDaemonLock(() => true)).toBe(true);
+    expect(Date.now() - t0).toBeGreaterThanOrEqual(900); // waited out the grace
   });
 
   it("a second live-owner acquire from a DIFFERENT pid is refused", async () => {

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { acquireDaemonLock } from "./notifyDaemon.ts";
+import { daemonLockDir, daemonLockOwnerPath } from "./notifyInbox.ts";
+
+// The lock steal/keep race codex flagged: a crashed daemon's stale lock must be
+// stealable (else runDaemon deadlocks forever), while a LIVE owner's lock must
+// be respected (else two daemons run). Liveness is injected so both branches are
+// deterministic.
+describe("notifyd singleton lock", () => {
+  let home: string;
+  const prev = process.env.AGENT_YES_HOME;
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-notify-lock-"));
+    process.env.AGENT_YES_HOME = home;
+  });
+  afterEach(async () => {
+    if (prev === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prev;
+    await rm(home, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("acquires the lock on a clean install (parent dir absent, no ENOENT trap)", async () => {
+    // notify/ does not exist yet — the classic clean-install bug was mkdir(lock)
+    // throwing ENOENT and being misread as "held". Must acquire cleanly.
+    expect(await acquireDaemonLock(() => false)).toBe(true);
+    const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
+    expect(owner.pid).toBe(process.pid);
+  });
+
+  it("steals a stale lock whose owner is dead (no permanent deadlock)", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(daemonLockOwnerPath(), JSON.stringify({ pid: 424242, started_at: 1 }));
+    // 424242 reported dead → steal.
+    expect(await acquireDaemonLock(() => false)).toBe(true);
+    const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
+    expect(owner.pid).toBe(process.pid);
+  });
+
+  it("refuses the lock when a LIVE owner holds it (no double daemon)", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(daemonLockOwnerPath(), JSON.stringify({ pid: 424242, started_at: 1 }));
+    // 424242 reported alive → must NOT steal.
+    expect(await acquireDaemonLock((pid) => pid === 424242)).toBe(false);
+    const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
+    expect(owner.pid).toBe(424242); // untouched
+  });
+
+  it("steals a lock with a torn/missing owner file (treated as stale)", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(daemonLockOwnerPath(), "{ not json");
+    expect(await acquireDaemonLock(() => true)).toBe(true);
+  });
+});

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { acquireDaemonLock, daemonStatus, reconcileFromInboxes } from "./notifyDaemon.ts";
+import {
+  acquireDaemonLock,
+  daemonStatus,
+  reconcileFromInboxes,
+  requestDaemonStop,
+} from "./notifyDaemon.ts";
+import { stat } from "fs/promises";
 import { daemonLockDir, daemonLockOwnerPath } from "./notifyInbox.ts";
 import { appendEvent, hostId } from "./notifyStore.ts";
 import type { NotifyEvent } from "./notifyInbox.ts";
@@ -138,6 +144,26 @@ describe("notifyd identity (status/stop safety)", () => {
       JSON.stringify({ pid: process.pid, ts: Date.now() }),
     );
     expect(await daemonStatus()).toBeNull();
+  });
+
+  it("requestDaemonStop removes the lock (cooperative) for a valid owner", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: process.pid, started_at: 1, ts: Date.now(), token: "T" }),
+    );
+    expect(await requestDaemonStop()).toBe(process.pid);
+    await expect(stat(daemonLockDir())).rejects.toThrow(); // lock removed
+  });
+
+  it("requestDaemonStop refuses an owner with no fencing token (can't confirm identity)", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: process.pid, started_at: 1, ts: Date.now() }), // no token
+    );
+    expect(await requestDaemonStop()).toBeNull();
+    await expect(stat(daemonLockDir())).resolves.toBeTruthy(); // lock untouched
   });
 });
 

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -108,6 +108,16 @@ describe("notifyd identity (status/stop safety)", () => {
   it("returns null when no owner file exists", async () => {
     expect(await daemonStatus()).toBeNull();
   });
+
+  it("returns null for an INCOMPLETE owner missing started_at (I1)", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    // pid alive + fresh ts, but no started_at → identity incomplete, not trusted.
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: process.pid, ts: Date.now() }),
+    );
+    expect(await daemonStatus()).toBeNull();
+  });
 });
 
 describe("startup reconcile pid-reuse guard", () => {
@@ -155,6 +165,14 @@ describe("startup reconcile pid-reuse guard", () => {
   it("does NOT seed a reaped child absent from the registry", async () => {
     await appendEvent(1, exitedEv(555, 1000));
     const seeded = await reconcileFromInboxes(host, new Map());
+    expect(seeded.has(555)).toBe(false);
+  });
+
+  it("does NOT seed an event with no child_started_at (C2: can't verify → re-emit)", async () => {
+    // A pre-C2 / synthetic event without a start time can't be identity-checked,
+    // so it must not seed (better a duplicate edge than a suppressed one).
+    await appendEvent(1, { ...exitedEv(555, 1000), child_started_at: 0 });
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]));
     expect(seeded.has(555)).toBe(false);
   });
 });

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { acquireDaemonLock } from "./notifyDaemon.ts";
+import { acquireDaemonLock, daemonStatus, reconcileFromInboxes } from "./notifyDaemon.ts";
 import { daemonLockDir, daemonLockOwnerPath } from "./notifyInbox.ts";
+import { appendEvent, hostId } from "./notifyStore.ts";
+import type { NotifyEvent } from "./notifyInbox.ts";
 
 // The lock steal/keep race codex flagged: a crashed daemon's stale lock must be
 // stealable (else runDaemon deadlocks forever), while a LIVE owner's lock must
@@ -53,5 +55,106 @@ describe("notifyd singleton lock", () => {
     await mkdir(daemonLockDir(), { recursive: true });
     await writeFile(daemonLockOwnerPath(), "{ not json");
     expect(await acquireDaemonLock(() => true)).toBe(true);
+  });
+
+  it("a second live-owner acquire from a DIFFERENT pid is refused", async () => {
+    // First acquire writes owner = our pid. A second caller that sees a different
+    // live owner must back off (mkdir(recursive:false) is the exclusive proof;
+    // the owner is alive so it isn't stolen).
+    expect(await acquireDaemonLock(() => true)).toBe(true);
+    const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
+    // Rewrite the owner to a DIFFERENT, "alive" pid to simulate another daemon.
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ ...owner, pid: owner.pid + 1 }),
+    );
+    expect(await acquireDaemonLock((pid) => pid === owner.pid + 1)).toBe(false);
+  });
+});
+
+describe("notifyd identity (status/stop safety)", () => {
+  let home: string;
+  const prev = process.env.AGENT_YES_HOME;
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-notify-id-"));
+    process.env.AGENT_YES_HOME = home;
+  });
+  afterEach(async () => {
+    if (prev === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prev;
+    await rm(home, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("trusts a live owner with a fresh heartbeat", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: process.pid, started_at: 1, ts: Date.now() }),
+    );
+    expect(await daemonStatus()).toBe(process.pid);
+  });
+
+  it("returns null for a STALE heartbeat even if the pid is alive (pid-reuse guard)", async () => {
+    // process.pid is alive, but its owner ts is ancient — a recycled pid that
+    // isn't refreshing THIS file must not be trusted or killed.
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: process.pid, started_at: 1, ts: 1 }),
+    );
+    expect(await daemonStatus()).toBeNull();
+  });
+
+  it("returns null when no owner file exists", async () => {
+    expect(await daemonStatus()).toBeNull();
+  });
+});
+
+describe("startup reconcile pid-reuse guard", () => {
+  let home: string;
+  const prev = process.env.AGENT_YES_HOME;
+  const host = hostId();
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-notify-rec-"));
+    process.env.AGENT_YES_HOME = home;
+  });
+  afterEach(async () => {
+    if (prev === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prev;
+    await rm(home, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const exitedEv = (childPid: number, childStartedAt: number): Omit<NotifyEvent, "seq"> => ({
+    ts: 1,
+    host,
+    parent_pid: 1,
+    child_pid: childPid,
+    child_started_at: childStartedAt,
+    cli: "claude",
+    cwd: "/repo",
+    edge: "exited",
+    prev_state: "active",
+    state: "stopped",
+    question: null,
+  });
+
+  it("seeds a child still live with the SAME start time (no re-emit)", async () => {
+    await appendEvent(1, exitedEv(555, 1000));
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 1000]]));
+    expect(seeded.get(555)?.exitedEmitted).toBe(true);
+  });
+
+  it("does NOT seed a pid whose live start time differs (reused pid emits fresh)", async () => {
+    await appendEvent(1, exitedEv(555, 1000));
+    // pid 555 now belongs to a NEW child (started_at 2000) → must not inherit
+    // the old child's exitedEmitted, else its own exit would be suppressed.
+    const seeded = await reconcileFromInboxes(host, new Map([[555, 2000]]));
+    expect(seeded.has(555)).toBe(false);
+  });
+
+  it("does NOT seed a reaped child absent from the registry", async () => {
+    await appendEvent(1, exitedEv(555, 1000));
+    const seeded = await reconcileFromInboxes(host, new Map());
+    expect(seeded.has(555)).toBe(false);
   });
 });

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -204,6 +204,29 @@ describe("startup reconcile pid-reuse guard", () => {
     expect(seeded.get(555)?.parent_started_at).toBe(42);
   });
 
+  it("does NOT seed the idle emitted flag — a restart RE-CONFIRMS idle (never suppress)", async () => {
+    const idleEv: Omit<NotifyEvent, "seq"> = {
+      ts: 1,
+      host,
+      parent_pid: 1,
+      child_pid: 555,
+      child_started_at: 1000,
+      cli: "claude",
+      cwd: "/repo",
+      edge: "idle",
+      prev_state: "active",
+      state: "idle",
+      question: null,
+    };
+    await appendEvent(1, idleEv);
+    const cs = (await reconcileFromInboxes(host, new Map([[555, 1000]]), new Set([1]))).get(555)!;
+    // Identity is seeded (hot-path guard), but the idle episode is NOT marked
+    // emitted → the post-restart idle observation re-confirms and re-emits.
+    expect(cs.started_at).toBe(1000);
+    expect(cs.idleEmitted).toBe(false);
+    expect(cs.idleSince).toBeNull();
+  });
+
   it("does NOT seed a pid whose live start time differs (reused pid emits fresh)", async () => {
     await appendEvent(1, exitedEv(555, 1000));
     // pid 555 now belongs to a NEW child (started_at 2000) → must not inherit

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -44,11 +44,23 @@ describe("notifyd singleton lock", () => {
 
   it("refuses the lock when a LIVE owner holds it (no double daemon)", async () => {
     await mkdir(daemonLockDir(), { recursive: true });
-    await writeFile(daemonLockOwnerPath(), JSON.stringify({ pid: 424242, started_at: 1 }));
-    // 424242 reported alive → must NOT steal.
+    // A complete, live, fresh owner (a real daemon always heartbeats its ts).
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: 424242, started_at: 1, ts: Date.now() }),
+    );
     expect(await acquireDaemonLock((pid) => pid === 424242)).toBe(false);
     const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
     expect(owner.pid).toBe(424242); // untouched
+  });
+
+  it("steals a live-but-STALE owner (heartbeat not refreshed → wedged/gone)", async () => {
+    await mkdir(daemonLockDir(), { recursive: true });
+    await writeFile(
+      daemonLockOwnerPath(),
+      JSON.stringify({ pid: 424242, started_at: 1, ts: 1 }), // ancient ts
+    );
+    expect(await acquireDaemonLock((pid) => pid === 424242)).toBe(true);
   });
 
   it("steals a lock with a torn/missing owner file (treated as stale)", async () => {

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -173,10 +173,18 @@ async function observeChildren(): Promise<ObserveResult> {
   const logFiles = new Map<number, string | null>();
   // Liveness of ALL children (any parent), pid → started_at — the router uses
   // this to avoid false-exiting a child it merely stopped observing (watcher
-  // lapsed), while still exiting a pid reused by a different child.
+  // lapsed), while still exiting a pid reused by a different child. Only a CURRENT
+  // (non-exited) record whose pid is alive counts as liveness evidence: a stale
+  // `exited` record must not vouch for a pid that a different process now reuses
+  // (which would make the router suppress the old child's exited forever).
   const aliveChildStartedAt = new Map<number, number>();
   for (const r of records) {
-    if (typeof r.parent_pid === "number" && r.parent_pid > 0 && isPidAlive(r.pid))
+    if (
+      typeof r.parent_pid === "number" &&
+      r.parent_pid > 0 &&
+      r.status !== "exited" &&
+      isPidAlive(r.pid)
+    )
       aliveChildStartedAt.set(r.pid, r.started_at);
   }
   for (const r of records) {
@@ -264,7 +272,7 @@ async function readDaemonOwnerToken(): Promise<string | null> {
  * ATOMICALLY (temp + rename) so a reader (status/stop/another daemon) never sees
  * a torn owner mid-write — a null read then reliably means "no owner file yet".
  */
-async function writeOwner(): Promise<void> {
+async function writeOwner(): Promise<boolean> {
   const tmp = `${daemonLockOwnerPath()}.${daemonToken}.tmp`;
   try {
     await writeFile(
@@ -272,8 +280,10 @@ async function writeOwner(): Promise<void> {
       JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now(), token: daemonToken }),
     );
     await rename(tmp, daemonLockOwnerPath());
+    return true;
   } catch {
     await rm(tmp, { force: true }).catch(() => {});
+    return false;
   }
 }
 
@@ -294,7 +304,12 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
       await mkdir(daemonLockDir(), { recursive: false });
       daemonStartedAt = Date.now(); // fixed for this daemon's lifetime
       daemonToken = randomUUID(); // fencing token for this ownership
-      await writeOwner();
+      // If we can't write our owner file, we don't own the lock — drop and retry.
+      if (!(await writeOwner())) {
+        await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+        await new Promise((r) => setTimeout(r, 15));
+        continue;
+      }
       return true;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e; // real error — propagate

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -19,6 +19,7 @@ import { execFile } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "fs/promises";
 import {
   type ChildObservation,
+  type PendingNotification,
   type RouterState,
   stepRouter,
 } from "./notifyRouter.ts";
@@ -112,6 +113,11 @@ export async function reconcileFromInboxes(
       state.set(childPid, {
         parent_pid: last.parent_pid,
         wrapper_pid: last.child_wrapper_pid,
+        // Carry BOTH start times into the seeded state, so the hot-path pid-reuse
+        // guard can fire on the next observation and a synthetic exited from this
+        // seed still stamps identity (else the guard is blind until re-observed).
+        started_at: last.child_started_at,
+        parent_started_at: last.parent_started_at,
         cli: last.cli,
         cwd: last.cwd,
         state: seededState,
@@ -134,6 +140,12 @@ interface ObserveResult {
   childStartedAt: Map<number, number>;
   /** log file per child pid, for payload enrichment. */
   logFiles: Map<number, string | null>;
+  /**
+   * EVERY currently-alive child pid in the registry (regardless of whether its
+   * parent is watching) — so the router can tell a truly-dead child from one it
+   * merely stopped observing when a watcher lapsed.
+   */
+  aliveChildPids: Set<number>;
   watcherCount: number;
 }
 
@@ -151,6 +163,13 @@ async function observeChildren(): Promise<ObserveResult> {
   const parentStartedAt = new Map<number, number>();
   const childStartedAt = new Map<number, number>();
   const logFiles = new Map<number, string | null>();
+  // Liveness of ALL children (any parent) — the router uses this to avoid
+  // false-exiting a child it merely stopped observing (watcher lapsed).
+  const aliveChildPids = new Set<number>();
+  for (const r of records) {
+    if (typeof r.parent_pid === "number" && r.parent_pid > 0 && isPidAlive(r.pid))
+      aliveChildPids.add(r.pid);
+  }
   for (const r of records) {
     const parent = r.parent_pid;
     if (typeof parent !== "number" || parent <= 0) continue;
@@ -175,7 +194,14 @@ async function observeChildren(): Promise<ObserveResult> {
     childStartedAt.set(r.pid, r.started_at);
     logFiles.set(r.pid, r.log_file ?? null);
   }
-  return { obs, parentStartedAt, childStartedAt, logFiles, watcherCount: watching.size };
+  return {
+    obs,
+    parentStartedAt,
+    childStartedAt,
+    logFiles,
+    aliveChildPids,
+    watcherCount: watching.size,
+  };
 }
 
 /** Registry snapshot: every record's pid → its started_at (for reconcile guard). */
@@ -204,11 +230,17 @@ export interface DaemonIdentity {
   ts: number;
 }
 
+// The daemon's start time, captured ONCE when it acquires the lock. The
+// heartbeat updates only `ts` — never `started_at` — so `stop`'s two-read
+// identity check (pid + started_at unchanged) can't see it move and mistake the
+// running daemon for "not running".
+let daemonStartedAt = 0;
+
 /** Stamp the lock owner file with our identity + a fresh heartbeat ts. */
 async function writeOwner(): Promise<void> {
   await writeFile(
     daemonLockOwnerPath(),
-    JSON.stringify({ pid: process.pid, started_at: Date.now(), ts: Date.now() }),
+    JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now() }),
   ).catch(() => {});
 }
 
@@ -228,6 +260,7 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
   for (;;) {
     try {
       await mkdir(daemonLockDir(), { recursive: false });
+      daemonStartedAt = Date.now(); // fixed for this daemon's lifetime
       await writeOwner();
       return true;
     } catch (e) {
@@ -292,8 +325,18 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   }
 
   let running = true;
+  // Heartbeat the owner ts on a BACKGROUND timer (not once per loop) so a slow
+  // tick — many watched children, slow log I/O — can't let the heartbeat cross
+  // OWNER_TTL and have another `watch` steal the lock as "stale" → double daemon.
+  // Refresh well inside the TTL; cleared on shutdown.
+  const ownerBeat = setInterval(
+    () => void writeOwner(),
+    Math.max(1000, Math.floor(OWNER_TTL_MS / 3)),
+  );
+  if (typeof ownerBeat.unref === "function") ownerBeat.unref();
   const cleanup = async () => {
     running = false;
+    clearInterval(ownerBeat);
     await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
   };
   process.on("SIGINT", () => void cleanup().then(() => process.exit(0)));
@@ -306,7 +349,6 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   let emptySince: number | null = null;
 
   while (running) {
-    await writeOwner(); // refresh the identity heartbeat so `status`/`stop` trust us
     const { next, watcherCount } = await tickState(host, prev);
     prev = next;
     ticks++;
@@ -329,8 +371,9 @@ async function tickState(
   host: string,
   prev: RouterState,
 ): Promise<{ next: RouterState; watcherCount: number }> {
-  const { obs, parentStartedAt, childStartedAt, logFiles, watcherCount } = await observeChildren();
-  const { events, next } = stepRouter(prev, obs, Date.now());
+  const { obs, parentStartedAt, childStartedAt, logFiles, aliveChildPids, watcherCount } =
+    await observeChildren();
+  const { events, next } = stepRouter(prev, obs, Date.now(), { aliveChildPids });
 
   // Enrich all edges CONCURRENTLY (a burst of N edges must not serialize N git
   // timeouts). Enrichment is best-effort and never throws; the append that
@@ -372,12 +415,68 @@ async function tickState(
       return stored;
     }),
   );
-  for (const stored of enriched) {
-    await appendEvent(stored.parent_pid, stored).catch((e) =>
-      logger.warn(`[notifyd] append failed for parent ${stored.parent_pid}: ${e}`),
-    );
+  for (let i = 0; i < enriched.length; i++) {
+    const stored = enriched[i]!;
+    const ev = events[i]!;
+    const ok = await appendWithRetry(stored);
+    if (!ok) {
+      // at-least-once: a transient FS/lock failure must NOT permanently drop an
+      // edge. Roll back this edge's "emitted" mark in the next state so the next
+      // tick re-detects and re-appends it (a duplicate is acceptable; a drop is
+      // not). Scoped to this child only — no cross-parent re-emission.
+      rollbackEmit(next, ev);
+      logger.warn(`[notifyd] append failed for parent ${stored.parent_pid} — will retry next tick`);
+    }
   }
   return { next, watcherCount };
+}
+
+/** Append with a few quick retries — a transient lock/FS blip shouldn't lose an edge. */
+async function appendWithRetry(stored: Omit<NotifyEvent, "seq">, attempts = 3): Promise<boolean> {
+  for (let a = 0; a < attempts; a++) {
+    try {
+      await appendEvent(stored.parent_pid, stored);
+      return true;
+    } catch {
+      await new Promise((r) => setTimeout(r, 25 * (a + 1)));
+    }
+  }
+  return false;
+}
+
+/**
+ * Undo the router's "emitted" mark for one edge so the NEXT tick re-emits it
+ * (used when its append failed). For a synthetic exited whose child was dropped
+ * from `next`, re-insert a minimal tracked state so the vanished-loop re-fires.
+ */
+function rollbackEmit(next: RouterState, ev: PendingNotification): void {
+  const cs = next.get(ev.child_pid);
+  if (cs) {
+    if (ev.edge === "idle") cs.idleEmitted = false;
+    else if (ev.edge === "needs_input") {
+      cs.inNeedsInput = false;
+      cs.needsInputQuestion = null;
+    } else if (ev.edge === "exited") cs.exitedEmitted = false;
+    return;
+  }
+  if (ev.edge === "exited") {
+    // Synthetic exited for a child already dropped from tracking — re-add it so
+    // the next tick's vanished-loop retries the exited append.
+    next.set(ev.child_pid, {
+      parent_pid: ev.parent_pid,
+      wrapper_pid: ev.child_wrapper_pid,
+      started_at: ev.child_started_at,
+      parent_started_at: ev.parent_started_at,
+      cli: ev.cli,
+      cwd: ev.cwd,
+      state: ev.prev_state ?? "active",
+      idleSince: null,
+      idleEmitted: false,
+      inNeedsInput: false,
+      needsInputQuestion: null,
+      exitedEmitted: false,
+    });
+  }
 }
 
 async function gcTick(host: string): Promise<void> {

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -315,7 +315,12 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   const intervalMs = opts.intervalMs ?? POLL_MS;
 
   if (opts.once) {
-    await tickState(host, new Map());
+    // A single reconciled tick (test/debug). Skip entirely if a real daemon is
+    // already running — otherwise we'd re-emit baselines it has handled — and
+    // seed from the inbox so even standalone we don't duplicate prior edges.
+    if (await daemonStatus()) return 0;
+    const prev = await reconcileFromInboxes(host, await liveChildrenSnapshot());
+    await tickState(host, prev);
     return 0;
   }
 

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -127,10 +127,19 @@ export async function reconcileFromInboxes(
         cli: last.cli,
         cwd: last.cwd,
         state: seededState,
-        idleSince: last.edge === "idle" ? 0 : null,
-        idleEmitted: last.edge === "idle",
-        inNeedsInput: last.edge === "needs_input",
-        needsInputQuestion: last.edge === "needs_input" ? last.question : null,
+        // "Never suppress, duplicate OK": do NOT seed the idle/needs_input emitted
+        // memory. If notifyd was down while a child went idle→active→idle, the new
+        // idle episode (the "probably done" signal — this feature's whole point)
+        // must NOT be swallowed as the "same" pre-restart episode. So a restart
+        // RE-CONFIRMS idle/needs_input as a fresh episode (a duplicate on the wire
+        // is acceptable; a lost edge is not). Only `exited` — a terminal state
+        // that can't recur for the same child — keeps its emitted flag to avoid a
+        // pointless duplicate. Identity (start times) is still seeded so the
+        // hot-path pid-reuse guard works on the next observation.
+        idleSince: null,
+        idleEmitted: false,
+        inNeedsInput: false,
+        needsInputQuestion: null,
         exitedEmitted: exitedChildren.has(childPid),
       });
     }
@@ -670,7 +679,20 @@ export async function ensureDaemon(): Promise<number | null> {
   // real outcome (null if the spawn didn't come up).
   child.on("error", () => {});
   child.unref();
-  // Give it a moment to acquire the lock + stamp its owner file.
-  await new Promise((r) => setTimeout(r, 300));
-  return daemonStatus();
+  // Poll for the daemon to come up with a bounded φ-backoff (golden-ratio, the
+  // repo convention) instead of a single fixed wait — a cold `bun` start or slow
+  // FS can take longer than any one fixed delay, so a fixed wait falsely reports
+  // "failed". Early-return the moment it's up; give up after a bounded total.
+  const PHI = 1.618;
+  let delay = 50;
+  let waited = 0;
+  const BUDGET_MS = 3000;
+  for (;;) {
+    await new Promise((r) => setTimeout(r, delay));
+    waited += delay;
+    const pid = await daemonStatus();
+    if (pid) return pid;
+    if (waited >= BUDGET_MS) return null;
+    delay = Math.min(Math.round(delay * PHI), 800);
+  }
 }

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -26,7 +26,6 @@ import {
   type NotifyEvent,
   daemonLockDir,
   daemonLockOwnerPath,
-  daemonPidPath,
   notifyDir,
 } from "./notifyInbox.ts";
 import {
@@ -73,8 +72,18 @@ async function recentTail(logFile: string | null | undefined): Promise<string | 
 /**
  * Seed the router's prior state from what each inbox has ALREADY recorded, so a
  * daemon restart does not re-emit a baseline the parent already saw.
+ *
+ * pid-reuse guard: seed a child ONLY if it is still in the registry with the
+ * SAME start time as the inbox recorded (`liveChildren`: pid → started_at). A pid
+ * whose live start time differs is a NEW child recycling the pid — seeding it
+ * would suppress its first notification, so we skip it (it starts fresh). A pid
+ * absent from the registry (reaped) is skipped too: it won't be observed again,
+ * and if the pid is later reused, that new child was never seeded.
  */
-async function reconcileFromInboxes(host: string): Promise<RouterState> {
+export async function reconcileFromInboxes(
+  host: string,
+  liveChildren: Map<number, number>,
+): Promise<RouterState> {
   const state: RouterState = new Map();
   for (const parent of await listInboxParents(host)) {
     const events = await readInbox(host, parent);
@@ -85,6 +94,9 @@ async function reconcileFromInboxes(host: string): Promise<RouterState> {
       if (e.edge === "exited") exitedChildren.add(e.child_pid);
     }
     for (const [childPid, last] of lastByChild) {
+      const liveStarted = liveChildren.get(childPid);
+      if (liveStarted === undefined) continue; // reaped / gone — nothing to suppress
+      if (last.child_started_at && liveStarted !== last.child_started_at) continue; // pid reused
       const seededState =
         last.edge === "exited"
           ? "stopped"
@@ -114,6 +126,8 @@ interface ObserveResult {
   obs: ChildObservation[];
   /** child pid → the parent's started_at, for the pid-reuse guard. */
   parentStartedAt: Map<number, number>;
+  /** child pid → the child's OWN started_at, stamped into events (reuse guard). */
+  childStartedAt: Map<number, number>;
   /** log file per child pid, for payload enrichment. */
   logFiles: Map<number, string | null>;
   watcherCount: number;
@@ -131,6 +145,7 @@ async function observeChildren(): Promise<ObserveResult> {
   }
   const obs: ChildObservation[] = [];
   const parentStartedAt = new Map<number, number>();
+  const childStartedAt = new Map<number, number>();
   const logFiles = new Map<number, string | null>();
   for (const r of records) {
     const parent = r.parent_pid;
@@ -147,15 +162,37 @@ async function observeChildren(): Promise<ObserveResult> {
       question,
     });
     parentStartedAt.set(r.pid, startedAtByWrapper.get(parent) ?? 0);
+    childStartedAt.set(r.pid, r.started_at);
     logFiles.set(r.pid, r.log_file ?? null);
   }
-  return { obs, parentStartedAt, logFiles, watcherCount: watching.size };
+  return { obs, parentStartedAt, childStartedAt, logFiles, watcherCount: watching.size };
+}
+
+/** Registry snapshot: every record's pid → its started_at (for reconcile guard). */
+async function liveChildrenSnapshot(): Promise<Map<number, number>> {
+  const records = await listRecords(undefined, LS_OPTS).catch(() => []);
+  const m = new Map<number, number>();
+  for (const r of records) m.set(r.pid, r.started_at);
+  return m;
 }
 
 export interface DaemonOptions {
   intervalMs?: number;
   /** Run a single tick and return (for tests / `--once`), no lock, no loop. */
   once?: boolean;
+}
+
+// How long an owner heartbeat stays "trusted" — a running daemon refreshes it
+// each tick, so a recycled pid (which isn't refreshing THIS file) reads as stale
+// and is neither trusted for `status` nor killed by `stop`.
+const OWNER_TTL_MS = 12_000;
+
+/** Stamp the lock owner file with our identity + a fresh heartbeat ts. */
+async function writeOwner(): Promise<void> {
+  await writeFile(
+    daemonLockOwnerPath(),
+    JSON.stringify({ pid: process.pid, started_at: Date.now(), ts: Date.now() }),
+  ).catch(() => {});
 }
 
 /**
@@ -170,10 +207,7 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       await mkdir(daemonLockDir(), { recursive: false });
-      await writeFile(
-        daemonLockOwnerPath(),
-        JSON.stringify({ pid: process.pid, started_at: Date.now() }),
-      ).catch(() => {});
+      await writeOwner();
       return true;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e; // real error — propagate
@@ -210,22 +244,23 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
     logger.debug("[notifyd] another live daemon holds the lock — exiting");
     return 0;
   }
-  await writeFile(daemonPidPath(), String(process.pid)).catch(() => {});
 
   let running = true;
   const cleanup = async () => {
     running = false;
     await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
-    await rm(daemonPidPath(), { force: true }).catch(() => {});
   };
   process.on("SIGINT", () => void cleanup().then(() => process.exit(0)));
   process.on("SIGTERM", () => void cleanup().then(() => process.exit(0)));
 
-  let prev = await reconcileFromInboxes(host);
+  // Seed the router from prior inbox state, guarded against pid reuse by the
+  // current registry snapshot (see reconcileFromInboxes).
+  let prev = await reconcileFromInboxes(host, await liveChildrenSnapshot());
   let ticks = 0;
   let emptySince: number | null = null;
 
   while (running) {
+    await writeOwner(); // refresh the identity heartbeat so `status`/`stop` trust us
     const { next, watcherCount } = await tickState(host, prev);
     prev = next;
     ticks++;
@@ -248,43 +283,47 @@ async function tickState(
   host: string,
   prev: RouterState,
 ): Promise<{ next: RouterState; watcherCount: number }> {
-  const { obs, parentStartedAt, logFiles, watcherCount } = await observeChildren();
+  const { obs, parentStartedAt, childStartedAt, logFiles, watcherCount } = await observeChildren();
   const { events, next } = stepRouter(prev, obs, Date.now());
-  for (const ev of events) {
-    // Enrich: tail + git head for actionable edges; exited is best-effort (the
-    // log may already be reaped). Never let git/log I/O block or crash emission.
-    let tail: string | null = null;
-    let git_head: string | null = null;
-    try {
+
+  // Enrich all edges CONCURRENTLY (a burst of N edges must not serialize N git
+  // timeouts). Enrichment is best-effort and never throws; the append that
+  // follows stays serial so per-inbox seq allocation is unambiguous.
+  const enriched = await Promise.all(
+    events.map(async (ev) => {
+      let tail: string | null = null;
+      let git_head: string | null = null;
       if (ev.edge !== "exited") {
         [tail, git_head] = await Promise.all([
-          recentTail(logFiles.get(ev.child_pid)),
-          gitHead(ev.cwd),
+          recentTail(logFiles.get(ev.child_pid)).catch(() => null),
+          gitHead(ev.cwd).catch(() => null),
         ]);
       }
-    } catch {
-      /* enrichment is best-effort */
-    }
-    const stored: Omit<NotifyEvent, "seq"> = {
-      ts: Date.now(),
-      host,
-      parent_pid: ev.parent_pid,
-      // The parent's start time — the read side rejects an event whose parent
-      // started_at doesn't match the reader's, guarding against pid reuse.
-      parent_started_at: parentStartedAt.get(ev.child_pid) ?? 0,
-      child_pid: ev.child_pid,
-      child_wrapper_pid: ev.child_wrapper_pid,
-      cli: ev.cli,
-      cwd: ev.cwd,
-      edge: ev.edge,
-      prev_state: ev.prev_state,
-      state: ev.state,
-      question: ev.question,
-      tail,
-      git_head,
-    };
-    await appendEvent(ev.parent_pid, stored).catch((e) =>
-      logger.warn(`[notifyd] append failed for parent ${ev.parent_pid}: ${e}`),
+      const stored: Omit<NotifyEvent, "seq"> = {
+        ts: Date.now(),
+        host,
+        parent_pid: ev.parent_pid,
+        // The parent's/child's start times — the read side and the startup
+        // reconcile reject an event whose start time disagrees, guarding pid reuse.
+        parent_started_at: parentStartedAt.get(ev.child_pid) ?? 0,
+        child_pid: ev.child_pid,
+        child_wrapper_pid: ev.child_wrapper_pid,
+        child_started_at: childStartedAt.get(ev.child_pid) ?? 0,
+        cli: ev.cli,
+        cwd: ev.cwd,
+        edge: ev.edge,
+        prev_state: ev.prev_state,
+        state: ev.state,
+        question: ev.question,
+        tail,
+        git_head,
+      };
+      return stored;
+    }),
+  );
+  for (const stored of enriched) {
+    await appendEvent(stored.parent_pid, stored).catch((e) =>
+      logger.warn(`[notifyd] append failed for parent ${stored.parent_pid}: ${e}`),
     );
   }
   return { next, watcherCount };
@@ -302,11 +341,23 @@ async function gcTick(host: string): Promise<void> {
   await gcInboxes(host, livePids, childParentPids);
 }
 
-/** Read the daemon's recorded pid, or null. */
-export async function daemonStatus(): Promise<number | null> {
-  const raw = await readFile(daemonPidPath(), "utf8").catch(() => "");
-  const pid = parseInt(raw.trim(), 10);
-  if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) return pid;
+/**
+ * The running daemon's pid, or null. The lock owner file is the SINGLE source of
+ * truth: we trust it only if its pid is alive AND its heartbeat is fresh — a
+ * recycled pid isn't refreshing this file, so its stale ts makes us return null
+ * instead of trusting (or killing via `stop`) an unrelated process.
+ */
+export async function daemonStatus(now = Date.now()): Promise<number | null> {
+  const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");
+  try {
+    const o = JSON.parse(raw) as { pid: number; ts?: number };
+    if (typeof o?.pid === "number" && o.pid > 0 && isPidAlive(o.pid)) {
+      // A running daemon refreshes ts every tick; tolerate a couple missed ticks.
+      if (o.ts === undefined || now - o.ts <= OWNER_TTL_MS) return o.pid;
+    }
+  } catch {
+    /* missing / torn owner — no daemon */
+  }
   return null;
 }
 
@@ -330,7 +381,7 @@ export async function ensureDaemon(): Promise<number | null> {
     stdio: "ignore",
   });
   child.unref();
-  // Give it a moment to acquire the lock + write its pidfile.
+  // Give it a moment to acquire the lock + stamp its owner file.
   await new Promise((r) => setTimeout(r, 300));
   return daemonStatus();
 }

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -1,17 +1,18 @@
 /**
  * `ay notifyd` — the always-on-while-watched detection engine. Polls every
- * agent's live state (the runtime-agnostic query layer, so BOTH Rust and TS
- * children are covered), runs the pure debounce router (`notifyRouter.ts`), and
- * appends the decided edges — enriched with a payload the parent can act on
+ * WATCHED agent's live state (the runtime-agnostic query layer, so BOTH Rust and
+ * TS children are covered), runs the pure debounce router (`notifyRouter.ts`),
+ * and appends the decided edges — enriched with a payload the parent can act on
  * without tailing — into each parent's inbox (`notifyStore.ts`).
  *
- * Lifecycle: a host singleton (mkdir lock). Started on demand by
- * `ay notify watch --ensure-daemon` (default) or explicitly via
- * `ay notifyd start`. Self-exits after a grace window with nothing to watch, so
- * it never lingers as a zombie. It is opt-IN at the consumer: if no parent ever
- * watches, the daemon is never started and NO files are created — fully
- * backward compatible with existing flows (the Monitor-on-HEAD polling keeps
- * working unchanged, now strictly dominated by this).
+ * Lifecycle: a host singleton, guarded by an mkdir lock that records its owner
+ * pid so a crashed daemon's stale lock is detected and STOLEN (never a permanent
+ * deadlock). Scope + liveness are driven by the WATCHER REGISTRY: the daemon only
+ * processes children whose parent is currently running `ay notify watch` (so an
+ * unrelated agent never gets an inbox), and it stays alive as long as any watcher
+ * heartbeat is live, self-exiting only after a grace window with no watchers.
+ * `ay notify watch` re-ensures the daemon every poll, so a parent that watches
+ * BEFORE spawning children (or across a fan-out gap) always has a live daemon.
  */
 
 import { execFile } from "node:child_process";
@@ -24,13 +25,16 @@ import {
 import {
   type NotifyEvent,
   daemonLockDir,
+  daemonLockOwnerPath,
   daemonPidPath,
+  notifyDir,
 } from "./notifyInbox.ts";
 import {
   appendEvent,
   gcInboxes,
   hostId,
   listInboxParents,
+  liveWatchers,
   readInbox,
 } from "./notifyStore.ts";
 import { deriveLiveState, isPidAlive, listRecords, renderLogTailLines } from "./subcommands.ts";
@@ -38,7 +42,7 @@ import { logger } from "./logger.ts";
 
 const POLL_MS = 2000;
 const GC_EVERY_TICKS = 30; // ~every 60s
-const IDLE_EXIT_GRACE_MS = 60_000; // exit if nothing to watch this long
+const IDLE_EXIT_GRACE_MS = 60_000; // exit if no watcher this long
 
 const LS_OPTS = { all: true, active: false, json: false, latest: false, cwdScope: null } as const;
 
@@ -68,9 +72,7 @@ async function recentTail(logFile: string | null | undefined): Promise<string | 
 
 /**
  * Seed the router's prior state from what each inbox has ALREADY recorded, so a
- * daemon restart does not re-emit a baseline the parent already saw. For each
- * child we reconstruct the emitted-edge memory from its last (and any exited)
- * event.
+ * daemon restart does not re-emit a baseline the parent already saw.
  */
 async function reconcileFromInboxes(host: string): Promise<RouterState> {
   const state: RouterState = new Map();
@@ -97,7 +99,6 @@ async function reconcileFromInboxes(host: string): Promise<RouterState> {
         cli: last.cli,
         cwd: last.cwd,
         state: seededState,
-        // A still-idle child keeps idleEmitted so we don't re-fire across restart.
         idleSince: last.edge === "idle" ? 0 : null,
         idleEmitted: last.edge === "idle",
         inNeedsInput: last.edge === "needs_input",
@@ -109,15 +110,32 @@ async function reconcileFromInboxes(host: string): Promise<RouterState> {
   return state;
 }
 
-/** Build this tick's observations for every child that has a parent. */
-async function observeChildren(): Promise<{ obs: ChildObservation[]; childParentPids: Set<number> }> {
+interface ObserveResult {
+  obs: ChildObservation[];
+  /** child pid → the parent's started_at, for the pid-reuse guard. */
+  parentStartedAt: Map<number, number>;
+  /** log file per child pid, for payload enrichment. */
+  logFiles: Map<number, string | null>;
+  watcherCount: number;
+}
+
+/** Observe every child WHOSE PARENT IS WATCHING. Nothing else gets an inbox. */
+async function observeChildren(): Promise<ObserveResult> {
+  const watching = await liveWatchers();
   const records = await listRecords(undefined, LS_OPTS);
+  // Parent wrapper pid → its own started_at (for the pid-reuse stamp).
+  const startedAtByWrapper = new Map<number, number>();
+  for (const r of records) {
+    if (typeof r.wrapper_pid === "number" && r.wrapper_pid > 0)
+      startedAtByWrapper.set(r.wrapper_pid, r.started_at);
+  }
   const obs: ChildObservation[] = [];
-  const childParentPids = new Set<number>();
+  const parentStartedAt = new Map<number, number>();
+  const logFiles = new Map<number, string | null>();
   for (const r of records) {
     const parent = r.parent_pid;
     if (typeof parent !== "number" || parent <= 0) continue;
-    childParentPids.add(parent);
+    if (!watching.has(parent)) continue; // scope: only watched parents' children
     const { state, question } = await deriveLiveState(r);
     obs.push({
       pid: r.pid,
@@ -128,14 +146,51 @@ async function observeChildren(): Promise<{ obs: ChildObservation[]; childParent
       state,
       question,
     });
+    parentStartedAt.set(r.pid, startedAtByWrapper.get(parent) ?? 0);
+    logFiles.set(r.pid, r.log_file ?? null);
   }
-  return { obs, childParentPids };
+  return { obs, parentStartedAt, logFiles, watcherCount: watching.size };
 }
 
 export interface DaemonOptions {
   intervalMs?: number;
   /** Run a single tick and return (for tests / `--once`), no lock, no loop. */
   once?: boolean;
+}
+
+/**
+ * Acquire the singleton lock, stealing a stale one whose owner is dead. The
+ * liveness predicate is injectable so the steal/keep race is unit-testable.
+ * Returns true if WE now hold the lock, false if a LIVE owner holds it.
+ */
+export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPidAlive): Promise<boolean> {
+  // The lock dir lives under notify/ — ensure that exists first, else mkdir of
+  // the lock throws ENOENT which must NOT be mistaken for "someone holds it".
+  await mkdir(notifyDir(), { recursive: true }).catch(() => {});
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await mkdir(daemonLockDir(), { recursive: false });
+      await writeFile(
+        daemonLockOwnerPath(),
+        JSON.stringify({ pid: process.pid, started_at: Date.now() }),
+      ).catch(() => {});
+      return true;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e; // real error — propagate
+      // Lock exists — is its owner still alive?
+      const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");
+      let ownerPid = 0;
+      try {
+        ownerPid = (JSON.parse(raw) as { pid: number }).pid ?? 0;
+      } catch {
+        /* missing/torn owner — treat as stale */
+      }
+      if (ownerPid > 0 && ownerPid !== process.pid && isAlive(ownerPid)) return false; // live daemon
+      // Stale (dead owner or unreadable) — steal and retry.
+      await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+    }
+  }
+  return false;
 }
 
 /**
@@ -147,15 +202,12 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   const intervalMs = opts.intervalMs ?? POLL_MS;
 
   if (opts.once) {
-    await tick(host, new Map());
+    await tickState(host, new Map());
     return 0;
   }
 
-  // Singleton guard: whoever holds the mkdir lock is THE daemon.
-  try {
-    await mkdir(daemonLockDir(), { recursive: false });
-  } catch {
-    logger.debug("[notifyd] another daemon already holds the lock — exiting");
+  if (!(await acquireDaemonLock())) {
+    logger.debug("[notifyd] another live daemon holds the lock — exiting");
     return 0;
   }
   await writeFile(daemonPidPath(), String(process.pid)).catch(() => {});
@@ -174,18 +226,16 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   let emptySince: number | null = null;
 
   while (running) {
-    const hadWork = await tickState(host, prev).then((r) => {
-      prev = r.next;
-      return r.hadChildren;
-    });
+    const { next, watcherCount } = await tickState(host, prev);
+    prev = next;
     ticks++;
     if (ticks % GC_EVERY_TICKS === 0) await gcTick(host).catch(() => {});
 
-    // Self-exit when there's nothing to watch for a grace window.
-    if (hadWork) emptySince = null;
+    // Self-exit when no parent is watching for a grace window.
+    if (watcherCount > 0) emptySince = null;
     else if (emptySince == null) emptySince = Date.now();
     if (emptySince != null && Date.now() - emptySince > IDLE_EXIT_GRACE_MS) {
-      logger.debug("[notifyd] nothing to watch — exiting");
+      logger.debug("[notifyd] no watchers — exiting");
       break;
     }
     await new Promise((r) => setTimeout(r, intervalMs));
@@ -194,28 +244,22 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   return 0;
 }
 
-/** One tick used by `--once` (no state threading). */
-async function tick(host: string, prev: RouterState): Promise<void> {
-  await tickState(host, prev);
-}
-
 async function tickState(
   host: string,
   prev: RouterState,
-): Promise<{ next: RouterState; hadChildren: boolean }> {
-  const { obs, childParentPids } = await observeChildren();
+): Promise<{ next: RouterState; watcherCount: number }> {
+  const { obs, parentStartedAt, logFiles, watcherCount } = await observeChildren();
   const { events, next } = stepRouter(prev, obs, Date.now());
   for (const ev of events) {
-    // Enrich: tail + git head for actionable edges; exited is best-effort (log
-    // may already be reaped). Never let git/log I/O block or crash emission.
+    // Enrich: tail + git head for actionable edges; exited is best-effort (the
+    // log may already be reaped). Never let git/log I/O block or crash emission.
     let tail: string | null = null;
     let git_head: string | null = null;
     try {
-      const rec = obs.find((o) => o.pid === ev.child_pid);
-      if (rec && ev.edge !== "exited") {
+      if (ev.edge !== "exited") {
         [tail, git_head] = await Promise.all([
-          recentTailForPid(ev.child_pid),
-          gitHead(rec.cwd),
+          recentTail(logFiles.get(ev.child_pid)),
+          gitHead(ev.cwd),
         ]);
       }
     } catch {
@@ -225,6 +269,9 @@ async function tickState(
       ts: Date.now(),
       host,
       parent_pid: ev.parent_pid,
+      // The parent's start time — the read side rejects an event whose parent
+      // started_at doesn't match the reader's, guarding against pid reuse.
+      parent_started_at: parentStartedAt.get(ev.child_pid) ?? 0,
       child_pid: ev.child_pid,
       child_wrapper_pid: ev.child_wrapper_pid,
       cli: ev.cli,
@@ -240,15 +287,7 @@ async function tickState(
       logger.warn(`[notifyd] append failed for parent ${ev.parent_pid}: ${e}`),
     );
   }
-  return { next, hadChildren: childParentPids.size > 0 };
-}
-
-// Resolve a child's log file to render its tail. We re-read the record set here
-// only for the (rare) emit path, keeping the hot observe path lean.
-async function recentTailForPid(childPid: number): Promise<string | null> {
-  const records = await listRecords(undefined, LS_OPTS).catch(() => []);
-  const r = records.find((x) => x.pid === childPid);
-  return recentTail(r?.log_file);
+  return { next, watcherCount };
 }
 
 async function gcTick(host: string): Promise<void> {

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -142,11 +142,12 @@ interface ObserveResult {
   /** log file per child pid, for payload enrichment. */
   logFiles: Map<number, string | null>;
   /**
-   * EVERY currently-alive child pid in the registry (regardless of whether its
-   * parent is watching) — so the router can tell a truly-dead child from one it
-   * merely stopped observing when a watcher lapsed.
+   * pid → started_at for EVERY currently-alive child in the registry (regardless
+   * of whether its parent is watching) — so the router can tell a truly-dead (or
+   * pid-reused) child from one it merely stopped observing when a watcher lapsed,
+   * identity-aware.
    */
-  aliveChildPids: Set<number>;
+  aliveChildStartedAt: Map<number, number>;
   watcherCount: number;
 }
 
@@ -164,12 +165,13 @@ async function observeChildren(): Promise<ObserveResult> {
   const parentStartedAt = new Map<number, number>();
   const childStartedAt = new Map<number, number>();
   const logFiles = new Map<number, string | null>();
-  // Liveness of ALL children (any parent) — the router uses this to avoid
-  // false-exiting a child it merely stopped observing (watcher lapsed).
-  const aliveChildPids = new Set<number>();
+  // Liveness of ALL children (any parent), pid → started_at — the router uses
+  // this to avoid false-exiting a child it merely stopped observing (watcher
+  // lapsed), while still exiting a pid reused by a different child.
+  const aliveChildStartedAt = new Map<number, number>();
   for (const r of records) {
     if (typeof r.parent_pid === "number" && r.parent_pid > 0 && isPidAlive(r.pid))
-      aliveChildPids.add(r.pid);
+      aliveChildStartedAt.set(r.pid, r.started_at);
   }
   for (const r of records) {
     const parent = r.parent_pid;
@@ -200,7 +202,7 @@ async function observeChildren(): Promise<ObserveResult> {
     parentStartedAt,
     childStartedAt,
     logFiles,
-    aliveChildPids,
+    aliveChildStartedAt,
     watcherCount: watching.size,
   };
 }
@@ -403,9 +405,9 @@ async function tickState(
   host: string,
   prev: RouterState,
 ): Promise<{ next: RouterState; watcherCount: number }> {
-  const { obs, parentStartedAt, childStartedAt, logFiles, aliveChildPids, watcherCount } =
+  const { obs, parentStartedAt, childStartedAt, logFiles, aliveChildStartedAt, watcherCount } =
     await observeChildren();
-  const { events, next } = stepRouter(prev, obs, Date.now(), { aliveChildPids });
+  const { events, next } = stepRouter(prev, obs, Date.now(), { aliveChildStartedAt });
 
   // Enrich all edges CONCURRENTLY (a burst of N edges must not serialize N git
   // timeouts). Enrichment is best-effort and never throws; the append that

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -35,6 +35,7 @@ import {
   listInboxParents,
   liveWatchers,
   readInbox,
+  shouldStealLock,
 } from "./notifyStore.ts";
 import { deriveLiveState, isPidAlive, listRecords, renderLogTailLines } from "./subcommands.ts";
 import { logger } from "./logger.ts";
@@ -224,8 +225,6 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
   // the lock throws ENOENT which must NOT be mistaken for "someone holds it".
   await mkdir(notifyDir(), { recursive: true }).catch(() => {});
   const start = Date.now();
-  const GRACE_MS = 1000;
-  const HARD_MS = 15_000;
   for (;;) {
     try {
       await mkdir(daemonLockDir(), { recursive: false });
@@ -234,15 +233,15 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e; // real error — propagate
       const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");
+      const now = Date.now();
+      // A COMPLETE, live, fresh owner belonging to a DIFFERENT pid → another
+      // daemon is already running; we are not it.
       let owner: { pid?: number; ts?: number } | null = null;
       try {
         owner = JSON.parse(raw) as { pid: number; ts: number };
       } catch {
         /* torn / not-yet-written */
       }
-      const now = Date.now();
-      const elapsed = now - start;
-      // A COMPLETE, live, fresh owner (a different daemon) → we are not it.
       if (
         owner &&
         typeof owner.pid === "number" &&
@@ -254,17 +253,22 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
       ) {
         return false;
       }
-      // Dead / stale / torn-past-grace → steal and re-prove via mkdir. A torn
-      // owner within the grace is another daemon mid-acquire: wait, don't steal.
-      const ownerPid = owner?.pid ?? 0;
-      const holderDead = ownerPid > 0 && ownerPid !== process.pid && !isAlive(ownerPid);
-      const holderStale = (owner?.ts ?? 0) > 0 && now - (owner!.ts ?? 0) > OWNER_TTL_MS;
-      const tornPastGrace = (!owner || ownerPid <= 0) && elapsed > GRACE_MS;
-      if (holderDead || holderStale || tornPastGrace || elapsed > HARD_MS) {
+      // Otherwise steal per the SHARED decision (dead / heartbeat-stale /
+      // torn-past-grace) — the same invariant the per-inbox lock uses, so a
+      // torn owner (the mkdir→writeOwner window of a concurrent daemon start) is
+      // respected within the grace and two starts can't both win. Else wait.
+      if (
+        shouldStealLock(raw, now, {
+          staleMs: OWNER_TTL_MS,
+          elapsed: now - start,
+          selfPid: process.pid,
+          isAlive,
+        })
+      ) {
         await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
         continue;
       }
-      await new Promise((r) => setTimeout(r, 15)); // torn within grace — wait it out
+      await new Promise((r) => setTimeout(r, 15));
     }
   }
 }

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -260,6 +260,8 @@ export interface DaemonIdentity {
   pid: number;
   started_at: number;
   ts: number;
+  /** The owner fencing token at validation time — pins THIS incarnation. */
+  token: string | null;
 }
 
 // The daemon's start time, captured ONCE when it acquires the lock. The
@@ -605,7 +607,12 @@ export async function daemonIdentity(now = Date.now()): Promise<DaemonIdentity |
       now - o.ts <= OWNER_TTL_MS &&
       isPidAlive(o.pid)
     ) {
-      return { pid: o.pid, started_at: o.started_at, ts: o.ts };
+      return {
+        pid: o.pid,
+        started_at: o.started_at,
+        ts: o.ts,
+        token: typeof o.token === "string" ? o.token : null,
+      };
     }
   } catch {
     /* missing / torn owner — no daemon */
@@ -628,15 +635,14 @@ export async function daemonStatus(now = Date.now()): Promise<number | null> {
  */
 export async function requestDaemonStop(): Promise<number | null> {
   const id = await daemonIdentity();
-  if (!id) return null;
-  // Capture the owner's fencing token, then RE-READ it right before removing the
-  // lock: if daemon A exited and B took over between the identity check and the
-  // rm, the token changed → we must NOT remove B's lock (which would stop the new
-  // daemon). Same fence discipline as the lock release.
-  const token1 = await readDaemonOwnerToken();
-  if (token1 === null) return null;
-  const token2 = await readDaemonOwnerToken();
-  if (token2 !== token1) return null; // taken over between reads — don't touch it
+  if (!id || id.token === null) return null;
+  // Re-read the owner token right before removing the lock and compare it to the
+  // token we VALIDATED above (this incarnation's). If daemon A validated, then
+  // exited, and B took over before the rm, the current token is B's — different
+  // from A's — so we do NOT remove B's lock (which would stop the new daemon).
+  // The residual re-read→rm window is the unavoidable FS-single-CAS gap (bounded).
+  const cur = await readDaemonOwnerToken();
+  if (cur !== id.token) return null;
   await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
   return id.pid;
 }
@@ -646,20 +652,23 @@ export async function ensureDaemon(): Promise<number | null> {
   const existing = await daemonStatus();
   if (existing) return existing;
   const { spawn } = await import("node:child_process");
-  // Resolve our own launcher the way serve/schedule do: on POSIX `ay` is a
-  // `#!/usr/bin/env bun` script (run via process.execPath), on Windows it's a
-  // self-contained ay.exe. Fall back to a bare `ay` on PATH.
-  const ayBin = Bun.which("ay");
-  const launcher = ayBin
-    ? process.platform === "win32"
-      ? [ayBin]
-      : [process.execPath, ayBin]
-    : ["ay"];
+  // Resolve our own launcher the way serve/schedule/restart do: on POSIX `ay` is
+  // a `#!/usr/bin/env bun` script (run via process.execPath), on Windows it's a
+  // self-contained ay.exe. Fall back to THIS process's own script path
+  // (process.argv[1]) — which is always present — rather than a bare `ay` that a
+  // minimal PATH / absolute-path launch wouldn't resolve.
+  const ayBin = Bun.which("ay") ?? process.argv[1];
+  if (!ayBin) return null;
+  const launcher = process.platform === "win32" ? [ayBin] : [process.execPath, ayBin];
   const [cmd, ...pre] = launcher;
   const child = spawn(cmd!, [...pre, "notifyd", "run"], {
     detached: true,
     stdio: "ignore",
   });
+  // spawn's ENOENT surfaces ASYNC as an 'error' event — without a handler it
+  // crashes the process. Swallow it; the daemonStatus() check below reports the
+  // real outcome (null if the spawn didn't come up).
+  child.on("error", () => {});
   child.unref();
   // Give it a moment to acquire the lock + stamp its owner file.
   await new Promise((r) => setTimeout(r, 300));

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -16,6 +16,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "fs/promises";
 import {
   type ChildObservation,
@@ -235,12 +236,26 @@ export interface DaemonIdentity {
 // identity check (pid + started_at unchanged) can't see it move and mistake the
 // running daemon for "not running".
 let daemonStartedAt = 0;
+// Fencing token for THIS daemon's lock ownership (see the inbox lock). We only
+// overwrite the owner file or delete the lock while it still carries our token,
+// so a stale-stolen daemon can't clobber or delete the new daemon's lock.
+let daemonToken = "";
 
-/** Stamp the lock owner file with our identity + a fresh heartbeat ts. */
+/** The token currently written in the daemon lock owner file, or null. */
+async function readDaemonOwnerToken(): Promise<string | null> {
+  try {
+    const o = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8")) as { token?: string };
+    return o.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Stamp the lock owner file with our identity + a fresh heartbeat ts + token. */
 async function writeOwner(): Promise<void> {
   await writeFile(
     daemonLockOwnerPath(),
-    JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now() }),
+    JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now(), token: daemonToken }),
   ).catch(() => {});
 }
 
@@ -261,6 +276,7 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
     try {
       await mkdir(daemonLockDir(), { recursive: false });
       daemonStartedAt = Date.now(); // fixed for this daemon's lifetime
+      daemonToken = randomUUID(); // fencing token for this ownership
       await writeOwner();
       return true;
     } catch (e) {
@@ -334,15 +350,26 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   // tick — many watched children, slow log I/O — can't let the heartbeat cross
   // OWNER_TTL and have another `watch` steal the lock as "stale" → double daemon.
   // Refresh well inside the TTL; cleared on shutdown.
-  const ownerBeat = setInterval(
-    () => void writeOwner(),
-    Math.max(1000, Math.floor(OWNER_TTL_MS / 3)),
-  );
+  const ownerBeat = setInterval(() => {
+    void (async () => {
+      // Stop beating (and never overwrite) if we've been superseded — the fencing
+      // token in the owner file is no longer ours.
+      const cur = await readDaemonOwnerToken();
+      if (cur !== null && cur !== daemonToken) {
+        clearInterval(ownerBeat);
+        return;
+      }
+      await writeOwner();
+    })();
+  }, Math.max(1000, Math.floor(OWNER_TTL_MS / 3)));
   if (typeof ownerBeat.unref === "function") ownerBeat.unref();
   const cleanup = async () => {
     running = false;
     clearInterval(ownerBeat);
-    await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+    // Delete the lock ONLY if it still carries our token — never remove a lock a
+    // newer daemon now owns.
+    if ((await readDaemonOwnerToken()) === daemonToken)
+      await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
   };
   process.on("SIGINT", () => void cleanup().then(() => process.exit(0)));
   process.on("SIGTERM", () => void cleanup().then(() => process.exit(0)));

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -96,7 +96,10 @@ export async function reconcileFromInboxes(
     for (const [childPid, last] of lastByChild) {
       const liveStarted = liveChildren.get(childPid);
       if (liveStarted === undefined) continue; // reaped / gone — nothing to suppress
-      if (last.child_started_at && liveStarted !== last.child_started_at) continue; // pid reused
+      // Seed ONLY on a positively-matched identity. An event with no/zero
+      // child_started_at can't be verified, so we don't seed it — better to risk
+      // one duplicate edge than to suppress a recycled pid's first notification.
+      if (!last.child_started_at || liveStarted !== last.child_started_at) continue;
       const seededState =
         last.edge === "exited"
           ? "stopped"
@@ -155,6 +158,7 @@ async function observeChildren(): Promise<ObserveResult> {
     obs.push({
       pid: r.pid,
       wrapper_pid: r.wrapper_pid ?? undefined,
+      started_at: r.started_at,
       parent_pid: parent,
       cli: r.cli,
       cwd: r.cwd,
@@ -183,9 +187,16 @@ export interface DaemonOptions {
 }
 
 // How long an owner heartbeat stays "trusted" — a running daemon refreshes it
-// each tick, so a recycled pid (which isn't refreshing THIS file) reads as stale
-// and is neither trusted for `status` nor killed by `stop`.
-const OWNER_TTL_MS = 12_000;
+// each tick (POLL_MS), so a recycled pid (which isn't refreshing THIS file) reads
+// as stale within a few ticks and is neither trusted for `status` nor killed by
+// `stop`. Kept tight (a few ticks) to shrink the pid-reuse window.
+const OWNER_TTL_MS = 3 * POLL_MS;
+
+export interface DaemonIdentity {
+  pid: number;
+  started_at: number;
+  ts: number;
+}
 
 /** Stamp the lock owner file with our identity + a fresh heartbeat ts. */
 async function writeOwner(): Promise<void> {
@@ -308,7 +319,9 @@ async function tickState(
         parent_started_at: parentStartedAt.get(ev.child_pid) ?? 0,
         child_pid: ev.child_pid,
         child_wrapper_pid: ev.child_wrapper_pid,
-        child_started_at: childStartedAt.get(ev.child_pid) ?? 0,
+        // Carried by the router (survives a synthetic exited for a vanished child,
+        // which is no longer in childStartedAt); fall back to the live map.
+        child_started_at: ev.child_started_at ?? childStartedAt.get(ev.child_pid) ?? 0,
         cli: ev.cli,
         cwd: ev.cwd,
         edge: ev.edge,
@@ -342,23 +355,37 @@ async function gcTick(host: string): Promise<void> {
 }
 
 /**
- * The running daemon's pid, or null. The lock owner file is the SINGLE source of
- * truth: we trust it only if its pid is alive AND its heartbeat is fresh — a
- * recycled pid isn't refreshing this file, so its stale ts makes us return null
- * instead of trusting (or killing via `stop`) an unrelated process.
+ * The running daemon's full identity, or null. The lock owner file is the SINGLE
+ * source of truth: trusted only if it is COMPLETE (pid + started_at + ts), its
+ * pid is alive, AND its heartbeat is fresh. A recycled pid isn't refreshing this
+ * file, so its stale ts (or a torn/partial owner) yields null — we never trust or
+ * kill an unrelated process. `stop` re-reads and re-checks this identity right
+ * before signalling, so it can't SIGTERM a pid recycled between status and stop.
  */
-export async function daemonStatus(now = Date.now()): Promise<number | null> {
+export async function daemonIdentity(now = Date.now()): Promise<DaemonIdentity | null> {
   const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");
   try {
-    const o = JSON.parse(raw) as { pid: number; ts?: number };
-    if (typeof o?.pid === "number" && o.pid > 0 && isPidAlive(o.pid)) {
-      // A running daemon refreshes ts every tick; tolerate a couple missed ticks.
-      if (o.ts === undefined || now - o.ts <= OWNER_TTL_MS) return o.pid;
+    const o = JSON.parse(raw) as Partial<DaemonIdentity>;
+    if (
+      typeof o?.pid === "number" &&
+      o.pid > 0 &&
+      typeof o.started_at === "number" &&
+      o.started_at > 0 &&
+      typeof o.ts === "number" &&
+      now - o.ts <= OWNER_TTL_MS &&
+      isPidAlive(o.pid)
+    ) {
+      return { pid: o.pid, started_at: o.started_at, ts: o.ts };
     }
   } catch {
     /* missing / torn owner — no daemon */
   }
   return null;
+}
+
+/** The running daemon's pid, or null (see daemonIdentity for the trust rules). */
+export async function daemonStatus(now = Date.now()): Promise<number | null> {
+  return (await daemonIdentity(now))?.pid ?? null;
 }
 
 /** Ensure a daemon is running; best-effort spawn detached. Returns its pid or null. */

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -96,11 +96,7 @@ export async function reconcileFromInboxes(
     if (!watchedParents.has(parent)) continue;
     const events = await readInbox(host, parent);
     const lastByChild = new Map<number, NotifyEvent>();
-    const exitedChildren = new Set<number>();
-    for (const e of events) {
-      lastByChild.set(e.child_pid, e);
-      if (e.edge === "exited") exitedChildren.add(e.child_pid);
-    }
+    for (const e of events) lastByChild.set(e.child_pid, e);
     for (const [childPid, last] of lastByChild) {
       const liveStarted = liveChildren.get(childPid);
       if (liveStarted === undefined) continue; // reaped / gone — nothing to suppress
@@ -140,7 +136,11 @@ export async function reconcileFromInboxes(
         idleEmitted: false,
         inNeedsInput: false,
         needsInputQuestion: null,
-        exitedEmitted: exitedChildren.has(childPid),
+        // Identity-aware: `last` already matched this incarnation's start time, so
+        // exitedEmitted is true ONLY if THIS child's last recorded edge is exited.
+        // A pid reused by a NEW child (whose last edge is e.g. idle) does NOT
+        // inherit the prior incarnation's exit — its own exit still fires.
+        exitedEmitted: last.edge === "exited",
       });
     }
   }

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -1,0 +1,297 @@
+/**
+ * `ay notifyd` — the always-on-while-watched detection engine. Polls every
+ * agent's live state (the runtime-agnostic query layer, so BOTH Rust and TS
+ * children are covered), runs the pure debounce router (`notifyRouter.ts`), and
+ * appends the decided edges — enriched with a payload the parent can act on
+ * without tailing — into each parent's inbox (`notifyStore.ts`).
+ *
+ * Lifecycle: a host singleton (mkdir lock). Started on demand by
+ * `ay notify watch --ensure-daemon` (default) or explicitly via
+ * `ay notifyd start`. Self-exits after a grace window with nothing to watch, so
+ * it never lingers as a zombie. It is opt-IN at the consumer: if no parent ever
+ * watches, the daemon is never started and NO files are created — fully
+ * backward compatible with existing flows (the Monitor-on-HEAD polling keeps
+ * working unchanged, now strictly dominated by this).
+ */
+
+import { execFile } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import {
+  type ChildObservation,
+  type RouterState,
+  stepRouter,
+} from "./notifyRouter.ts";
+import {
+  type NotifyEvent,
+  daemonLockDir,
+  daemonPidPath,
+} from "./notifyInbox.ts";
+import {
+  appendEvent,
+  gcInboxes,
+  hostId,
+  listInboxParents,
+  readInbox,
+} from "./notifyStore.ts";
+import { deriveLiveState, isPidAlive, listRecords, renderLogTailLines } from "./subcommands.ts";
+import { logger } from "./logger.ts";
+
+const POLL_MS = 2000;
+const GC_EVERY_TICKS = 30; // ~every 60s
+const IDLE_EXIT_GRACE_MS = 60_000; // exit if nothing to watch this long
+
+const LS_OPTS = { all: true, active: false, json: false, latest: false, cwdScope: null } as const;
+
+/** Short git HEAD of a cwd, best-effort, never blocks emission. */
+function gitHead(cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      "git",
+      ["-C", cwd, "rev-parse", "--short", "HEAD"],
+      { timeout: 1500, windowsHide: true },
+      (err, stdout) => resolve(err ? null : stdout.trim() || null),
+    );
+  });
+}
+
+/** Last few rendered log lines, compacted, so the parent needn't tail. */
+async function recentTail(logFile: string | null | undefined): Promise<string | null> {
+  if (!logFile) return null;
+  const lines = await renderLogTailLines(logFile, 12).catch(() => null);
+  if (!lines) return null;
+  const compact = lines
+    .map((l) => l.replace(/\s+$/, ""))
+    .filter((l) => l.trim())
+    .slice(-8);
+  return compact.length ? compact.join("\n").slice(0, 1200) : null;
+}
+
+/**
+ * Seed the router's prior state from what each inbox has ALREADY recorded, so a
+ * daemon restart does not re-emit a baseline the parent already saw. For each
+ * child we reconstruct the emitted-edge memory from its last (and any exited)
+ * event.
+ */
+async function reconcileFromInboxes(host: string): Promise<RouterState> {
+  const state: RouterState = new Map();
+  for (const parent of await listInboxParents(host)) {
+    const events = await readInbox(host, parent);
+    const lastByChild = new Map<number, NotifyEvent>();
+    const exitedChildren = new Set<number>();
+    for (const e of events) {
+      lastByChild.set(e.child_pid, e);
+      if (e.edge === "exited") exitedChildren.add(e.child_pid);
+    }
+    for (const [childPid, last] of lastByChild) {
+      const seededState =
+        last.edge === "exited"
+          ? "stopped"
+          : last.edge === "needs_input"
+            ? "needs_input"
+            : last.edge === "idle"
+              ? "idle"
+              : "active";
+      state.set(childPid, {
+        parent_pid: last.parent_pid,
+        wrapper_pid: last.child_wrapper_pid,
+        cli: last.cli,
+        cwd: last.cwd,
+        state: seededState,
+        // A still-idle child keeps idleEmitted so we don't re-fire across restart.
+        idleSince: last.edge === "idle" ? 0 : null,
+        idleEmitted: last.edge === "idle",
+        inNeedsInput: last.edge === "needs_input",
+        needsInputQuestion: last.edge === "needs_input" ? last.question : null,
+        exitedEmitted: exitedChildren.has(childPid),
+      });
+    }
+  }
+  return state;
+}
+
+/** Build this tick's observations for every child that has a parent. */
+async function observeChildren(): Promise<{ obs: ChildObservation[]; childParentPids: Set<number> }> {
+  const records = await listRecords(undefined, LS_OPTS);
+  const obs: ChildObservation[] = [];
+  const childParentPids = new Set<number>();
+  for (const r of records) {
+    const parent = r.parent_pid;
+    if (typeof parent !== "number" || parent <= 0) continue;
+    childParentPids.add(parent);
+    const { state, question } = await deriveLiveState(r);
+    obs.push({
+      pid: r.pid,
+      wrapper_pid: r.wrapper_pid ?? undefined,
+      parent_pid: parent,
+      cli: r.cli,
+      cwd: r.cwd,
+      state,
+      question,
+    });
+  }
+  return { obs, childParentPids };
+}
+
+export interface DaemonOptions {
+  intervalMs?: number;
+  /** Run a single tick and return (for tests / `--once`), no lock, no loop. */
+  once?: boolean;
+}
+
+/**
+ * Run the daemon loop in the FOREGROUND. `ay notifyd start` spawns this detached;
+ * `ay notifyd run` runs it inline. Holds the host singleton lock for its lifetime.
+ */
+export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
+  const host = hostId();
+  const intervalMs = opts.intervalMs ?? POLL_MS;
+
+  if (opts.once) {
+    await tick(host, new Map());
+    return 0;
+  }
+
+  // Singleton guard: whoever holds the mkdir lock is THE daemon.
+  try {
+    await mkdir(daemonLockDir(), { recursive: false });
+  } catch {
+    logger.debug("[notifyd] another daemon already holds the lock — exiting");
+    return 0;
+  }
+  await writeFile(daemonPidPath(), String(process.pid)).catch(() => {});
+
+  let running = true;
+  const cleanup = async () => {
+    running = false;
+    await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+    await rm(daemonPidPath(), { force: true }).catch(() => {});
+  };
+  process.on("SIGINT", () => void cleanup().then(() => process.exit(0)));
+  process.on("SIGTERM", () => void cleanup().then(() => process.exit(0)));
+
+  let prev = await reconcileFromInboxes(host);
+  let ticks = 0;
+  let emptySince: number | null = null;
+
+  while (running) {
+    const hadWork = await tickState(host, prev).then((r) => {
+      prev = r.next;
+      return r.hadChildren;
+    });
+    ticks++;
+    if (ticks % GC_EVERY_TICKS === 0) await gcTick(host).catch(() => {});
+
+    // Self-exit when there's nothing to watch for a grace window.
+    if (hadWork) emptySince = null;
+    else if (emptySince == null) emptySince = Date.now();
+    if (emptySince != null && Date.now() - emptySince > IDLE_EXIT_GRACE_MS) {
+      logger.debug("[notifyd] nothing to watch — exiting");
+      break;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  await cleanup();
+  return 0;
+}
+
+/** One tick used by `--once` (no state threading). */
+async function tick(host: string, prev: RouterState): Promise<void> {
+  await tickState(host, prev);
+}
+
+async function tickState(
+  host: string,
+  prev: RouterState,
+): Promise<{ next: RouterState; hadChildren: boolean }> {
+  const { obs, childParentPids } = await observeChildren();
+  const { events, next } = stepRouter(prev, obs, Date.now());
+  for (const ev of events) {
+    // Enrich: tail + git head for actionable edges; exited is best-effort (log
+    // may already be reaped). Never let git/log I/O block or crash emission.
+    let tail: string | null = null;
+    let git_head: string | null = null;
+    try {
+      const rec = obs.find((o) => o.pid === ev.child_pid);
+      if (rec && ev.edge !== "exited") {
+        [tail, git_head] = await Promise.all([
+          recentTailForPid(ev.child_pid),
+          gitHead(rec.cwd),
+        ]);
+      }
+    } catch {
+      /* enrichment is best-effort */
+    }
+    const stored: Omit<NotifyEvent, "seq"> = {
+      ts: Date.now(),
+      host,
+      parent_pid: ev.parent_pid,
+      child_pid: ev.child_pid,
+      child_wrapper_pid: ev.child_wrapper_pid,
+      cli: ev.cli,
+      cwd: ev.cwd,
+      edge: ev.edge,
+      prev_state: ev.prev_state,
+      state: ev.state,
+      question: ev.question,
+      tail,
+      git_head,
+    };
+    await appendEvent(ev.parent_pid, stored).catch((e) =>
+      logger.warn(`[notifyd] append failed for parent ${ev.parent_pid}: ${e}`),
+    );
+  }
+  return { next, hadChildren: childParentPids.size > 0 };
+}
+
+// Resolve a child's log file to render its tail. We re-read the record set here
+// only for the (rare) emit path, keeping the hot observe path lean.
+async function recentTailForPid(childPid: number): Promise<string | null> {
+  const records = await listRecords(undefined, LS_OPTS).catch(() => []);
+  const r = records.find((x) => x.pid === childPid);
+  return recentTail(r?.log_file);
+}
+
+async function gcTick(host: string): Promise<void> {
+  const records = await listRecords(undefined, { ...LS_OPTS, all: true }).catch(() => []);
+  const livePids = new Set<number>();
+  const childParentPids = new Set<number>();
+  for (const r of records) {
+    if (isPidAlive(r.pid)) livePids.add(r.wrapper_pid ?? r.pid);
+    if (typeof r.parent_pid === "number" && r.parent_pid > 0 && isPidAlive(r.pid))
+      childParentPids.add(r.parent_pid);
+  }
+  await gcInboxes(host, livePids, childParentPids);
+}
+
+/** Read the daemon's recorded pid, or null. */
+export async function daemonStatus(): Promise<number | null> {
+  const raw = await readFile(daemonPidPath(), "utf8").catch(() => "");
+  const pid = parseInt(raw.trim(), 10);
+  if (Number.isFinite(pid) && pid > 0 && isPidAlive(pid)) return pid;
+  return null;
+}
+
+/** Ensure a daemon is running; best-effort spawn detached. Returns its pid or null. */
+export async function ensureDaemon(): Promise<number | null> {
+  const existing = await daemonStatus();
+  if (existing) return existing;
+  const { spawn } = await import("node:child_process");
+  // Resolve our own launcher the way serve/schedule do: on POSIX `ay` is a
+  // `#!/usr/bin/env bun` script (run via process.execPath), on Windows it's a
+  // self-contained ay.exe. Fall back to a bare `ay` on PATH.
+  const ayBin = Bun.which("ay");
+  const launcher = ayBin
+    ? process.platform === "win32"
+      ? [ayBin]
+      : [process.execPath, ayBin]
+    : ["ay"];
+  const [cmd, ...pre] = launcher;
+  const child = spawn(cmd!, [...pre, "notifyd", "run"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  // Give it a moment to acquire the lock + write its pidfile.
+  await new Promise((r) => setTimeout(r, 300));
+  return daemonStatus();
+}

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -190,6 +190,16 @@ async function observeChildren(): Promise<ObserveResult> {
     const parent = r.parent_pid;
     if (typeof parent !== "number" || parent <= 0) continue;
     if (!watching.has(parent)) continue; // scope: only watched parents' children
+    // Cross-session guard: a child cannot predate its parent, so a child of THIS
+    // watcher incarnation must have started at/after it. Exclude a stale orphan
+    // spawned under a PRIOR agent that held this pid (now recycled by the current
+    // watcher) — otherwise its state/tail/question would be mis-delivered to an
+    // unrelated session. (The child record carries parent_pid but not the parent's
+    // start time, so we rely on the invariant child.started_at >= parent.started_at;
+    // pids are unique among live processes, so pid-match + this bound pins the
+    // exact incarnation.)
+    const watcherStart = watching.get(parent) ?? 0;
+    if (watcherStart > 0 && r.started_at < watcherStart) continue;
     const { state, question } = await deriveLiveState(r);
     // Parent start time: prefer the WATCHER's self-reported value (authoritative,
     // never 0) over a registry-wrapper lookup that can miss and stamp a 0 — a 0
@@ -433,6 +443,13 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   const pendingRetry = new Map<string, Omit<NotifyEvent, "seq">>();
 
   while (running) {
+    // Cooperative stop: `notify notifyd stop` removes our lock rather than
+    // SIGTERM-ing a possibly-recycled pid. If our lock is gone (or taken over),
+    // exit gracefully.
+    if ((await readDaemonOwnerToken()) !== daemonToken) {
+      logger.debug("[notifyd] lock lost/removed — exiting");
+      break;
+    }
     const { next, watcherCount } = await tickState(host, prev, pendingRetry);
     prev = next;
     ticks++;
@@ -599,6 +616,21 @@ export async function daemonIdentity(now = Date.now()): Promise<DaemonIdentity |
 /** The running daemon's pid, or null (see daemonIdentity for the trust rules). */
 export async function daemonStatus(now = Date.now()): Promise<number | null> {
   return (await daemonIdentity(now))?.pid ?? null;
+}
+
+/**
+ * Cooperatively request the running daemon to stop, NON-DESTRUCTIVELY: remove its
+ * lock rather than SIGTERM-ing the pid. The daemon checks its owner token every
+ * tick and exits when the lock is gone, so a pid recycled onto an unrelated
+ * process is never signalled. Returns the daemon's pid if one was running, else
+ * null. (A wedged daemon that isn't ticking relies on OS/self-exit — a residual
+ * tracked in the follow-up issue.)
+ */
+export async function requestDaemonStop(): Promise<number | null> {
+  const id = await daemonIdentity();
+  if (!id) return null;
+  await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+  return id.pid;
 }
 
 /** Ensure a daemon is running; best-effort spawn detached. Returns its pid or null. */

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -155,18 +155,22 @@ async function observeChildren(): Promise<ObserveResult> {
     if (typeof parent !== "number" || parent <= 0) continue;
     if (!watching.has(parent)) continue; // scope: only watched parents' children
     const { state, question } = await deriveLiveState(r);
+    // Parent start time: prefer the WATCHER's self-reported value (authoritative,
+    // never 0) over a registry-wrapper lookup that can miss and stamp a 0 — a 0
+    // would slip past the reader's parent pid-reuse guard.
+    const parentStart = watching.get(parent) || startedAtByWrapper.get(parent) || 0;
     obs.push({
       pid: r.pid,
       wrapper_pid: r.wrapper_pid ?? undefined,
       started_at: r.started_at,
       parent_pid: parent,
-      parent_started_at: startedAtByWrapper.get(parent) ?? 0,
+      parent_started_at: parentStart,
       cli: r.cli,
       cwd: r.cwd,
       state,
       question,
     });
-    parentStartedAt.set(r.pid, startedAtByWrapper.get(parent) ?? 0);
+    parentStartedAt.set(r.pid, parentStart);
     childStartedAt.set(r.pid, r.started_at);
     logFiles.set(r.pid, r.log_file ?? null);
   }

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -629,6 +629,14 @@ export async function daemonStatus(now = Date.now()): Promise<number | null> {
 export async function requestDaemonStop(): Promise<number | null> {
   const id = await daemonIdentity();
   if (!id) return null;
+  // Capture the owner's fencing token, then RE-READ it right before removing the
+  // lock: if daemon A exited and B took over between the identity check and the
+  // rm, the token changed → we must NOT remove B's lock (which would stop the new
+  // daemon). Same fence discipline as the lock release.
+  const token1 = await readDaemonOwnerToken();
+  if (token1 === null) return null;
+  const token2 = await readDaemonOwnerToken();
+  if (token2 !== token1) return null; // taken over between reads — don't touch it
   await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
   return id.pid;
 }

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -20,7 +20,6 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, rm, stat, writeFile } from "fs/promises";
 import {
   type ChildObservation,
-  type PendingNotification,
   type RouterState,
   stepRouter,
 } from "./notifyRouter.ts";
@@ -235,11 +234,17 @@ export interface DaemonOptions {
   once?: boolean;
 }
 
-// How long an owner heartbeat stays "trusted" — a running daemon refreshes it
-// each tick (POLL_MS), so a recycled pid (which isn't refreshing THIS file) reads
-// as stale within a few ticks and is neither trusted for `status` nor killed by
-// `stop`. Kept tight (a few ticks) to shrink the pid-reuse window.
-const OWNER_TTL_MS = 3 * POLL_MS;
+// How long an owner heartbeat stays "trusted". A background timer refreshes it
+// every OWNER_TTL/3 (decoupled from tick duration). Set comfortably ABOVE any
+// realistic SYNCHRONOUS event-loop block, so a slow tick can't let the heartbeat
+// go stale and have another `watch` steal the singleton lock → double daemon.
+// The daemon loop is all `await`s (log render + git are async, reconcile runs
+// once at startup), so it never blocks the loop for seconds — but a single-
+// threaded JS process can only bound, not eliminate, an event-loop-block false
+// steal (a worker-isolated heartbeat would be needed to close it; tracked as a
+// follow-up). 30s also bounds the `stop` pid-reuse window (mitigated further by
+// the pid+started_at re-check before SIGTERM).
+const OWNER_TTL_MS = 30_000;
 
 export interface DaemonIdentity {
   pid: number;
@@ -424,9 +429,11 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   );
   let ticks = 0;
   let emptySince: number | null = null;
+  // Durable across ticks: edges whose append failed, retried until they land.
+  const pendingRetry = new Map<string, Omit<NotifyEvent, "seq">>();
 
   while (running) {
-    const { next, watcherCount } = await tickState(host, prev);
+    const { next, watcherCount } = await tickState(host, prev, pendingRetry);
     prev = next;
     ticks++;
     if (ticks % GC_EVERY_TICKS === 0) await gcTick(host).catch(() => {});
@@ -444,10 +451,30 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   return 0;
 }
 
+/**
+ * A durable-in-memory retry queue for edges whose append failed. Keyed by the
+ * event's identity so a pid reused by a different child never collides (the key
+ * includes child_started_at). The router state is NOT rolled back on failure —
+ * re-delivery is owned entirely by this queue, so a failed OLD-child exited and
+ * the NEW same-pid child's edges are retried independently (at-least-once per
+ * event). Bounded so a permanently-unwritable inbox can't grow it without bound.
+ */
+const RETRY_CAP = 1000;
+function retryKey(e: Omit<NotifyEvent, "seq">): string {
+  return `${e.parent_pid}:${e.child_pid}:${e.child_started_at ?? 0}:${e.edge}:${e.ts}`;
+}
+
 async function tickState(
   host: string,
   prev: RouterState,
+  pendingRetry: Map<string, Omit<NotifyEvent, "seq">> = new Map(),
 ): Promise<{ next: RouterState; watcherCount: number }> {
+  // First, retry anything a previous tick couldn't append (transient FS/lock
+  // blip). Success removes it; a persistent failure stays queued for next tick.
+  for (const [k, stored] of pendingRetry) {
+    if (await appendWithRetry(stored)) pendingRetry.delete(k);
+  }
+
   const { obs, parentStartedAt, childStartedAt, logFiles, aliveChildStartedAt, watcherCount } =
     await observeChildren();
   const { events, next } = stepRouter(prev, obs, Date.now(), { aliveChildStartedAt });
@@ -492,17 +519,16 @@ async function tickState(
       return stored;
     }),
   );
-  for (let i = 0; i < enriched.length; i++) {
-    const stored = enriched[i]!;
-    const ev = events[i]!;
-    const ok = await appendWithRetry(stored);
-    if (!ok) {
-      // at-least-once: a transient FS/lock failure must NOT permanently drop an
-      // edge. Roll back this edge's "emitted" mark in the next state so the next
-      // tick re-detects and re-appends it (a duplicate is acceptable; a drop is
-      // not). Scoped to this child only — no cross-parent re-emission.
-      rollbackEmit(next, ev);
-      logger.warn(`[notifyd] append failed for parent ${stored.parent_pid} — will retry next tick`);
+  for (const stored of enriched) {
+    if (await appendWithRetry(stored)) continue;
+    // at-least-once: a transient FS/lock failure must NOT drop an edge. Queue it
+    // by IDENTITY for re-append on a later tick — never touch the router state
+    // (which is keyed by pid and can't hold both an old and a new same-pid child).
+    if (pendingRetry.size < RETRY_CAP) {
+      pendingRetry.set(retryKey(stored), stored);
+      logger.warn(`[notifyd] append failed for parent ${stored.parent_pid} — queued for retry`);
+    } else {
+      logger.warn(`[notifyd] retry queue full (${RETRY_CAP}) — dropping edge for parent ${stored.parent_pid}`);
     }
   }
   return { next, watcherCount };
@@ -519,41 +545,6 @@ async function appendWithRetry(stored: Omit<NotifyEvent, "seq">, attempts = 3): 
     }
   }
   return false;
-}
-
-/**
- * Undo the router's "emitted" mark for one edge so the NEXT tick re-emits it
- * (used when its append failed). For a synthetic exited whose child was dropped
- * from `next`, re-insert a minimal tracked state so the vanished-loop re-fires.
- */
-function rollbackEmit(next: RouterState, ev: PendingNotification): void {
-  const cs = next.get(ev.child_pid);
-  if (cs) {
-    if (ev.edge === "idle") cs.idleEmitted = false;
-    else if (ev.edge === "needs_input") {
-      cs.inNeedsInput = false;
-      cs.needsInputQuestion = null;
-    } else if (ev.edge === "exited") cs.exitedEmitted = false;
-    return;
-  }
-  if (ev.edge === "exited") {
-    // Synthetic exited for a child already dropped from tracking — re-add it so
-    // the next tick's vanished-loop retries the exited append.
-    next.set(ev.child_pid, {
-      parent_pid: ev.parent_pid,
-      wrapper_pid: ev.child_wrapper_pid,
-      started_at: ev.child_started_at,
-      parent_started_at: ev.parent_started_at,
-      cli: ev.cli,
-      cwd: ev.cwd,
-      state: ev.prev_state ?? "active",
-      idleSince: null,
-      idleEmitted: false,
-      inNeedsInput: false,
-      needsInputQuestion: null,
-      exitedEmitted: false,
-    });
-  }
 }
 
 async function gcTick(host: string): Promise<void> {

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -160,6 +160,7 @@ async function observeChildren(): Promise<ObserveResult> {
       wrapper_pid: r.wrapper_pid ?? undefined,
       started_at: r.started_at,
       parent_pid: parent,
+      parent_started_at: startedAtByWrapper.get(parent) ?? 0,
       cli: r.cli,
       cwd: r.cwd,
       state,
@@ -207,35 +208,61 @@ async function writeOwner(): Promise<void> {
 }
 
 /**
- * Acquire the singleton lock, stealing a stale one whose owner is dead. The
- * liveness predicate is injectable so the steal/keep race is unit-testable.
- * Returns true if WE now hold the lock, false if a LIVE owner holds it.
+ * Acquire the singleton lock. Returns true if WE now hold it, false if a LIVE
+ * daemon already does. Shares the inbox lock's invariant: ownership is proven by
+ * `mkdir(recursive:false)`, and a lock is stolen only when its owner is dead or
+ * its heartbeat is stale — never on a torn/empty owner WITHIN the grace (the
+ * mkdir→writeOwner window of another daemon coming up), so two concurrent starts
+ * can't both "win". The liveness predicate is injectable for tests.
  */
 export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPidAlive): Promise<boolean> {
   // The lock dir lives under notify/ — ensure that exists first, else mkdir of
   // the lock throws ENOENT which must NOT be mistaken for "someone holds it".
   await mkdir(notifyDir(), { recursive: true }).catch(() => {});
-  for (let attempt = 0; attempt < 3; attempt++) {
+  const start = Date.now();
+  const GRACE_MS = 1000;
+  const HARD_MS = 15_000;
+  for (;;) {
     try {
       await mkdir(daemonLockDir(), { recursive: false });
       await writeOwner();
       return true;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e; // real error — propagate
-      // Lock exists — is its owner still alive?
       const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");
-      let ownerPid = 0;
+      let owner: { pid?: number; ts?: number } | null = null;
       try {
-        ownerPid = (JSON.parse(raw) as { pid: number }).pid ?? 0;
+        owner = JSON.parse(raw) as { pid: number; ts: number };
       } catch {
-        /* missing/torn owner — treat as stale */
+        /* torn / not-yet-written */
       }
-      if (ownerPid > 0 && ownerPid !== process.pid && isAlive(ownerPid)) return false; // live daemon
-      // Stale (dead owner or unreadable) — steal and retry.
-      await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+      const now = Date.now();
+      const elapsed = now - start;
+      // A COMPLETE, live, fresh owner (a different daemon) → we are not it.
+      if (
+        owner &&
+        typeof owner.pid === "number" &&
+        owner.pid > 0 &&
+        owner.pid !== process.pid &&
+        typeof owner.ts === "number" &&
+        now - owner.ts <= OWNER_TTL_MS &&
+        isAlive(owner.pid)
+      ) {
+        return false;
+      }
+      // Dead / stale / torn-past-grace → steal and re-prove via mkdir. A torn
+      // owner within the grace is another daemon mid-acquire: wait, don't steal.
+      const ownerPid = owner?.pid ?? 0;
+      const holderDead = ownerPid > 0 && ownerPid !== process.pid && !isAlive(ownerPid);
+      const holderStale = (owner?.ts ?? 0) > 0 && now - (owner!.ts ?? 0) > OWNER_TTL_MS;
+      const tornPastGrace = (!owner || ownerPid <= 0) && elapsed > GRACE_MS;
+      if (holderDead || holderStale || tornPastGrace || elapsed > HARD_MS) {
+        await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
+        continue;
+      }
+      await new Promise((r) => setTimeout(r, 15)); // torn within grace — wait it out
     }
   }
-  return false;
 }
 
 /**
@@ -316,7 +343,10 @@ async function tickState(
         parent_pid: ev.parent_pid,
         // The parent's/child's start times — the read side and the startup
         // reconcile reject an event whose start time disagrees, guarding pid reuse.
-        parent_started_at: parentStartedAt.get(ev.child_pid) ?? 0,
+        // Carried by the router so a synthetic exited (child gone from the live
+        // set) still stamps the real parent start, not 0 (which would bypass the
+        // reader's parent guard). Fall back to the live map, then 0.
+        parent_started_at: ev.parent_started_at ?? parentStartedAt.get(ev.child_pid) ?? 0,
         child_pid: ev.child_pid,
         child_wrapper_pid: ev.child_wrapper_pid,
         // Carried by the router (survives a synthetic exited for a vanished child,
@@ -361,6 +391,14 @@ async function gcTick(host: string): Promise<void> {
  * file, so its stale ts (or a torn/partial owner) yields null — we never trust or
  * kill an unrelated process. `stop` re-reads and re-checks this identity right
  * before signalling, so it can't SIGTERM a pid recycled between status and stop.
+ *
+ * Residual edge (documented, not yet closed): a pid recycled onto an UNRELATED
+ * live process WITHIN the tight OWNER_TTL window (a few ticks) could be briefly
+ * trusted, since we compare our recorded `started_at` against the owner file, not
+ * against the OS's actual process start time (which is non-portable to read:
+ * `/proc/<pid>/stat` on Linux vs `proc_pidinfo`/`ps -o lstart` on macOS). The
+ * heartbeat freshness + tight TTL keep the window to seconds; a real OS
+ * start-time cross-check is deferred to a future issue.
  */
 export async function daemonIdentity(now = Date.now()): Promise<DaemonIdentity | null> {
   const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -17,7 +17,7 @@
 
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "fs/promises";
 import {
   type ChildObservation,
   type PendingNotification,
@@ -86,9 +86,15 @@ async function recentTail(logFile: string | null | undefined): Promise<string | 
 export async function reconcileFromInboxes(
   host: string,
   liveChildren: Map<number, number>,
+  watchedParents: Set<number>,
 ): Promise<RouterState> {
   const state: RouterState = new Map();
   for (const parent of await listInboxParents(host)) {
+    // Scope to CURRENTLY-watched parents only. Seeding an unwatched parent's
+    // inbox would let this daemon carry its children forward and later write a
+    // synthetic exited into an inbox nobody is watching — violating "nothing
+    // happens unless you watch".
+    if (!watchedParents.has(parent)) continue;
     const events = await readInbox(host, parent);
     const lastByChild = new Map<number, NotifyEvent>();
     const exitedChildren = new Set<number>();
@@ -253,12 +259,22 @@ async function readDaemonOwnerToken(): Promise<string | null> {
   }
 }
 
-/** Stamp the lock owner file with our identity + a fresh heartbeat ts + token. */
+/**
+ * Stamp the lock owner file with our identity + a fresh heartbeat ts + token,
+ * ATOMICALLY (temp + rename) so a reader (status/stop/another daemon) never sees
+ * a torn owner mid-write — a null read then reliably means "no owner file yet".
+ */
 async function writeOwner(): Promise<void> {
-  await writeFile(
-    daemonLockOwnerPath(),
-    JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now(), token: daemonToken }),
-  ).catch(() => {});
+  const tmp = `${daemonLockOwnerPath()}.${daemonToken}.tmp`;
+  try {
+    await writeFile(
+      tmp,
+      JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now(), token: daemonToken }),
+    );
+    await rename(tmp, daemonLockOwnerPath());
+  } catch {
+    await rm(tmp, { force: true }).catch(() => {});
+  }
 }
 
 /**
@@ -273,7 +289,6 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
   // The lock dir lives under notify/ — ensure that exists first, else mkdir of
   // the lock throws ENOENT which must NOT be mistaken for "someone holds it".
   await mkdir(notifyDir(), { recursive: true }).catch(() => {});
-  const start = Date.now();
   for (;;) {
     try {
       await mkdir(daemonLockDir(), { recursive: false });
@@ -308,10 +323,15 @@ export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPi
       // torn-past-grace) — the same invariant the per-inbox lock uses, so a
       // torn owner (the mkdir→writeOwner window of a concurrent daemon start) is
       // respected within the grace and two starts can't both win. Else wait.
+      const lockAgeMs =
+        now -
+        (await stat(daemonLockDir())
+          .then((s) => s.mtimeMs)
+          .catch(() => now));
       if (
         shouldStealLock(raw, now, {
           staleMs: OWNER_TTL_MS,
-          elapsed: now - start,
+          lockAgeMs,
           selfPid: process.pid,
           isAlive,
         })
@@ -337,7 +357,8 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
     // already running — otherwise we'd re-emit baselines it has handled — and
     // seed from the inbox so even standalone we don't duplicate prior edges.
     if (await daemonStatus()) return 0;
-    const prev = await reconcileFromInboxes(host, await liveChildrenSnapshot());
+    const watched = new Set((await liveWatchers()).keys());
+    const prev = await reconcileFromInboxes(host, await liveChildrenSnapshot(), watched);
     await tickState(host, prev);
     return 0;
   }
@@ -354,10 +375,12 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   // Refresh well inside the TTL; cleared on shutdown.
   const ownerBeat = setInterval(() => {
     void (async () => {
-      // Stop beating (and never overwrite) if we've been superseded — the fencing
-      // token in the owner file is no longer ours.
-      const cur = await readDaemonOwnerToken();
-      if (cur !== null && cur !== daemonToken) {
+      // Refresh ONLY while the owner still carries OUR token. Any other value — a
+      // different token (superseded) OR null/absent (a new daemon's mkdir→write
+      // window) — means we no longer own it, so stop rather than clobber an
+      // unknown/absent owner. Atomic writeOwner means a null read is never our own
+      // write in flight.
+      if ((await readDaemonOwnerToken()) !== daemonToken) {
         clearInterval(ownerBeat);
         return;
       }
@@ -376,9 +399,14 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   process.on("SIGINT", () => void cleanup().then(() => process.exit(0)));
   process.on("SIGTERM", () => void cleanup().then(() => process.exit(0)));
 
-  // Seed the router from prior inbox state, guarded against pid reuse by the
-  // current registry snapshot (see reconcileFromInboxes).
-  let prev = await reconcileFromInboxes(host, await liveChildrenSnapshot());
+  // Seed the router from prior inbox state — scoped to currently-watched parents
+  // and guarded against pid reuse by the current registry snapshot.
+  const watchedAtStart = new Set((await liveWatchers()).keys());
+  let prev = await reconcileFromInboxes(
+    host,
+    await liveChildrenSnapshot(),
+    watchedAtStart,
+  );
   let ticks = 0;
   let emptySince: number | null = null;
 

--- a/ts/notifyInbox.spec.ts
+++ b/ts/notifyInbox.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import path from "path";
+import {
+  type NotifyEvent,
+  notifyDir,
+  filterSinceSeq,
+  filterSinceTs,
+  filterUnread,
+  inboxPath,
+  inboxesToGC,
+  maxSeq,
+  nextSeq,
+  parseCursor,
+  parseInboxText,
+  rotateKeep,
+  serializeCursor,
+  serializeEvent,
+} from "./notifyInbox.ts";
+
+const ev = (over: Partial<NotifyEvent> = {}): NotifyEvent => ({
+  seq: 1,
+  ts: 1_000,
+  host: "h1",
+  parent_pid: 1,
+  child_pid: 100,
+  cli: "claude",
+  cwd: "/repo",
+  edge: "idle",
+  prev_state: "active",
+  state: "idle",
+  question: null,
+  ...over,
+});
+
+describe("notifyInbox — paths", () => {
+  it("namespaces the inbox by host and parent pid", () => {
+    const p = inboxPath("my-host", 42);
+    expect(p).toContain("notify");
+    expect(p.endsWith("42.ndjson")).toBe(true);
+    expect(p).toContain("my-host");
+  });
+
+  it("sanitizes an unsafe host so the path stays inside the notify dir", () => {
+    const p = path.resolve(inboxPath("../../etc", 1));
+    // Separators are stripped, so the resolved path can't climb out of notify/
+    // even though the dots survive as harmless literal filename chars.
+    expect(p.startsWith(path.resolve(notifyDir()) + path.sep)).toBe(true);
+  });
+});
+
+describe("notifyInbox — NDJSON round-trip + torn-line tolerance", () => {
+  it("serializes and re-parses an event", () => {
+    const line = serializeEvent(ev({ seq: 7 }));
+    const [got] = parseInboxText(line);
+    expect(got!.seq).toBe(7);
+    expect(got!.edge).toBe("idle");
+  });
+
+  it("skips a torn final line from a mid-append writer", () => {
+    const text = serializeEvent(ev({ seq: 1 })) + "\n" + serializeEvent(ev({ seq: 2 })) + "\n{ \"seq\": 3, \"ed";
+    const got = parseInboxText(text);
+    expect(got.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  it("ignores blank lines and non-event JSON", () => {
+    const text = ["", serializeEvent(ev({ seq: 1 })), "  ", "42", '{"foo":"bar"}'].join("\n");
+    const got = parseInboxText(text);
+    expect(got.map((e) => e.seq)).toEqual([1]);
+  });
+});
+
+describe("notifyInbox — seq allocation", () => {
+  it("nextSeq increments the last stored seq", () => {
+    expect(nextSeq(0)).toBe(1);
+    expect(nextSeq(41)).toBe(42);
+  });
+
+  it("nextSeq treats a missing/garbage counter as 0", () => {
+    expect(nextSeq(NaN)).toBe(1);
+    expect(nextSeq(-5)).toBe(1);
+  });
+
+  it("maxSeq finds the highest seq in an inbox (0 when empty)", () => {
+    expect(maxSeq([])).toBe(0);
+    expect(maxSeq([ev({ seq: 3 }), ev({ seq: 9 }), ev({ seq: 5 })])).toBe(9);
+  });
+});
+
+describe("notifyInbox — watermark filtering", () => {
+  const events = [ev({ seq: 1, ts: 100 }), ev({ seq: 2, ts: 200 }), ev({ seq: 3, ts: 300 })];
+
+  it("filterSinceSeq returns strictly-greater seqs", () => {
+    expect(filterSinceSeq(events, 1).map((e) => e.seq)).toEqual([2, 3]);
+    expect(filterSinceSeq(events, 0).map((e) => e.seq)).toEqual([1, 2, 3]);
+    expect(filterSinceSeq(events, undefined).map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("filterSinceTs returns events at/after a wall-clock bound", () => {
+    expect(filterSinceTs(events, 200).map((e) => e.seq)).toEqual([2, 3]);
+  });
+
+  it("filterUnread returns seqs above the cursor", () => {
+    expect(filterUnread(events, 2).map((e) => e.seq)).toEqual([3]);
+    expect(filterUnread(events, 0).map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("notifyInbox — cursor", () => {
+  it("round-trips a cursor", () => {
+    expect(parseCursor(serializeCursor(5))).toEqual({ seq: 5 });
+  });
+
+  it("reads a missing/garbage cursor as seq 0", () => {
+    expect(parseCursor(null)).toEqual({ seq: 0 });
+    expect(parseCursor("not json")).toEqual({ seq: 0 });
+    expect(parseCursor('{"seq":-1}')).toEqual({ seq: 0 });
+  });
+});
+
+describe("notifyInbox — retention", () => {
+  it("GCs an inbox whose parent is dead and unreferenced by any live child", () => {
+    const gc = inboxesToGC([1, 2, 3], new Set([2]), new Set([3]));
+    // parent 1: dead + no live child → GC. parent 2: alive → keep. parent 3:
+    // referenced by a live child → keep.
+    expect(gc).toEqual([1]);
+  });
+
+  it("keeps everything when all parents are alive", () => {
+    expect(inboxesToGC([1, 2], new Set([1, 2]), new Set())).toEqual([]);
+  });
+});
+
+describe("notifyInbox — rotation", () => {
+  it("keeps the newest events within the byte cap, preserving a minimum", () => {
+    const events = Array.from({ length: 500 }, (_, i) => ev({ seq: i + 1 }));
+    const kept = rotateKeep(events, 200, 10);
+    expect(kept.length).toBeGreaterThanOrEqual(10);
+    expect(kept.length).toBeLessThan(500);
+    // newest are retained, in ascending order
+    expect(kept[kept.length - 1]!.seq).toBe(500);
+    expect(kept[0]!.seq).toBeLessThan(kept[kept.length - 1]!.seq);
+  });
+
+  it("returns everything when under minKeep", () => {
+    const events = [ev({ seq: 1 }), ev({ seq: 2 })];
+    expect(rotateKeep(events, 1, 100).map((e) => e.seq)).toEqual([1, 2]);
+  });
+});

--- a/ts/notifyInbox.spec.ts
+++ b/ts/notifyInbox.spec.ts
@@ -68,6 +68,14 @@ describe("notifyInbox — NDJSON round-trip + torn-line tolerance", () => {
     const got = parseInboxText(text);
     expect(got.map((e) => e.seq)).toEqual([1]);
   });
+
+  it("drops a partial event missing correlation fields (full validation)", () => {
+    const partial = JSON.stringify({ seq: 2, edge: "idle" }); // no parent_pid/child_pid/cwd
+    const badEdge = JSON.stringify({ ...ev({ seq: 3 }), edge: "bogus" });
+    const text = [serializeEvent(ev({ seq: 1 })), partial, badEdge].join("\n");
+    // Only the fully-formed event survives to a consumer's output.
+    expect(parseInboxText(text).map((e) => e.seq)).toEqual([1]);
+  });
 });
 
 describe("notifyInbox — seq allocation", () => {

--- a/ts/notifyInbox.spec.ts
+++ b/ts/notifyInbox.spec.ts
@@ -8,6 +8,7 @@ import {
   filterUnread,
   inboxPath,
   inboxesToGC,
+  liveWatcherPids,
   maxSeq,
   nextSeq,
   parseCursor,
@@ -131,18 +132,53 @@ describe("notifyInbox — retention", () => {
 });
 
 describe("notifyInbox — rotation", () => {
-  it("keeps the newest events within the byte cap, preserving a minimum", () => {
-    const events = Array.from({ length: 500 }, (_, i) => ev({ seq: i + 1 }));
-    const kept = rotateKeep(events, 200, 10);
-    expect(kept.length).toBeGreaterThanOrEqual(10);
+  const many = () => Array.from({ length: 500 }, (_, i) => ev({ seq: i + 1 }));
+
+  it("keeps EVERYTHING when nothing is acked (min cursor 0) — at-least-once", () => {
+    // Every event is unacked, so none may be dropped even under a tiny cap. The
+    // inbox only shrinks once a consumer acks (advances its cursor).
+    const kept = rotateKeep(many(), 1, 0, 10);
+    expect(kept.length).toBe(500);
+  });
+
+  it("trims ACKED events (below the min cursor) under the byte cap", () => {
+    // seq 1..495 acked (min cursor 495), 496..500 unacked → only acked ones are
+    // eligible for eviction under the tiny cap.
+    const kept = rotateKeep(many(), 1, 495, 5);
     expect(kept.length).toBeLessThan(500);
-    // newest are retained, in ascending order
-    expect(kept[kept.length - 1]!.seq).toBe(500);
-    expect(kept[0]!.seq).toBeLessThan(kept[kept.length - 1]!.seq);
+    expect(kept[kept.length - 1]!.seq).toBe(500); // newest retained
+    expect(kept.some((e) => e.seq === 1)).toBe(false); // old acked evicted
+    for (let seq = 496; seq <= 500; seq++) expect(kept.some((e) => e.seq === seq)).toBe(true);
+  });
+
+  it("NEVER evicts an unacked event above the min cursor (at-least-once)", () => {
+    // protectAboveSeq=490 → every event with seq>490 must survive even under a
+    // tiny cap and a small minKeep. This is the guarantee codex flagged.
+    const kept = rotateKeep(many(), 1, 490, 5);
+    for (let seq = 491; seq <= 500; seq++) {
+      expect(kept.some((e) => e.seq === seq)).toBe(true);
+    }
+    expect(kept.length).toBeLessThan(500); // older, acked events still trimmed
   });
 
   it("returns everything when under minKeep", () => {
     const events = [ev({ seq: 1 }), ev({ seq: 2 })];
-    expect(rotateKeep(events, 1, 100).map((e) => e.seq)).toEqual([1, 2]);
+    expect(rotateKeep(events, 1, 0, 100).map((e) => e.seq)).toEqual([1, 2]);
+  });
+});
+
+describe("notifyInbox — watcher liveness", () => {
+  it("counts only heartbeats within the TTL", () => {
+    const now = 100_000;
+    const live = liveWatcherPids(
+      [
+        { pid: 1, ts: now - 1_000 }, // fresh
+        { pid: 2, ts: now - 999_999 }, // stale
+        { pid: 3, ts: now }, // fresh
+      ],
+      now,
+      15_000,
+    );
+    expect([...live].sort()).toEqual([1, 3]);
   });
 });

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure, fs-free core for the subagent→parent notification inbox — the storage
+ * and watermark layer under `ay notify` / `ay notifyd`.
+ *
+ * Motivation (real incident): a parent agent fanned out sub-agents that finished
+ * their work but sat at an idle `❯` prompt WITHOUT exiting (claude-yes does not
+ * exit on idle). Claude Code's background-task notification only fires on process
+ * EXIT, so the parent never learned the children went idle and left them parked
+ * 16 minutes. `ay ls --watch` already streams transitions, but it is PULL: the
+ * parent must run the watch loop. The whole point of this pain is the parent is
+ * NOT watching. So we accumulate qualifying edges into a per-parent append-only
+ * inbox that the parent drains on its own schedule (its Monitor loop), with a
+ * persisted cursor so a parent that restarts reads only the unread edges.
+ *
+ * This module is the pure part (path math, NDJSON (de)serialization, seq/cursor
+ * filtering, retention decisions) so it is trivially unit-testable, mirroring
+ * `lsWatch.ts` / `needsInput.ts` / `resultEnvelope.ts`. The fs read/write + lock
+ * + CLI live in `subcommands.ts`; the detection/debounce lives in
+ * `notifyRouter.ts`.
+ */
+
+import path from "path";
+import { agentYesHome } from "./agentYesHome.ts";
+
+/** The three edges we deliver — the inverse of "background notify on EXIT only". */
+export type NotifyEdge = "needs_input" | "idle" | "exited";
+
+/**
+ * One notification, as stored (one NDJSON line) and streamed. `seq` is the
+ * authoritative monotonic watermark within a single parent inbox; `ts` is a
+ * display/filter convenience (clock skew means it is NOT the ordering key).
+ */
+export interface NotifyEvent {
+  /** Monotonic per-inbox sequence; the watermark a cursor compares against. */
+  seq: number;
+  ts: number;
+  /** Local host id (pid namespace is per-host); also encoded in the path. */
+  host: string;
+  /** The parent this edge is addressed to (parent wrapper pid). */
+  parent_pid: number;
+  /** Parent's start time, to reject a pid-reuse mismatch on read. Optional. */
+  parent_started_at?: number;
+  /** The child that transitioned. */
+  child_pid: number;
+  child_wrapper_pid?: number;
+  cli: string;
+  cwd: string;
+  edge: NotifyEdge;
+  /** The state the child was in before this edge (for context). */
+  prev_state: string | null;
+  /** The child's state now (redundant with `edge` but explicit). */
+  state: string;
+  /** Compact question text when edge === "needs_input", else null. */
+  question: string | null;
+  /** Best-effort recent output tail (last few lines), so the parent needn't tail. */
+  tail?: string | null;
+  /** Best-effort short git HEAD of the child's cwd. */
+  git_head?: string | null;
+}
+
+/** Root dir for all notification state. */
+export function notifyDir(): string {
+  return path.join(agentYesHome(), "notify");
+}
+
+/** Per-host inbox directory (pids are only unique within a host). */
+export function inboxDir(host: string): string {
+  return path.join(notifyDir(), "inbox", sanitizeHost(host));
+}
+
+/** Absolute path of one parent's append-only NDJSON inbox. */
+export function inboxPath(host: string, parentPid: number): string {
+  return path.join(inboxDir(host), `${parentPid}.ndjson`);
+}
+
+/** Sidecar seq counter for a parent inbox (last allocated seq). */
+export function seqPath(host: string, parentPid: number): string {
+  return path.join(inboxDir(host), `${parentPid}.seq`);
+}
+
+/** Per-consumer cursor directory for a parent inbox. */
+export function cursorDir(host: string, parentPid: number): string {
+  return path.join(notifyDir(), "cursors", sanitizeHost(host), String(parentPid));
+}
+
+/** Absolute path of one consumer's cursor file for a parent inbox. */
+export function cursorPath(host: string, parentPid: number, consumer = "parent"): string {
+  return path.join(cursorDir(host, parentPid), `${sanitizeConsumer(consumer)}.json`);
+}
+
+/** Opt-in marker directory — a child that spawned with `--notify-parent`. */
+export function optinDir(): string {
+  return path.join(notifyDir(), "optin");
+}
+
+/** Marker path for one opted-in child (keyed by its wrapper pid). */
+export function optinMarkerPath(childWrapperPid: number): string {
+  return path.join(optinDir(), `${childWrapperPid}.json`);
+}
+
+/** The daemon singleton lock dir (mkdir-based, like pidStore). */
+export function daemonLockDir(): string {
+  return path.join(notifyDir(), "notifyd.lock");
+}
+
+/** Where the running daemon records its pid, for `ay notifyd status/stop`. */
+export function daemonPidPath(): string {
+  return path.join(notifyDir(), "notifyd.pid");
+}
+
+// Path-segment hygiene: a hostname or consumer label must never escape the
+// notify dir or collide via separators. Keep it filesystem-safe and stable.
+function sanitizeHost(host: string): string {
+  return host.replace(/[^A-Za-z0-9._-]/g, "_") || "localhost";
+}
+function sanitizeConsumer(consumer: string): string {
+  return consumer.replace(/[^A-Za-z0-9._-]/g, "_") || "parent";
+}
+
+/** Serialize one event to its NDJSON line (no trailing newline). */
+export function serializeEvent(ev: NotifyEvent): string {
+  return JSON.stringify(ev);
+}
+
+/**
+ * Parse an inbox's raw text into events. Tolerant by design: a torn final line
+ * (a writer mid-append) or any unparseable line is skipped, never throws — a
+ * reader must survive a concurrent writer. Order is file order (= seq order,
+ * since a single locked writer appends in increasing seq).
+ */
+export function parseInboxText(text: string): NotifyEvent[] {
+  const out: NotifyEvent[] = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const ev = JSON.parse(t) as NotifyEvent;
+      if (ev && typeof ev.seq === "number" && typeof ev.edge === "string") out.push(ev);
+    } catch {
+      /* torn / malformed line — skip */
+    }
+  }
+  return out;
+}
+
+/** Next seq to allocate given the last stored seq counter (or the inbox max). */
+export function nextSeq(lastSeq: number): number {
+  return (Number.isFinite(lastSeq) && lastSeq > 0 ? lastSeq : 0) + 1;
+}
+
+/** Highest seq present in a parsed inbox (0 when empty). */
+export function maxSeq(events: NotifyEvent[]): number {
+  let m = 0;
+  for (const e of events) if (e.seq > m) m = e.seq;
+  return m;
+}
+
+/**
+ * Filter events for `--since <seq>`: strictly-greater than the given seq. A
+ * `since` of 0/undefined returns everything.
+ */
+export function filterSinceSeq(events: NotifyEvent[], sinceSeq: number | undefined): NotifyEvent[] {
+  if (!sinceSeq || sinceSeq <= 0) return events.slice();
+  return events.filter((e) => e.seq > sinceSeq);
+}
+
+/** Filter events after a wall-clock `--since <ts>` (inclusive lower bound). */
+export function filterSinceTs(events: NotifyEvent[], sinceTs: number | undefined): NotifyEvent[] {
+  if (!sinceTs || sinceTs <= 0) return events.slice();
+  return events.filter((e) => e.ts >= sinceTs);
+}
+
+/** Unread = seq strictly greater than the consumer's cursor. */
+export function filterUnread(events: NotifyEvent[], cursorSeq: number): NotifyEvent[] {
+  return events.filter((e) => e.seq > (cursorSeq > 0 ? cursorSeq : 0));
+}
+
+export interface Cursor {
+  seq: number;
+}
+
+/** Parse a cursor file's text; a missing/garbage cursor reads as seq 0. */
+export function parseCursor(text: string | null | undefined): Cursor {
+  if (!text) return { seq: 0 };
+  try {
+    const c = JSON.parse(text) as Cursor;
+    return { seq: Number.isFinite(c?.seq) && c.seq > 0 ? c.seq : 0 };
+  } catch {
+    return { seq: 0 };
+  }
+}
+
+export function serializeCursor(seq: number): string {
+  return JSON.stringify({ seq: Math.max(0, Math.floor(seq)) } satisfies Cursor);
+}
+
+/**
+ * Retention decision (pure): which parent inboxes are eligible for GC. An inbox
+ * is collectable when its parent pid is no longer alive AND no live child still
+ * references it as a parent — then nobody will read or write it again. The
+ * caller supplies the live-pid set and the live child→parent references it
+ * gathered from the registry.
+ */
+export function inboxesToGC(
+  inboxParentPids: number[],
+  livePids: Set<number>,
+  liveChildParentPids: Set<number>,
+): number[] {
+  return inboxParentPids.filter((p) => !livePids.has(p) && !liveChildParentPids.has(p));
+}
+
+/**
+ * Rotation decision (pure): given an inbox's events and a byte cap, return the
+ * events to KEEP after rotating. We never drop an event at-or-below the minimum
+ * un-acked cursor is the caller's concern; here we keep the newest events whose
+ * serialized size fits the cap, always preserving at least `minKeep` newest.
+ */
+export function rotateKeep(events: NotifyEvent[], capBytes: number, minKeep = 100): NotifyEvent[] {
+  if (events.length <= minKeep) return events.slice();
+  const kept: NotifyEvent[] = [];
+  let bytes = 0;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const line = serializeEvent(events[i]!) + "\n";
+    bytes += line.length;
+    if (bytes > capBytes && kept.length >= minKeep) break;
+    kept.push(events[i]!);
+  }
+  kept.reverse();
+  return kept;
+}

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -129,12 +129,18 @@ export function liveWatcherPids(
 }
 
 // Path-segment hygiene: a hostname or consumer label must never escape the
-// notify dir or collide via separators. Keep it filesystem-safe and stable.
+// notify dir or collide via separators. Keep it filesystem-safe and stable, and
+// reject the reserved "." / ".." segments (which dot-permitting sanitization
+// would otherwise pass through as a real relative-path component).
+function sanitizeSegment(s: string, fallback: string): string {
+  const cleaned = s.replace(/[^A-Za-z0-9._-]/g, "_");
+  return cleaned === "" || cleaned === "." || cleaned === ".." ? fallback : cleaned;
+}
 function sanitizeHost(host: string): string {
-  return host.replace(/[^A-Za-z0-9._-]/g, "_") || "localhost";
+  return sanitizeSegment(host, "localhost");
 }
 function sanitizeConsumer(consumer: string): string {
-  return consumer.replace(/[^A-Za-z0-9._-]/g, "_") || "parent";
+  return sanitizeSegment(consumer, "parent");
 }
 
 /** Serialize one event to its NDJSON line (no trailing newline). */

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -181,12 +181,16 @@ function isValidEvent(ev: unknown): ev is NotifyEvent {
   const e = ev as Record<string, unknown>;
   return (
     typeof e.seq === "number" &&
+    typeof e.ts === "number" &&
+    typeof e.host === "string" &&
     typeof e.parent_pid === "number" &&
     typeof e.child_pid === "number" &&
     typeof e.cli === "string" &&
     typeof e.cwd === "string" &&
     typeof e.edge === "string" &&
-    EDGES.has(e.edge)
+    EDGES.has(e.edge) &&
+    typeof e.state === "string" &&
+    (e.question === null || typeof e.question === "string")
   );
 }
 

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -43,6 +43,8 @@ export interface NotifyEvent {
   /** The child that transitioned. */
   child_pid: number;
   child_wrapper_pid?: number;
+  /** Child's start time — guards startup-reconcile seeding against pid reuse. */
+  child_started_at?: number;
   cli: string;
   cwd: string;
   edge: NotifyEdge;
@@ -88,22 +90,16 @@ export function cursorPath(host: string, parentPid: number, consumer = "parent")
   return path.join(cursorDir(host, parentPid), `${sanitizeConsumer(consumer)}.json`);
 }
 
-/** Opt-in marker directory — a child that spawned with `--notify-parent`. */
-export function optinDir(): string {
-  return path.join(notifyDir(), "optin");
-}
-
-/** Marker path for one opted-in child (keyed by its wrapper pid). */
-export function optinMarkerPath(childWrapperPid: number): string {
-  return path.join(optinDir(), `${childWrapperPid}.json`);
-}
-
 /** The daemon singleton lock dir (mkdir-based, like pidStore). */
 export function daemonLockDir(): string {
   return path.join(notifyDir(), "notifyd.lock");
 }
 
-/** Owner metadata inside the lock dir, for stale-lock liveness detection. */
+/**
+ * Owner metadata inside the lock dir ({pid, started_at, ts}) — the SINGLE source
+ * of truth for the running daemon's identity, used for stale-lock steal and for
+ * `notifyd status`/`stop` (a running daemon refreshes `ts` each tick).
+ */
 export function daemonLockOwnerPath(): string {
   return path.join(daemonLockDir(), "owner.json");
 }
@@ -130,11 +126,6 @@ export function liveWatcherPids(
   const out = new Set<number>();
   for (const e of entries) if (now - e.ts <= ttlMs) out.add(e.pid);
   return out;
-}
-
-/** Where the running daemon records its pid, for `ay notifyd status/stop`. */
-export function daemonPidPath(): string {
-  return path.join(notifyDir(), "notifyd.pid");
 }
 
 // Path-segment hygiene: a hostname or consumer label must never escape the

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -161,12 +161,33 @@ export function parseInboxText(text: string): NotifyEvent[] {
     if (!t) continue;
     try {
       const ev = JSON.parse(t) as NotifyEvent;
-      if (ev && typeof ev.seq === "number" && typeof ev.edge === "string") out.push(ev);
+      if (isValidEvent(ev)) out.push(ev);
     } catch {
       /* torn / malformed line — skip */
     }
   }
   return out;
+}
+
+const EDGES = new Set<string>(["needs_input", "idle", "exited"]);
+
+/**
+ * Full shape validation at the storage boundary — a torn/partial line missing
+ * the correlation fields must never flow through to a consumer's output. Every
+ * event we surface has the fields a reader relies on.
+ */
+function isValidEvent(ev: unknown): ev is NotifyEvent {
+  if (!ev || typeof ev !== "object") return false;
+  const e = ev as Record<string, unknown>;
+  return (
+    typeof e.seq === "number" &&
+    typeof e.parent_pid === "number" &&
+    typeof e.child_pid === "number" &&
+    typeof e.cli === "string" &&
+    typeof e.cwd === "string" &&
+    typeof e.edge === "string" &&
+    EDGES.has(e.edge)
+  );
 }
 
 /** Next seq to allocate given the last stored seq counter (or the inbox max). */

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -103,6 +103,35 @@ export function daemonLockDir(): string {
   return path.join(notifyDir(), "notifyd.lock");
 }
 
+/** Owner metadata inside the lock dir, for stale-lock liveness detection. */
+export function daemonLockOwnerPath(): string {
+  return path.join(daemonLockDir(), "owner.json");
+}
+
+/** Registry dir of parents currently running `ay notify watch` (heartbeats). */
+export function watchersDir(): string {
+  return path.join(notifyDir(), "watchers");
+}
+
+/** Heartbeat file for one watching parent. */
+export function watcherPath(parentPid: number): string {
+  return path.join(watchersDir(), `${parentPid}.json`);
+}
+
+/** A watcher heartbeat is "live" if refreshed within this window. */
+export const WATCHER_TTL_MS = 15_000;
+
+/** Parse a set of live parent pids from watcher heartbeat file contents. */
+export function liveWatcherPids(
+  entries: { pid: number; ts: number }[],
+  now: number,
+  ttlMs = WATCHER_TTL_MS,
+): Set<number> {
+  const out = new Set<number>();
+  for (const e of entries) if (now - e.ts <= ttlMs) out.add(e.pid);
+  return out;
+}
+
 /** Where the running daemon records its pid, for `ay notifyd status/stop`. */
 export function daemonPidPath(): string {
   return path.join(notifyDir(), "notifyd.pid");
@@ -210,20 +239,33 @@ export function inboxesToGC(
 }
 
 /**
- * Rotation decision (pure): given an inbox's events and a byte cap, return the
- * events to KEEP after rotating. We never drop an event at-or-below the minimum
- * un-acked cursor is the caller's concern; here we keep the newest events whose
- * serialized size fits the cap, always preserving at least `minKeep` newest.
+ * Rotation decision (pure): given an inbox's events, a byte cap, and the minimum
+ * un-acked cursor across ALL consumers, return the events to KEEP after
+ * rotating. Critically, an event with `seq > protectAboveSeq` is NEVER dropped —
+ * that is the at-least-once guarantee: we must not evict an edge no consumer has
+ * acknowledged yet, even under the byte cap. Below that watermark we keep the
+ * newest events that fit the cap (and at least `minKeep`).
  */
-export function rotateKeep(events: NotifyEvent[], capBytes: number, minKeep = 100): NotifyEvent[] {
+export function rotateKeep(
+  events: NotifyEvent[],
+  capBytes: number,
+  protectAboveSeq = 0,
+  minKeep = 100,
+): NotifyEvent[] {
   if (events.length <= minKeep) return events.slice();
   const kept: NotifyEvent[] = [];
   let bytes = 0;
   for (let i = events.length - 1; i >= 0; i--) {
-    const line = serializeEvent(events[i]!) + "\n";
+    const e = events[i]!;
+    const line = serializeEvent(e) + "\n";
     bytes += line.length;
-    if (bytes > capBytes && kept.length >= minKeep) break;
-    kept.push(events[i]!);
+    // Always retain unacked events (above the min cursor) and the newest minKeep.
+    if (e.seq > protectAboveSeq || kept.length < minKeep || bytes <= capBytes) {
+      kept.push(e);
+    }
+    // Once we're past the cap AND past minKeep AND below the protection
+    // watermark, older events can be dropped — stop scanning.
+    else break;
   }
   kept.reverse();
   return kept;

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -191,33 +191,45 @@ describe("notifyRouter — idle-prompt fixture (P1 regression)", () => {
 });
 
 describe("notifyRouter — carry-forward vs exited (C2: watcher-lapse ≠ child-death)", () => {
-  it("carries forward an unobserved-but-ALIVE child (no false exited)", () => {
-    // Track a child, then a tick with NO observation of it but its pid still
-    // alive (its parent's watcher lapsed). It must NOT be false-exited.
+  it("carries forward an unobserved SAME child (alive, matching start time)", () => {
+    // Track a child, then a tick with NO observation of it but the SAME child
+    // still alive (matching started_at → parent's watcher merely lapsed).
     let s: RouterState = new Map();
-    s = stepRouter(s, [child({ pid: 100, state: "active" })], 0).next;
-    const r = stepRouter(s, [], 1_000, { aliveChildPids: new Set([100]) });
+    s = stepRouter(s, [child({ pid: 100, started_at: 7000, state: "active" })], 0).next;
+    const r = stepRouter(s, [], 1_000, { aliveChildStartedAt: new Map([[100, 7000]]) });
     expect(r.events).toEqual([]); // no false exited
     expect(r.next.has(100)).toBe(true); // carried forward
     expect(r.next.get(100)!.started_at).toBe(7000); // identity preserved
   });
 
-  it("synthesizes exited only when the child is gone AND not alive", () => {
+  it("synthesizes exited when the child's pid is not alive at all", () => {
     let s: RouterState = new Map();
     s = stepRouter(s, [child({ pid: 100, state: "active" })], 0).next;
-    const r = stepRouter(s, [], 1_000, { aliveChildPids: new Set() }); // pid dead
+    const r = stepRouter(s, [], 1_000, { aliveChildStartedAt: new Map() }); // pid dead
     expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
     expect(r.events[0]!.child_started_at).toBe(7000);
   });
 
-  it("recovers the old child's exited on watcher RETURN (pid reused during lapse)", () => {
-    // Child tracked; watcher lapses (carry-forward while pid appears alive); when
-    // the watcher returns, the pid is observed with a NEW start time → the old
-    // child's exited is recovered by the hot-path identity guard (delayed, not
-    // lost), and the new child starts fresh.
+  it("synthesizes exited IMMEDIATELY when the pid is reused by a different child during a lapse", () => {
+    // The identity-aware fix: pid 100 is alive but its start time now differs
+    // (7000 → 9000) — the old child died and its pid was reused. We must NOT
+    // carry it forward as if still running; emit the old child's exited now, no
+    // waiting for the watcher to return.
+    let s: RouterState = new Map();
+    s = stepRouter(s, [child({ pid: 100, started_at: 7000, state: "active" })], 0).next;
+    const r = stepRouter(s, [], 1_000, { aliveChildStartedAt: new Map([[100, 9000]]) });
+    expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
+    expect(r.events[0]!.child_started_at).toBe(7000); // the OLD child's identity
+    expect(r.next.has(100)).toBe(false); // dropped
+  });
+
+  it("recovers the old child's exited on watcher RETURN (same-child lapse then reuse)", () => {
+    // Child tracked; watcher lapses with the SAME child still alive (carried);
+    // when the watcher returns, the pid is observed with a NEW start time → the
+    // old child's exited is recovered by the hot-path guard, new child fresh.
     let s: RouterState = new Map();
     s = stepRouter(s, [child({ pid: 100, started_at: 1000, state: "idle" })], 0).next;
-    s = stepRouter(s, [], 1_000, { aliveChildPids: new Set([100]) }).next; // lapse, carried
+    s = stepRouter(s, [], 1_000, { aliveChildStartedAt: new Map([[100, 1000]]) }).next; // carried
     const r = stepRouter(
       s,
       [child({ pid: 100, started_at: 2000, state: "needs_input", question: "New?" })],

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -18,6 +18,7 @@ const child = (over: Partial<ChildObservation> = {}): ChildObservation => ({
   wrapper_pid: 100,
   started_at: 7000,
   parent_pid: 1,
+  parent_started_at: 3000,
   cli: "claude",
   cwd: "/repo",
   state: "active",
@@ -112,10 +113,12 @@ describe("notifyRouter — exited", () => {
     const r = step(s, [], 1_000); // child gone from the live set
     expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
     expect(r.events[0]!.child_pid).toBe(100);
-    // C2: the synthetic exited must carry the child's start time even though the
-    // child is gone from the current observation — else the pid-reuse guard on
-    // reconcile can't verify identity and could suppress a recycled pid's edge.
+    // C2/I3: the synthetic exited must carry BOTH start times even though the
+    // child is gone from the current observation — else the pid-reuse guards
+    // (child on reconcile, parent on the read side) can't verify identity and
+    // a recycled pid's edge could be suppressed or mis-delivered.
     expect(r.events[0]!.child_started_at).toBe(7000);
+    expect(r.events[0]!.parent_started_at).toBe(3000);
     expect(r.next.has(100)).toBe(false); // forgotten
   });
 

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -16,6 +16,7 @@ const CFG = {
 const child = (over: Partial<ChildObservation> = {}): ChildObservation => ({
   pid: 100,
   wrapper_pid: 100,
+  started_at: 7000,
   parent_pid: 1,
   cli: "claude",
   cwd: "/repo",
@@ -111,6 +112,10 @@ describe("notifyRouter — exited", () => {
     const r = step(s, [], 1_000); // child gone from the live set
     expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
     expect(r.events[0]!.child_pid).toBe(100);
+    // C2: the synthetic exited must carry the child's start time even though the
+    // child is gone from the current observation — else the pid-reuse guard on
+    // reconcile can't verify identity and could suppress a recycled pid's edge.
+    expect(r.events[0]!.child_started_at).toBe(7000);
     expect(r.next.has(100)).toBe(false); // forgotten
   });
 

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -187,6 +187,39 @@ describe("notifyRouter — idle-prompt fixture (P1 regression)", () => {
   });
 });
 
+describe("notifyRouter — hot-path pid reuse (Important)", () => {
+  it("treats a same-pid child with a NEW start time as a fresh child", () => {
+    // Old child exits at pid 100; then pid 100 is recycled by a NEW child that
+    // goes needs_input. The new child's needs_input must fire (not be suppressed
+    // by the old child's state), and the old child gets a synthetic exited.
+    let s: RouterState = new Map();
+    s = step(s, [child({ pid: 100, started_at: 1000, state: "idle" })], 0).next;
+    s = step(s, [child({ pid: 100, started_at: 1000, state: "idle" })], 30_000).next; // old idle-emitted
+    const r = step(
+      s,
+      [child({ pid: 100, started_at: 2000, state: "needs_input", question: "New?" })],
+      31_000,
+    );
+    const edges = r.events.map((e) => e.edge);
+    expect(edges).toContain("exited"); // old child (started_at 1000) closed out
+    expect(edges).toContain("needs_input"); // new child (started_at 2000) fires
+    expect(r.events.find((e) => e.edge === "exited")!.child_started_at).toBe(1000);
+    expect(r.events.find((e) => e.edge === "needs_input")!.child_started_at).toBe(2000);
+    // The next state reflects the NEW child only.
+    expect(r.next.get(100)!.started_at).toBe(2000);
+    expect(r.next.get(100)!.exitedEmitted).toBe(false);
+  });
+
+  it("does not double-close an old child that had already exited", () => {
+    let s: RouterState = new Map();
+    s = step(s, [child({ pid: 100, started_at: 1000, state: "stopped" })], 0).next; // exited emitted
+    const r = step(s, [child({ pid: 100, started_at: 2000, state: "idle" })], 1_000);
+    // Old child already exited → no second exited; new child just starts its idle timer.
+    expect(r.events).toEqual([]);
+    expect(r.next.get(100)!.started_at).toBe(2000);
+  });
+});
+
 describe("notifyRouter — startup reconcile (baseline)", () => {
   it("emits needs_input immediately for a child already blocked at daemon start", () => {
     const r = step(new Map(), [child({ state: "needs_input", question: "Q" })], 5_000);

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -254,6 +254,36 @@ describe("notifyRouter — hot-path pid reuse (Important)", () => {
     expect(r.next.get(100)!.exitedEmitted).toBe(false);
   });
 
+  it("does NOT inherit emitted-memory from a tracked state with no start time (fail-safe)", () => {
+    // Old state seeded WITHOUT a start time (unverifiable). A same-pid child now
+    // observed with a start time must NOT inherit idleEmitted/exitedEmitted — else
+    // its first edge is suppressed. It rebuilds fresh (a duplicate is acceptable),
+    // and NO synthetic exited is emitted (it may be the same child).
+    const seeded: RouterState = new Map([
+      [
+        100,
+        {
+          parent_pid: 1,
+          started_at: undefined, // unverifiable
+          cli: "claude",
+          cwd: "/repo",
+          state: "idle",
+          idleSince: 0,
+          idleEmitted: true, // already emitted for the OLD episode
+          inNeedsInput: false,
+          needsInputQuestion: null,
+          exitedEmitted: false,
+        },
+      ],
+    ]);
+    const r = stepRouter(seeded, [child({ pid: 100, started_at: 5000, state: "idle" })], 0, {
+      idleConfirmMs: 30_000,
+    });
+    expect(r.events.some((e) => e.edge === "exited")).toBe(false); // no false exited
+    expect(r.next.get(100)!.idleEmitted).toBe(false); // fresh — not inherited
+    expect(r.next.get(100)!.started_at).toBe(5000);
+  });
+
   it("does not double-close an old child that had already exited", () => {
     let s: RouterState = new Map();
     s = step(s, [child({ pid: 100, started_at: 1000, state: "stopped" })], 0).next; // exited emitted
@@ -286,13 +316,16 @@ describe("notifyRouter — startup reconcile (baseline)", () => {
 
   it("respects a SEEDED prior state (no duplicate baseline across daemon restart)", () => {
     // The daemon seeds prior emitted state from the inbox so a restart doesn't
-    // re-emit. A seeded exitedEmitted child that is still `stopped` stays quiet.
+    // re-emit. A seeded exitedEmitted child that is still `stopped` stays quiet —
+    // the seed carries the SAME start time as the observation, so the identity is
+    // verifiable and the emitted-memory is (correctly) inherited.
     const seeded: RouterState = new Map([
       [
         100,
         {
           parent_pid: 1,
           wrapper_pid: 100,
+          started_at: 7000, // matches the child() factory → verifiable identity
           cli: "claude",
           cwd: "/repo",
           state: "stopped",

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import { classifyNeedsInput } from "./needsInput.ts";
+import {
+  type ChildObservation,
+  type RouterState,
+  stepRouter,
+} from "./notifyRouter.ts";
+
+// Mirror the claude `needsInput`/`working` config (rs/default.config.yaml): the
+// menu cursor sits on a NUMBERED option, and a spinner marker means "working".
+const CFG = {
+  needsInput: [/❯ ?\d+\./m],
+  working: [/esc to interrupt/, /to run in background/],
+};
+
+const child = (over: Partial<ChildObservation> = {}): ChildObservation => ({
+  pid: 100,
+  wrapper_pid: 100,
+  parent_pid: 1,
+  cli: "claude",
+  cwd: "/repo",
+  state: "active",
+  question: null,
+  ...over,
+});
+
+const step = (prev: RouterState, obs: ChildObservation[], now: number, idleConfirmMs = 30_000) =>
+  stepRouter(prev, obs, now, { idleConfirmMs });
+
+describe("notifyRouter — idle hysteresis (P1)", () => {
+  it("does NOT emit idle until the child has been idle for idleConfirmMs", () => {
+    let s: RouterState = new Map();
+    let r = step(s, [child({ state: "idle" })], 0);
+    expect(r.events).toEqual([]); // timer just started
+    s = r.next;
+
+    r = step(s, [child({ state: "idle" })], 10_000);
+    expect(r.events).toEqual([]); // still within the window
+    s = r.next;
+
+    r = step(s, [child({ state: "idle" })], 30_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["idle"]); // confirmed
+    s = r.next;
+
+    r = step(s, [child({ state: "idle" })], 40_000);
+    expect(r.events).toEqual([]); // edge, not level — one per episode
+  });
+
+  it("treats active→idle→active→idle as two separate idle episodes", () => {
+    let s: RouterState = new Map();
+    s = step(s, [child({ state: "idle" })], 0).next;
+    s = step(s, [child({ state: "idle" })], 30_000).next; // episode 1 emits
+    // work resumes — resets the episode
+    s = step(s, [child({ state: "active" })], 35_000).next;
+    let r = step(s, [child({ state: "idle" })], 40_000);
+    expect(r.events).toEqual([]); // new episode, timer restarts
+    s = r.next;
+    r = step(s, [child({ state: "idle" })], 70_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["idle"]); // episode 2 emits
+  });
+
+  it("a long silent working spell (state stays active) never emits idle", () => {
+    // The load-bearing guard: a 2-minute test run is `active`, not `idle`, so no
+    // amount of elapsed wall-clock produces a false idle edge.
+    let s: RouterState = new Map();
+    for (const t of [0, 30_000, 60_000, 120_000]) {
+      const r = step(s, [child({ state: "active" })], t);
+      expect(r.events).toEqual([]);
+      s = r.next;
+    }
+  });
+});
+
+describe("notifyRouter — needs_input", () => {
+  it("emits immediately on entering needs_input, with the question", () => {
+    const r = step(new Map(), [child({ state: "needs_input", question: "Approve? 1.Yes 2.No" })], 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0]!.edge).toBe("needs_input");
+    expect(r.events[0]!.question).toBe("Approve? 1.Yes 2.No");
+  });
+
+  it("does not re-fire while the same question stays on screen", () => {
+    let s: RouterState = new Map();
+    s = step(s, [child({ state: "needs_input", question: "Q1" })], 0).next;
+    const r = step(s, [child({ state: "needs_input", question: "Q1" })], 1_000);
+    expect(r.events).toEqual([]);
+  });
+
+  it("re-fires when the compact question changes (a genuinely new question)", () => {
+    let s: RouterState = new Map();
+    s = step(s, [child({ state: "needs_input", question: "Q1" })], 0).next;
+    const r = step(s, [child({ state: "needs_input", question: "Q2" })], 1_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["needs_input"]);
+    expect(r.events[0]!.question).toBe("Q2");
+  });
+});
+
+describe("notifyRouter — exited", () => {
+  it("emits exactly once on stop", () => {
+    let s: RouterState = new Map();
+    let r = step(s, [child({ state: "stopped" })], 0);
+    expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
+    s = r.next;
+    r = step(s, [child({ state: "stopped" })], 1_000);
+    expect(r.events).toEqual([]);
+  });
+
+  it("synthesizes an exited edge when a tracked child vanishes (reaped)", () => {
+    let s: RouterState = new Map();
+    s = step(s, [child({ state: "active" })], 0).next; // now tracked
+    const r = step(s, [], 1_000); // child gone from the live set
+    expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
+    expect(r.events[0]!.child_pid).toBe(100);
+    expect(r.next.has(100)).toBe(false); // forgotten
+  });
+
+  it("does not synthesize a second exited if we already emitted stopped", () => {
+    let s: RouterState = new Map();
+    s = step(s, [child({ state: "stopped" })], 0).next; // emitted exited
+    const r = step(s, [], 1_000); // then reaped
+    expect(r.events).toEqual([]);
+  });
+});
+
+describe("notifyRouter — routing scope", () => {
+  it("ignores children with no parent_pid (top-level agents)", () => {
+    const r = step(new Map(), [child({ state: "needs_input", parent_pid: 0, question: "Q" })], 0);
+    expect(r.events).toEqual([]);
+  });
+
+  it("addresses each edge to the child's parent_pid", () => {
+    const r = step(new Map(), [child({ state: "stopped", parent_pid: 42 })], 0);
+    expect(r.events[0]!.parent_pid).toBe(42);
+  });
+});
+
+// P1 regression: the real render the parent hit — a child parked at an idle
+// prompt with a RESOLVED prior menu lingering in scrollback must NOT be
+// misclassified as needs_input (which would mask the idle edge).
+describe("notifyRouter — idle-prompt fixture (P1 regression)", () => {
+  const idlePromptWithResolvedMenu = [
+    "  Do you want to proceed?",
+    "  1. Yes",
+    "  2. No, keep planning",
+    "  ⎿  Selected 1. Yes",
+    "",
+    "● Committed as abc1234 and pushed to origin/feat-x.",
+    "",
+    "╭──────────────────────────────────────────╮",
+    "│ > push it                                │",
+    "╰──────────────────────────────────────────╯",
+    "  ? for shortcuts",
+  ];
+
+  it("a resolved menu in scrollback is NOT needs_input (cursor not on a number)", () => {
+    // The numbered options linger but no `❯ N.` cursor remains — so the screen
+    // is quiet, classified idle, not needs_input.
+    expect(classifyNeedsInput(idlePromptWithResolvedMenu, CFG)).toBeNull();
+  });
+
+  it("an ACTIVE menu (cursor on a number) still classifies as needs_input", () => {
+    const activeMenu = [
+      "  Do you want to proceed?",
+      "❯ 1. Yes",
+      "  2. No, keep planning",
+    ];
+    expect(classifyNeedsInput(activeMenu, CFG)).not.toBeNull();
+  });
+
+  it("a working spinner wins over a lingering menu (no false needs_input)", () => {
+    const workingWithOldMenu = ["❯ 2. No, keep planning", "● Running tests… (esc to interrupt)"];
+    expect(classifyNeedsInput(workingWithOldMenu, CFG)).toBeNull();
+  });
+
+  it("end-to-end: such an idle child emits ONE idle edge after the confirm window", () => {
+    // Feeding the router the `idle` state (what deriveLiveState yields for the
+    // fixture above) produces exactly one idle edge per episode.
+    let s: RouterState = new Map();
+    s = step(s, [child({ state: "idle" })], 0).next;
+    const r = step(s, [child({ state: "idle" })], 30_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["idle"]);
+  });
+});
+
+describe("notifyRouter — startup reconcile (baseline)", () => {
+  it("emits needs_input immediately for a child already blocked at daemon start", () => {
+    const r = step(new Map(), [child({ state: "needs_input", question: "Q" })], 5_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["needs_input"]);
+  });
+
+  it("emits exited immediately for a child already stopped at daemon start", () => {
+    const r = step(new Map(), [child({ state: "stopped" })], 5_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
+  });
+
+  it("a child already idle at start emits only after the confirm window (from now)", () => {
+    let s: RouterState = new Map();
+    let r = step(s, [child({ state: "idle" })], 5_000);
+    expect(r.events).toEqual([]); // timer anchored at first observation
+    s = r.next;
+    r = step(s, [child({ state: "idle" })], 35_000);
+    expect(r.events.map((e) => e.edge)).toEqual(["idle"]);
+  });
+
+  it("respects a SEEDED prior state (no duplicate baseline across daemon restart)", () => {
+    // The daemon seeds prior emitted state from the inbox so a restart doesn't
+    // re-emit. A seeded exitedEmitted child that is still `stopped` stays quiet.
+    const seeded: RouterState = new Map([
+      [
+        100,
+        {
+          parent_pid: 1,
+          wrapper_pid: 100,
+          cli: "claude",
+          cwd: "/repo",
+          state: "stopped",
+          idleSince: null,
+          idleEmitted: false,
+          inNeedsInput: false,
+          needsInputQuestion: null,
+          exitedEmitted: true,
+        },
+      ],
+    ]);
+    const r = step(seeded, [child({ state: "stopped" })], 0);
+    expect(r.events).toEqual([]);
+  });
+});

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -190,6 +190,47 @@ describe("notifyRouter — idle-prompt fixture (P1 regression)", () => {
   });
 });
 
+describe("notifyRouter — carry-forward vs exited (C2: watcher-lapse ≠ child-death)", () => {
+  it("carries forward an unobserved-but-ALIVE child (no false exited)", () => {
+    // Track a child, then a tick with NO observation of it but its pid still
+    // alive (its parent's watcher lapsed). It must NOT be false-exited.
+    let s: RouterState = new Map();
+    s = stepRouter(s, [child({ pid: 100, state: "active" })], 0).next;
+    const r = stepRouter(s, [], 1_000, { aliveChildPids: new Set([100]) });
+    expect(r.events).toEqual([]); // no false exited
+    expect(r.next.has(100)).toBe(true); // carried forward
+    expect(r.next.get(100)!.started_at).toBe(7000); // identity preserved
+  });
+
+  it("synthesizes exited only when the child is gone AND not alive", () => {
+    let s: RouterState = new Map();
+    s = stepRouter(s, [child({ pid: 100, state: "active" })], 0).next;
+    const r = stepRouter(s, [], 1_000, { aliveChildPids: new Set() }); // pid dead
+    expect(r.events.map((e) => e.edge)).toEqual(["exited"]);
+    expect(r.events[0]!.child_started_at).toBe(7000);
+  });
+
+  it("recovers the old child's exited on watcher RETURN (pid reused during lapse)", () => {
+    // Child tracked; watcher lapses (carry-forward while pid appears alive); when
+    // the watcher returns, the pid is observed with a NEW start time → the old
+    // child's exited is recovered by the hot-path identity guard (delayed, not
+    // lost), and the new child starts fresh.
+    let s: RouterState = new Map();
+    s = stepRouter(s, [child({ pid: 100, started_at: 1000, state: "idle" })], 0).next;
+    s = stepRouter(s, [], 1_000, { aliveChildPids: new Set([100]) }).next; // lapse, carried
+    const r = stepRouter(
+      s,
+      [child({ pid: 100, started_at: 2000, state: "needs_input", question: "New?" })],
+      2_000,
+    );
+    const edges = r.events.map((e) => e.edge);
+    expect(edges).toContain("exited"); // old child (1000) recovered
+    expect(r.events.find((e) => e.edge === "exited")!.child_started_at).toBe(1000);
+    expect(edges).toContain("needs_input"); // new child (2000) fresh
+    expect(r.next.get(100)!.started_at).toBe(2000);
+  });
+});
+
 describe("notifyRouter — hot-path pid reuse (Important)", () => {
   it("treats a same-pid child with a NEW start time as a fresh child", () => {
     // Old child exits at pid 100; then pid 100 is recycled by a NEW child that

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -131,20 +131,21 @@ export function stepRouter(
     if (typeof obs.parent_pid !== "number" || obs.parent_pid <= 0) continue;
     seen.add(obs.pid);
     let p = prev.get(obs.pid);
-    // Hot-path pid-reuse guard (mirrors the startup reconcile guard): if this pid
-    // is now a DIFFERENT child (its start time changed), the old child is gone —
-    // `seen` marks the pid, so the vanished-loop below won't fire for it. Emit its
-    // synthetic exited here, then drop `p` so the new child rebuilds fresh state
-    // (else it would inherit the old child's idleEmitted/exitedEmitted and have
-    // its first idle/needs_input/exited suppressed).
-    if (
-      p &&
-      p.started_at != null &&
-      obs.started_at != null &&
-      p.started_at !== obs.started_at
-    ) {
+    // Hot-path pid-reuse guard (mirrors the startup reconcile guard). Two cases,
+    // both fail-safe — an unverifiable identity is NEVER inherited:
+    //  1. CONFIRMED reuse: both start times known and different → the old child
+    //     is gone. `seen` marks the pid so the vanished-loop won't fire; emit its
+    //     synthetic exited here, then drop `p` so the new child rebuilds fresh.
+    //  2. UNVERIFIABLE: the observation has a start time but the tracked state has
+    //     none (e.g. seeded without one). We can't confirm it's the same child,
+    //     so we DON'T inherit its emitted-edge memory (a re-emit / duplicate is
+    //     safe; a suppressed first edge is not) — but we also DON'T synthesize an
+    //     exited, since it may well be the same child (avoid a false exited).
+    if (p && obs.started_at != null && p.started_at != null && p.started_at !== obs.started_at) {
       if (!p.exitedEmitted) events.push(syntheticExited(p, obs.pid));
       p = undefined;
+    } else if (p && obs.started_at != null && p.started_at == null) {
+      p = undefined; // unverifiable — rebuild fresh, no inherit, no synthetic exited
     }
     const cs: ChildRouterState = {
       parent_pid: obs.parent_pid,

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure edge-detection + debounce state machine for subagent→parent
+ * notifications. The heart of `ay notifyd`: given each tick's observed child
+ * states, decide which EDGES to push to which parent, exactly once per episode,
+ * without spamming on transient flicker.
+ *
+ * Design (frozen with codex + the two agents who hit the pain):
+ *  - Signal is the query-layer `deriveLiveState` state — NOT a bare no-output
+ *    timer. `idle` already means "idle prompt visible AND no working spinner",
+ *    so a long, silent tool call (a 2-minute test run) is classified `active`
+ *    and never produces a false idle edge. This is the load-bearing P1 guard.
+ *  - Three edges, child→parent only (never cascade a parent's own state):
+ *      needs_input : immediate; re-fire only when the COMPACT question changes.
+ *      exited      : immediate, once.
+ *      idle        : only after the child has been continuously `idle` for
+ *                    `idleConfirmMs` (hysteresis), once per idle episode.
+ *  - Edge, not level: a state that stays idle emits one edge, not one per tick.
+ *  - Reaped-child safety: a child that vanishes from the live set without our
+ *    seeing `stopped` gets a synthetic `exited` (mirrors `diffLsStates`).
+ *
+ * Pure + synchronous (no clock, no fs — the caller passes `now`) so it is
+ * trivially unit-testable, like `lsWatch.ts` / `needsInput.ts`. The poll loop,
+ * inbox writes, payload enrichment, and startup reconcile live in
+ * `subcommands.ts` (`cmdNotifyd`); persistence lives in `notifyInbox.ts`.
+ */
+
+import type { NotifyEdge } from "./notifyInbox.ts";
+
+/** One child's observed state this tick (from `deriveLiveState` + the registry). */
+export interface ChildObservation {
+  pid: number;
+  wrapper_pid?: number;
+  /** The parent this child links to (parent wrapper pid). Required to route. */
+  parent_pid: number;
+  cli: string;
+  cwd: string;
+  /** `deriveLiveState` state: active | idle | stopped | needs_input | stuck. */
+  state: string;
+  /** Compact question when state === "needs_input", else null. */
+  question: string | null;
+}
+
+/** A decided notification, before the daemon enriches it (seq/ts/tail/git). */
+export interface PendingNotification {
+  parent_pid: number;
+  child_pid: number;
+  child_wrapper_pid?: number;
+  cli: string;
+  cwd: string;
+  edge: NotifyEdge;
+  prev_state: string | null;
+  state: string;
+  question: string | null;
+}
+
+/** Per-child debounce memory, carried across ticks. */
+export interface ChildRouterState {
+  parent_pid: number;
+  wrapper_pid?: number;
+  cli: string;
+  cwd: string;
+  /** Last observed state. */
+  state: string;
+  /** When the current idle episode began (ms), or null if not idle. */
+  idleSince: number | null;
+  /** Whether we already emitted the idle edge for the current episode. */
+  idleEmitted: boolean;
+  /** Whether we are inside a needs_input episode we've emitted at least once. */
+  inNeedsInput: boolean;
+  /** The compact question of the last emitted needs_input (for change re-fire). */
+  needsInputQuestion: string | null;
+  /** Whether we already emitted the exited edge for this child. */
+  exitedEmitted: boolean;
+}
+
+export type RouterState = Map<number, ChildRouterState>;
+
+export interface RouterConfig {
+  /** How long a child must stay continuously idle before we emit an idle edge. */
+  idleConfirmMs: number;
+}
+
+const DEFAULT_IDLE_CONFIRM_MS = 30_000;
+
+/**
+ * Advance the router by one tick. Returns the notifications to push plus the
+ * next RouterState. Only children with a numeric `parent_pid` are considered —
+ * the caller is responsible for including only opted-in children.
+ *
+ * First-observation (baseline / startup-reconcile) semantics: a child we've
+ * never seen that is ALREADY terminal emits immediately for `needs_input` /
+ * `stopped`, and starts its idle timer at `now` for `idle` (so a child parked
+ * idle when the daemon starts still notifies after the confirm window). To avoid
+ * re-emitting the same baseline on every daemon restart, the caller SEEDS the
+ * prior state from each inbox's already-written edges (see cmdNotifyd).
+ */
+export function stepRouter(
+  prev: RouterState,
+  observations: ChildObservation[],
+  now: number,
+  config: Partial<RouterConfig> = {},
+): { events: PendingNotification[]; next: RouterState } {
+  const idleConfirmMs = config.idleConfirmMs ?? DEFAULT_IDLE_CONFIRM_MS;
+  const events: PendingNotification[] = [];
+  const next: RouterState = new Map();
+  const seen = new Set<number>();
+
+  for (const obs of observations) {
+    if (typeof obs.parent_pid !== "number" || obs.parent_pid <= 0) continue;
+    seen.add(obs.pid);
+    const p = prev.get(obs.pid);
+    const cs: ChildRouterState = {
+      parent_pid: obs.parent_pid,
+      wrapper_pid: obs.wrapper_pid,
+      cli: obs.cli,
+      cwd: obs.cwd,
+      state: obs.state,
+      idleSince: p?.idleSince ?? null,
+      idleEmitted: p?.idleEmitted ?? false,
+      inNeedsInput: p?.inNeedsInput ?? false,
+      needsInputQuestion: p?.needsInputQuestion ?? null,
+      exitedEmitted: p?.exitedEmitted ?? false,
+    };
+    const prevState = p?.state ?? null;
+    const emit = (edge: NotifyEdge) =>
+      events.push({
+        parent_pid: obs.parent_pid,
+        child_pid: obs.pid,
+        child_wrapper_pid: obs.wrapper_pid,
+        cli: obs.cli,
+        cwd: obs.cwd,
+        edge,
+        prev_state: prevState,
+        state: obs.state,
+        question: edge === "needs_input" ? obs.question : null,
+      });
+
+    switch (obs.state) {
+      case "needs_input": {
+        // Leaving idle/other → reset those episodes.
+        cs.idleSince = null;
+        cs.idleEmitted = false;
+        // Fire on entry, or when the compact question changed (a NEW question).
+        // Compare the compact (chrome-stripped) question so a spinner/elapsed-
+        // seconds cosmetic redraw doesn't double-fire.
+        if (!cs.inNeedsInput || cs.needsInputQuestion !== obs.question) {
+          emit("needs_input");
+          cs.inNeedsInput = true;
+          cs.needsInputQuestion = obs.question;
+        }
+        break;
+      }
+      case "idle": {
+        cs.inNeedsInput = false;
+        cs.needsInputQuestion = null;
+        // Continue the episode if we were already idle; else start it now.
+        if (p?.state === "idle" && p.idleSince != null) {
+          cs.idleSince = p.idleSince;
+          cs.idleEmitted = p.idleEmitted;
+        } else {
+          cs.idleSince = now;
+          cs.idleEmitted = false;
+        }
+        if (!cs.idleEmitted && now - (cs.idleSince ?? now) >= idleConfirmMs) {
+          emit("idle");
+          cs.idleEmitted = true;
+        }
+        break;
+      }
+      case "stopped": {
+        cs.idleSince = null;
+        cs.idleEmitted = false;
+        cs.inNeedsInput = false;
+        cs.needsInputQuestion = null;
+        if (!cs.exitedEmitted) {
+          emit("exited");
+          cs.exitedEmitted = true;
+        }
+        break;
+      }
+      // "active", "stuck", or any unknown busy state: real work (or a wedge) is
+      // happening — reset the idle/needs_input episodes so a later idle counts
+      // as a fresh episode, and emit nothing.
+      default: {
+        cs.idleSince = null;
+        cs.idleEmitted = false;
+        cs.inNeedsInput = false;
+        cs.needsInputQuestion = null;
+        break;
+      }
+    }
+
+    next.set(obs.pid, cs);
+  }
+
+  // Reaped-child safety: a child we were tracking dropped out of the live set
+  // without our observing `stopped`. Synthesize one exited edge (once) so a
+  // "done" transition is never dropped, then forget it.
+  for (const [pid, cs] of prev) {
+    if (seen.has(pid)) continue;
+    if (!cs.exitedEmitted) {
+      events.push({
+        parent_pid: cs.parent_pid,
+        child_pid: pid,
+        child_wrapper_pid: cs.wrapper_pid,
+        cli: cs.cli,
+        cwd: cs.cwd,
+        edge: "exited",
+        prev_state: cs.state,
+        state: "stopped",
+        question: null,
+      });
+    }
+    // Do not carry a vanished child forward — it is gone from the registry.
+  }
+
+  return { events, next };
+}

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -91,15 +91,18 @@ export interface RouterConfig {
   /** How long a child must stay continuously idle before we emit an idle edge. */
   idleConfirmMs: number;
   /**
-   * The pids of children that are ACTUALLY ALIVE right now (from the registry).
-   * A tracked child that drops out of this tick's observations is only given a
-   * synthetic `exited` if its pid is NOT in this set — i.e. it truly died. A
-   * child absent from observations but still alive (e.g. its parent's watcher
-   * lapsed, so the daemon stopped observing it) is CARRIED FORWARD, never
-   * false-exited. When omitted, any unobserved tracked child is treated as
-   * exited (the caller has no liveness info).
+   * pid → started_at for every child ACTUALLY ALIVE right now (from the registry).
+   * A tracked child that drops out of this tick's observations is carried forward
+   * (not false-exited) ONLY when the live pid's start time still MATCHES the
+   * tracked one — i.e. it is the SAME child, merely unobserved (its parent's
+   * watcher lapsed). If the pid is alive but with a DIFFERENT start time, the old
+   * child died and its pid was reused during the lapse → synthesize its exited
+   * immediately (identity-aware, no waiting for the watcher to return). If the
+   * tracked start time is unknown (rare), fall back to liveness-only carry-forward
+   * to avoid a false exited. When omitted entirely, any unobserved tracked child
+   * is treated as exited (the caller has no liveness info).
    */
-  aliveChildPids?: Set<number>;
+  aliveChildStartedAt?: Map<number, number>;
 }
 
 const DEFAULT_IDLE_CONFIRM_MS = 30_000;
@@ -241,16 +244,23 @@ export function stepRouter(
   for (const [pid, cs] of prev) {
     if (seen.has(pid)) continue;
     // Distinguish "child died" from "child merely not observed this tick" (its
-    // parent's watcher lapsed, so it fell out of the observed scope). Only a
-    // child whose pid is NOT alive is truly gone → synthesize its exited. A child
-    // still alive is carried forward untouched, so we never emit a false exited
-    // for a still-running child.
-    if (config.aliveChildPids && config.aliveChildPids.has(pid)) {
-      next.set(pid, cs);
-      continue;
+    // parent's watcher lapsed, so it fell out of the observed scope) — and do it
+    // IDENTITY-AWARE, so a pid reused during the lapse doesn't masquerade as the
+    // same still-running child. Carry forward only when the SAME child is still
+    // alive (live start time matches, or the tracked start time is unknown —
+    // fail-safe against a false exited). Otherwise the child is gone (dead, or its
+    // pid now belongs to a different child) → synthesize its exited.
+    if (config.aliveChildStartedAt) {
+      const liveStart = config.aliveChildStartedAt.get(pid);
+      const sameChildAlive =
+        liveStart !== undefined && (cs.started_at == null || liveStart === cs.started_at);
+      if (sameChildAlive) {
+        next.set(pid, cs);
+        continue;
+      }
     }
     if (!cs.exitedEmitted) events.push(syntheticExited(cs, pid));
-    // Dead & gone — drop from the tracked set.
+    // Dead & gone (or pid reused) — drop from the tracked set.
   }
 
   return { events, next };

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -114,7 +114,22 @@ export function stepRouter(
   for (const obs of observations) {
     if (typeof obs.parent_pid !== "number" || obs.parent_pid <= 0) continue;
     seen.add(obs.pid);
-    const p = prev.get(obs.pid);
+    let p = prev.get(obs.pid);
+    // Hot-path pid-reuse guard (mirrors the startup reconcile guard): if this pid
+    // is now a DIFFERENT child (its start time changed), the old child is gone —
+    // `seen` marks the pid, so the vanished-loop below won't fire for it. Emit its
+    // synthetic exited here, then drop `p` so the new child rebuilds fresh state
+    // (else it would inherit the old child's idleEmitted/exitedEmitted and have
+    // its first idle/needs_input/exited suppressed).
+    if (
+      p &&
+      p.started_at != null &&
+      obs.started_at != null &&
+      p.started_at !== obs.started_at
+    ) {
+      if (!p.exitedEmitted) events.push(syntheticExited(p, obs.pid));
+      p = undefined;
+    }
     const cs: ChildRouterState = {
       parent_pid: obs.parent_pid,
       wrapper_pid: obs.wrapper_pid,
@@ -206,22 +221,29 @@ export function stepRouter(
   // "done" transition is never dropped, then forget it.
   for (const [pid, cs] of prev) {
     if (seen.has(pid)) continue;
-    if (!cs.exitedEmitted) {
-      events.push({
-        parent_pid: cs.parent_pid,
-        child_pid: pid,
-        child_wrapper_pid: cs.wrapper_pid,
-        child_started_at: cs.started_at,
-        cli: cs.cli,
-        cwd: cs.cwd,
-        edge: "exited",
-        prev_state: cs.state,
-        state: "stopped",
-        question: null,
-      });
-    }
+    if (!cs.exitedEmitted) events.push(syntheticExited(cs, pid));
     // Do not carry a vanished child forward — it is gone from the registry.
   }
 
   return { events, next };
+}
+
+/**
+ * A synthetic `exited` for a child that left the live set without our observing
+ * its stop — either reaped between ticks, or displaced by a pid-reuse. Built from
+ * the last-known router state so it still carries the child's identity.
+ */
+function syntheticExited(cs: ChildRouterState, pid: number): PendingNotification {
+  return {
+    parent_pid: cs.parent_pid,
+    child_pid: pid,
+    child_wrapper_pid: cs.wrapper_pid,
+    child_started_at: cs.started_at,
+    cli: cs.cli,
+    cwd: cs.cwd,
+    edge: "exited",
+    prev_state: cs.state,
+    state: "stopped",
+    question: null,
+  };
 }

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -90,6 +90,16 @@ export type RouterState = Map<number, ChildRouterState>;
 export interface RouterConfig {
   /** How long a child must stay continuously idle before we emit an idle edge. */
   idleConfirmMs: number;
+  /**
+   * The pids of children that are ACTUALLY ALIVE right now (from the registry).
+   * A tracked child that drops out of this tick's observations is only given a
+   * synthetic `exited` if its pid is NOT in this set — i.e. it truly died. A
+   * child absent from observations but still alive (e.g. its parent's watcher
+   * lapsed, so the daemon stopped observing it) is CARRIED FORWARD, never
+   * false-exited. When omitted, any unobserved tracked child is treated as
+   * exited (the caller has no liveness info).
+   */
+  aliveChildPids?: Set<number>;
 }
 
 const DEFAULT_IDLE_CONFIRM_MS = 30_000;
@@ -229,8 +239,17 @@ export function stepRouter(
   // "done" transition is never dropped, then forget it.
   for (const [pid, cs] of prev) {
     if (seen.has(pid)) continue;
+    // Distinguish "child died" from "child merely not observed this tick" (its
+    // parent's watcher lapsed, so it fell out of the observed scope). Only a
+    // child whose pid is NOT alive is truly gone → synthesize its exited. A child
+    // still alive is carried forward untouched, so we never emit a false exited
+    // for a still-running child.
+    if (config.aliveChildPids && config.aliveChildPids.has(pid)) {
+      next.set(pid, cs);
+      continue;
+    }
     if (!cs.exitedEmitted) events.push(syntheticExited(cs, pid));
-    // Do not carry a vanished child forward — it is gone from the registry.
+    // Dead & gone — drop from the tracked set.
   }
 
   return { events, next };

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -30,6 +30,8 @@ import type { NotifyEdge } from "./notifyInbox.ts";
 export interface ChildObservation {
   pid: number;
   wrapper_pid?: number;
+  /** The child's own start time — carried into events for the pid-reuse guard. */
+  started_at?: number;
   /** The parent this child links to (parent wrapper pid). Required to route. */
   parent_pid: number;
   cli: string;
@@ -45,6 +47,8 @@ export interface PendingNotification {
   parent_pid: number;
   child_pid: number;
   child_wrapper_pid?: number;
+  /** The child's start time (from the observation / carried state). */
+  child_started_at?: number;
   cli: string;
   cwd: string;
   edge: NotifyEdge;
@@ -57,6 +61,8 @@ export interface PendingNotification {
 export interface ChildRouterState {
   parent_pid: number;
   wrapper_pid?: number;
+  /** The child's start time — so a synthetic exited (child already gone) keeps it. */
+  started_at?: number;
   cli: string;
   cwd: string;
   /** Last observed state. */
@@ -112,6 +118,7 @@ export function stepRouter(
     const cs: ChildRouterState = {
       parent_pid: obs.parent_pid,
       wrapper_pid: obs.wrapper_pid,
+      started_at: obs.started_at,
       cli: obs.cli,
       cwd: obs.cwd,
       state: obs.state,
@@ -127,6 +134,7 @@ export function stepRouter(
         parent_pid: obs.parent_pid,
         child_pid: obs.pid,
         child_wrapper_pid: obs.wrapper_pid,
+        child_started_at: obs.started_at,
         cli: obs.cli,
         cwd: obs.cwd,
         edge,
@@ -203,6 +211,7 @@ export function stepRouter(
         parent_pid: cs.parent_pid,
         child_pid: pid,
         child_wrapper_pid: cs.wrapper_pid,
+        child_started_at: cs.started_at,
         cli: cs.cli,
         cwd: cs.cwd,
         edge: "exited",

--- a/ts/notifyRouter.ts
+++ b/ts/notifyRouter.ts
@@ -34,6 +34,8 @@ export interface ChildObservation {
   started_at?: number;
   /** The parent this child links to (parent wrapper pid). Required to route. */
   parent_pid: number;
+  /** The parent's start time — carried so a synthetic exited keeps the parent guard. */
+  parent_started_at?: number;
   cli: string;
   cwd: string;
   /** `deriveLiveState` state: active | idle | stopped | needs_input | stuck. */
@@ -49,6 +51,8 @@ export interface PendingNotification {
   child_wrapper_pid?: number;
   /** The child's start time (from the observation / carried state). */
   child_started_at?: number;
+  /** The parent's start time (from the observation / carried state). */
+  parent_started_at?: number;
   cli: string;
   cwd: string;
   edge: NotifyEdge;
@@ -63,6 +67,8 @@ export interface ChildRouterState {
   wrapper_pid?: number;
   /** The child's start time — so a synthetic exited (child already gone) keeps it. */
   started_at?: number;
+  /** The parent's start time — carried so a synthetic exited keeps the parent guard. */
+  parent_started_at?: number;
   cli: string;
   cwd: string;
   /** Last observed state. */
@@ -134,6 +140,7 @@ export function stepRouter(
       parent_pid: obs.parent_pid,
       wrapper_pid: obs.wrapper_pid,
       started_at: obs.started_at,
+      parent_started_at: obs.parent_started_at,
       cli: obs.cli,
       cwd: obs.cwd,
       state: obs.state,
@@ -150,6 +157,7 @@ export function stepRouter(
         child_pid: obs.pid,
         child_wrapper_pid: obs.wrapper_pid,
         child_started_at: obs.started_at,
+        parent_started_at: obs.parent_started_at,
         cli: obs.cli,
         cwd: obs.cwd,
         edge,
@@ -239,6 +247,7 @@ function syntheticExited(cs: ChildRouterState, pid: number): PendingNotification
     child_pid: pid,
     child_wrapper_pid: cs.wrapper_pid,
     child_started_at: cs.started_at,
+    parent_started_at: cs.parent_started_at,
     cli: cs.cli,
     cwd: cs.cwd,
     edge: "exited",

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -145,6 +145,18 @@ describe("notifyStore (fs)", () => {
     await release();
   });
 
+  it("never reuses a RESERVED-but-unused seq (crash-safety: gap OK, dup NG)", async () => {
+    const { mkdir, writeFile } = await import("fs/promises");
+    const { inboxDir, inboxPath, seqPath } = await import("./notifyInbox.ts");
+    await mkdir(inboxDir(host), { recursive: true });
+    // Simulate a crash between "reserve seq 5" and "append line": the counter
+    // says 5, but the inbox only has 1..3 (4 and 5 are reserved gaps).
+    await writeFile(inboxPath(host, 700), [1, 2, 3].map((s) => JSON.stringify(baseEvent("idle", { seq: s }))).join("\n") + "\n");
+    await writeFile(seqPath(host, 700), "5");
+    const next = await appendEvent(700, baseEvent("idle"));
+    expect(next).toBe(6); // continues past the reserved gap, never reuses 4 or 5
+  });
+
   it("registers and expires watcher heartbeats (fresh AND process alive)", async () => {
     const alive = process.pid; // a definitely-alive pid
     await heartbeatWatcher(alive, 111);

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -37,17 +37,18 @@ describe("notifyStore — lock steal decision (C1: holder liveness, not wait tim
   const now = 1_000_000;
   const opts = (over = {}) => ({
     staleMs: 30_000,
-    hardMs: 60_000,
     elapsed: 0,
     selfPid: 1,
     isAlive: (p: number) => p === 42, // only pid 42 is "alive"
     ...over,
   });
 
-  it("does NOT steal a LIVE holder with a fresh heartbeat, even after a long wait", () => {
+  it("does NOT steal a LIVE holder with a fresh heartbeat, even after an extreme wait", () => {
     const owner = JSON.stringify({ pid: 42, ts: now - 1_000 });
-    // 50s elapsed but holder alive + fresh → must NOT steal (this was the bug).
+    // With no wall-clock backstop, elapsed alone NEVER steals — a live, fresh
+    // holder is inviolable no matter how long we've waited.
     expect(shouldStealLock(owner, now, opts({ elapsed: 50_000 }))).toBe(false);
+    expect(shouldStealLock(owner, now, opts({ elapsed: 10 * 60_000 }))).toBe(false);
   });
 
   it("steals a DEAD holder", () => {
@@ -71,9 +72,10 @@ describe("notifyStore — lock steal decision (C1: holder liveness, not wait tim
     expect(shouldStealLock("", now, opts({ elapsed: 1500, graceMs: 1000 }))).toBe(true);
   });
 
-  it("hardMs backstop steals even a fresh-looking holder after an extreme wait", () => {
-    const owner = JSON.stringify({ pid: 42, ts: now });
-    expect(shouldStealLock(owner, now, opts({ elapsed: 61_000 }))).toBe(true);
+  it("treats an owner with no heartbeat ts as torn (grace), not immediately steal", () => {
+    const owner = JSON.stringify({ pid: 42, started_at: 1 }); // no ts
+    expect(shouldStealLock(owner, now, opts({ elapsed: 0, graceMs: 1000 }))).toBe(false);
+    expect(shouldStealLock(owner, now, opts({ elapsed: 1500, graceMs: 1000 }))).toBe(true);
   });
 });
 

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -57,6 +57,19 @@ describe("notifyStore (fs)", () => {
     expect(inbox.map((e) => e.seq).sort((a, b) => a - b)).toEqual([1, 2, 3]);
   });
 
+  it("many concurrent appends get unique, contiguous seqs (lock serializes)", async () => {
+    // 30 writers race on the same inbox. Ownership is proven only by mkdir, so
+    // even under the steal path no two writers share the critical section →
+    // seqs are 1..30 with no gap or duplicate.
+    const seqs = await Promise.all(
+      Array.from({ length: 30 }, () => appendEvent(999, baseEvent("idle"))),
+    );
+    expect([...seqs].sort((a, b) => a - b)).toEqual(Array.from({ length: 30 }, (_, i) => i + 1));
+    const inbox = await readInbox(host, 999);
+    expect(inbox.length).toBe(30);
+    expect(new Set(inbox.map((e) => e.seq)).size).toBe(30); // no duplicates
+  });
+
   it("registers and expires watcher heartbeats", async () => {
     await heartbeatWatcher(1, 111);
     await heartbeatWatcher(2, 222);
@@ -81,6 +94,25 @@ describe("notifyStore (fs)", () => {
     // 999 dead + unreferenced → GC; 888 referenced by a live child → keep.
     await gcInboxes(host, new Set<number>(), new Set([888]));
     expect(await listInboxParents(host)).toEqual([888]);
+  });
+
+  it("concurrent GC and appends never lose an event (read+write both under lock)", async () => {
+    // Seed enough to trigger rotation, ack a chunk so GC has something to trim.
+    for (let i = 0; i < 40; i++) await appendEvent(999, baseEvent("idle"));
+    await setCursor(host, 999, 15, "parent");
+    // Fire a GC pass concurrently with a burst of appends. Because GC reads AND
+    // writes inside the inbox lock, no append can be clobbered by a stale-snapshot
+    // rewrite — every appended seq must survive.
+    const appends = Array.from({ length: 20 }, () => appendEvent(999, baseEvent("needs_input")));
+    const [seqs] = await Promise.all([
+      Promise.all(appends),
+      gcInboxes(host, new Set([999]), new Set([999]), 1),
+    ]);
+    const inbox = await readInbox(host, 999);
+    const present = new Set(inbox.map((e) => e.seq));
+    for (const s of seqs) expect(present.has(s)).toBe(true); // no append lost
+    // Seqs are still unique (no duplication from a racing rewrite).
+    expect(inbox.length).toBe(new Set(inbox.map((e) => e.seq)).size);
   });
 
   it("GC rotation never drops unacked events even past the byte cap", async () => {

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -37,18 +37,18 @@ describe("notifyStore — lock steal decision (C1: holder liveness, not wait tim
   const now = 1_000_000;
   const opts = (over = {}) => ({
     staleMs: 30_000,
-    elapsed: 0,
+    lockAgeMs: 0,
     selfPid: 1,
     isAlive: (p: number) => p === 42, // only pid 42 is "alive"
     ...over,
   });
 
-  it("does NOT steal a LIVE holder with a fresh heartbeat, even after an extreme wait", () => {
+  it("does NOT steal a LIVE holder with a fresh heartbeat, regardless of lock age", () => {
     const owner = JSON.stringify({ pid: 42, ts: now - 1_000 });
-    // With no wall-clock backstop, elapsed alone NEVER steals — a live, fresh
-    // holder is inviolable no matter how long we've waited.
-    expect(shouldStealLock(owner, now, opts({ elapsed: 50_000 }))).toBe(false);
-    expect(shouldStealLock(owner, now, opts({ elapsed: 10 * 60_000 }))).toBe(false);
+    // A live holder with a fresh heartbeat is inviolable — lockAgeMs only gates
+    // the torn-owner grace, never a holder we have positive live evidence for.
+    expect(shouldStealLock(owner, now, opts({ lockAgeMs: 50_000 }))).toBe(false);
+    expect(shouldStealLock(owner, now, opts({ lockAgeMs: 10 * 60_000 }))).toBe(false);
   });
 
   it("steals a DEAD holder", () => {
@@ -64,18 +64,18 @@ describe("notifyStore — lock steal decision (C1: holder liveness, not wait tim
   it("does NOT steal a torn/empty owner within the grace (mkdir→writeFile window)", () => {
     // A just-created lock whose owner file isn't written yet must be respected,
     // else two writers race into the critical section and duplicate a seq.
-    expect(shouldStealLock("", now, opts({ elapsed: 0, graceMs: 1000 }))).toBe(false);
-    expect(shouldStealLock("{ torn", now, opts({ elapsed: 100, graceMs: 1000 }))).toBe(false);
+    expect(shouldStealLock("", now, opts({ lockAgeMs: 0, graceMs: 1000 }))).toBe(false);
+    expect(shouldStealLock("{ torn", now, opts({ lockAgeMs: 100, graceMs: 1000 }))).toBe(false);
   });
 
   it("steals a torn/empty owner once the grace elapses (holder crashed mid-acquire)", () => {
-    expect(shouldStealLock("", now, opts({ elapsed: 1500, graceMs: 1000 }))).toBe(true);
+    expect(shouldStealLock("", now, opts({ lockAgeMs: 1500, graceMs: 1000 }))).toBe(true);
   });
 
   it("treats an owner with no heartbeat ts as torn (grace), not immediately steal", () => {
     const owner = JSON.stringify({ pid: 42, started_at: 1 }); // no ts
-    expect(shouldStealLock(owner, now, opts({ elapsed: 0, graceMs: 1000 }))).toBe(false);
-    expect(shouldStealLock(owner, now, opts({ elapsed: 1500, graceMs: 1000 }))).toBe(true);
+    expect(shouldStealLock(owner, now, opts({ lockAgeMs: 0, graceMs: 1000 }))).toBe(false);
+    expect(shouldStealLock(owner, now, opts({ lockAgeMs: 1500, graceMs: 1000 }))).toBe(true);
   });
 });
 

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, stat, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import {
+  appendEvent,
+  clearWatcher,
+  gcInboxes,
+  heartbeatWatcher,
+  hostId,
+  listInboxParents,
+  liveWatchers,
+  minConsumerCursor,
+  readInbox,
+  setCursor,
+} from "./notifyStore.ts";
+import { inboxPath, type NotifyEvent } from "./notifyInbox.ts";
+
+const host = hostId();
+const baseEvent = (edge: NotifyEvent["edge"], over: Partial<NotifyEvent> = {}) => ({
+  ts: 1_000,
+  host,
+  parent_pid: 999,
+  child_pid: 555,
+  cli: "claude",
+  cwd: "/repo",
+  edge,
+  prev_state: "active",
+  state: edge === "exited" ? "stopped" : edge,
+  question: null,
+  ...over,
+});
+
+describe("notifyStore (fs)", () => {
+  let home: string;
+  const prev = process.env.AGENT_YES_HOME;
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-notify-store-"));
+    process.env.AGENT_YES_HOME = home;
+  });
+  afterEach(async () => {
+    if (prev === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prev;
+    await rm(home, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("appends events with a strictly increasing per-inbox seq (locked)", async () => {
+    // Concurrent appends must still get unique, increasing seqs.
+    const seqs = await Promise.all([
+      appendEvent(999, baseEvent("idle")),
+      appendEvent(999, baseEvent("needs_input")),
+      appendEvent(999, baseEvent("exited")),
+    ]);
+    const sorted = [...seqs].sort((a, b) => a - b);
+    expect(sorted).toEqual([1, 2, 3]);
+    const inbox = await readInbox(host, 999);
+    expect(inbox.map((e) => e.seq).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it("registers and expires watcher heartbeats", async () => {
+    await heartbeatWatcher(1, 111);
+    await heartbeatWatcher(2, 222);
+    expect([...(await liveWatchers())].sort()).toEqual([1, 2]);
+    await clearWatcher(1);
+    expect([...(await liveWatchers())]).toEqual([2]);
+    // A far-future `now` makes both heartbeats stale.
+    expect((await liveWatchers(Date.now() + 10 * 60_000)).size).toBe(0);
+  });
+
+  it("minConsumerCursor returns the smallest cursor across consumers (0 if none)", async () => {
+    expect(await minConsumerCursor(host, 999)).toBe(0);
+    await setCursor(host, 999, 8, "parent");
+    await setCursor(host, 999, 3, "auditor");
+    expect(await minConsumerCursor(host, 999)).toBe(3);
+  });
+
+  it("GC deletes a dead-parent inbox but keeps a referenced one", async () => {
+    await appendEvent(999, baseEvent("idle"));
+    await appendEvent(888, baseEvent("idle", { parent_pid: 888 }));
+    expect((await listInboxParents(host)).sort((a, b) => a - b)).toEqual([888, 999]);
+    // 999 dead + unreferenced → GC; 888 referenced by a live child → keep.
+    await gcInboxes(host, new Set<number>(), new Set([888]));
+    expect(await listInboxParents(host)).toEqual([888]);
+  });
+
+  it("GC rotation never drops unacked events even past the byte cap", async () => {
+    for (let i = 0; i < 50; i++) await appendEvent(999, baseEvent("idle"));
+    // Ack up to seq 20 for the sole consumer; cap of 1 byte forces rotation.
+    await setCursor(host, 999, 20, "parent");
+    await gcInboxes(host, new Set([999]), new Set([999]), 1);
+    const inbox = await readInbox(host, 999);
+    // Every unacked event (seq > 20) survives.
+    for (let seq = 21; seq <= 50; seq++) expect(inbox.some((e) => e.seq === seq)).toBe(true);
+    // The file did shrink (some acked events evicted) OR stayed — either way, no
+    // unacked loss. Confirm the inbox still exists.
+    await expect(stat(inboxPath(host, 999))).resolves.toBeTruthy();
+  });
+});

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -200,6 +200,13 @@ describe("notifyStore (fs)", () => {
     expect((await liveWatchers()).has(424242)).toBe(false);
   });
 
+  it("drops a watcher with a missing/non-positive started_at (fail-closed)", async () => {
+    // A 0 started_at would defeat the daemon's cross-session scope guard, so such
+    // a heartbeat is treated as NOT live.
+    await heartbeatWatcher(process.pid, 0);
+    expect((await liveWatchers()).has(process.pid)).toBe(false);
+  });
+
   it("minConsumerCursor returns the smallest cursor across consumers (0 if none)", async () => {
     expect(await minConsumerCursor(host, 999)).toBe(0);
     await setCursor(host, 999, 8, "parent");

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -131,6 +131,31 @@ describe("notifyStore (fs)", () => {
     expect(nextSeq).toBe(131); // continues from the counter, no seq reuse
   });
 
+  it("release() does NOT delete a lock that was STOLEN out from under it (fencing)", async () => {
+    const { mkdtemp, writeFile } = await import("fs/promises");
+    const { tmpdir } = await import("os");
+    const lockDir = path.join(await mkdtemp(path.join(tmpdir(), "ay-fence-")), "L");
+    const release = await acquireLock(lockDir, 30_000);
+    // Simulate another writer stealing + re-creating the lock: its owner file now
+    // carries a DIFFERENT fencing token.
+    await writeFile(
+      path.join(lockDir, "owner"),
+      JSON.stringify({ pid: 999999, ts: Date.now(), token: "someone-else" }),
+    );
+    await release();
+    // We must NOT have removed the new owner's lock.
+    await expect(stat(lockDir)).resolves.toBeTruthy();
+  });
+
+  it("release() deletes the lock when we still hold it", async () => {
+    const { mkdtemp } = await import("fs/promises");
+    const { tmpdir } = await import("os");
+    const lockDir = path.join(await mkdtemp(path.join(tmpdir(), "ay-fence2-")), "L");
+    const release = await acquireLock(lockDir, 30_000);
+    await release();
+    await expect(stat(lockDir)).rejects.toThrow(); // gone
+  });
+
   it("refreshes the lock owner heartbeat while held (I2: a long GC can't be stolen)", async () => {
     const { mkdtemp } = await import("fs/promises");
     const { tmpdir } = await import("os");

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, rm, stat, writeFile } from "fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import {
+  acquireLock,
   appendEvent,
   clearWatcher,
   gcInboxes,
@@ -126,6 +127,20 @@ describe("notifyStore (fs)", () => {
     expect(after.length).toBeLessThan(130); // did shrink
     const nextSeq = await appendEvent(999, baseEvent("needs_input"));
     expect(nextSeq).toBe(131); // continues from the counter, no seq reuse
+  });
+
+  it("refreshes the lock owner heartbeat while held (I2: a long GC can't be stolen)", async () => {
+    const { mkdtemp } = await import("fs/promises");
+    const { tmpdir } = await import("os");
+    const lockDir = path.join(await mkdtemp(path.join(tmpdir(), "ay-lock-")), "L");
+    // staleMs 1500 → beat every max(500, 500) = 500ms.
+    const release = await acquireLock(lockDir, 1500);
+    const ownerFile = path.join(lockDir, "owner");
+    const ts1 = JSON.parse(await readFile(ownerFile, "utf8")).ts as number;
+    await new Promise((r) => setTimeout(r, 700)); // past one beat interval
+    const ts2 = JSON.parse(await readFile(ownerFile, "utf8")).ts as number;
+    expect(ts2).toBeGreaterThan(ts1); // heartbeat advanced → holder stays "fresh"
+    await release();
   });
 
   it("registers and expires watcher heartbeats", async () => {

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -13,6 +13,7 @@ import {
   minConsumerCursor,
   readInbox,
   setCursor,
+  shouldStealLock,
 } from "./notifyStore.ts";
 import { inboxPath, type NotifyEvent } from "./notifyInbox.ts";
 
@@ -29,6 +30,50 @@ const baseEvent = (edge: NotifyEvent["edge"], over: Partial<NotifyEvent> = {}) =
   state: edge === "exited" ? "stopped" : edge,
   question: null,
   ...over,
+});
+
+describe("notifyStore — lock steal decision (C1: holder liveness, not wait time)", () => {
+  const now = 1_000_000;
+  const opts = (over = {}) => ({
+    staleMs: 30_000,
+    hardMs: 60_000,
+    elapsed: 0,
+    selfPid: 1,
+    isAlive: (p: number) => p === 42, // only pid 42 is "alive"
+    ...over,
+  });
+
+  it("does NOT steal a LIVE holder with a fresh heartbeat, even after a long wait", () => {
+    const owner = JSON.stringify({ pid: 42, ts: now - 1_000 });
+    // 50s elapsed but holder alive + fresh → must NOT steal (this was the bug).
+    expect(shouldStealLock(owner, now, opts({ elapsed: 50_000 }))).toBe(false);
+  });
+
+  it("steals a DEAD holder", () => {
+    const owner = JSON.stringify({ pid: 99, ts: now }); // 99 not alive
+    expect(shouldStealLock(owner, now, opts())).toBe(true);
+  });
+
+  it("steals a live holder whose heartbeat is STALE (wedged)", () => {
+    const owner = JSON.stringify({ pid: 42, ts: now - 40_000 }); // alive but stale
+    expect(shouldStealLock(owner, now, opts())).toBe(true);
+  });
+
+  it("does NOT steal a torn/empty owner within the grace (mkdir→writeFile window)", () => {
+    // A just-created lock whose owner file isn't written yet must be respected,
+    // else two writers race into the critical section and duplicate a seq.
+    expect(shouldStealLock("", now, opts({ elapsed: 0, graceMs: 1000 }))).toBe(false);
+    expect(shouldStealLock("{ torn", now, opts({ elapsed: 100, graceMs: 1000 }))).toBe(false);
+  });
+
+  it("steals a torn/empty owner once the grace elapses (holder crashed mid-acquire)", () => {
+    expect(shouldStealLock("", now, opts({ elapsed: 1500, graceMs: 1000 }))).toBe(true);
+  });
+
+  it("hardMs backstop steals even a fresh-looking holder after an extreme wait", () => {
+    const owner = JSON.stringify({ pid: 42, ts: now });
+    expect(shouldStealLock(owner, now, opts({ elapsed: 61_000 }))).toBe(true);
+  });
 });
 
 describe("notifyStore (fs)", () => {
@@ -68,6 +113,19 @@ describe("notifyStore (fs)", () => {
     const inbox = await readInbox(host, 999);
     expect(inbox.length).toBe(30);
     expect(new Set(inbox.map((e) => e.seq)).size).toBe(30); // no duplicates
+  });
+
+  it("trusts the sidecar seq counter across a GC that shrank the inbox (I2)", async () => {
+    // Fill past rotateKeep's minKeep(100), ack most, then GC to a smaller inbox;
+    // the counter must keep seq monotonic so the next append is maxSeq+1, NOT
+    // max(remaining events)+1.
+    for (let i = 0; i < 130; i++) await appendEvent(999, baseEvent("idle"));
+    await setCursor(host, 999, 120, "parent");
+    await gcInboxes(host, new Set([999]), new Set([999]), 1); // trims acked (<=120)
+    const after = await readInbox(host, 999);
+    expect(after.length).toBeLessThan(130); // did shrink
+    const nextSeq = await appendEvent(999, baseEvent("needs_input"));
+    expect(nextSeq).toBe(131); // continues from the counter, no seq reuse
   });
 
   it("registers and expires watcher heartbeats", async () => {

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -143,14 +143,22 @@ describe("notifyStore (fs)", () => {
     await release();
   });
 
-  it("registers and expires watcher heartbeats", async () => {
-    await heartbeatWatcher(1, 111);
-    await heartbeatWatcher(2, 222);
-    expect([...(await liveWatchers())].sort()).toEqual([1, 2]);
-    await clearWatcher(1);
-    expect([...(await liveWatchers())]).toEqual([2]);
-    // A far-future `now` makes both heartbeats stale.
+  it("registers and expires watcher heartbeats (fresh AND process alive)", async () => {
+    const alive = process.pid; // a definitely-alive pid
+    await heartbeatWatcher(alive, 111);
+    const live = await liveWatchers();
+    expect(live.has(alive)).toBe(true);
+    expect(live.get(alive)).toBe(111); // parent's self-reported started_at
+    await clearWatcher(alive);
+    expect((await liveWatchers()).has(alive)).toBe(false);
+    // A far-future `now` makes the heartbeat stale even for a live pid.
+    await heartbeatWatcher(alive, 111);
     expect((await liveWatchers(Date.now() + 10 * 60_000)).size).toBe(0);
+  });
+
+  it("drops a watcher whose heartbeat is fresh but whose process is DEAD (I3)", async () => {
+    await heartbeatWatcher(424242, 999); // 424242 is not a live process
+    expect((await liveWatchers()).has(424242)).toBe(false);
   });
 
   it("minConsumerCursor returns the smallest cursor across consumers (0 if none)", async () => {

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -287,7 +287,9 @@ export async function getCursor(host: string, parentPid: number, consumer = "par
 /**
  * Minimum cursor across ALL consumers of a parent inbox — the watermark below
  * which rotation may evict events (nothing above it has been acked by every
- * reader). Returns 0 when there are no consumers (nothing to protect).
+ * reader). Returns 0 when there are no consumers — which PROTECTS EVERYTHING:
+ * with a 0 watermark, `rotateKeep` treats every event as unacked and evicts
+ * nothing (an inbox nobody reads is never trimmed).
  */
 export async function minConsumerCursor(host: string, parentPid: number): Promise<number> {
   const names = await readdir(cursorDir(host, parentPid)).catch(() => [] as string[]);

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -190,9 +190,14 @@ export async function appendEvent(
       last = maxSeq(existing);
     }
     const seq = nextSeq(last);
+    // RESERVE the seq before writing the line: update the counter FIRST, then
+    // append. If a crash lands between the two, we're left with a reserved-but-
+    // unused seq (a harmless GAP) — never a REUSED seq. That ordering matters
+    // because the cursor is seq-based: a duplicated seq would let an acked batch
+    // silently skip a later, distinct notification. Gap OK, dup NOT ok.
     const full: NotifyEvent = { ...ev, seq };
-    await appendFile(inboxPath(host, parentPid), serializeEvent(full) + "\n");
     await writeFile(seqPath(host, parentPid), String(seq));
+    await appendFile(inboxPath(host, parentPid), serializeEvent(full) + "\n");
     return seq;
   } finally {
     await release();

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -9,7 +9,7 @@
  * contention is negligible even with many parents.
  */
 
-import { mkdir, readFile, readdir, rm, stat, writeFile, appendFile } from "fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile, appendFile } from "fs/promises";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "path";
@@ -52,17 +52,23 @@ function pidAlive(pid: number): boolean {
 
 /**
  * Pure steal decision for a per-inbox lock (extracted so it's unit-testable):
- * steal the lock ONLY when its holder is provably gone (torn/missing owner past
- * the grace, or a dead pid) or its heartbeat is stale — NEVER merely because
- * we've waited a while, so a live holder mid-critical-section keeps its lock.
- * There is no wall-clock backstop: `elapsed` gates only the torn-owner grace.
+ * steal the lock ONLY when its holder is provably gone (torn/missing owner on a
+ * lock that has EXISTED longer than the grace, or a dead pid) or its heartbeat is
+ * stale — NEVER merely because the contender has waited a while.
+ *
+ * Crucially, the torn-owner grace is measured from the LOCK INSTANCE's age
+ * (`lockAgeMs` = now − lockDir mtime), NOT from how long the contender has been
+ * waiting. Otherwise a contender that waited out one holder could instantly steal
+ * the NEXT holder's freshly-created lock during its mkdir→write-owner window
+ * (torn but brand-new) — letting two writers into the critical section.
  */
 export function shouldStealLock(
   ownerRaw: string,
   now: number,
   opts: {
     staleMs: number;
-    elapsed: number;
+    /** Age of THIS lock instance (now − lockDir mtime). Gates the torn grace. */
+    lockAgeMs: number;
     selfPid: number;
     isAlive: (p: number) => boolean;
     /** Grace for a JUST-created lock whose owner file isn't written yet. */
@@ -81,13 +87,12 @@ export function shouldStealLock(
   } catch {
     /* torn / not-yet-written owner */
   }
-  // An empty/torn owner (or one with no heartbeat ts yet) is the mkdir→writeFile
+  // An empty/torn owner (or one with no heartbeat ts yet) is the mkdir→write-owner
   // window of a holder mid-acquire — NOT proof of a dead holder. Only steal it
-  // after a short grace, so we can't rob a lock that was just legitimately
-  // created (which would let two writers into the critical section and duplicate
-  // a seq). A holder that actually crashed in that window is reclaimed once the
-  // grace elapses.
-  if (!parsed || ownerPid <= 0 || ownerTs <= 0) return opts.elapsed > graceMs;
+  // once THIS lock instance has existed torn longer than the grace (a real crash
+  // in that window), so we can never rob a lock that was just legitimately created
+  // (which would let two writers into the critical section and duplicate a seq).
+  if (!parsed || ownerPid <= 0 || ownerTs <= 0) return opts.lockAgeMs > graceMs;
   // Steal ONLY on positive evidence the holder is gone: its pid is dead, or its
   // heartbeat went stale. A LIVE holder refreshes its heartbeat for the whole
   // time it holds the lock (see acquireLock), so a long-but-legitimate critical
@@ -121,7 +126,6 @@ export async function acquireLock(
   staleMs = 30_000,
 ): Promise<() => Promise<void>> {
   const ownerFile = path.join(lockDir, "owner");
-  const start = Date.now();
   // A fencing token unique to THIS acquisition. Everything we do to the lock is
   // gated on the owner file still carrying our token — so if we were stale-stolen
   // mid-critical-section and the lock re-created by another writer, we neither
@@ -134,23 +138,39 @@ export async function acquireLock(
       return null;
     }
   };
-  const stampOwner = () =>
-    writeFile(ownerFile, JSON.stringify({ pid: process.pid, ts: Date.now(), token })).catch(
-      () => {},
-    );
+  // ATOMIC owner write (temp + rename): a reader never observes a torn/partial
+  // owner mid-write, so `readOwnerToken()===null` reliably means "no owner file"
+  // (a NEW instance mid-acquire), never "our own write in progress". That in turn
+  // lets the heartbeat safely stop on a null read without self-eviction.
+  const stampOwner = async () => {
+    const tmp = `${ownerFile}.${token}.tmp`;
+    try {
+      await writeFile(tmp, JSON.stringify({ pid: process.pid, ts: Date.now(), token }));
+      await rename(tmp, ownerFile);
+    } catch {
+      await rm(tmp, { force: true }).catch(() => {});
+    }
+  };
+  const lockAgeMs = async (): Promise<number> => {
+    const m = await stat(lockDir)
+      .then((s) => s.mtimeMs)
+      .catch(() => Date.now());
+    return Date.now() - m;
+  };
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
       await stampOwner();
       // Heartbeat the owner ts while we hold the lock, so a LONG critical section
-      // (a big gcInboxes rewrite) never crosses staleMs and gets stolen out from
-      // under us. Before each refresh, verify we STILL own it (token match) — if
-      // we were superseded (a torn/late steal), stop beating so we don't clobber
-      // the new owner's owner file. Refresh well inside staleMs; cleared on release.
+      // (a big gcInboxes rewrite) never crosses staleMs and gets stolen. Refresh
+      // ONLY while the owner still carries OUR token: any other value — a
+      // different token (superseded) OR null/absent (a new instance's mkdir→write
+      // window) — means we no longer own it, so we stop rather than clobber an
+      // unknown/absent owner. Atomic writes above mean a null read is never just
+      // our own write in flight. Refresh well inside staleMs; cleared on release.
       const beat = setInterval(() => {
         void (async () => {
-          const cur = await readOwnerToken();
-          if (cur !== null && cur !== token) {
+          if ((await readOwnerToken()) !== token) {
             clearInterval(beat);
             return;
           }
@@ -171,7 +191,7 @@ export async function acquireLock(
       if (
         shouldStealLock(raw, Date.now(), {
           staleMs,
-          elapsed: Date.now() - start,
+          lockAgeMs: await lockAgeMs(),
           selfPid: process.pid,
           isAlive: pidAlive,
         })

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -14,18 +14,22 @@ import os from "node:os";
 import path from "path";
 import {
   type NotifyEvent,
+  WATCHER_TTL_MS,
+  cursorDir,
   cursorPath,
   inboxDir,
   inboxPath,
+  liveWatcherPids,
   maxSeq,
   nextSeq,
-  notifyDir,
   parseCursor,
   parseInboxText,
   rotateKeep,
   seqPath,
   serializeCursor,
   serializeEvent,
+  watcherPath,
+  watchersDir,
 } from "./notifyInbox.ts";
 
 /** Stable local host id — the pid namespace is per-host. */
@@ -119,6 +123,20 @@ export async function getCursor(host: string, parentPid: number, consumer = "par
   return parseCursor(text).seq;
 }
 
+/**
+ * Minimum cursor across ALL consumers of a parent inbox — the watermark below
+ * which rotation may evict events (nothing above it has been acked by every
+ * reader). Returns 0 when there are no consumers (nothing to protect).
+ */
+export async function minConsumerCursor(host: string, parentPid: number): Promise<number> {
+  const names = await readdir(cursorDir(host, parentPid)).catch(() => [] as string[]);
+  const cursors = names.filter((n) => n.endsWith(".json")).map((n) => n.slice(0, -5));
+  if (cursors.length === 0) return 0;
+  let min = Infinity;
+  for (const c of cursors) min = Math.min(min, await getCursor(host, parentPid, c));
+  return Number.isFinite(min) ? min : 0;
+}
+
 export async function setCursor(
   host: string,
   parentPid: number,
@@ -146,19 +164,19 @@ export async function gcInboxes(
     if (!livePids.has(p) && !liveChildParentPids.has(p)) {
       await rm(inboxPath(host, p), { force: true }).catch(() => {});
       await rm(seqPath(host, p), { force: true }).catch(() => {});
-      await rm(path.join(notifyDir(), "cursors", host, String(p)), {
-        recursive: true,
-        force: true,
-      }).catch(() => {});
+      // Sanitized cursor dir (matches cursorPath), not a raw host join.
+      await rm(cursorDir(host, p), { recursive: true, force: true }).catch(() => {});
       continue;
     }
-    // Live inbox — rotate if oversized.
+    // Live inbox — rotate if oversized, but NEVER evict an event above the min
+    // consumer cursor (unacked): at-least-once must survive rotation.
     const size = await stat(inboxPath(host, p))
       .then((s) => s.size)
       .catch(() => 0);
     if (size > capBytes) {
       const events = await readInbox(host, p);
-      const kept = rotateKeep(events, capBytes);
+      const protectAboveSeq = await minConsumerCursor(host, p);
+      const kept = rotateKeep(events, capBytes, protectAboveSeq);
       if (kept.length < events.length) {
         const lock = path.join(inboxDir(host), `${p}.lock`);
         const release = await acquireLock(lock);
@@ -170,4 +188,42 @@ export async function gcInboxes(
       }
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Watcher registry — the set of parents currently running `ay notify watch`.
+// The daemon scopes its work to these parents (so an unrelated agent's children
+// never get an inbox) and stays alive while any watcher is live; a watcher
+// refreshes its heartbeat every poll and removes it on exit.
+// ---------------------------------------------------------------------------
+
+/** Register / refresh this parent's watch heartbeat. */
+export async function heartbeatWatcher(parentPid: number, startedAt: number): Promise<void> {
+  await ensureDir(watchersDir());
+  await writeFile(
+    watcherPath(parentPid),
+    JSON.stringify({ pid: parentPid, started_at: startedAt, ts: Date.now() }),
+  ).catch(() => {});
+}
+
+/** Remove this parent's watch heartbeat (on watch exit). */
+export async function clearWatcher(parentPid: number): Promise<void> {
+  await rm(watcherPath(parentPid), { force: true }).catch(() => {});
+}
+
+/** The set of parent pids with a fresh (non-expired) watch heartbeat. */
+export async function liveWatchers(now = Date.now()): Promise<Set<number>> {
+  const names = await readdir(watchersDir()).catch(() => [] as string[]);
+  const entries: { pid: number; ts: number }[] = [];
+  for (const n of names) {
+    if (!n.endsWith(".json")) continue;
+    const raw = await readFile(path.join(watchersDir(), n), "utf8").catch(() => "");
+    try {
+      const o = JSON.parse(raw) as { pid: number; ts: number };
+      if (typeof o?.pid === "number" && typeof o?.ts === "number") entries.push(o);
+    } catch {
+      /* skip torn heartbeat */
+    }
+  }
+  return liveWatcherPids(entries, now, WATCHER_TTL_MS);
 }

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -19,7 +19,6 @@ import {
   cursorPath,
   inboxDir,
   inboxPath,
-  liveWatcherPids,
   maxSeq,
   nextSeq,
   parseCursor,
@@ -307,19 +306,33 @@ export async function clearWatcher(parentPid: number): Promise<void> {
   await rm(watcherPath(parentPid), { force: true }).catch(() => {});
 }
 
-/** The set of parent pids with a fresh (non-expired) watch heartbeat. */
-export async function liveWatchers(now = Date.now()): Promise<Set<number>> {
+/**
+ * Live watchers as a map of parent pid → the parent's own `started_at` (its
+ * authoritative self-reported start time, so the daemon never has to guess it
+ * from the registry and stamp a 0). A watcher counts as live ONLY if its
+ * heartbeat is fresh AND its process is actually alive — so a crashed `watch`
+ * whose heartbeat lingers for the TTL doesn't keep the daemon writing to a dead
+ * parent's inbox (which would violate "nothing happens unless you watch").
+ */
+export async function liveWatchers(now = Date.now()): Promise<Map<number, number>> {
   const names = await readdir(watchersDir()).catch(() => [] as string[]);
-  const entries: { pid: number; ts: number }[] = [];
+  const live = new Map<number, number>();
   for (const n of names) {
     if (!n.endsWith(".json")) continue;
     const raw = await readFile(path.join(watchersDir(), n), "utf8").catch(() => "");
     try {
-      const o = JSON.parse(raw) as { pid: number; ts: number };
-      if (typeof o?.pid === "number" && typeof o?.ts === "number") entries.push(o);
+      const o = JSON.parse(raw) as { pid: number; started_at?: number; ts: number };
+      if (
+        typeof o?.pid === "number" &&
+        typeof o?.ts === "number" &&
+        now - o.ts <= WATCHER_TTL_MS &&
+        pidAlive(o.pid)
+      ) {
+        live.set(o.pid, typeof o.started_at === "number" ? o.started_at : 0);
+      }
     } catch {
       /* skip torn heartbeat */
     }
   }
-  return liveWatcherPids(entries, now, WATCHER_TTL_MS);
+  return live;
 }

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -104,8 +104,9 @@ async function ensureDir(dir: string): Promise<void> {
  * holder is dead or its heartbeat is stale. So a live holder whose critical
  * section legitimately runs long (a big GC rewrite, a slow disk) is never robbed
  * — which, together with the counter-trusting append below, closes the seq-dup /
- * event-loss window. A generous `hardMs` is a final backstop against a wedged-
- * but-"alive" holder.
+ * event-loss window. The one EXCEPTION is `hardMs`: a last-resort backstop that
+ * reclaims even a "live"-looking holder after an extreme wait, to guarantee
+ * forward progress against a holder wedged without updating its heartbeat.
  */
 async function acquireLock(
   lockDir: string,

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -37,39 +37,108 @@ export function hostId(): string {
   return os.hostname() || "localhost";
 }
 
+// Local liveness probe (kill(pid,0)) — kept here so notifyStore doesn't import
+// subcommands (which imports notifyStore: a cycle). Mirrors isPidAlive.
+function pidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM"; // exists, not ours
+  }
+}
+
+/**
+ * Pure steal decision for a per-inbox lock (extracted so it's unit-testable):
+ * steal the lock ONLY when its holder is provably gone (torn/missing owner, or a
+ * dead pid) or its heartbeat is stale — NEVER merely because we've waited a
+ * while, so a live holder mid-critical-section keeps its lock. `elapsed > hardMs`
+ * is a last-resort backstop against a wedged-but-"alive" holder.
+ */
+export function shouldStealLock(
+  ownerRaw: string,
+  now: number,
+  opts: {
+    staleMs: number;
+    hardMs: number;
+    elapsed: number;
+    selfPid: number;
+    isAlive: (p: number) => boolean;
+    /** Grace for a JUST-created lock whose owner file isn't written yet. */
+    graceMs?: number;
+  },
+): boolean {
+  const graceMs = opts.graceMs ?? 1000;
+  let ownerPid = 0;
+  let ownerTs = 0;
+  let parsed = false;
+  try {
+    const o = JSON.parse(ownerRaw) as { pid: number; ts: number };
+    ownerPid = o?.pid ?? 0;
+    ownerTs = o?.ts ?? 0;
+    parsed = true;
+  } catch {
+    /* torn / not-yet-written owner */
+  }
+  // An empty/torn owner is the mkdir→writeFile window of a holder mid-acquire —
+  // NOT proof of a dead holder. Only steal it after a short grace, so we can't
+  // rob a lock that was just legitimately created (which would let two writers
+  // into the critical section and duplicate a seq). The hardMs backstop still
+  // reclaims a holder that crashed exactly in that window.
+  if (!parsed || ownerPid <= 0) return opts.elapsed > graceMs;
+  const holderDead = ownerPid !== opts.selfPid && !opts.isAlive(ownerPid);
+  const holderStale = ownerTs > 0 && now - ownerTs > opts.staleMs;
+  return holderDead || holderStale || opts.elapsed > opts.hardMs;
+}
+
 async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true }).catch(() => {});
 }
 
 /**
- * Acquire a per-inbox mkdir lock; returns a release fn. Ownership is proven ONLY
- * by a successful `mkdir(recursive:false)` — the atomic, exclusive create. A
- * presumed-stale lock (held past `staleMs`) is removed ONCE and then we re-
- * contend: whoever's next `mkdir` succeeds owns it, so two would-be stealers can
- * never both enter the critical section (the loser EEXISTs and keeps waiting).
+ * Acquire a per-inbox lock; returns a release fn. Ownership is proven ONLY by a
+ * successful `mkdir(recursive:false)` (atomic exclusive create), and stealing is
+ * driven by HOLDER LIVENESS, not elapsed wait time: the holder writes an
+ * `owner` file ({pid, ts}) on acquire, and a contender steals ONLY when that
+ * holder is dead or its heartbeat is stale. So a live holder whose critical
+ * section legitimately runs long (a big GC rewrite, a slow disk) is never robbed
+ * — which, together with the counter-trusting append below, closes the seq-dup /
+ * event-loss window. A generous `hardMs` is a final backstop against a wedged-
+ * but-"alive" holder.
  */
 async function acquireLock(
   lockDir: string,
-  staleMs = 2000,
-  hardMs = 10_000,
+  staleMs = 30_000,
+  hardMs = 60_000,
 ): Promise<() => Promise<void>> {
+  const ownerFile = path.join(lockDir, "owner");
   const start = Date.now();
-  let stole = false;
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
+      await writeFile(ownerFile, JSON.stringify({ pid: process.pid, ts: Date.now() })).catch(
+        () => {},
+      );
       return async () => {
         await rm(lockDir, { recursive: true, force: true }).catch(() => {});
       };
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
-      const elapsed = Date.now() - start;
-      if (elapsed > hardMs) throw new Error(`notify lock timed out: ${lockDir}`);
-      // Remove the presumed-stale lock at most once, then loop back to re-contend
-      // — the next mkdir(recursive:false) is the sole ownership proof.
-      if (elapsed > staleMs && !stole) {
-        stole = true;
+      const raw = await readFile(ownerFile, "utf8").catch(() => "");
+      if (
+        shouldStealLock(raw, Date.now(), {
+          staleMs,
+          hardMs,
+          elapsed: Date.now() - start,
+          selfPid: process.pid,
+          isAlive: pidAlive,
+        })
+      ) {
+        // Steal, then loop back — the next mkdir(recursive:false) re-proves
+        // ownership, so two contenders can't both enter the critical section.
         await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+        continue;
       }
       await new Promise((r) => setTimeout(r, 15));
     }
@@ -90,16 +159,23 @@ export async function appendEvent(
   const lock = path.join(dir, `${parentPid}.lock`);
   const release = await acquireLock(lock);
   try {
-    // Prefer the sidecar counter; fall back to scanning the inbox (self-heals if
-    // the counter is lost). Guarantees a strictly increasing per-inbox seq.
+    // TRUST the sidecar counter — it is written under this same lock on every
+    // append, so it is always the authoritative last-allocated seq (and it stays
+    // valid across a GC rewrite, whose kept seqs are all <= the counter). Only
+    // when the counter is missing/corrupt do we fall back to an O(file) scan to
+    // self-heal. This keeps the hot path — and thus the lock-hold window — O(1),
+    // which is what makes a long steal window (C1) a non-issue.
     let last = 0;
     const counterRaw = await readFile(seqPath(host, parentPid), "utf8").catch(() => "");
     const parsed = parseInt(counterRaw.trim(), 10);
-    if (Number.isFinite(parsed) && parsed > 0) last = parsed;
-    const existing = parseInboxText(
-      await readFile(inboxPath(host, parentPid), "utf8").catch(() => ""),
-    );
-    last = Math.max(last, maxSeq(existing));
+    if (Number.isFinite(parsed) && parsed > 0) {
+      last = parsed;
+    } else {
+      const existing = parseInboxText(
+        await readFile(inboxPath(host, parentPid), "utf8").catch(() => ""),
+      );
+      last = maxSeq(existing);
+    }
     const seq = nextSeq(last);
     const full: NotifyEvent = { ...ev, seq };
     await appendFile(inboxPath(host, parentPid), serializeEvent(full) + "\n");

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -12,6 +12,7 @@
 import { mkdir, readFile, readdir, rm, stat, writeFile, appendFile } from "fs/promises";
 import os from "node:os";
 import path from "path";
+import { logger } from "./logger.ts";
 import {
   type NotifyEvent,
   WATCHER_TTL_MS,
@@ -282,6 +283,14 @@ export async function gcInboxes(
         const kept = rotateKeep(events, capBytes, protectAboveSeq);
         if (kept.length < events.length) {
           await writeFile(inboxPath(host, p), kept.map(serializeEvent).join("\n") + "\n");
+        } else {
+          // Oversize but nothing was trimmable — every event is unacked (min
+          // cursor at/below the oldest). `capBytes` is a SOFT cap here (we never
+          // drop an unacked edge), so surface the unbounded growth rather than
+          // silently exceeding it. A parent that never acks is the usual cause.
+          logger.warn(
+            `[notify] inbox for parent ${p} is ${size} bytes (> soft cap ${capBytes}) but all events are unacked — cursor not advancing?`,
+          );
         }
       } finally {
         await release();

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -108,20 +108,27 @@ async function ensureDir(dir: string): Promise<void> {
  * reclaims even a "live"-looking holder after an extreme wait, to guarantee
  * forward progress against a holder wedged without updating its heartbeat.
  */
-async function acquireLock(
+export async function acquireLock(
   lockDir: string,
   staleMs = 30_000,
   hardMs = 60_000,
 ): Promise<() => Promise<void>> {
   const ownerFile = path.join(lockDir, "owner");
   const start = Date.now();
+  const stampOwner = () =>
+    writeFile(ownerFile, JSON.stringify({ pid: process.pid, ts: Date.now() })).catch(() => {});
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
-      await writeFile(ownerFile, JSON.stringify({ pid: process.pid, ts: Date.now() })).catch(
-        () => {},
-      );
+      await stampOwner();
+      // Heartbeat the owner ts while we hold the lock, so a LONG critical section
+      // (a big gcInboxes rewrite) never crosses staleMs and gets stolen out from
+      // under us — which would let a second writer in and clobber/duplicate a seq.
+      // Refresh well inside staleMs; cleared on release.
+      const beat = setInterval(() => void stampOwner(), Math.max(500, Math.floor(staleMs / 3)));
+      if (typeof beat.unref === "function") beat.unref();
       return async () => {
+        clearInterval(beat);
         await rm(lockDir, { recursive: true, force: true }).catch(() => {});
       };
     } catch (e) {

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -110,6 +110,23 @@ async function ensureDir(dir: string): Promise<void> {
 }
 
 /**
+ * Atomically overwrite a single file (temp + rename) so a concurrent reader never
+ * observes a torn/partial write — the sweep invariant for every single-file
+ * mutation (cursor, watcher heartbeat, lock owner). Returns whether it landed.
+ */
+async function atomicWrite(file: string, data: string): Promise<boolean> {
+  const tmp = `${file}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(tmp, data);
+    await rename(tmp, file);
+    return true;
+  } catch {
+    await rm(tmp, { force: true }).catch(() => {});
+    return false;
+  }
+}
+
+/**
  * Acquire a per-inbox lock; returns a release fn. Ownership is proven ONLY by a
  * successful `mkdir(recursive:false)` (atomic exclusive create), and stealing is
  * driven by HOLDER LIVENESS, not elapsed wait time: the holder writes an
@@ -308,7 +325,7 @@ export async function setCursor(
 ): Promise<void> {
   const p = cursorPath(host, parentPid, consumer);
   await ensureDir(path.dirname(p));
-  await writeFile(p, serializeCursor(seq));
+  await atomicWrite(p, serializeCursor(seq));
 }
 
 /**
@@ -324,41 +341,41 @@ export async function gcInboxes(
 ): Promise<void> {
   const parents = await listInboxParents(host);
   for (const p of parents) {
-    if (!livePids.has(p) && !liveChildParentPids.has(p)) {
-      await rm(inboxPath(host, p), { force: true }).catch(() => {});
-      await rm(seqPath(host, p), { force: true }).catch(() => {});
-      // Sanitized cursor dir (matches cursorPath), not a raw host join.
-      await rm(cursorDir(host, p), { recursive: true, force: true }).catch(() => {});
-      continue;
-    }
-    // Live inbox — rotate if oversized, but NEVER evict an event above the min
-    // consumer cursor (unacked): at-least-once must survive rotation. The size
-    // check is a cheap gate; the read→compute→write all happen UNDER the lock so
-    // a concurrent appendEvent can't be lost between a stale read and the write.
-    const size = await stat(inboxPath(host, p))
-      .then((s) => s.size)
-      .catch(() => 0);
-    if (size > capBytes) {
-      const lock = path.join(inboxDir(host), `${p}.lock`);
-      const release = await acquireLock(lock);
-      try {
-        const events = await readInbox(host, p);
-        const protectAboveSeq = await minConsumerCursor(host, p);
-        const kept = rotateKeep(events, capBytes, protectAboveSeq);
-        if (kept.length < events.length) {
-          await writeFile(inboxPath(host, p), kept.map(serializeEvent).join("\n") + "\n");
-        } else {
-          // Oversize but nothing was trimmable — every event is unacked (min
-          // cursor at/below the oldest). `capBytes` is a SOFT cap here (we never
-          // drop an unacked edge), so surface the unbounded growth rather than
-          // silently exceeding it. A parent that never acks is the usual cause.
-          logger.warn(
-            `[notify] inbox for parent ${p} is ${size} bytes (> soft cap ${capBytes}) but all events are unacked — cursor not advancing?`,
-          );
-        }
-      } finally {
-        await release();
+    // BOTH the delete and the rotation mutate the inbox/.seq/cursor, so BOTH run
+    // under the same per-inbox lock `appendEvent` takes — a concurrent append can
+    // never be lost to a mid-flight delete or rotation.
+    const lock = path.join(inboxDir(host), `${p}.lock`);
+    const release = await acquireLock(lock);
+    try {
+      if (!livePids.has(p) && !liveChildParentPids.has(p)) {
+        await rm(inboxPath(host, p), { force: true }).catch(() => {});
+        await rm(seqPath(host, p), { force: true }).catch(() => {});
+        // Sanitized cursor dir (matches cursorPath), not a raw host join.
+        await rm(cursorDir(host, p), { recursive: true, force: true }).catch(() => {});
+        continue;
       }
+      // Live inbox — rotate if oversized, but NEVER evict an event above the min
+      // consumer cursor (unacked): at-least-once must survive rotation.
+      const size = await stat(inboxPath(host, p))
+        .then((s) => s.size)
+        .catch(() => 0);
+      if (size <= capBytes) continue;
+      const events = await readInbox(host, p);
+      const protectAboveSeq = await minConsumerCursor(host, p);
+      const kept = rotateKeep(events, capBytes, protectAboveSeq);
+      if (kept.length < events.length) {
+        await writeFile(inboxPath(host, p), kept.map(serializeEvent).join("\n") + "\n");
+      } else {
+        // Oversize but nothing was trimmable — every event is unacked (min cursor
+        // at/below the oldest). `capBytes` is a SOFT cap here (we never drop an
+        // unacked edge), so surface the unbounded growth rather than silently
+        // exceeding it. A parent that never acks is the usual cause.
+        logger.warn(
+          `[notify] inbox for parent ${p} is ${size} bytes (> soft cap ${capBytes}) but all events are unacked — cursor not advancing?`,
+        );
+      }
+    } finally {
+      await release();
     }
   }
 }
@@ -370,13 +387,14 @@ export async function gcInboxes(
 // refreshes its heartbeat every poll and removes it on exit.
 // ---------------------------------------------------------------------------
 
-/** Register / refresh this parent's watch heartbeat. */
+/** Register / refresh this parent's watch heartbeat (atomically, so a concurrent
+ * liveWatchers never reads a torn file and transiently drops the watcher). */
 export async function heartbeatWatcher(parentPid: number, startedAt: number): Promise<void> {
   await ensureDir(watchersDir());
-  await writeFile(
+  await atomicWrite(
     watcherPath(parentPid),
     JSON.stringify({ pid: parentPid, started_at: startedAt, ts: Date.now() }),
-  ).catch(() => {});
+  );
 }
 
 /** Remove this parent's watch heartbeat (on watch exit). */
@@ -390,7 +408,10 @@ export async function clearWatcher(parentPid: number): Promise<void> {
  * from the registry and stamp a 0). A watcher counts as live ONLY if its
  * heartbeat is fresh AND its process is actually alive — so a crashed `watch`
  * whose heartbeat lingers for the TTL doesn't keep the daemon writing to a dead
- * parent's inbox (which would violate "nothing happens unless you watch").
+ * parent's inbox (which would violate "nothing happens unless you watch"). A
+ * heartbeat with a missing/non-positive `started_at` is treated as NOT live: the
+ * daemon's cross-session scope guard keys off a positive parent start time, so a
+ * 0 would defeat it — fail closed.
  */
 export async function liveWatchers(now = Date.now()): Promise<Map<number, number>> {
   const names = await readdir(watchersDir()).catch(() => [] as string[]);
@@ -402,11 +423,13 @@ export async function liveWatchers(now = Date.now()): Promise<Map<number, number
       const o = JSON.parse(raw) as { pid: number; started_at?: number; ts: number };
       if (
         typeof o?.pid === "number" &&
+        typeof o?.started_at === "number" &&
+        o.started_at > 0 &&
         typeof o?.ts === "number" &&
         now - o.ts <= WATCHER_TTL_MS &&
         pidAlive(o.pid)
       ) {
-        live.set(o.pid, typeof o.started_at === "number" ? o.started_at : 0);
+        live.set(o.pid, o.started_at);
       }
     } catch {
       /* skip torn heartbeat */

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -41,25 +41,35 @@ async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true }).catch(() => {});
 }
 
-/** Acquire a per-inbox mkdir lock; returns a release fn. Best-effort, bounded. */
-async function acquireLock(lockDir: string, timeoutMs = 2000): Promise<() => Promise<void>> {
+/**
+ * Acquire a per-inbox mkdir lock; returns a release fn. Ownership is proven ONLY
+ * by a successful `mkdir(recursive:false)` — the atomic, exclusive create. A
+ * presumed-stale lock (held past `staleMs`) is removed ONCE and then we re-
+ * contend: whoever's next `mkdir` succeeds owns it, so two would-be stealers can
+ * never both enter the critical section (the loser EEXISTs and keeps waiting).
+ */
+async function acquireLock(
+  lockDir: string,
+  staleMs = 2000,
+  hardMs = 10_000,
+): Promise<() => Promise<void>> {
   const start = Date.now();
-  // Back off between attempts; the critical section is tiny so this rarely loops.
+  let stole = false;
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
       return async () => {
         await rm(lockDir, { recursive: true, force: true }).catch(() => {});
       };
-    } catch {
-      if (Date.now() - start > timeoutMs) {
-        // Stale lock (a crashed writer) — steal it rather than deadlock. The
-        // critical section is idempotent-safe on seq via re-read below.
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      const elapsed = Date.now() - start;
+      if (elapsed > hardMs) throw new Error(`notify lock timed out: ${lockDir}`);
+      // Remove the presumed-stale lock at most once, then loop back to re-contend
+      // — the next mkdir(recursive:false) is the sole ownership proof.
+      if (elapsed > staleMs && !stole) {
+        stole = true;
         await rm(lockDir, { recursive: true, force: true }).catch(() => {});
-        await mkdir(lockDir, { recursive: true }).catch(() => {});
-        return async () => {
-          await rm(lockDir, { recursive: true, force: true }).catch(() => {});
-        };
       }
       await new Promise((r) => setTimeout(r, 15));
     }
@@ -169,22 +179,24 @@ export async function gcInboxes(
       continue;
     }
     // Live inbox — rotate if oversized, but NEVER evict an event above the min
-    // consumer cursor (unacked): at-least-once must survive rotation.
+    // consumer cursor (unacked): at-least-once must survive rotation. The size
+    // check is a cheap gate; the read→compute→write all happen UNDER the lock so
+    // a concurrent appendEvent can't be lost between a stale read and the write.
     const size = await stat(inboxPath(host, p))
       .then((s) => s.size)
       .catch(() => 0);
     if (size > capBytes) {
-      const events = await readInbox(host, p);
-      const protectAboveSeq = await minConsumerCursor(host, p);
-      const kept = rotateKeep(events, capBytes, protectAboveSeq);
-      if (kept.length < events.length) {
-        const lock = path.join(inboxDir(host), `${p}.lock`);
-        const release = await acquireLock(lock);
-        try {
+      const lock = path.join(inboxDir(host), `${p}.lock`);
+      const release = await acquireLock(lock);
+      try {
+        const events = await readInbox(host, p);
+        const protectAboveSeq = await minConsumerCursor(host, p);
+        const kept = rotateKeep(events, capBytes, protectAboveSeq);
+        if (kept.length < events.length) {
           await writeFile(inboxPath(host, p), kept.map(serializeEvent).join("\n") + "\n");
-        } finally {
-          await release();
         }
+      } finally {
+        await release();
       }
     }
   }

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -1,0 +1,173 @@
+/**
+ * Filesystem side of the notification inbox — the impure half of the pure
+ * `notifyInbox.ts` path/serialization core. Handles the locked append (so
+ * concurrent daemon ticks / future writers never interleave a seq), inbox and
+ * cursor reads/writes, and retention GC.
+ *
+ * The lock is a mkdir-based advisory lock (same primitive `pidStore` uses), held
+ * only for the microseconds of a read-counter → append-line → write-counter, so
+ * contention is negligible even with many parents.
+ */
+
+import { mkdir, readFile, readdir, rm, stat, writeFile, appendFile } from "fs/promises";
+import os from "node:os";
+import path from "path";
+import {
+  type NotifyEvent,
+  cursorPath,
+  inboxDir,
+  inboxPath,
+  maxSeq,
+  nextSeq,
+  notifyDir,
+  parseCursor,
+  parseInboxText,
+  rotateKeep,
+  seqPath,
+  serializeCursor,
+  serializeEvent,
+} from "./notifyInbox.ts";
+
+/** Stable local host id — the pid namespace is per-host. */
+export function hostId(): string {
+  return os.hostname() || "localhost";
+}
+
+async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true }).catch(() => {});
+}
+
+/** Acquire a per-inbox mkdir lock; returns a release fn. Best-effort, bounded. */
+async function acquireLock(lockDir: string, timeoutMs = 2000): Promise<() => Promise<void>> {
+  const start = Date.now();
+  // Back off between attempts; the critical section is tiny so this rarely loops.
+  for (;;) {
+    try {
+      await mkdir(lockDir, { recursive: false });
+      return async () => {
+        await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+      };
+    } catch {
+      if (Date.now() - start > timeoutMs) {
+        // Stale lock (a crashed writer) — steal it rather than deadlock. The
+        // critical section is idempotent-safe on seq via re-read below.
+        await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+        await mkdir(lockDir, { recursive: true }).catch(() => {});
+        return async () => {
+          await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+        };
+      }
+      await new Promise((r) => setTimeout(r, 15));
+    }
+  }
+}
+
+/**
+ * Append one event to a parent's inbox under lock, allocating the next seq. The
+ * caller passes the event WITHOUT seq (we stamp it). Returns the stamped seq.
+ */
+export async function appendEvent(
+  parentPid: number,
+  ev: Omit<NotifyEvent, "seq">,
+): Promise<number> {
+  const host = ev.host;
+  const dir = inboxDir(host);
+  await ensureDir(dir);
+  const lock = path.join(dir, `${parentPid}.lock`);
+  const release = await acquireLock(lock);
+  try {
+    // Prefer the sidecar counter; fall back to scanning the inbox (self-heals if
+    // the counter is lost). Guarantees a strictly increasing per-inbox seq.
+    let last = 0;
+    const counterRaw = await readFile(seqPath(host, parentPid), "utf8").catch(() => "");
+    const parsed = parseInt(counterRaw.trim(), 10);
+    if (Number.isFinite(parsed) && parsed > 0) last = parsed;
+    const existing = parseInboxText(
+      await readFile(inboxPath(host, parentPid), "utf8").catch(() => ""),
+    );
+    last = Math.max(last, maxSeq(existing));
+    const seq = nextSeq(last);
+    const full: NotifyEvent = { ...ev, seq };
+    await appendFile(inboxPath(host, parentPid), serializeEvent(full) + "\n");
+    await writeFile(seqPath(host, parentPid), String(seq));
+    return seq;
+  } finally {
+    await release();
+  }
+}
+
+/** Read + parse a parent's inbox (empty array when none). */
+export async function readInbox(host: string, parentPid: number): Promise<NotifyEvent[]> {
+  const text = await readFile(inboxPath(host, parentPid), "utf8").catch(() => "");
+  return parseInboxText(text);
+}
+
+/** All parent pids that currently have an inbox on this host. */
+export async function listInboxParents(host: string): Promise<number[]> {
+  const dir = inboxDir(host);
+  const names = await readdir(dir).catch(() => [] as string[]);
+  const pids: number[] = [];
+  for (const n of names) {
+    const m = /^(\d+)\.ndjson$/.exec(n);
+    if (m) pids.push(parseInt(m[1]!, 10));
+  }
+  return pids;
+}
+
+export async function getCursor(host: string, parentPid: number, consumer = "parent"): Promise<number> {
+  const text = await readFile(cursorPath(host, parentPid, consumer), "utf8").catch(() => null);
+  return parseCursor(text).seq;
+}
+
+export async function setCursor(
+  host: string,
+  parentPid: number,
+  seq: number,
+  consumer = "parent",
+): Promise<void> {
+  const p = cursorPath(host, parentPid, consumer);
+  await ensureDir(path.dirname(p));
+  await writeFile(p, serializeCursor(seq));
+}
+
+/**
+ * Retention: delete inboxes (+ their seq counter + cursors) for parents that are
+ * both dead and unreferenced by any live child. `capBytes` also rotates a live
+ * inbox that has grown past the cap, keeping the newest events.
+ */
+export async function gcInboxes(
+  host: string,
+  livePids: Set<number>,
+  liveChildParentPids: Set<number>,
+  capBytes = 10 * 1024 * 1024,
+): Promise<void> {
+  const parents = await listInboxParents(host);
+  for (const p of parents) {
+    if (!livePids.has(p) && !liveChildParentPids.has(p)) {
+      await rm(inboxPath(host, p), { force: true }).catch(() => {});
+      await rm(seqPath(host, p), { force: true }).catch(() => {});
+      await rm(path.join(notifyDir(), "cursors", host, String(p)), {
+        recursive: true,
+        force: true,
+      }).catch(() => {});
+      continue;
+    }
+    // Live inbox — rotate if oversized.
+    const size = await stat(inboxPath(host, p))
+      .then((s) => s.size)
+      .catch(() => 0);
+    if (size > capBytes) {
+      const events = await readInbox(host, p);
+      const kept = rotateKeep(events, capBytes);
+      if (kept.length < events.length) {
+        const lock = path.join(inboxDir(host), `${p}.lock`);
+        const release = await acquireLock(lock);
+        try {
+          await writeFile(inboxPath(host, p), kept.map(serializeEvent).join("\n") + "\n");
+        } finally {
+          await release();
+        }
+      }
+    }
+  }
+}

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -10,6 +10,7 @@
  */
 
 import { mkdir, readFile, readdir, rm, stat, writeFile, appendFile } from "fs/promises";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "path";
 import { logger } from "./logger.ts";
@@ -121,21 +122,48 @@ export async function acquireLock(
 ): Promise<() => Promise<void>> {
   const ownerFile = path.join(lockDir, "owner");
   const start = Date.now();
+  // A fencing token unique to THIS acquisition. Everything we do to the lock is
+  // gated on the owner file still carrying our token — so if we were stale-stolen
+  // mid-critical-section and the lock re-created by another writer, we neither
+  // overwrite their owner nor delete their lock. Classic fencing.
+  const token = randomUUID();
+  const readOwnerToken = async (): Promise<string | null> => {
+    try {
+      return (JSON.parse(await readFile(ownerFile, "utf8")) as { token?: string }).token ?? null;
+    } catch {
+      return null;
+    }
+  };
   const stampOwner = () =>
-    writeFile(ownerFile, JSON.stringify({ pid: process.pid, ts: Date.now() })).catch(() => {});
+    writeFile(ownerFile, JSON.stringify({ pid: process.pid, ts: Date.now(), token })).catch(
+      () => {},
+    );
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
       await stampOwner();
       // Heartbeat the owner ts while we hold the lock, so a LONG critical section
       // (a big gcInboxes rewrite) never crosses staleMs and gets stolen out from
-      // under us — which would let a second writer in and clobber/duplicate a seq.
-      // Refresh well inside staleMs; cleared on release.
-      const beat = setInterval(() => void stampOwner(), Math.max(500, Math.floor(staleMs / 3)));
+      // under us. Before each refresh, verify we STILL own it (token match) — if
+      // we were superseded (a torn/late steal), stop beating so we don't clobber
+      // the new owner's owner file. Refresh well inside staleMs; cleared on release.
+      const beat = setInterval(() => {
+        void (async () => {
+          const cur = await readOwnerToken();
+          if (cur !== null && cur !== token) {
+            clearInterval(beat);
+            return;
+          }
+          await stampOwner();
+        })();
+      }, Math.max(500, Math.floor(staleMs / 3)));
       if (typeof beat.unref === "function") beat.unref();
       return async () => {
         clearInterval(beat);
-        await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+        // Release ONLY if we still hold it — never delete a lock another writer
+        // now owns (which would open the critical section to a third writer).
+        if ((await readOwnerToken()) === token)
+          await rm(lockDir, { recursive: true, force: true }).catch(() => {});
       };
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -50,10 +50,10 @@ function pidAlive(pid: number): boolean {
 
 /**
  * Pure steal decision for a per-inbox lock (extracted so it's unit-testable):
- * steal the lock ONLY when its holder is provably gone (torn/missing owner, or a
- * dead pid) or its heartbeat is stale — NEVER merely because we've waited a
- * while, so a live holder mid-critical-section keeps its lock. `elapsed > hardMs`
- * is a last-resort backstop against a wedged-but-"alive" holder.
+ * steal the lock ONLY when its holder is provably gone (torn/missing owner past
+ * the grace, or a dead pid) or its heartbeat is stale — NEVER merely because
+ * we've waited a while, so a live holder mid-critical-section keeps its lock.
+ * There is no wall-clock backstop: `elapsed` gates only the torn-owner grace.
  */
 export function shouldStealLock(
   ownerRaw: string,

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -142,13 +142,15 @@ export async function acquireLock(
   // owner mid-write, so `readOwnerToken()===null` reliably means "no owner file"
   // (a NEW instance mid-acquire), never "our own write in progress". That in turn
   // lets the heartbeat safely stop on a null read without self-eviction.
-  const stampOwner = async () => {
+  const stampOwner = async (): Promise<boolean> => {
     const tmp = `${ownerFile}.${token}.tmp`;
     try {
       await writeFile(tmp, JSON.stringify({ pid: process.pid, ts: Date.now(), token }));
       await rename(tmp, ownerFile);
+      return true;
     } catch {
       await rm(tmp, { force: true }).catch(() => {});
+      return false;
     }
   };
   const lockAgeMs = async (): Promise<number> => {
@@ -160,7 +162,14 @@ export async function acquireLock(
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
-      await stampOwner();
+      // If we can't write our owner file, we do NOT own the lock — a later
+      // contender would see a torn owner, steal past the grace, and enter the
+      // critical section alongside us. Drop the lock dir and retry.
+      if (!(await stampOwner())) {
+        await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+        await new Promise((r) => setTimeout(r, 15));
+        continue;
+      }
       // Heartbeat the owner ts while we hold the lock, so a LONG critical section
       // (a big gcInboxes rewrite) never crosses staleMs and gets stolen. Refresh
       // ONLY while the owner still carries OUR token: any other value — a

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -60,7 +60,6 @@ export function shouldStealLock(
   now: number,
   opts: {
     staleMs: number;
-    hardMs: number;
     elapsed: number;
     selfPid: number;
     isAlive: (p: number) => boolean;
@@ -80,15 +79,23 @@ export function shouldStealLock(
   } catch {
     /* torn / not-yet-written owner */
   }
-  // An empty/torn owner is the mkdir→writeFile window of a holder mid-acquire —
-  // NOT proof of a dead holder. Only steal it after a short grace, so we can't
-  // rob a lock that was just legitimately created (which would let two writers
-  // into the critical section and duplicate a seq). The hardMs backstop still
-  // reclaims a holder that crashed exactly in that window.
-  if (!parsed || ownerPid <= 0) return opts.elapsed > graceMs;
+  // An empty/torn owner (or one with no heartbeat ts yet) is the mkdir→writeFile
+  // window of a holder mid-acquire — NOT proof of a dead holder. Only steal it
+  // after a short grace, so we can't rob a lock that was just legitimately
+  // created (which would let two writers into the critical section and duplicate
+  // a seq). A holder that actually crashed in that window is reclaimed once the
+  // grace elapses.
+  if (!parsed || ownerPid <= 0 || ownerTs <= 0) return opts.elapsed > graceMs;
+  // Steal ONLY on positive evidence the holder is gone: its pid is dead, or its
+  // heartbeat went stale. A LIVE holder refreshes its heartbeat for the whole
+  // time it holds the lock (see acquireLock), so a long-but-legitimate critical
+  // section (a big GC rewrite) is never robbed — and a wedged holder stops
+  // refreshing, so staleMs still reclaims it. Wall-clock wait time ALONE never
+  // steals (no hardMs backstop): that was the only path left that could rob a
+  // live holder.
   const holderDead = ownerPid !== opts.selfPid && !opts.isAlive(ownerPid);
-  const holderStale = ownerTs > 0 && now - ownerTs > opts.staleMs;
-  return holderDead || holderStale || opts.elapsed > opts.hardMs;
+  const holderStale = now - ownerTs > opts.staleMs;
+  return holderDead || holderStale;
 }
 
 async function ensureDir(dir: string): Promise<void> {
@@ -99,18 +106,17 @@ async function ensureDir(dir: string): Promise<void> {
  * Acquire a per-inbox lock; returns a release fn. Ownership is proven ONLY by a
  * successful `mkdir(recursive:false)` (atomic exclusive create), and stealing is
  * driven by HOLDER LIVENESS, not elapsed wait time: the holder writes an
- * `owner` file ({pid, ts}) on acquire, and a contender steals ONLY when that
- * holder is dead or its heartbeat is stale. So a live holder whose critical
- * section legitimately runs long (a big GC rewrite, a slow disk) is never robbed
- * — which, together with the counter-trusting append below, closes the seq-dup /
- * event-loss window. The one EXCEPTION is `hardMs`: a last-resort backstop that
- * reclaims even a "live"-looking holder after an extreme wait, to guarantee
- * forward progress against a holder wedged without updating its heartbeat.
+ * `owner` file ({pid, ts}) on acquire AND heartbeats its ts for the whole time
+ * it holds the lock, so a contender steals ONLY when that holder is dead or its
+ * heartbeat is stale. A live holder whose critical section legitimately runs long
+ * (a big GC rewrite, a slow disk) is never robbed — its heartbeat stays fresh;
+ * and a wedged holder stops heartbeating, so staleMs still reclaims it. There is
+ * deliberately NO wall-clock backstop: elapsed wait time alone never steals, so a
+ * live holder is inviolable.
  */
 export async function acquireLock(
   lockDir: string,
   staleMs = 30_000,
-  hardMs = 60_000,
 ): Promise<() => Promise<void>> {
   const ownerFile = path.join(lockDir, "owner");
   const start = Date.now();
@@ -136,7 +142,6 @@ export async function acquireLock(
       if (
         shouldStealLock(raw, Date.now(), {
           staleMs,
-          hardMs,
           elapsed: Date.now() - start,
           selfPid: process.pid,
           isAlive: pidAlive,

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -28,7 +28,14 @@ import {
 } from "./needsInput.ts";
 import { diffLsStates, type LiveState, type LsAgentState } from "./lsWatch.ts";
 import { filterSinceSeq, filterSinceTs, filterUnread, maxSeq, type NotifyEvent } from "./notifyInbox.ts";
-import { getCursor, hostId, readInbox, setCursor } from "./notifyStore.ts";
+import {
+  clearWatcher,
+  getCursor,
+  heartbeatWatcher,
+  hostId,
+  readInbox,
+  setCursor,
+} from "./notifyStore.ts";
 import {
   buildStoredResult,
   normalizeEnvelope,
@@ -4086,9 +4093,17 @@ async function cmdNotify(rest: string[]): Promise<number> {
   const parent = resolveParentPid(argv.parent as number | undefined);
   const host = hostId();
   const consumer = String(argv.consumer);
+  // The reader's own start time — used to reject inbox events addressed to a
+  // PRIOR incarnation of this pid (pid reuse). 0 = unknown → skip the guard.
+  const selfStartedAt = await resolveParentStartedAt(parent);
 
   const drain = async (sinceSeqOverride?: number): Promise<number> => {
     let events = await readInbox(host, parent);
+    // pid-reuse guard: drop events whose parent_started_at disagrees with ours.
+    if (selfStartedAt > 0)
+      events = events.filter(
+        (e) => !e.parent_started_at || e.parent_started_at === selfStartedAt,
+      );
     if (argv.unread) {
       const cursor = await getCursor(host, parent, consumer);
       events = filterUnread(events, sinceSeqOverride ?? cursor);
@@ -4110,10 +4125,16 @@ async function cmdNotify(rest: string[]): Promise<number> {
 
   // watch: tail -f the inbox. Default no-ack (at-least-once) so a consumer that
   // crashes mid-handling re-reads on restart; pass --ack to advance the cursor.
-  if (argv["ensure-daemon"]) {
+  const ensure = async () => {
+    if (!argv["ensure-daemon"]) return;
     const { ensureDaemon } = await import("./notifyDaemon.ts");
     await ensureDaemon().catch(() => null);
-  }
+  };
+  // Register this parent as a live watcher BEFORE the first poll and ensure a
+  // daemon exists — so a parent that watches *before* spawning any child (or
+  // across a fan-out gap) still has a running, correctly-scoped daemon.
+  await heartbeatWatcher(parent, selfStartedAt);
+  await ensure();
   const intervalMs = Math.max(500, (Number.isFinite(argv.interval) ? argv.interval : 2) * 1000);
   // Baseline: from the cursor (unread) or the caller's --since, else from now
   // (only new edges). Track high-water seq in-memory between polls.
@@ -4123,17 +4144,42 @@ async function cmdNotify(rest: string[]): Promise<number> {
       ? (argv.since as number)
       : maxSeq(await readInbox(host, parent));
   let stop = false;
+  // On signal: drop our heartbeat and exit promptly. (Even if this is missed on
+  // a hard kill, the watcher's TTL makes the stale heartbeat non-live, so the
+  // daemon's scope/self-exit stays correct — this is just prompt cleanup.)
   const onSig = () => {
     stop = true;
+    void clearWatcher(parent).finally(() => process.exit(0));
   };
   process.on("SIGINT", onSig);
   process.on("SIGTERM", onSig);
-  while (!stop) {
-    const top = await drain(lastSeq);
-    if (top > lastSeq) lastSeq = top;
-    await new Promise((r) => setTimeout(r, intervalMs));
+  try {
+    while (!stop) {
+      // Refresh our heartbeat and keep the daemon alive every tick — it self-
+      // exits after a grace window with no watchers, so a long watch must renew.
+      await heartbeatWatcher(parent, selfStartedAt);
+      await ensure();
+      const top = await drain(lastSeq);
+      if (top > lastSeq) lastSeq = top;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  } finally {
+    await clearWatcher(parent);
   }
   return 0;
+}
+
+/** Resolve the started_at of the agent whose wrapper pid is `parent` (0 if unknown). */
+async function resolveParentStartedAt(parent: number): Promise<number> {
+  const records = await listRecords(undefined, {
+    all: true,
+    active: false,
+    json: false,
+    latest: false,
+    cwdScope: null,
+  }).catch(() => [] as GlobalPidRecord[]);
+  const rec = records.find((r) => r.wrapper_pid === parent || r.pid === parent);
+  return rec?.started_at ?? 0;
 }
 
 async function cmdNotifyCursor(args: string[]): Promise<number> {
@@ -4196,7 +4242,7 @@ async function cmdNotifyd(rest: string[]): Promise<number> {
       return 0;
     }
     default:
-      process.stderr.write("usage: ay notifyd <run|start|status|stop>\n");
+      process.stderr.write("usage: ay notifyd <run|once|start|status|stop>\n");
       return 1;
   }
 }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4071,7 +4071,7 @@ async function cmdNotify(rest: string[]): Promise<number> {
   if (verb === "cursor") return cmdNotifyCursor(args);
   if (verb !== "read" && verb !== "watch") {
     process.stderr.write(
-      "usage: ay notify <read|watch|cursor> [--parent <pid>] [--since <seq>] [--unread] [--ack] [--json]\n",
+      "usage: ay notify <read|watch|cursor> [--parent <pid>] [--since <seq>] [--since-ts <ms>] [--unread] [--ack] [--json]\n",
     );
     return 1;
   }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4268,26 +4268,13 @@ async function cmdNotifyd(rest: string[]): Promise<number> {
       return pid ? 0 : 1;
     }
     case "stop": {
-      const id = await daemon.daemonIdentity();
-      if (!id) {
-        process.stdout.write("notifyd: not running\n");
-        return 0;
-      }
-      // Re-read the owner identity immediately before signalling: if the pid was
-      // recycled (or a new daemon took over) between the read above and now, the
-      // pid+started_at won't match and we must NOT SIGTERM an unrelated process.
-      const again = await daemon.daemonIdentity();
-      if (!again || again.pid !== id.pid || again.started_at !== id.started_at) {
-        process.stdout.write("notifyd: not running\n");
-        return 0;
-      }
-      try {
-        process.kill(again.pid, "SIGTERM");
-        process.stdout.write(`notifyd stopped (pid ${again.pid})\n`);
-      } catch (e) {
-        process.stderr.write(`notifyd: failed to stop pid ${again.pid}: ${e}\n`);
-        return 1;
-      }
+      // Cooperative, non-destructive stop: remove the daemon's lock and let it
+      // exit itself on the next tick — never SIGTERM a pid that may have been
+      // recycled onto an unrelated process.
+      const pid = await daemon.requestDaemonStop();
+      process.stdout.write(
+        pid ? `notifyd: stop requested (pid ${pid} will exit shortly)\n` : "notifyd: not running\n",
+      );
       return 0;
     }
     default:

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4114,13 +4114,20 @@ async function cmdNotify(rest: string[]): Promise<number> {
       if (Number.isFinite(argv["since-ts"])) events = filterSinceTs(events, argv["since-ts"] as number);
     }
     printNotifyEvents(events, argv.json);
-    const top = maxSeq(events);
-    if (argv.ack && top > 0) await setCursor(host, parent, top, consumer);
-    return top;
+    return maxSeq(events);
+  };
+
+  // Advance the cursor MONOTONICALLY — never below its current value, and never
+  // regressing on an empty batch. This is what makes `watch --ack` safe across a
+  // consumer restart: the high-water of what we've shown is always persisted.
+  const ackTo = async (seq: number) => {
+    const cur = await getCursor(host, parent, consumer);
+    if (seq > cur) await setCursor(host, parent, seq, consumer);
   };
 
   if (verb === "read") {
-    await drain();
+    const top = await drain();
+    if (argv.ack && top > 0) await ackTo(top);
     return 0;
   }
 
@@ -4144,6 +4151,7 @@ async function cmdNotify(rest: string[]): Promise<number> {
     : Number.isFinite(argv.since)
       ? (argv.since as number)
       : maxSeq(await readInbox(host, parent));
+  let acked = lastSeq; // high-water already persisted to the cursor
   let stop = false;
   // On signal: drop our heartbeat and exit promptly. (Even if this is missed on
   // a hard kill, the watcher's TTL makes the stale heartbeat non-live, so the
@@ -4162,6 +4170,14 @@ async function cmdNotify(rest: string[]): Promise<number> {
       await ensure();
       const top = await drain(lastSeq);
       if (top > lastSeq) lastSeq = top;
+      // Persist the high-water monotonically (only when it advanced), so a batch
+      // that showed events is acked even if the NEXT poll is empty — a restarted
+      // `watch --ack` then resumes past what it already delivered, not from the
+      // stale cursor.
+      if (argv.ack && lastSeq > acked) {
+        await ackTo(lastSeq);
+        acked = lastSeq;
+      }
       await new Promise((r) => setTimeout(r, intervalMs));
     }
   } finally {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -27,6 +27,8 @@ import {
   type NeedsInput,
 } from "./needsInput.ts";
 import { diffLsStates, type LiveState, type LsAgentState } from "./lsWatch.ts";
+import { filterSinceSeq, filterSinceTs, filterUnread, maxSeq, type NotifyEvent } from "./notifyInbox.ts";
+import { getCursor, hostId, readInbox, setCursor } from "./notifyStore.ts";
 import {
   buildStoredResult,
   normalizeEnvelope,
@@ -255,6 +257,8 @@ const SUBCOMMANDS = new Set([
   "ps",
   "status",
   "result",
+  "notify",
+  "notifyd",
   "read",
   "cat",
   "tail",
@@ -341,6 +345,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdStatus(rest);
       case "result":
         return await cmdResult(rest);
+      case "notify":
+        return await cmdNotify(rest);
+      case "notifyd":
+        return await cmdNotifyd(rest);
       case "read":
       case "cat":
         return await cmdRead(rest, { mode: "cat" });
@@ -1171,7 +1179,7 @@ export async function deriveLiveStatus(r: GlobalPidRecord): Promise<"active" | "
  * consumer. Builds on the cheap deriveLiveStatus, then adds the menu (needs_input)
  * override, which DOES read the log tail.
  */
-async function deriveLiveState(
+export async function deriveLiveState(
   r: GlobalPidRecord,
 ): Promise<{ state: LiveState; question: string | null }> {
   const base = await deriveLiveStatus(r);
@@ -2107,7 +2115,7 @@ function cliDefaults(): Promise<Record<string, AgentCliConfig>> {
  * null on any read/render error or an empty log. Shared by the needs_input and
  * stuck classifiers so they don't each re-implement the tail read.
  */
-async function renderLogTailLines(logPath: string, n = 40): Promise<string[] | null> {
+export async function renderLogTailLines(logPath: string, n = 40): Promise<string[] | null> {
   const TAIL_BYTES = 32 * 1024;
   let buf: Uint8Array;
   try {
@@ -4001,4 +4009,194 @@ async function cmdResultSet(rest: string[]): Promise<number> {
   await writeFile(resultPath(pid), JSON.stringify(stored) + "\n");
   process.stdout.write(`result envelope written for pid ${pid}\n`);
   return 0;
+}
+
+// ---------------------------------------------------------------------------
+// ay notify / ay notifyd — subagent→parent status-transition notifications.
+//
+// See docs/subagent-notify.md. `ay notifyd` is the detection engine (query-layer
+// watcher, runtime-agnostic); `ay notify` is the parent-facing inbox reader. A
+// parent typically runs ONE command in its Monitor loop:
+//
+//     ay notify watch --unread          # tail its inbox, ensure the daemon
+//
+// and gets every child's needs_input / sustained-idle / exited edge, each with a
+// payload (question / tail / git head) so it can act without tailing the child.
+// ---------------------------------------------------------------------------
+
+/** Resolve the parent pid a `ay notify` invocation is draining. */
+function resolveParentPid(explicit: number | undefined): number {
+  if (Number.isFinite(explicit) && (explicit as number) > 0) return explicit as number;
+  const self = Number(process.env.AGENT_YES_PID);
+  if (Number.isFinite(self) && self > 0) return self;
+  throw new Error(
+    "ay notify: not running inside an agent (no AGENT_YES_PID) — pass --parent <pid>",
+  );
+}
+
+function printNotifyEvents(events: NotifyEvent[], json: boolean): void {
+  if (json) {
+    for (const e of events) process.stdout.write(JSON.stringify(e) + "\n");
+    return;
+  }
+  for (const e of events) {
+    const tag =
+      e.edge === "needs_input" ? "❓ needs_input" : e.edge === "idle" ? "💤 idle" : "✓ exited";
+    const head = `[${e.seq}] ${tag}  pid ${e.child_pid} (${e.cli}) ${e.cwd}`;
+    process.stdout.write(head + "\n");
+    if (e.git_head) process.stdout.write(`      HEAD ${e.git_head}\n`);
+    if (e.question) process.stdout.write(`      Q: ${e.question}\n`);
+    if (e.tail)
+      process.stdout.write(
+        e.tail
+          .split("\n")
+          .map((l) => `      | ${l}`)
+          .join("\n") + "\n",
+      );
+  }
+}
+
+async function cmdNotify(rest: string[]): Promise<number> {
+  const verb = rest[0];
+  const args = rest.slice(1);
+
+  if (verb === "cursor") return cmdNotifyCursor(args);
+  if (verb !== "read" && verb !== "watch") {
+    process.stderr.write(
+      "usage: ay notify <read|watch|cursor> [--parent <pid>] [--since <seq>] [--unread] [--ack] [--json]\n",
+    );
+    return 1;
+  }
+
+  const y = yargs(args)
+    .option("parent", { type: "number", description: "Parent pid whose inbox to drain (default: $AGENT_YES_PID)" })
+    .option("since", { type: "number", description: "Only edges with seq greater than this" })
+    .option("since-ts", { type: "number", description: "Only edges at/after this epoch-ms" })
+    .option("unread", { type: "boolean", default: false, description: "Only edges past the saved cursor" })
+    .option("ack", { type: "boolean", default: false, description: "Advance the cursor past what's shown (at-least-once: off by default)" })
+    .option("json", { type: "boolean", default: false, description: "Emit raw NDJSON events" })
+    .option("consumer", { type: "string", default: "parent", description: "Cursor identity (for multiple readers)" })
+    .option("interval", { type: "number", default: 2, description: "Poll interval in seconds (watch)" })
+    .option("ensure-daemon", { type: "boolean", default: true, description: "Start the notifyd singleton if not running (watch)" })
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+  const argv = await y.parseAsync();
+
+  const parent = resolveParentPid(argv.parent as number | undefined);
+  const host = hostId();
+  const consumer = String(argv.consumer);
+
+  const drain = async (sinceSeqOverride?: number): Promise<number> => {
+    let events = await readInbox(host, parent);
+    if (argv.unread) {
+      const cursor = await getCursor(host, parent, consumer);
+      events = filterUnread(events, sinceSeqOverride ?? cursor);
+    } else {
+      if (sinceSeqOverride !== undefined) events = filterSinceSeq(events, sinceSeqOverride);
+      else if (Number.isFinite(argv.since)) events = filterSinceSeq(events, argv.since as number);
+      if (Number.isFinite(argv["since-ts"])) events = filterSinceTs(events, argv["since-ts"] as number);
+    }
+    printNotifyEvents(events, argv.json);
+    const top = maxSeq(events);
+    if (argv.ack && top > 0) await setCursor(host, parent, top, consumer);
+    return top;
+  };
+
+  if (verb === "read") {
+    await drain();
+    return 0;
+  }
+
+  // watch: tail -f the inbox. Default no-ack (at-least-once) so a consumer that
+  // crashes mid-handling re-reads on restart; pass --ack to advance the cursor.
+  if (argv["ensure-daemon"]) {
+    const { ensureDaemon } = await import("./notifyDaemon.ts");
+    await ensureDaemon().catch(() => null);
+  }
+  const intervalMs = Math.max(500, (Number.isFinite(argv.interval) ? argv.interval : 2) * 1000);
+  // Baseline: from the cursor (unread) or the caller's --since, else from now
+  // (only new edges). Track high-water seq in-memory between polls.
+  let lastSeq = argv.unread
+    ? await getCursor(host, parent, consumer)
+    : Number.isFinite(argv.since)
+      ? (argv.since as number)
+      : maxSeq(await readInbox(host, parent));
+  let stop = false;
+  const onSig = () => {
+    stop = true;
+  };
+  process.on("SIGINT", onSig);
+  process.on("SIGTERM", onSig);
+  while (!stop) {
+    const top = await drain(lastSeq);
+    if (top > lastSeq) lastSeq = top;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return 0;
+}
+
+async function cmdNotifyCursor(args: string[]): Promise<number> {
+  const action = args[0];
+  const y = yargs(args.slice(1))
+    .option("parent", { type: "number" })
+    .option("consumer", { type: "string", default: "parent" })
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+  const argv = await y.parseAsync();
+  const parent = resolveParentPid(argv.parent as number | undefined);
+  const host = hostId();
+  const consumer = String(argv.consumer);
+  if (action === "get") {
+    process.stdout.write(String(await getCursor(host, parent, consumer)) + "\n");
+    return 0;
+  }
+  if (action === "set") {
+    const seq = Number(argv._[0]);
+    if (!Number.isFinite(seq) || seq < 0) throw new Error("ay notify cursor set <seq>");
+    await setCursor(host, parent, seq, consumer);
+    return 0;
+  }
+  process.stderr.write("usage: ay notify cursor <get|set <seq>> [--parent <pid>]\n");
+  return 1;
+}
+
+async function cmdNotifyd(rest: string[]): Promise<number> {
+  const sub = rest[0] ?? "status";
+  const daemon = await import("./notifyDaemon.ts");
+  switch (sub) {
+    case "run":
+      return daemon.runDaemon();
+    case "once":
+      return daemon.runDaemon({ once: true });
+    case "start": {
+      const pid = await daemon.ensureDaemon();
+      process.stdout.write(pid ? `notifyd running (pid ${pid})\n` : "notifyd: failed to start\n");
+      return pid ? 0 : 1;
+    }
+    case "status": {
+      const pid = await daemon.daemonStatus();
+      process.stdout.write(pid ? `notifyd running (pid ${pid})\n` : "notifyd: not running\n");
+      return pid ? 0 : 1;
+    }
+    case "stop": {
+      const pid = await daemon.daemonStatus();
+      if (!pid) {
+        process.stdout.write("notifyd: not running\n");
+        return 0;
+      }
+      try {
+        process.kill(pid, "SIGTERM");
+        process.stdout.write(`notifyd stopped (pid ${pid})\n`);
+      } catch (e) {
+        process.stderr.write(`notifyd: failed to stop pid ${pid}: ${e}\n`);
+        return 1;
+      }
+      return 0;
+    }
+    default:
+      process.stderr.write("usage: ay notifyd <run|start|status|stop>\n");
+      return 1;
+  }
 }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4095,8 +4095,17 @@ async function cmdNotify(rest: string[]): Promise<number> {
   const host = hostId();
   const consumer = String(argv.consumer);
   // The reader's own start time — used to reject inbox events addressed to a
-  // PRIOR incarnation of this pid (pid reuse). 0 = unknown → skip the guard.
+  // PRIOR incarnation of this pid (pid reuse). FAIL-CLOSED: if we can't resolve
+  // the parent's identity (no live registry record → started_at 0), we refuse to
+  // open the notification path at all rather than fail-open and risk delivering a
+  // recycled pid's inbox to an unrelated agent (or registering a 0-identity
+  // watcher). "If we don't know who the parent is, don't open the path."
   const selfStartedAt = await resolveParentStartedAt(parent);
+  if (selfStartedAt <= 0)
+    throw new Error(
+      `ay notify: cannot resolve identity for pid ${parent} (no live agent record) — ` +
+        `refusing to open the notification path (pass --parent for a live agent).`,
+    );
 
   const drain = async (sinceSeqOverride?: number): Promise<number> => {
     let events = await readInbox(host, parent);

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4197,7 +4197,13 @@ async function cmdNotify(rest: string[]): Promise<number> {
   return 0;
 }
 
-/** Resolve the started_at of the agent whose wrapper pid is `parent` (0 if unknown). */
+/**
+ * Resolve the started_at of the LIVE agent whose wrapper pid is `parent`. Returns
+ * 0 (→ the caller fails closed) when there is no such record, when the matching
+ * record is stale (exited / pid not alive), or when the match is ambiguous
+ * (>1 live record) — so a leftover stale record can't make a recycled parent pid
+ * resolve to a PRIOR incarnation's start time and fail-open the identity guard.
+ */
 async function resolveParentStartedAt(parent: number): Promise<number> {
   const records = await listRecords(undefined, {
     all: true,
@@ -4206,8 +4212,15 @@ async function resolveParentStartedAt(parent: number): Promise<number> {
     latest: false,
     cwdScope: null,
   }).catch(() => [] as GlobalPidRecord[]);
-  const rec = records.find((r) => r.wrapper_pid === parent || r.pid === parent);
-  return rec?.started_at ?? 0;
+  const live = records.filter(
+    (r) =>
+      (r.wrapper_pid === parent || r.pid === parent) &&
+      r.status !== "exited" &&
+      isPidAlive(r.pid),
+  );
+  // Exactly one live match, or fail closed.
+  if (live.length !== 1) return 0;
+  return live[0]!.started_at ?? 0;
 }
 
 async function cmdNotifyCursor(args: string[]): Promise<number> {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4227,16 +4227,24 @@ async function cmdNotifyd(rest: string[]): Promise<number> {
       return pid ? 0 : 1;
     }
     case "stop": {
-      const pid = await daemon.daemonStatus();
-      if (!pid) {
+      const id = await daemon.daemonIdentity();
+      if (!id) {
+        process.stdout.write("notifyd: not running\n");
+        return 0;
+      }
+      // Re-read the owner identity immediately before signalling: if the pid was
+      // recycled (or a new daemon took over) between the read above and now, the
+      // pid+started_at won't match and we must NOT SIGTERM an unrelated process.
+      const again = await daemon.daemonIdentity();
+      if (!again || again.pid !== id.pid || again.started_at !== id.started_at) {
         process.stdout.write("notifyd: not running\n");
         return 0;
       }
       try {
-        process.kill(pid, "SIGTERM");
-        process.stdout.write(`notifyd stopped (pid ${pid})\n`);
+        process.kill(again.pid, "SIGTERM");
+        process.stdout.write(`notifyd stopped (pid ${again.pid})\n`);
       } catch (e) {
-        process.stderr.write(`notifyd: failed to stop pid ${pid}: ${e}\n`);
+        process.stderr.write(`notifyd: failed to stop pid ${again.pid}: ${e}\n`);
         return 1;
       }
       return 0;

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4103,7 +4103,7 @@ async function cmdNotify(rest: string[]): Promise<number> {
   const selfStartedAt = await resolveParentStartedAt(parent);
   if (selfStartedAt <= 0)
     throw new Error(
-      `ay notify: cannot resolve identity for pid ${parent} (no live agent record) — ` +
+      `cannot resolve identity for pid ${parent} (no live agent record) — ` +
         `refusing to open the notification path (pass --parent for a live agent).`,
     );
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4047,9 +4047,10 @@ function printNotifyEvents(events: NotifyEvent[], json: boolean): void {
     return;
   }
   for (const e of events) {
-    const tag =
-      e.edge === "needs_input" ? "❓ needs_input" : e.edge === "idle" ? "💤 idle" : "✓ exited";
-    const head = `[${e.seq}] ${tag}  pid ${e.child_pid} (${e.cli}) ${e.cwd}`;
+    // Plain ASCII tag (no emoji): stays legible over the Rust/CLI path and old
+    // terminals, and is easy to grep for consumers that log-parse the stream.
+    const tag = `[${e.edge}]`;
+    const head = `[${e.seq}] ${tag} pid ${e.child_pid} (${e.cli}) ${e.cwd}`;
     process.stdout.write(head + "\n");
     if (e.git_head) process.stdout.write(`      HEAD ${e.git_head}\n`);
     if (e.question) process.stdout.write(`      Q: ${e.question}\n`);

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4100,11 +4100,13 @@ async function cmdNotify(rest: string[]): Promise<number> {
 
   const drain = async (sinceSeqOverride?: number): Promise<number> => {
     let events = await readInbox(host, parent);
-    // pid-reuse guard: drop events whose parent_started_at disagrees with ours.
-    if (selfStartedAt > 0)
-      events = events.filter(
-        (e) => !e.parent_started_at || e.parent_started_at === selfStartedAt,
-      );
+    // Parent pid-reuse guard (fail-safe): when we know our own start time, deliver
+    // ONLY events whose parent_started_at EXACTLY matches it — a mismatched OR
+    // missing parent identity is dropped, never fail-open-delivered to a possibly-
+    // recycled pid. The daemon always stamps parent_started_at from the watcher's
+    // heartbeat (the same value this reader resolves), so every legitimate event
+    // matches; only truly-legacy identity-less events fall out.
+    if (selfStartedAt > 0) events = events.filter((e) => e.parent_started_at === selfStartedAt);
     if (argv.unread) {
       const cursor = await getCursor(host, parent, consumer);
       events = filterUnread(events, sinceSeqOverride ?? cursor);


### PR DESCRIPTION
## Problem (real incident)

A parent agent fanned out sub-agents that **committed their work but then sat at an idle `❯` prompt without exiting** (`claude-yes` doesn't exit on idle). Claude Code's background-task notification fires **only on process EXIT**, so the parent never learned the children went idle and left two parked **16 minutes**. Monitor-on-HEAD polling catches a *commit* but is blind to a child that finished **without** committing. `ay ls --watch` streams transitions but is **pull** — the parent isn't watching.

## Solution — a push layer on the existing `needs_input`/`deriveLiveState` machinery

Designed with codex + the two agents who hit the pain (see `docs/subagent-notify.md`).

- **`ay notifyd`** — a host-singleton, **query-layer** watcher (runtime-agnostic → covers both Rust and TS children; Rust is default and `needs_input` is only classified in the TS query layer, so this is the correct ownership boundary). Polls `deriveLiveState`, runs a **pure** debounce router, appends edges to each parent's append-only inbox. Started on demand; self-exits when idle.
- **Three edges, child→parent only**: `needs_input` (immediate; re-fires only on a new *compact* question), **sustained `idle`** (the load-bearing guard: `deriveLiveState` idle **AND** continuously idle for a confirm window — never a bare no-output timer, so a 2-min silent tool run doesn't false-fire), and `exited`. Edge, not level; once per episode.
- **`ay notify read/watch/cursor`** — inbox reader with a persisted per-consumer **cursor** (watermark by monotonic `seq`). `watch` is **at-least-once** (no ack unless `--ack`). Payload carries the question, a recent tail, and the child's git HEAD.
- **Startup reconcile** seeds router memory → a restart doesn't re-emit. **Retention** GCs dead parents' inboxes.

Parent runs one command in its Monitor loop: `ay notify watch --unread`.

## Backward compatibility

**Consumer-side opt-in**: if no parent watches, the daemon never runs and **no files are created**. Monitor-on-HEAD keeps working — this strictly dominates it.

## Tests / verification

- Pure cores unit-tested — **36 cases** (idle-hysteresis P1 guard, idle-prompt regression fixture, question-change re-fire, exit-once, reaped-child synthesis, watermark/cursor, retention). Adjacent specs green — no regression.
- Live smoke: inbox append/seq/cursor/`--unread` via CLI; `ay notifyd once` ran the full observe→`deriveLiveState`→router path against 9 real nested agents.
- `cargo check` green (`SUBCOMMANDS` mirror in `rs/src/cli.rs` updated). Note: a live Rust binary needs `bun run build:rs`.

## Not done — drafted for later

Producer-side `--notify-parent` flag, a `stuck` edge, cross-host fan-in, native runtime push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)