### PR TITLE
ci: add timeout-minutes to every job (cap 6h runaways)

### DIFF
--- a/.github/workflows/deploy-agent-yes.yml
+++ b/.github/workflows/deploy-agent-yes.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Deploy worker + synced UI to Cloudflare

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -98,6 +99,7 @@ jobs:
 
   build-and-push-mini:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,6 +19,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/matrix-test.yml
+++ b/.github/workflows/matrix-test.yml
@@ -20,6 +20,10 @@ jobs:
             runtime-version: "latest"
 
     runs-on: ${{ matrix.os }}
+    # Cap runaways: with no timeout, a hung test ran GitHub's 6h default and
+    # burned ~2,176 macOS minutes ($134.91) in a single day (Jul 3), which
+    # billing-locked the account. Fail fast instead of paying for 6h of a hang.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -27,6 +27,9 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    # Generous cap for Rust LTO + cross/zig darwin builds, but far under the 6h
+    # default so a stuck compile/link can't run away.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -166,6 +169,7 @@ jobs:
     name: Combine Artifacts
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -195,6 +199,7 @@ jobs:
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.upload_release == true)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -32,6 +32,7 @@ jobs:
   # Deterministic, hermetic DOM test of the real console — blocking.
   ui-dom:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
@@ -46,6 +47,7 @@ jobs:
   # Heavier xterm render fidelity test (Gemini Vision) — non-blocking.
   ui-render:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
@@ -74,6 +76,7 @@ jobs:
     needs: [ui-dom]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Why

No workflow had a \`timeout-minutes\`, so GitHub's **360-minute (6h) default** applied to every job. On **Jul 3** a hung \`Matrix Test\` job ran the full 6 hours, and ~6 \`macos-latest\` jobs did the same in one day → **2,176 macOS minutes = \$134.91**, which **billing-locked the account** (every job since fails at setup: *"account is locked due to a billing issue"*).

Discovered by grouping snomiao's billing usage by repository — agent-yes was \$179.54 this month, almost entirely that one day's hung-job macOS burn.

## What

Job-level \`timeout-minutes\` on all **12 jobs** across the 7 workflows:

| tier | mins | jobs |
|---|---|---|
| tests / deploys | 15-20 | matrix-test, ui-dom/render, gh-pages, deploy-agent-yes, ui deploy |
| docker / release | 30 | build-and-push (+mini), release |
| rust build | 45 | rust-build (LTO + cross/zig darwin) |
| combine / upload | 15-20 | rust-build combine + release |

A hung job now fails in **minutes** instead of burning 6 billed hours.

## Not in scope

This is the **cost/blast-radius cap**, not the fix for the underlying hang. \`Matrix Test\` hangs on **ubuntu and macOS both** (a test that never returns — likely PTY/server/FIFO) — that's being fixed separately on the \`heal-ci\` branch.

Also note: CI stays red until the **billing lock** is cleared at github.com/settings/billing (owner action); this PR prevents recurrence once it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)