### PR TITLE
ci(docker): bump build timeout 30→60m for cold-cache multi-arch QEMU

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -99,7 +99,7 @@ jobs:
 
   build-and-push-mini:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Follow-up to #180. The 30m job timeout was too tight for the docker `build-and-push` jobs — they build `linux/amd64,linux/arm64` via **QEMU emulation**, and a **cold** `type=gha` buildx cache (arm64 emulation) legitimately exceeds 30min. On `8983bcc` it hit exactly **30m → cancelled**; a warm cache runs ~4min.

A timeout should cap *runaways*, not a slow-but-valid build. Bump both docker jobs to **60m** (still far below the 6h default). Cold cache recurs on eviction (~7d inactivity / cache-key change), so this is a permanent fix rather than relying on a warm re-run.

**Future (separate PR):** switch arm64 from QEMU emulation to a native `ubuntu-24.04-arm` runner (free on public repos) + manifest-merge — removes the emulation slowness entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)