### PR TITLE
fix(provision): run provisionHook with the recovered login-shell PATH

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -285,12 +285,15 @@ async function runProvisionHook(
   const timeoutMs = Number(process.env.AGENT_YES_PROVISION_HOOK_TIMEOUT_MS) || 60_000;
   let code: number | null = null;
   try {
-    // The daemon's own env (NOT freshAgentEnv): the hook wants gh/git on PATH and
-    // the machine's real HOME/credentials to switch accounts. `set -e` so any
-    // failing step denies the provision.
+    // Recovered login-shell env (freshAgentEnv), NOT the daemon's raw env: the
+    // oxmgr/launchd daemon runs with a minimal PATH (/usr/bin:/bin:…) that lacks
+    // Homebrew/bun/etc., so `gh`/`git` would be "command not found" and `set -e`
+    // would deny EVERY provision. freshAgentEnv re-derives the user's real PATH
+    // (as a fresh terminal would) while preserving HOME — so the hook finds `gh`
+    // and its credential store. `set -e` so any failing step denies the provision.
     const child = Bun.spawn([shell, "-c", `set -e\n${hook}`], {
       cwd,
-      env: { ...process.env, ...koho },
+      env: { ...freshAgentEnv(), ...koho },
       stdin: "ignore",
       stdout: Bun.file(outPath),
       stderr: Bun.file(outPath),


### PR DESCRIPTION
Follow-up to #176.

## Bug

`runProvisionHook` ran the hook with the daemon's **raw `process.env`**. The oxmgr/launchd `ay serve` daemon has a **minimal PATH** (`/usr/bin:/bin:/usr/sbin:/sbin`) — no Homebrew, no bun — so a hook that calls `gh`/`git` (the whole point of koho: `gh auth switch`) hits **"command not found"**, `set -e` returns non-zero, and the gate **denies EVERY fork/from (403)**. Caught before activating on the live daemon (whose PATH I confirmed is exactly that minimal set).

## Fix

Run the hook with `freshAgentEnv()` — the same login-shell env recovery console-spawned agents already use — which re-derives the user's real PATH (Homebrew/bun/…) while preserving `HOME` (so `gh` still finds its credential store).

## Test

- Simulated the daemon's minimal PATH: `$SHELL -ilc 'env -0'` recovers `/opt/homebrew/bin`, and `gh --version` resolves under the recovered PATH.
- End-to-end against a local serve with the real config hook (`case $KOHO_OWNER in takusym|symval) gh auth switch --user takusym;; *) gh auth switch --user snomiao;; esac`): a **symval** fork → `200 forked` and gh switched to **takusym**; an **acme** fork → `200 forked` and gh switched to **snomiao**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)