### PR TITLE
feat(console): reach fork from the ⌘K palette via /fork [topic]

### DIFF
--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -12,7 +12,7 @@ Three ways to produce the `cwd`, in precedence order:
 
 | Request body                | What happens                                                                                      | Backed by                                 |
 | --------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `fork: { fromCwd, branch }` | Fork an existing worktree to a **new branch carrying its uncommitted work**, then spawn there     | `codehost/provision` `forkWorktree`       |
+| `fork: { fromCwd, branch }` | Fork an existing worktree to a **new branch (clean — committed work only)**, then spawn there      | `codehost/provision` `forkWorktree`       |
 | `from: "<source>"`          | Provision a GitHub source (clone / worktree / ff-pull) into `<root>/<owner>/<repo>/tree/<branch>` | `codehost/provision` `provision`          |
 | `cwd: "<dir>"` (or omitted) | Resolve against the workspace root and `mkdir -p` (a missing dir no longer ENOENTs into a 500)    | `ts/workspaceConfig.ts` `resolveSpawnCwd` |
 

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3899,7 +3899,8 @@
       // ⋯-menu recovery buttons. Typing "/" in the omnibox lists them; "/k" / "/r"
       // narrows. Each runs the very same handler the dropdown button does, so the
       // confirm prompt and server call are identical — /kill = Force-kill (SIGKILL),
-      // /restart = Restart (resume).
+      // /restart = Restart (resume). "/fork [topic]" is also offered here (built in
+      // omniCommandRows, not this list, since it spawns rather than acts in place).
       const OMNI_COMMANDS = [
         {
           cmd: "/restart",
@@ -3923,12 +3924,35 @@
       function omniCommandRows(q) {
         const target = omniAnchor();
         if (!target) return [];
-        const term = q.slice(1).toLowerCase(); // text after the leading "/"
-        return OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(term)).map((c) => ({
+        // Match on the FIRST token so a command can carry args after it
+        // (e.g. "/fork fix the auth bug" → cmd "fork", topic "fix the auth bug").
+        const parts = q.slice(1).trim().split(/\s+/).filter(Boolean);
+        const cmdTerm = (parts[0] || "").toLowerCase(); // command token after "/"
+        const rows = OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(cmdTerm)).map((c) => ({
           kind: "cmd",
           cmd: c,
           target,
         }));
+        // "/fork [topic]" — a slash alias for the fork spawn row so fork is reachable
+        // straight from the command palette (⌘K → "/fork"), not only via the row that
+        // auto-appends to a search. It's a spawn (kind:"fork"), not a kind:"cmd" that
+        // acts on an existing agent, so it's built here rather than in OMNI_COMMANDS —
+        // omniActivate's fork branch (branch prompt → /api/spawn {fork}) handles it.
+        // Needs a real fork source (the open agent with a live git branch); when the
+        // anchor has none, forking is meaningless so the row is omitted.
+        if ("fork".startsWith(cmdTerm)) {
+          const src = omniForkSource();
+          if (src)
+            rows.push({
+              kind: "fork",
+              branch: forkSlug(parts.slice(1).join(" "), src.git.branch),
+              srcBranch: src.git.branch,
+              fromCwd: src.cwd,
+              cli: src.cli,
+              room: src._room,
+            });
+        }
+        return rows;
       }
 
       // Which agent the highlighted candidate should preview in the background: an


### PR DESCRIPTION
## What

Two fork-related fixes.

### 1. `/fork [topic]` in the ⌘K command palette (new)

Fork could only be triggered by the row that **auto-appends to a search query** — there was no slash-command entry, so it was undiscoverable via `/fork`. `omniCommandRows` now:
- matches on the **first `/…` token** (so a slash command can carry args), and
- for `fork`, builds the same `kind:"fork"` spawn row from `omniForkSource()`.

`omniActivate`'s existing fork branch (branch prompt → `POST /api/spawn {fork}`) handles it unchanged. `"/fork fix the auth bug"` pre-slugs the branch name. The row is omitted when the open agent has no live git branch (forking is meaningless without a source branch).

### 2. Docs correction

`docs/provisioning.md` said fork carries "uncommitted work"; the code is **clean — committed work only** (`forkWorktree` defaults `wip:false`, serve.ts doesn't opt in). Fixed the table to match.

## Note on "fork not working" (part 1 of the report)

Root cause was **operational, not a code bug**: `codehost/provision` (the optional dep that backs both `from` and `fork`) was not linked into the working tree that the global `ay serve` symlinks to, so `POST /api/spawn {fork}` returned **501**. Fixed on the host with the documented `bun link codehost`. No source change needed for that; the palette + docs changes above are the shippable diff.

## Test

- `codehost/provision` now resolves from the working-tree context the serve imports from (`forkWorktree`/`provision` are functions).
- `bun run build` green; `cf/public` synced from `lab/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)