### PR TITLE
feat(console): fold subagent trees by default with a working/total chip

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -488,6 +488,48 @@ function toAgentNode(n) {
   return { kind: "agent", entry: n.entry, children: n.children.map(toAgentNode) };
 }
 
+// When the subagent trees are folded away, each surviving root agent shows a
+// summary chip of the descendants hidden beneath it. Given the FULL layeredRows
+// output, returns a Map keyed by the root agent's `entry` →
+// { total, working, lastActive }:
+//   total      = alive (non-exited) descendant subagents, at every depth
+//   working    = those whose status is "active"
+//   lastActive = newest last_active_at (fallback started_at) among the alive
+//                descendants, or null when none is stamped
+// Descendants roll up to their nearest folded-away ancestor's root, so a folded
+// tree summarizes its whole subtree in one chip. Roots with no alive descendant
+// aren't in the map (no chip). Pure so tests can exercise it without a DOM.
+export function foldSummaries(rows) {
+  // Direct parent-agent entry → child agent entries (skip room/peer headers).
+  const kids = new Map();
+  for (const r of rows) {
+    if (r.kind !== "agent" || !r.parentEntry) continue;
+    const arr = kids.get(r.parentEntry) || [];
+    arr.push(r.entry);
+    kids.set(r.parentEntry, arr);
+  }
+  const summaries = new Map();
+  for (const r of rows) {
+    if (r.kind !== "agent" || r.parentEntry) continue; // roots only
+    const acc = { total: 0, working: 0, lastActive: null };
+    const stack = [...(kids.get(r.entry) || [])];
+    const seen = new Set();
+    while (stack.length) {
+      const e = stack.pop();
+      if (seen.has(e)) continue; // guard a pathological parent cycle
+      seen.add(e);
+      for (const c of kids.get(e) || []) stack.push(c);
+      if (e.status === "exited") continue;
+      acc.total++;
+      if (e.status === "active") acc.working++;
+      const at = e.last_active_at ?? e.started_at;
+      if (at != null && (acc.lastActive == null || at > acc.lastActive)) acc.lastActive = at;
+    }
+    if (acc.total > 0) summaries.set(r.entry, acc);
+  }
+  return summaries;
+}
+
 // Next selection index when stepping the list by `dir` (+1 down / -1 up).
 // No current selection (i<0) lands on the first (down) or last (up) row;
 // otherwise clamps at the ends. Returns -1 for an empty list.

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -895,6 +895,26 @@
         color: var(--green);
         border-color: #2a3a2a;
       }
+      /* Folded-subagent summary chip ("⊞ 3/5" = 3 working of 5 hidden subagents),
+         shown on a root agent row when the subagent trees are collapsed. Same pill
+         shape as .tasks; the ⊞ glyph echoes the fold toolbar button. Turns accent
+         when any hidden subagent is still working, so a collapsed tree with live
+         children stands out from a quiet one. Hover for the count + last-active. */
+      .subs {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--muted);
+        white-space: nowrap;
+        flex: none;
+        padding: 0 5px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        cursor: pointer;
+      }
+      .subs.active {
+        color: var(--accent);
+        border-color: var(--accent);
+      }
       /* Status-flag chip ("badge") matched server-side against the agent's
          screen — e.g. an active /goal loop (ts/badges.ts). Same pill shape as
          .tasks but accent-colored so a matched flag stands out as a distinct
@@ -1374,6 +1394,7 @@
           <div class="meta">
             <span id="count"></span>
             <span class="metaright">
+              <button id="foldbtn" class="viewbtn" title="fold subagent trees">⊞ subs</button>
               <button id="sortbtn" class="viewbtn" title="cycle sort order">⇅ state</button>
               <button id="viewbtn" class="viewbtn" title="toggle compact list">☰</button>
               <button id="newbtn" class="newbtn" title="spawn a new agent on this fleet">
@@ -1558,6 +1579,7 @@
         hasIdent,
         deviceCount,
         layeredRows,
+        foldSummaries,
         sortEntries,
         SORT_MODES,
         taskLabel,
@@ -3197,6 +3219,14 @@
       // Compact list: one line per agent (dot + cli + title), persisted per device.
       let compactList = localStorage.getItem("ay.compactList") === "1";
 
+      // Fold subagent trees: hide nested (sub)agent rows and roll each root's
+      // hidden descendants into a summary chip. Folded BY DEFAULT (only "0" opts
+      // out) so a busy fleet reads as a flat list of top-level agents at a glance.
+      let foldSubs = localStorage.getItem("ay.foldSubs") !== "0";
+      // Per-render Map(rootEntry → { total, working, lastActive }); rebuilt by
+      // renderList whenever folding is on, consumed by foldChipHtml.
+      let foldSum = null;
+
       // Display sort order, cycled by the sort button and persisted per device.
       // Default "state" (attention-first state, then git busyness). Guard against
       // a stale/garbage stored value so we never start in an unknown mode.
@@ -3240,6 +3270,21 @@
         return `<span class="tasks${allDone ? " done" : ""}" title="${esc(tip)}">${esc(label)}</span>`;
       }
 
+      // Folded-subagent summary chip ("⊞ 3/5") for a root agent whose subagent
+      // tree is collapsed — working/total of its hidden descendants, from the
+      // per-render foldSum map. "" when folding is off or this row has no hidden
+      // subagents. Clicking it expands the trees (see the list click handler).
+      // The tooltip carries the recency the badge face omits ("last active 5s ago").
+      function foldChipHtml(e) {
+        const s = foldSum && foldSum.get(e);
+        if (!s) return "";
+        const rel = s.lastActive != null ? age({ last_active_at: s.lastActive }) : "";
+        const tip =
+          `${s.total} subagent${s.total === 1 ? "" : "s"} folded · ${s.working} working` +
+          (rel ? ` · last active ${rel} ago` : "");
+        return `<span class="subs${s.working ? " active" : ""}" data-fold-chip="1" title="${esc(tip)}">⊞ ${s.working}/${s.total}</span>`;
+      }
+
       // Status-flag chips ("badges") matched server-side against the agent's
       // screen (ts/badges.ts) — e.g. an active /goal loop. One small pill per
       // matched flag; "" when none matched. CSS class is "flag" (not "badge")
@@ -3270,9 +3315,18 @@
         const toks = $("q").value.trim().split(/\s+/).filter(Boolean);
         // Build the full signalling-server > rooms > peers > agents > subagents
         // tree. Single-node room/peer layers fold away; ≥2 become ├ └ │ branches.
-        const rows = layeredRows(orderedEntries(toks));
-        const agentRows = rows.filter((r) => r.kind === "agent");
+        const fullRows = layeredRows(orderedEntries(toks));
+        const agentRows = fullRows.filter((r) => r.kind === "agent");
+        // Fold: summarize each root's hidden descendants, then drop subagent rows
+        // (any agent row with a parent agent). The count still reports every
+        // matching agent, so folding never makes the fleet look smaller.
+        foldSum = foldSubs ? foldSummaries(fullRows) : null;
+        const rows = foldSubs
+          ? fullRows.filter((r) => !(r.kind === "agent" && r.parentEntry))
+          : fullRows;
         $("count").textContent = `${agentRows.length} / ${entries.length} agents`;
+        $("foldbtn").textContent = foldSubs ? "⊞ subs" : "⊟ subs";
+        $("foldbtn").classList.toggle("on", !foldSubs);
         $("viewbtn").classList.toggle("on", compactList);
         // Show the active sort mode on the button so it's self-documenting; the
         // default ("state") is also highlighted to hint it's the implicit order.
@@ -3299,6 +3353,7 @@
         ${hasIdent(id) ? `<span class="cident" title="${esc(fullIdent(e))}">${esc(id)}</span>` : ""}
         ${cli ? `<span class="cname">${esc(cli)}</span>` : ""}
         <span class="ctitle ${e.title ? "" : "dim"}" title="${esc(t)}">${esc(t)}</span>
+        ${foldChipHtml(e)}
         ${taskChipHtml(e)}
         ${badgeChipsHtml(e)}
         ${gitChipHtml(e)}
@@ -3325,6 +3380,7 @@
         <div class="r1">${r.branch ? `<span class="tbranch">${esc(r.branch)}</span>` : ""}<span class="dot ${esc(e.status)}"></span>
           <span class="name">${esc(cliLabel(e) || ident(e) || "agent")}</span>
           <span class="badge">pid ${e.pid}</span>
+          ${foldChipHtml(e)}
           ${taskChipHtml(e)}
           ${badgeChipsHtml(e)}
           ${gitChipHtml(e)}
@@ -3686,6 +3742,14 @@
       }
 
       $("list").addEventListener("click", (ev) => {
+        // Clicking a folded-subagent chip expands the trees instead of selecting
+        // the row, so the hidden children it summarizes become reachable.
+        if (ev.target.closest("[data-fold-chip]")) {
+          foldSubs = false;
+          localStorage.setItem("ay.foldSubs", "0");
+          renderList();
+          return;
+        }
         const row = ev.target.closest(".row");
         if (row) select(row.dataset.key);
       });
@@ -3745,6 +3809,12 @@
         localStorage.setItem("ay.compactList", compactList ? "1" : "0");
         renderList();
       });
+      // Fold / unfold every subagent tree (global toggle, persisted per device).
+      $("foldbtn").addEventListener("click", () => {
+        foldSubs = !foldSubs;
+        localStorage.setItem("ay.foldSubs", foldSubs ? "1" : "0");
+        renderList();
+      });
       // Cycle the sort order: state → created → identity → state.
       $("sortbtn").addEventListener("click", () => {
         sortMode = SORT_MODES[(SORT_MODES.indexOf(sortMode) + 1) % SORT_MODES.length];
@@ -3787,9 +3857,10 @@
       // renders. Clamps at the ends, scrolls the row into view.
       function stepSelection(dir) {
         const toks = $("q").value.trim().split(/\s+/).filter(Boolean);
-        // Must match renderList's order; step only over agent rows (skip headers).
+        // Must match renderList's order; step only over agent rows (skip headers),
+        // and skip folded-away subagents so nav lands only on visible rows.
         const shown = layeredRows(orderedEntries(toks))
-          .filter((r) => r.kind === "agent")
+          .filter((r) => r.kind === "agent" && !(foldSubs && r.parentEntry))
           .map((r) => r.entry);
         if (!shown.length) return;
         const cur = shown.findIndex((e) => e._key === sel);

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -481,3 +481,74 @@ describe("console DOM behaviour", () => {
     }
   });
 });
+
+// A nested fixture: root 201 with two subagents (202 active, 203 idle) and a
+// grandchild 204 under 202. All in one worktree so the parent_pid links drive
+// the forest. Exercises the fold toggle + summary chip, which the flat fixture
+// above (all roots) can't reach.
+describe("fold subagent trees", () => {
+  let browser: Browser;
+  let url: string;
+  let close: () => void;
+  const NESTED = [
+    { pid: 201, wrapper_pid: 201, cli: "claude", cwd: "/home/u/ws/o/r/tree/w", title: "root", status: "active", started_at: 1_700_000_000_000 },
+    { pid: 202, wrapper_pid: 202, parent_pid: 201, cli: "claude", cwd: "/home/u/ws/o/r/tree/w/a", title: "sub-a", status: "active", started_at: 1_700_000_000_000, last_active_at: 1_700_000_005_000 },
+    { pid: 203, wrapper_pid: 203, parent_pid: 201, cli: "claude", cwd: "/home/u/ws/o/r/tree/w/b", title: "sub-b", status: "idle", started_at: 1_700_000_000_000, last_active_at: 1_700_000_001_000 },
+    { pid: 204, wrapper_pid: 204, parent_pid: 202, cli: "claude", cwd: "/home/u/ws/o/r/tree/w/a/c", title: "grandchild", status: "active", started_at: 1_700_000_000_000, last_active_at: 1_700_000_003_000 },
+  ];
+
+  beforeAll(async () => {
+    ({ url, close } = await startServer(NESTED));
+    browser = await chromium.launch({ headless: true });
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    close?.();
+  });
+
+  it("folds by default, hiding subagents behind a working/total chip", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      // Only the root is visible; its three descendants are folded away.
+      await expect.poll(() => page.locator(".list .row").count()).toBe(1);
+      await expect
+        .poll(() => page.locator(".row[data-key='local#201'] .subs").innerText())
+        .toBe("⊞ 2/3");
+      // The recency the badge face omits lives in the tooltip.
+      expect(await page.locator(".row[data-key='local#201'] .subs").getAttribute("title")).toContain(
+        "last active",
+      );
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("the toolbar button unfolds every tree, and folds again", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      await expect.poll(() => page.locator(".list .row").count()).toBe(1);
+      await page.click("#foldbtn");
+      // All four agents (root + 3 descendants) now render; the chip is gone.
+      await expect.poll(() => page.locator(".list .row").count()).toBe(4);
+      expect(await page.locator(".subs").count()).toBe(0);
+      await page.click("#foldbtn");
+      await expect.poll(() => page.locator(".list .row").count()).toBe(1);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("clicking the summary chip expands the trees instead of selecting the row", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      await expect.poll(() => page.locator(".list .row").count()).toBe(1);
+      await page.click(".row[data-key='local#201'] .subs");
+      await expect.poll(() => page.locator(".list .row").count()).toBe(4);
+      // The click expanded rather than selecting the root row.
+      expect(await page.locator(".row.sel").count()).toBe(0);
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/tests/ui-dom/server.ts
+++ b/tests/ui-dom/server.ts
@@ -66,7 +66,12 @@ function file(res: http.ServerResponse, path: string, type: string) {
   res.end(readFileSync(path));
 }
 
-export async function startServer(): Promise<{ url: string; close: () => void }> {
+// `agents` defaults to the flat AGENTS fixture; a test can pass its own set
+// (e.g. a nested parent+subagent tree) to exercise fold-specific wiring without
+// disturbing the shared fixture the other tests assert exact counts against.
+export async function startServer(
+  agents: unknown[] = AGENTS,
+): Promise<{ url: string; close: () => void }> {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url || "/", "http://localhost");
     const p = url.pathname;
@@ -84,7 +89,7 @@ export async function startServer(): Promise<{ url: string; close: () => void }>
 
     if (req.method === "GET" && p === "/api/ls") {
       res.writeHead(200, { "Content-Type": "application/json" });
-      return res.end(JSON.stringify(AGENTS));
+      return res.end(JSON.stringify(agents));
     }
     if (req.method === "GET" && p.startsWith("/api/size/")) {
       res.writeHead(200, { "Content-Type": "application/json" });

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -21,6 +21,7 @@ import {
   deviceCount,
   forestOrder,
   layeredRows,
+  foldSummaries,
   sortEntries,
   SORT_MODES,
   taskLabel,
@@ -236,6 +237,59 @@ describe("layeredRows parentEntry", () => {
     const childRow = rows.find((r) => r.entry?.pid === 2);
     expect(rootRow?.parentEntry).toBeNull();
     expect(childRow?.parentEntry).toBe(root);
+  });
+});
+
+describe("foldSummaries (collapsed subagent roll-up)", () => {
+  // A root with two direct subagents and one grandchild, all in one worktree so
+  // parent_pid wiring drives the tree (see forestOrder tests above).
+  const tree = () => [
+    agent({ pid: 1, wrapper_pid: 1, cwd: "/x/o/r/tree/w", status: "active" }),
+    agent({
+      pid: 2,
+      wrapper_pid: 2,
+      parent_pid: 1,
+      cwd: "/x/o/r/tree/w/a",
+      status: "active",
+      last_active_at: 1000,
+    }),
+    agent({
+      pid: 3,
+      wrapper_pid: 3,
+      parent_pid: 1,
+      cwd: "/x/o/r/tree/w/b",
+      status: "idle",
+      last_active_at: 5000,
+    }),
+    agent({
+      pid: 4,
+      wrapper_pid: 4,
+      parent_pid: 2,
+      cwd: "/x/o/r/tree/w/a/c",
+      status: "active",
+      last_active_at: 3000,
+    }),
+  ];
+
+  it("rolls a root's whole subtree into working/total + newest last-active", () => {
+    const rows = layeredRows(tree());
+    const sum = foldSummaries(rows);
+    const root = rows.find((r) => r.entry?.pid === 1).entry;
+    expect(sum.get(root)).toEqual({ total: 3, working: 2, lastActive: 5000 });
+  });
+
+  it("excludes exited descendants from total, working and last-active", () => {
+    const list = tree();
+    list[2].status = "exited"; // pid 3 (had the newest last_active_at)
+    const rows = layeredRows(list);
+    const sum = foldSummaries(rows);
+    const root = rows.find((r) => r.entry?.pid === 1).entry;
+    expect(sum.get(root)).toEqual({ total: 2, working: 2, lastActive: 3000 });
+  });
+
+  it("omits roots with no (alive) subagents", () => {
+    const rows = layeredRows([agent({ pid: 1, wrapper_pid: 1 })]);
+    expect(foldSummaries(rows).size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## What

Ships a **fold subagent trees** toggle in the console left panel, **folded by default**, plus a per-root summary chip so a busy fleet reads as a flat list of top-level agents at a glance.

- **`⊞ subs` toolbar button** — global toggle; collapses/expands every subagent tree. Persisted per device (`ay.foldSubs`), folded by default.
- **Summary chip `⊞ working/total`** (e.g. `⊞ 2/3`) on each root whose subagents are hidden — how many descendants are actively working out of how many are alive. Turns accent-colored when any hidden child is still working.
- **Most-recent last-active time in the chip tooltip** (`3 subagents folded · 2 working · last active 5s ago`) — kept off the badge face to avoid per-second churn.
- **Clicking the chip expands the trees**; keyboard nav skips folded-away rows.

## Design rationale

Compared badge options (count-only, timestamp-only, both, working/total) and global-toggle vs per-row chevrons **with codex-cli**. It recommended **working/total** (matches the existing `2/5` task chip, strongest monitoring signal, no timestamp twitch) and a **global toggle** for v1 (predictable, no per-row expansion state) — surfacing recency in the tooltip instead. This PR implements that.

## Implementation

- `foldSummaries(rows)` in `lab/ui/console-logic.js` — pure function that rolls each root's whole subtree into `{ total, working, lastActive }`, excluding exited descendants. Unit-tested.
- `renderList` computes the summary from the full tree, then drops subagent rows; the agent count still reports every matching agent so folding never makes the fleet look smaller.

## Tests

- `tests/ui-logic/console-logic.spec.ts` — `foldSummaries` roll-up, exited exclusion, empty case.
- `tests/ui-dom/console-dom.test.ts` — drives the real UI: default-folded chip `⊞ 2/3` + tooltip, toolbar toggle, click-to-expand. `startServer` now accepts a nested fixture.

All new tests pass. (The pre-existing `Alt+ArrowDown cycles selection` DOM test fails on clean `main` too — unrelated Playwright/env issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)