### PR TITLE
feat(console): sort-by-stdin + denoise last_stdin_at (no resize false-flash)

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -348,7 +348,7 @@ function agentForestNodes(list) {
 // flat entry list BEFORE layeredRows builds the room/peer/agent tree (which keeps
 // the given order for siblings and first-seen order for room/peer groups). So
 // sorting reorders roots and siblings without breaking the nesting.
-export const SORT_MODES = ["state", "active", "created", "identity"];
+export const SORT_MODES = ["state", "active", "stdin", "created", "identity"];
 
 // Attention-first state ranking: someone scanning the fleet wants the agents that
 // need them (needs_input) up top, then the wedged ones (stuck), then live work,
@@ -383,21 +383,26 @@ function lastActive(e) {
 
 // Return a NEW array sorted for display per `mode` (default "state"):
 //   - "state":    attention-first state, then git busyness, then newest.
-//   - "active":   most recently active first (last_active_at desc).
+//   - "active":   most recently active first (last_active_at, i.e. stdout, desc).
+//   - "stdin":    most recently FED first (last_stdin_at desc) — which agent was
+//                 just driven/typed-into/`ay send`-ed. Agents never fed sort last.
 //   - "created":  newest first (started_at desc).
 //   - "identity": user@host:owner/repo/branch (alphabetical).
 // Every comparator falls back to newest-first so order is total & deterministic.
 export function sortEntries(entries, mode = "state") {
   const byNewest = (a, b) => (b.started_at || 0) - (a.started_at || 0);
   const byActive = (a, b) => lastActive(b) - lastActive(a) || byNewest(a, b);
+  const byStdin = (a, b) => (b.last_stdin_at ?? 0) - (a.last_stdin_at ?? 0) || byNewest(a, b);
   const cmp =
     mode === "active"
       ? byActive
-      : mode === "created"
-        ? byNewest
-        : mode === "identity"
-          ? (a, b) => fullIdent(a).localeCompare(fullIdent(b)) || byNewest(a, b)
-          : (a, b) => stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
+      : mode === "stdin"
+        ? byStdin
+        : mode === "created"
+          ? byNewest
+          : mode === "identity"
+            ? (a, b) => fullIdent(a).localeCompare(fullIdent(b)) || byNewest(a, b)
+            : (a, b) => stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
   return entries.slice().sort(cmp);
 }
 

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2860,7 +2860,10 @@
         const listEl = $("list");
         if (!listEl) return;
         for (const el of listEl.querySelectorAll(".row[data-key]")) {
-          const on = (flashUntil.get(el.getAttribute("data-key")) || 0) > now;
+          const key = el.getAttribute("data-key");
+          // Mirror rowFlags: never pulse the agent you have open (you see its input
+          // live; also stops your own terminal's protocol replies blinking the row).
+          const on = key !== sel && (flashUntil.get(key) || 0) > now;
           el.classList.toggle("stdinflash", on);
         }
       }, 200);
@@ -3451,9 +3454,13 @@
       // Extra row classes for collaborative presence: a yellow bar when a human
       // peer is watching this agent, plus the stdin pulse while its input just
       // advanced. Empty in the solo case, so a single-user list is unchanged.
+      // The pulse is suppressed on the agent YOU have open (e._key === sel): you
+      // already see its input land live in the terminal, so a flash there is
+      // redundant — and it's the only row your own terminal's protocol replies
+      // could ever nudge, so this also keeps a resize from blinking your own row.
       function rowFlags(e) {
         const peers = focusByKey.get(e._key) || 0;
-        const flash = (flashUntil.get(e._key) || 0) > Date.now();
+        const flash = e._key !== sel && (flashUntil.get(e._key) || 0) > Date.now();
         return (peers ? " peerfocus" : "") + (flash ? " stdinflash" : "");
       }
       // A yellow chip showing how many peers are watching this agent ("" if none).

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -856,7 +856,7 @@ describe("sortEntries", () => {
   const keys = (arr, k = "_k") => arr.map((e) => e[k]);
 
   it("SORT_MODES is the documented cycle", () => {
-    expect(SORT_MODES).toEqual(["state", "active", "created", "identity"]);
+    expect(SORT_MODES).toEqual(["state", "active", "stdin", "created", "identity"]);
   });
 
   it("returns a new array and does not mutate the input", () => {
@@ -921,6 +921,24 @@ describe("sortEntries", () => {
       a({ _k: "new", started_at: 900 }),
     ];
     expect(keys(sortEntries(list, "active"))).toEqual(["new", "old"]);
+  });
+
+  it("stdin mode: most recently fed (last_stdin_at) first, never-fed sort last", () => {
+    const list = [
+      a({ _k: "old", started_at: 900, last_stdin_at: 100 }),
+      a({ _k: "never", started_at: 800 }), // no last_stdin_at → sorts last
+      a({ _k: "fresh", started_at: 100, last_stdin_at: 900 }),
+      a({ _k: "mid", started_at: 500, last_stdin_at: 500 }),
+    ];
+    expect(keys(sortEntries(list, "stdin"))).toEqual(["fresh", "mid", "old", "never"]);
+  });
+
+  it("stdin mode: ties (same/absent last_stdin_at) fall back to newest started_at", () => {
+    const list = [
+      a({ _k: "olderNoStdin", started_at: 100 }),
+      a({ _k: "newerNoStdin", started_at: 900 }),
+    ];
+    expect(keys(sortEntries(list, "stdin"))).toEqual(["newerNoStdin", "olderNoStdin"]);
   });
 
   it("identity mode: alphabetical by full identity (user@host:owner/repo/branch)", () => {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1232,6 +1232,47 @@ export async function cmdServe(rest: string[]): Promise<number> {
     return ensureRepoWatch(root).val; // cached — the request path never spawns `git status`
   };
 
+  // Denoised "last meaningful stdin" tracking — drives the console's stdin flash
+  // and the `stdin` sort order. The FIFO's mtime alone is too noisy: xterm forwards
+  // the agent TUI's terminal-protocol auto-replies (cursor-position / device-
+  // attributes reports) to stdin, so a mere resize/redraw would bump it and the row
+  // would false-flash. So we stamp what WE write, split two ways: `meaningfulStdinAt`
+  // skips those auto-replies; `anyDaemonWriteAt` records every write we make. A FIFO
+  // mtime NEWER than any write we made can only be a local `ay send` (which writes
+  // the FIFO directly, bypassing us) — always meaningful — so it still counts. See
+  // resolveLastStdinAt below and the /api/send handler that stamps these.
+  const meaningfulStdinAt = new Map<number, number>();
+  const anyDaemonWriteAt = new Map<number, number>();
+  // A payload that is PURELY a terminal auto-reply (Cursor Position Report, Device
+  // Attributes, Device Status Report) — protocol chatter a TUI emits on redraw/resize,
+  // not a keystroke. Anchored so a chunk that also carries real input never matches;
+  // real typing (incl. arrow keys like `ESC[A`) never looks like one of these.
+  const isTerminalReply = (s: string) => /^\x1b\[(\d+;\d+R|\?[\d;]*c|>[\d;]*c|\d*n)$/.test(s);
+  // Stamp both maps after a daemon FIFO write, keyed off the FIFO's post-write mtime
+  // (so `anyDaemonWriteAt` is exactly our write's mtime — an external write bumps it
+  // strictly higher, which is how resolveLastStdinAt tells them apart with no clock skew).
+  const noteStdinWrite = async (pid: number, fifo: string, meaningful: boolean) => {
+    const mt = await stat(fifo)
+      .then((s) => s.mtimeMs)
+      .catch(() => null);
+    if (mt == null) return;
+    anyDaemonWriteAt.set(pid, mt);
+    if (meaningful) meaningfulStdinAt.set(pid, mt);
+  };
+  // last_stdin_at for a record: newest of (a) the last meaningful write we made and
+  // (b) a FIFO write we did NOT make (a local `ay send`, always meaningful). A mtime
+  // at/below our last write means the newest write was ours → use the meaningful stamp
+  // (which excludes auto-replies); a strictly newer mtime is an external real write.
+  const resolveLastStdinAt = async (r: { pid: number; fifo_file?: string | null }) => {
+    const meaningful = meaningfulStdinAt.get(r.pid) ?? null;
+    if (!r.fifo_file) return meaningful;
+    const mtime = await stat(r.fifo_file)
+      .then((s) => s.mtimeMs)
+      .catch(() => null);
+    if (mtime == null) return meaningful;
+    return mtime > (anyDaemonWriteAt.get(r.pid) ?? 0) ? mtime : meaningful;
+  };
+
   // One agent record decorated for the console: the latest OSC title + a git
   // snapshot (skipped for exited agents — their repo state is no longer live).
   const withMeta = async (r: Awaited<ReturnType<typeof listRecords>>[number]) => {
@@ -1255,19 +1296,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
           .then((s) => s.mtimeMs)
           .catch(() => r.started_at)
       : r.started_at;
-    // Last-stdin time: the mtime of the agent's stdin FIFO, which the kernel
-    // bumps on EVERY write to it — the console composer, a remote `ay send`, or
-    // a peer's `ay send` all funnel through writeToIpc(fifo_file, …). So this is
-    // a source-agnostic "someone just fed this agent input" signal, distinct from
-    // last_active_at (stdout). The console flashes a row when it advances, so a
-    // collaborator sees keystrokes land even when they weren't the one typing.
-    // Null when there's no live input pipe (exited, or no fifo yet).
-    const lastStdinAt =
-      status !== "exited" && r.fifo_file
-        ? await stat(r.fifo_file)
-            .then((s) => s.mtimeMs)
-            .catch(() => null)
-        : null;
+    // Last-stdin time: when this agent was last fed MEANINGFUL input — a real
+    // keystroke, the console composer, or an `ay send` (local or remote) — but NOT
+    // the TUI's terminal-protocol auto-replies, which would otherwise make a resize
+    // or redraw look like input. The console flashes a row when this advances (so a
+    // collaborator sees input land even when they weren't the one sending it) and can
+    // sort by it. See resolveLastStdinAt / noteStdinWrite. Null for exited agents.
+    const lastStdinAt = status !== "exited" ? await resolveLastStdinAt(r) : null;
     return {
       ...r,
       last_active_at: lastActiveAt,
@@ -1667,6 +1702,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
         } else {
           await writeToIpc(record.fifo_file, msg + trailing);
         }
+        // Record this write for the stdin flash / sort. A payload that is purely a
+        // terminal auto-reply (xterm answering the TUI's cursor/DA query, forwarded
+        // over this same wire) is protocol noise, not input — stamp anyDaemonWriteAt
+        // but not the "meaningful" time, so a resize/redraw can't trip the flash.
+        await noteStdinWrite(record.pid, record.fifo_file, !isTerminalReply(msg));
         return Response.json({ ok: true, pid: record.pid });
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });


### PR DESCRIPTION
Auto-opened during repo tidy/coordination (sibling agent's single-commit feature). Codex-reviewed before merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)