### PR TITLE
feat(provision): koho-style provisionHook — user script gates fork/from

### DIFF
--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -62,11 +62,25 @@ so config lives per host, never synced between peers.
   `<owner>/<repo>`, or `*` (allow everything). Env
   `CODEHOST_PROVISION_ALLOWLIST` (comma-separated) overrides. See
   `isProvisionAllowed()`.
+- **`provisionHook`** — a host-local shell hook run **before** the `from`/`fork`
+  git op ("koho-style" provisioning), so it can **prepare the host** — most
+  usefully **select the git identity** for this repo before the clone/worktree +
+  `setup-repo.sh`. When set it is ALSO the **gate**: its exit code decides
+  admission (**0 = allow, non-zero = deny**), which **overrides
+  `provisionAllowlist`** (define one _or_ the other). The hook receives the
+  provisioning context as env: `KOHO_ACTION` (`fork`|`from`), `KOHO_OWNER`,
+  `KOHO_REPO`, `KOHO_BRANCH`, `KOHO_FROM_CWD` (fork only), `KOHO_SOURCE` (from
+  only), `KOHO_WS_ROOT`. Env `AGENT_YES_PROVISION_HOOK` overrides the config
+  form; `AGENT_YES_PROVISION_HOOK_TIMEOUT_MS` bounds it (default 60s). See
+  `getProvisionHook()`.
 
 ```jsonc
 {
   "provisionRoot": "/code",
   "provisionAllowlist": ["snomiao"],
+  // koho-style: pick the account per owner, then allow (exit 0). This REPLACES
+  // provisionAllowlist as the gate — a non-zero exit denies the provision.
+  "provisionHook": "case \"$KOHO_OWNER\" in symval) gh auth switch --user snomiao;; snomiao) gh auth switch --user snomiao;; *) echo \"unknown owner $KOHO_OWNER\"; exit 1;; esac",
 }
 ```
 
@@ -78,6 +92,14 @@ so config lives per host, never synced between peers.
   everything. The `/api/spawn` token is still the trust boundary (it already
   grants agent-RCE); the allowlist narrows the _new_ "clone an arbitrary repo and
   run its setup" surface.
+- **Or hook-gated (`provisionHook`).** When a `provisionHook` is configured it
+  runs first and **its exit code is the gate** (overriding the allowlist), so a
+  host can express dynamic policy — e.g. allow only owners it can `gh auth switch`
+  to, denying the rest with `exit 1`. Like `spawnHook` it is arbitrary local code
+  and is therefore **never network-writable**: the config-file form is ignored
+  unless `config.json` is a real file, owned by us, and not group/world-writable;
+  only the env form (`AGENT_YES_PROVISION_HOOK`, from the daemon's own env) skips
+  that guard.
 - **No injection.** The clone URL is hard-pinned to `https://github.com/<o>/<r>`,
   git runs via `execFile` (no shell), and every path segment is validated
   (`isSafeSegment`: non-empty, not `.`/`..`, no leading `-`, no separators or
@@ -104,9 +126,10 @@ implementation originated before being promoted into codehost).
 
 ## Related code
 
-- `ts/serve.ts` — `POST /api/spawn` (`from` / `fork` / `cwd` handling).
+- `ts/serve.ts` — `POST /api/spawn` (`from` / `fork` / `cwd` handling);
+  `runProvisionHook` (the koho-style gate) + `originOwnerRepo`.
 - `ts/workspaceConfig.ts` — `getProvisionRoot`, `getProvisionAllowlist`,
-  `isProvisionAllowed`, `resolveSpawnCwd`.
+  `isProvisionAllowed`, `getProvisionHook` / `hasProvisionHook`, `resolveSpawnCwd`.
 - `tsdown.config.ts` — externalizes `codehost/*`.
 - `lab/ui/index.html` — the "Spawn from" field + the Cmd+K fork / spawn-in-dir rows.
 - codehost `src/provision/` + its `docs/provisioning.md` — the standard.

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -12,6 +12,7 @@ import {
   extractBadges,
   extractNeedsInput,
   extractTaskCounts,
+  isUserTyping,
   listRecords,
   readNotes,
   readPtysize,
@@ -21,6 +22,7 @@ import {
   writeToIpc,
   type CommonOpts,
 } from "./subcommands.ts";
+import { TYPING_BADGE } from "./badges.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { spawnRejectionReason } from "./spawnGate.ts";
 import { findSpawnHiddenLauncher } from "./rustBinary.ts";
@@ -28,8 +30,10 @@ import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
 import {
+  getProvisionHook,
   getProvisionRoot,
   getSpawnHook,
+  hasProvisionHook,
   hasSpawnHook,
   isProvisionAllowed,
   resolveSpawnCwd,
@@ -233,6 +237,80 @@ function freshAgentEnv(): Record<string, string> {
     }
   }
   return env;
+}
+
+// Best-effort owner/repo from a worktree's github origin remote — used to build
+// the KOHO_* env a provision hook branches on (which account to select for this
+// repo). Mirrors codehost's forkWorktree parse; null when there's no github
+// origin (the hook still runs, just without KOHO_OWNER/REPO).
+function originOwnerRepo(cwd: string): { owner: string; repo: string } | null {
+  try {
+    const r = Bun.spawnSync(["git", "-C", cwd, "remote", "get-url", "origin"]);
+    if (r.exitCode !== 0) return null;
+    const url = new TextDecoder().decode(r.stdout).trim();
+    const m = url.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?\/?$/i);
+    return m && m[1] && m[2] ? { owner: m[1], repo: m[2] } : null;
+  } catch {
+    return null;
+  }
+}
+
+type ProvisionHookResult =
+  | { ran: false }
+  | { ran: true; ok: boolean; code: number | null; detail: string };
+
+// Run the "koho-style" provision hook (a host-local trusted shell hook) BEFORE a
+// fork/from git op. Its purpose is to prepare the host for provisioning — most
+// usefully to select the right git identity (e.g. `gh auth switch --user <who>`,
+// keyed on the KOHO_* env we export) before the clone/worktree/setup runs. When
+// configured it is ALSO the provisioning gate: its exit code decides admission
+// (0 = allow, non-zero = deny), overriding the static provisionAllowlist.
+// Returns { ran:false } when no hook is set, so the caller falls back to the
+// allowlist. Unlike the spawn hook there is no `exec "$@"`: this hook runs to
+// completion and hands control back — it prepares state, it is not the agent.
+async function runProvisionHook(
+  cwd: string,
+  koho: Record<string, string>,
+): Promise<ProvisionHookResult> {
+  const hook = getProvisionHook();
+  if (!hook) return { ran: false };
+  const shell =
+    process.env.AGENT_YES_PROVISION_SHELL?.trim() ||
+    process.env.AGENT_YES_SPAWN_SHELL?.trim() ||
+    "/bin/sh";
+  const outPath = path.join(
+    agentYesHome(),
+    `provision-hook-${process.pid}-${performance.now().toString(36).replace(".", "")}.log`,
+  );
+  const timeoutMs = Number(process.env.AGENT_YES_PROVISION_HOOK_TIMEOUT_MS) || 60_000;
+  let code: number | null = null;
+  try {
+    // The daemon's own env (NOT freshAgentEnv): the hook wants gh/git on PATH and
+    // the machine's real HOME/credentials to switch accounts. `set -e` so any
+    // failing step denies the provision.
+    const child = Bun.spawn([shell, "-c", `set -e\n${hook}`], {
+      cwd,
+      env: { ...process.env, ...koho },
+      stdin: "ignore",
+      stdout: Bun.file(outPath),
+      stderr: Bun.file(outPath),
+    });
+    code = await Promise.race([
+      child.exited,
+      new Promise<number>((r) => setTimeout(() => r(124), timeoutMs)),
+    ]);
+    if (code === 124) child.kill();
+  } catch (e) {
+    return { ran: true, ok: false, code: null, detail: (e as Error).message };
+  }
+  let detail = "";
+  try {
+    detail = (await Bun.file(outPath).text()).slice(0, 4096).trimEnd();
+  } catch {
+    /* no output captured */
+  }
+  await unlink(outPath).catch(() => {});
+  return { ran: true, ok: code === 0, code, detail };
 }
 
 // ---------------------------------------------------------------------------
@@ -1192,8 +1270,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
       // badge). Skipped for exited agents — their screen is no longer live.
       tasks: status === "exited" ? null : await logTasks(r.log_file),
       // Status flags matched against the rendered screen (see badges.ts) — e.g.
-      // an active /goal loop. [] when none matched or for exited agents.
-      badges: status === "exited" ? [] : await logBadges(r.log_file),
+      // an active /goal loop. [] when none matched or for exited agents. The
+      // time-derived "typing" chip (user typing at the terminal) is appended
+      // from the stdin-activity marker, not the screen — same chip `ay ls` shows.
+      badges:
+        status === "exited"
+          ? []
+          : await logBadges(r.log_file).then(async (b) =>
+              (await isUserTyping(r.pid)) ? [...b, TYPING_BADGE.id] : b,
+            ),
     };
   };
 
@@ -1361,7 +1446,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // share token are not necessarily host admins. Setting it stays host-local
     // (edit ~/.agent-yes/config.json) — there is no PUT.
     if (req.method === "GET" && p === "/api/spawn-config") {
-      return Response.json({ hasSpawnHook: hasSpawnHook() });
+      return Response.json({
+        hasSpawnHook: hasSpawnHook(),
+        hasProvisionHook: hasProvisionHook(),
+      });
     }
 
     // GET /api/notes
@@ -1815,6 +1903,25 @@ export async function cmdServe(rest: string[]): Promise<number> {
             { status: 501 },
           );
         }
+        // koho-style provision gate — runs BEFORE the worktree + setup-repo.sh so
+        // it can select the git identity for this fork; its exit code overrides
+        // the allowlist. When no hook is configured, falls through to the allowlist
+        // check after the fork resolves owner/repo.
+        const forkOrigin = originOwnerRepo(fork.fromCwd);
+        const forkHook = await runProvisionHook(fork.fromCwd, {
+          KOHO_ACTION: "fork",
+          KOHO_FROM_CWD: fork.fromCwd,
+          KOHO_BRANCH: fork.branch,
+          KOHO_OWNER: forkOrigin?.owner ?? "",
+          KOHO_REPO: forkOrigin?.repo ?? "",
+          KOHO_WS_ROOT: getProvisionRoot() ?? "",
+        });
+        if (forkHook.ran && !forkHook.ok)
+          return new Response(
+            `provision hook denied this fork (exit ${forkHook.code})` +
+              (forkHook.detail ? `:\n${forkHook.detail}` : ""),
+            { status: 403 },
+          );
         let result: {
           ok: boolean;
           folder: string;
@@ -1833,11 +1940,14 @@ export async function cmdServe(rest: string[]): Promise<number> {
           return new Response(`fork failed: ${(e as Error).message}`, { status: 502 });
         }
         if (!result?.ok) return new Response(result?.error ?? "fork failed", { status: 502 });
-        // Same allowlist gate as `from` — the fork runs setup-repo.sh (code exec).
-        if (result.spec && !isProvisionAllowed(result.spec.owner, result.spec.repo))
+        // Allowlist gate — only when a provision hook did NOT already gate this
+        // (a configured hook overrides the allowlist). The fork runs setup-repo.sh
+        // (code exec), the same risk surface as `from`.
+        if (!forkHook.ran && result.spec && !isProvisionAllowed(result.spec.owner, result.spec.repo))
           return new Response(
             `forking '${result.spec.owner}/${result.spec.repo}' is not allowed — add the owner ` +
-              `to provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all)`,
+              `to provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all), ` +
+              `or set a provisionHook to gate it yourself`,
             { status: 403 },
           );
         cwd = result.folder;
@@ -1873,14 +1983,34 @@ export async function cmdServe(rest: string[]): Promise<number> {
         }
         if (!spec) return new Response(`unrecognized spawn source: ${from}`, { status: 400 });
         // Provisioning clones the repo and runs its setup script (dependency
-        // installs + package lifecycle hooks = code execution on the host), so
-        // gate it behind an owner/repo allowlist — empty allowlist = deny all.
-        if (!isProvisionAllowed(spec.owner, spec.repo))
+        // installs + package lifecycle hooks = code execution on the host), so it
+        // is gated. A koho-style provision hook, when configured, runs first (to
+        // select the git identity for the clone) and its exit code IS the gate,
+        // overriding the allowlist; otherwise the owner/repo allowlist gates it
+        // (empty allowlist = deny all).
+        const fromHook = await runProvisionHook(getProvisionRoot() ?? homedir(), {
+          KOHO_ACTION: "from",
+          KOHO_SOURCE: from,
+          KOHO_OWNER: spec.owner,
+          KOHO_REPO: spec.repo,
+          KOHO_BRANCH: spec.branch,
+          KOHO_WS_ROOT: getProvisionRoot() ?? "",
+        });
+        if (fromHook.ran) {
+          if (!fromHook.ok)
+            return new Response(
+              `provision hook denied '${spec.owner}/${spec.repo}' (exit ${fromHook.code})` +
+                (fromHook.detail ? `:\n${fromHook.detail}` : ""),
+              { status: 403 },
+            );
+        } else if (!isProvisionAllowed(spec.owner, spec.repo)) {
           return new Response(
             `provisioning '${spec.owner}/${spec.repo}' is not allowed — add the owner to ` +
-              `provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all)`,
+              `provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all), ` +
+              `or set a provisionHook to gate it yourself`,
             { status: 403 },
           );
+        }
         let result: { ok: boolean; folder: string; action: string; error?: string };
         try {
           const wsRoot = getProvisionRoot();

--- a/ts/workspaceConfig.spec.ts
+++ b/ts/workspaceConfig.spec.ts
@@ -8,9 +8,11 @@ import {
   getMinFreeMb,
   getSpawnWaitMs,
   getProvisionAllowlist,
+  getProvisionHook,
   getProvisionRoot,
   getSpawnHook,
   getWorkspaceRoot,
+  hasProvisionHook,
   hasSpawnHook,
   isProvisionAllowed,
   resolveSpawnCwd,
@@ -31,6 +33,7 @@ describe("workspaceConfig", () => {
     delete process.env.CODEHOST_WS_ROOT;
     delete process.env.CODEHOST_PROVISION_ALLOWLIST;
     delete process.env.AGENT_YES_SPAWN_HOOK;
+    delete process.env.AGENT_YES_PROVISION_HOOK;
     delete process.env.AGENT_YES_MAX_AGENTS;
     delete process.env.AGENT_YES_MIN_FREE_MB;
     delete process.env.AGENT_YES_SPAWN_WAIT_MS;
@@ -265,6 +268,51 @@ describe("workspaceConfig", () => {
         expect(getSpawnHook()).toBeNull();
         chmodSync(path.join(tmp, "config.json"), 0o600);
         expect(getSpawnHook()).toBe("echo pwned");
+      },
+    );
+  });
+
+  describe("getProvisionHook / hasProvisionHook", () => {
+    const isPosix = process.platform !== "win32";
+
+    it("is null/false when unset", () => {
+      expect(getProvisionHook()).toBeNull();
+      expect(hasProvisionHook()).toBe(false);
+    });
+
+    it("returns the configured hook from a private (0600) config", () => {
+      writeConfig({ provisionHook: 'gh auth switch --user "$KOHO_OWNER"' });
+      if (isPosix) chmodSync(path.join(tmp, "config.json"), 0o600);
+      expect(getProvisionHook()).toBe('gh auth switch --user "$KOHO_OWNER"');
+      expect(hasProvisionHook()).toBe(true);
+    });
+
+    it("ignores a blank hook", () => {
+      writeConfig({ provisionHook: "   " });
+      expect(getProvisionHook()).toBeNull();
+    });
+
+    it("env AGENT_YES_PROVISION_HOOK overrides the config", () => {
+      writeConfig({ provisionHook: "from-file" });
+      process.env.AGENT_YES_PROVISION_HOOK = "from-env";
+      expect(getProvisionHook()).toBe("from-env");
+    });
+
+    it("is independent of the spawn hook", () => {
+      writeConfig({ spawnHook: "spawn-only" });
+      if (isPosix) chmodSync(path.join(tmp, "config.json"), 0o600);
+      expect(getSpawnHook()).toBe("spawn-only");
+      expect(getProvisionHook()).toBeNull();
+    });
+
+    it.skipIf(!isPosix)(
+      "refuses a file-backed hook when the config is group/world-writable (tampering guard)",
+      () => {
+        writeConfig({ provisionHook: "echo pwned" });
+        chmodSync(path.join(tmp, "config.json"), 0o666);
+        expect(getProvisionHook()).toBeNull();
+        chmodSync(path.join(tmp, "config.json"), 0o600);
+        expect(getProvisionHook()).toBe("echo pwned");
       },
     );
   });

--- a/ts/workspaceConfig.ts
+++ b/ts/workspaceConfig.ts
@@ -26,6 +26,15 @@ interface Config {
    */
   spawnHook?: string;
   /**
+   * A trusted, HOST-LOCAL shell hook run before a `fork`/`from` provisioning git
+   * op ("koho-style" provisioning). See {@link getProvisionHook}. When set it is
+   * the provisioning GATE: exit 0 = allow (and it has prepared the environment,
+   * e.g. `gh auth switch` to the right account), non-zero = deny — it OVERRIDES
+   * {@link provisionAllowlist}. Like {@link spawnHook} it is arbitrary local code,
+   * so it is intentionally NOT settable over the network.
+   */
+  provisionHook?: string;
+  /**
    * Max number of concurrently-live agents the daemon will admit via
    * `/api/spawn`. `0`/unset = unlimited (current behavior). See {@link getMaxAgents}.
    */
@@ -129,8 +138,18 @@ export function isProvisionAllowed(owner: string, repo: string): boolean {
 export function getSpawnHook(): string | null {
   const env = process.env.AGENT_YES_SPAWN_HOOK;
   if (env && env.trim()) return env;
-  const h = readConfig().spawnHook;
-  if (!h || !h.trim()) return null;
+  return configHookIfTrusted(readConfig().spawnHook);
+}
+
+/**
+ * Return a config-file hook value only when the config file is safe to trust as
+ * a source of code to run: not a symlink (can't be swapped out from under us),
+ * owned by us, and not group/world-writable (no other user can rewrite it). The
+ * env-var forms of these hooks bypass this — they come from the daemon's own
+ * environment, which is already trusted. Returns null when unset or guarded out.
+ */
+function configHookIfTrusted(value: string | undefined): string | null {
+  if (!value || !value.trim()) return null;
   if (process.platform !== "win32") {
     try {
       if (lstatSync(configPath()).isSymbolicLink()) return null;
@@ -141,12 +160,36 @@ export function getSpawnHook(): string | null {
       return null;
     }
   }
-  return h;
+  return value;
 }
 
 /** Whether a usable {@link getSpawnHook} is configured (for read-only disclosure). */
 export function hasSpawnHook(): boolean {
   return getSpawnHook() !== null;
+}
+
+/**
+ * A trusted, HOST-LOCAL shell hook run BEFORE a `fork`/`from` provisioning git
+ * op — "koho-style" (codehost-style) provisioning. Env `AGENT_YES_PROVISION_HOOK`
+ * overrides the config `provisionHook`; the config form is subject to the same
+ * tamper guard as {@link getSpawnHook} ({@link configHookIfTrusted}).
+ *
+ * Its purpose is to prepare the host for provisioning — most usefully to select
+ * the right git identity (e.g. `gh auth switch --user <who>`, keyed on the
+ * `KOHO_OWNER`/`KOHO_REPO` env the caller exports) before the clone/worktree/
+ * setup runs. When configured it is ALSO the provisioning gate: its exit code
+ * decides admission (0 = allow, non-zero = deny), overriding
+ * {@link getProvisionAllowlist}. Returns null when unset/guarded.
+ */
+export function getProvisionHook(): string | null {
+  const env = process.env.AGENT_YES_PROVISION_HOOK;
+  if (env && env.trim()) return env;
+  return configHookIfTrusted(readConfig().provisionHook);
+}
+
+/** Whether a usable {@link getProvisionHook} is configured (for read-only disclosure). */
+export function hasProvisionHook(): boolean {
+  return getProvisionHook() !== null;
 }
 
 /**


### PR DESCRIPTION
## What

Adds a host-local **`provisionHook`** ("koho-style" provisioning): a user-defined shell script that runs **before** every `fork`/`from` git op so it can **prepare the host** — most usefully **select the git identity** (`gh auth switch --user <who>`, keyed on the repo) before the clone/worktree + `setup-repo.sh`.

When configured, the hook is **also the gate**: its **exit code decides admission** (0 = allow, non-zero = deny), and that **overrides `provisionAllowlist`** — a host expresses dynamic policy in shell instead of a static list. With **no hook**, the allowlist gates exactly as before (fully backward-compatible).

Motivation: this machine has two GitHub accounts; forking `symval/symval` needs the right one active. Rather than statically allowlisting owners, the host now scripts "pick the account for `$KOHO_OWNER`, then allow" and denies the rest.

## Interface

- Config `provisionHook` in `~/.agent-yes/config.json`, or env `AGENT_YES_PROVISION_HOOK` (overrides config). `AGENT_YES_PROVISION_HOOK_TIMEOUT_MS` bounds it (default 60s).
- Hook env: `KOHO_ACTION` (`fork`|`from`), `KOHO_OWNER`, `KOHO_REPO`, `KOHO_BRANCH`, `KOHO_FROM_CWD` (fork), `KOHO_SOURCE` (from), `KOHO_WS_ROOT`.
- Same tamper guard as `spawnHook`: config-file form ignored unless `config.json` is a real file, owned by us, and not group/world-writable; only the env form skips the guard.
- `GET /api/spawn-config` now also reports `hasProvisionHook` (boolean only).

Entirely agent-yes-side — `codehost/provision` is unchanged.

## Files

- `ts/workspaceConfig.ts` — `provisionHook` config + `getProvisionHook`/`hasProvisionHook`; factor the shared trust guard (`configHookIfTrusted`, reused by `getSpawnHook`).
- `ts/serve.ts` — `runProvisionHook` + `originOwnerRepo`; wire the gate into the `fork` and `from` branches.
- `ts/workspaceConfig.spec.ts` — 6 new tests. 43 pass.
- `docs/provisioning.md`.

## Test — verified end-to-end against a local serve

| Case | Setup | Result |
|---|---|---|
| deny | hook `exit 3` | **403** `provision hook denied (exit 3)` + hook output; all `KOHO_*` populated |
| allow | hook `exit 0`, **empty** allowlist | **200** `forked` — allowlist **bypass** confirmed |
| regression | no hook, empty allowlist | **403** allowlist (unchanged) |

`bun run build` green; `workspaceConfig.spec.ts` 43/43 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)