### PR TITLE
ci(rust-build): drop --locked from zigbuild (rs/Cargo.lock is gitignored)

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -136,7 +136,7 @@ jobs:
             -w /io \
             -e CARGO_TERM_COLOR=always \
             ghcr.io/rust-cross/cargo-zigbuild:latest \
-            bash -c "rustup target add ${{ matrix.target }} && cargo zigbuild --release --locked --target ${{ matrix.target }} --bin agent-yes"
+            bash -c "rustup target add ${{ matrix.target }} && cargo zigbuild --release --target ${{ matrix.target }} --bin agent-yes"
 
       - name: Build with cargo
         if: "!matrix.cross && !matrix.zig"


### PR DESCRIPTION
## Why
First real CI run after the billing unlock caught this — `Build x86_64-apple-darwin` failed:
```
error: cannot create the lock file /io/Cargo.lock because --locked was passed to prevent this
```
`rs/Cargo.lock` is **gitignored** (`rs/.gitignore`), so a fresh CI checkout has no lock and `--locked` refuses to generate one. It passed #174's local Docker test only because that `rs/` had a stale lock from `build:rs`.

## Fix
Drop `--locked` — matches the native `cargo build --release` step (never used `--locked`); nothing committed to lock against anyway.

## Verified
Built in the `cargo-zigbuild` container against an `rs/` with **no Cargo.lock** (real CI condition) → valid `Mach-O x86_64` in ~47s.

Also fixes the `Release` cascade (Release only failed at "Wait for Rust build to complete" because this build failed). Follow-up to #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)