### PR TITLE
feat(rgui): live agent-tree viewer at /rgui (rgui.agent-yes.pages.dev)

### DIFF
--- a/.github/workflows/deploy-agent-yes.yml
+++ b/.github/workflows/deploy-agent-yes.yml
@@ -14,6 +14,7 @@ on:
     branches: [main]
     paths:
       - "lab/ui/**"
+      - "scripts/build-rgui.ts"
       - ".github/workflows/deploy-agent-yes.yml"
   workflow_dispatch:
 
@@ -26,7 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # submodules: the /rgui page is bundled from the lib/rgui submodule at
+      # deploy time (wrangler build.command → scripts/build-rgui.ts).
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # bun runs scripts/build-rgui.ts inside wrangler's build step.
+      - uses: oven-sh/setup-bun@v2
       - name: Deploy worker + synced UI to Cloudflare
         working-directory: lab/ui/cf
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ lab/ui/cf/public/
 
 # agent-yes e2e scratch dir (ts/tests/shared-e2e.spec.ts)
 tmp-test-shared-e2e/
+
+# wrangler local cache (scripts/cf.ts) + rech/playwright scratch
+.wrangler/
+.playwright-cli-multi-tab/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/rgui"]
+	path = lib/rgui
+	url = https://github.com/snomiao/rgui

--- a/lab/ui/cf/wrangler.jsonc
+++ b/lab/ui/cf/wrangler.jsonc
@@ -19,7 +19,11 @@
     // ./public/blog/ (served at /blog/ — linked from the landing nav), and the
     // install scripts to ./public/ (agent-yes.com/setup.sh | setup.ps1). A glob
     // (../*.js) avoids silently breaking when the UI gains a new import.
-    "command": "mkdir -p ./public/w && cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/ && cp ../landing.html ./public/index.html && cp ../architecture.html ./public/architecture.html && rm -rf ./public/blog && cp -R ../blog ./public/blog && cp ../setup.sh ../setup.ps1 ./public/",
+    // The rgui variant of agent-yes (lab/ui/rgui) is bundled from the
+    // @snomiao/rgui submodule source (scripts/build-rgui.ts) into ./public/r —
+    // served at agent-yes.com/r/ (the rgui counterpart of the console at /w/).
+    // Also mirrored to /rgui for the older path.
+    "command": "mkdir -p ./public/w && cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/ && cp ../landing.html ./public/index.html && cp ../architecture.html ./public/architecture.html && rm -rf ./public/blog && cp -R ../blog ./public/blog && cp ../setup.sh ../setup.ps1 ./public/ && bun ../../../scripts/build-rgui.ts ./public/r && rm -rf ./public/rgui && cp -R ./public/r ./public/rgui",
   },
   // Static console UI (served for every non-WebSocket request).
   "assets": { "directory": "./public", "binding": "ASSETS" },

--- a/lab/ui/rgui/dev.ts
+++ b/lab/ui/rgui/dev.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+// Local dev server for the /rgui page — serves the built bundle same-origin with
+// a token-injecting /api proxy, so the page hits REAL live agent data from a
+// local `ay serve --http`.
+//
+//   1. run the API daemon:   ay serve --http --port 7432
+//   2. run this:             bun run dev:rgui      (→ http://localhost:7788)
+//
+// It rebuilds the bundle on start (scripts/build-rgui.ts), so editing
+// lab/ui/rgui/main.ts (or the rgui submodule / local worktree) + refresh shows
+// changes. Pass --watch to rebuild on every request (cheap; Bun.build is fast).
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { $ } from "bun";
+
+const root = path.join(import.meta.dir, "..", "..", ".."); // repo root
+const dist = path.join(import.meta.dir, "dist");
+const PORT = Number(process.env.RGUI_PORT ?? 7788);
+const AY_API = process.env.AY_API ?? "http://127.0.0.1:7432";
+const TOKEN = readFileSync(path.join(homedir(), ".agent-yes", ".serve-token"), "utf-8").trim();
+const watch = process.argv.includes("--watch");
+
+async function build() {
+  await $`bun ${path.join(root, "scripts/build-rgui.ts")}`.cwd(root).quiet();
+}
+await build();
+
+Bun.serve({
+  port: PORT,
+  idleTimeout: 0, // never time out SSE
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    // token-injecting proxy → the local ay serve --http daemon (same-origin, so
+    // the browser needs no token and hits no CORS wall).
+    if (url.pathname.startsWith("/api/")) {
+      const upstream = AY_API + url.pathname + url.search;
+      return fetch(upstream, {
+        method: req.method,
+        headers: { Authorization: `Bearer ${TOKEN}` },
+        body: req.method === "GET" || req.method === "HEAD" ? undefined : await req.text(),
+        // @ts-expect-error Bun streaming passthrough
+        signal: req.signal,
+      }).catch((e) => new Response(`upstream unreachable: ${e}`, { status: 502 }));
+    }
+
+    if (watch) await build();
+    const p = url.pathname === "/" ? "/index.html" : url.pathname;
+    return new Response(Bun.file(path.join(dist, p)));
+  },
+});
+
+console.log(`rgui dev  →  http://localhost:${PORT}   (proxying ${AY_API})`);
+console.log(watch ? "  --watch: rebuilding bundle on every request" : "  restart to rebuild (or pass --watch)");

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -1,0 +1,494 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>agent-yes · rgui — live agent tree</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231c2126'/%3E%3Crect x='6' y='6' width='9' height='9' rx='2' fill='%239b34bf'/%3E%3Crect x='17' y='6' width='9' height='9' rx='2' fill='%23c74be0'/%3E%3Crect x='6' y='17' width='9' height='9' rx='2' fill='%23f3820d'/%3E%3Crect x='17' y='17' width='9' height='9' rx='2' fill='%23ffd21c'/%3E%3C/svg%3E"
+    />
+    <meta
+      name="description"
+      content="The live agent-yes agent forest rendered with @snomiao/rgui — a semantic-zoom readable-grid node graph. Parent agents contain their subagents; zoom out and a busy tree renormalizes into one readable block."
+    />
+    <script>
+      // set the theme BEFORE first paint (no flash): saved choice, else OS
+      document.documentElement.dataset.theme =
+        localStorage.getItem("rgui-theme") ??
+        (matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+    </script>
+    <style>
+      :root {
+        --bg: #1c2126;
+        --text: #e6e9ec;
+        --text-dim: #aeb6bf;
+        --text-muted: #8b949e;
+        --border: #3a4048;
+        --panel: rgba(20, 22, 26, 0.85);
+        --accent: #ffd60a;
+      }
+      :root[data-theme="light"] {
+        --bg: #f3f1ea;
+        --text: #22262b;
+        --text-dim: #4c545c;
+        --text-muted: #69737d;
+        --border: #cfc9bc;
+        --panel: rgba(252, 251, 247, 0.9);
+        --accent: #c8860a;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        background: var(--bg);
+        color: var(--text);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      #viewer {
+        position: fixed;
+        inset: 0;
+        display: block;
+        width: 100vw;
+        height: 100vh;
+        touch-action: none;
+        cursor: grab;
+      }
+      /* top bar — title + live/demo status + refresh */
+      #bar {
+        position: fixed;
+        top: 10px;
+        left: 12px;
+        z-index: 20;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 12px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        font-size: 13px;
+        user-select: none;
+      }
+      #bar .brand {
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+      #bar .brand b {
+        color: var(--accent);
+      }
+      #status {
+        color: var(--text-muted);
+        font-size: 12px;
+      }
+      #status .dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        margin-right: 4px;
+        vertical-align: baseline;
+        background: var(--text-muted);
+      }
+      #status.live .dot {
+        background: #3fb950;
+      }
+      #status.demo .dot {
+        background: #d29922;
+      }
+      #bar button {
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--text-dim);
+        border-radius: 6px;
+        padding: 3px 9px;
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      #bar button:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      #debug {
+        position: fixed;
+        bottom: 8px;
+        left: 8px;
+        z-index: 10;
+        padding: 6px 8px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        color: var(--text);
+        font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        white-space: pre;
+        pointer-events: none;
+        user-select: none;
+      }
+      #debug .dim {
+        color: var(--text-muted);
+      }
+      #debug .hi {
+        color: var(--accent);
+      }
+      /* second debug panel (we own it): selected node + its terminal overlay,
+         in screen px. rgui owns #debug and rewrites it every frame. */
+      #debug2 {
+        position: fixed;
+        top: 56px;
+        right: 12px;
+        z-index: 10;
+        padding: 6px 8px;
+        max-width: 46vw;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        color: var(--text);
+        font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        white-space: pre;
+        pointer-events: none;
+        user-select: none;
+      }
+      #debug2:empty {
+        display: none;
+      }
+      #debug2 .k {
+        color: var(--text-muted);
+      }
+      #debug2 .hi {
+        color: var(--accent);
+      }
+      /* ── per-node live terminal panel (rgui overlay, anchor:"over") ──────
+         Mirrors the console's right-side agent view: a title bar + the raw
+         xterm. rgui glues it over the node's screen rect and scale:"fit"s it,
+         so it's the node's content when zoomed in and yields to the summary
+         card when zoomed out. */
+      .ay-term {
+        /* hug the xterm's native px size (cols/rows from /api/size), so the raw
+           absolute-cursor stream lands on the right grid; rgui scale:"fit" then
+           fits the whole panel into the node's screen rect. */
+        display: flex;
+        flex-direction: column;
+        width: max-content;
+        background: #0d1117;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        /* promote to its own compositor layer so rgui's per-frame transform:scale
+           doesn't re-raster the live canvas each frame */
+        will-change: transform;
+        contain: layout paint;
+      }
+      .ay-term.ay-term-focused {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+      }
+      :root[data-theme="light"] .ay-term {
+        background: #ffffff;
+      }
+      .ay-term-bar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        background: #161b22;
+        color: #c9d1d9;
+        font-size: 13px;
+        line-height: 1.3;
+        border-bottom: 1px solid #30363d;
+        white-space: nowrap;
+      }
+      :root[data-theme="light"] .ay-term-bar {
+        background: #f3f1ea;
+        color: #22262b;
+        border-bottom-color: #cfc9bc;
+      }
+      .ay-term-bar .dot {
+        flex: 0 0 auto;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #8b949e;
+      }
+      .ay-term-bar .dot.active {
+        background: #3fb950;
+      }
+      .ay-term-bar .dot.needs_input {
+        background: #d29922;
+      }
+      .ay-term-bar .dot.stuck {
+        background: #f85149;
+      }
+      .ay-term-bar .dot.exited {
+        background: #6e7781;
+      }
+      .ay-term-bar .t {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-weight: 600;
+      }
+      .ay-term-bar .pid {
+        flex: 0 0 auto;
+        color: #8b949e;
+        font-size: 11px;
+      }
+      .ay-term-body {
+        padding: 4px 6px;
+      }
+
+      /* ── ⌘K command palette (go to / focus an agent) ─────────────────── */
+      #cmdk {
+        position: fixed;
+        inset: 0;
+        z-index: 100;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding-top: 12vh;
+        background: rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(2px);
+      }
+      #cmdk[hidden] {
+        display: none;
+      }
+      .cmdk-box {
+        width: min(680px, 92vw);
+        max-height: 70vh;
+        display: flex;
+        flex-direction: column;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        box-shadow: 0 16px 48px rgba(0, 0, 0, 0.55);
+        overflow: hidden;
+      }
+      #cmdk-input {
+        border: 0;
+        outline: 0;
+        padding: 14px 16px;
+        background: transparent;
+        color: var(--text);
+        font: 15px ui-monospace, SFMono-Regular, Menlo, monospace;
+        border-bottom: 1px solid var(--border);
+      }
+      #cmdk-input::placeholder {
+        color: var(--text-faint, var(--text-muted));
+      }
+      #cmdk-list {
+        overflow-y: auto;
+        padding: 6px;
+      }
+      .cmdk-row {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        padding: 7px 10px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 13px;
+        white-space: nowrap;
+      }
+      .cmdk-row.sel {
+        background: var(--accent);
+        color: #1c2126;
+      }
+      .cmdk-row.sel .cmdk-dim,
+      .cmdk-row.sel .cmdk-pid {
+        color: #1c2126;
+        opacity: 0.75;
+      }
+      .cmdk-row .dot {
+        flex: 0 0 auto;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--text-muted);
+        align-self: center;
+      }
+      .cmdk-row .dot.active {
+        background: #3fb950;
+      }
+      .cmdk-row .dot.needs_input {
+        background: #d29922;
+      }
+      .cmdk-row .dot.stuck {
+        background: #f85149;
+      }
+      .cmdk-row .dot.exited {
+        background: #6e7781;
+      }
+      .cmdk-title {
+        flex: 0 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-weight: 600;
+      }
+      .cmdk-pid {
+        flex: 0 0 auto;
+        color: var(--text-muted);
+        font-size: 11px;
+      }
+      .cmdk-dim {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--text-muted);
+        font-size: 11px;
+        text-align: right;
+      }
+      .cmdk-foot {
+        padding: 7px 12px;
+        border-top: 1px solid var(--border);
+        color: var(--text-muted);
+        font-size: 11px;
+        display: flex;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+      .cmdk-foot b {
+        color: var(--text-dim);
+        font-weight: 600;
+      }
+
+      /* ── right-click batch-send popup ─────────────────────────────────── */
+      #ctxmenu {
+        position: fixed;
+        z-index: 110;
+        width: 340px;
+        max-width: 90vw;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+        overflow: hidden;
+        font-size: 13px;
+      }
+      #ctxmenu[hidden] {
+        display: none;
+      }
+      #ctxmenu .ctx-head {
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-dim);
+        font-weight: 600;
+      }
+      #ctxmenu .ctx-head b {
+        color: var(--accent);
+      }
+      #ctxmenu textarea {
+        width: 100%;
+        box-sizing: border-box;
+        border: 0;
+        outline: 0;
+        resize: none;
+        padding: 10px 12px;
+        min-height: 44px;
+        background: transparent;
+        color: var(--text);
+        font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      #ctxmenu textarea::placeholder {
+        color: var(--text-muted);
+      }
+      #ctxmenu .ctx-foot {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 7px 12px;
+        border-top: 1px solid var(--border);
+        color: var(--text-muted);
+        font-size: 11px;
+      }
+      #ctxmenu .ctx-foot button {
+        border: 1px solid var(--border);
+        background: var(--accent);
+        color: #1c2126;
+        border-radius: 6px;
+        padding: 4px 12px;
+        font: inherit;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      #hint {
+        position: fixed;
+        bottom: 8px;
+        right: 12px;
+        z-index: 10;
+        color: var(--text-muted);
+        font-size: 11px;
+        letter-spacing: 0.03em;
+        pointer-events: none;
+        user-select: none;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="viewer"></canvas>
+
+    <div id="bar">
+      <span class="brand">agent-yes · <b>rgui</b></span>
+      <span id="status"><span class="dot"></span><span class="label">connecting…</span></span>
+      <button id="fit" title="Fit all agents to view">fit</button>
+      <button id="wires" title="Toggle read/tail relationship wires">⇢ wires</button>
+      <button id="theme" title="Toggle light/dark">◐</button>
+    </div>
+
+    <div id="debug"></div>
+    <div id="debug2"></div>
+
+    <div id="ctxmenu" hidden>
+      <div class="ctx-head">Send to <b id="ctx-count">0</b> agent<span id="ctx-s">s</span></div>
+      <textarea
+        id="ctx-input"
+        rows="2"
+        autocomplete="off"
+        spellcheck="false"
+        placeholder="command or prompt — sent verbatim + Enter to each…"
+      ></textarea>
+      <div class="ctx-foot">
+        <span><b>⏎</b> send · <b>shift+⏎</b> newline · <b>esc</b> cancel</span>
+        <button id="ctx-send">Send</button>
+      </div>
+    </div>
+
+    <div id="cmdk" hidden>
+      <div class="cmdk-box">
+        <input
+          id="cmdk-input"
+          type="text"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="Go to agent — search title / branch / cwd / pid…"
+        />
+        <div id="cmdk-list"></div>
+        <div class="cmdk-foot">
+          <span><b>↑↓</b> select</span>
+          <span><b>⏎</b> focus node</span>
+          <span><b>⌘⏎</b> focus terminal</span>
+          <span><b>esc</b> close</span>
+        </div>
+      </div>
+    </div>
+    <div id="hint">⌘K = go to agent · drag = select · right-click = batch send · scroll = zoom</div>
+
+    <!-- xterm.js — SAME versions the console (agent-yes.com/w) uses, so each
+         node's live terminal renders the raw PTY stream identically. -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+    <!-- canvas renderer: a bitmap <canvas> CSS-scales as a cheap GPU composite,
+         so zooming doesn't make xterm re-measure chars + re-render every frame
+         (the DOM renderer's getBoundingClientRect includes the ancestor scale
+         transform → constant re-measure = the zoom flash) -->
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-canvas@0.7.0/lib/addon-canvas.min.js"></script>
+
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -1,0 +1,1238 @@
+/**
+ * agent-yes · /rgui — render the live agent forest with @snomiao/rgui.
+ *
+ * Data source: the same-origin `GET /api/ls` the console uses (a local
+ * `ay serve` daemon, proxied by lab/ui/server.ts). Each agent becomes an rgui
+ * node; a subagent's `parent_pid === parent.wrapper_pid` becomes rgui
+ * CONTAINMENT (the child renders inside the parent's frame and, zoomed out,
+ * renormalizes into the parent block — semantic-zoom LOD). When no `/api` is
+ * reachable (e.g. the static rgui.agent-yes.pages.dev preview), we fall back to
+ * a baked sample forest so the page still demonstrates the mapping.
+ *
+ * rgui is imported from source (submodule lib/rgui or the local dev worktree),
+ * bundled by scripts/build-rgui.ts — never the published npm package, so the
+ * page tracks rgui's heavy dev directly.
+ */
+import createRgui, { nodeHeight, type Edge, type Graph, type GraphNode, type Rgui } from "@snomiao/rgui";
+
+// ── /api/ls record shape (subset we use; see ts/globalPidIndex.ts + serve.ts) ──
+type AgentStatus = "active" | "idle" | "needs_input" | "stuck" | "exited";
+interface AgentRecord {
+  pid: number;
+  cli: string;
+  prompt: string | null;
+  cwd: string;
+  status: AgentStatus;
+  started_at: number;
+  last_active_at?: number;
+  wrapper_pid?: number | null;
+  parent_pid?: number | null;
+  question?: string | null;
+  title?: string | null;
+  git?: { branch: string | null; dirty?: boolean } | null;
+  badges?: string[];
+}
+
+// ── node geometry (world units) ──────────────────────────────────────────────
+// Leaf cards use ~a terminal's aspect ratio (80×24 + a title bar ≈ 1.3:1) so the
+// live-terminal overlay (scale:"fit") fills the node instead of letterboxing and
+// letting the canvas card bleed around it.
+const CARD_W = 320;
+const CARD_H = 236;
+const PAD = 18; // inner padding of a container frame
+const HEADER = 46; // room the container title needs above its children
+const GAP = 14; // gap between siblings inside a container
+const ROW_GAP = 30; // gap between top-level subtrees
+const WRAP_W = 3400; // wrap top-level subtrees to a new band past this x
+
+// status → rgui category (open string; rgui derives a stable color per string)
+const CATEGORY: Record<AgentStatus, string> = {
+  active: "active",
+  needs_input: "waiting",
+  stuck: "stuck",
+  idle: "idle",
+  exited: "exited",
+};
+
+// Repo key = the worktree root, everything before "/tree/" in the cwd — so every
+// branch worktree of one repo (…/owner/repo/tree/<branch>[/lib/…]) shares a key.
+// Label = owner/repo.
+function repoOf(cwd: string): { key: string; label: string } {
+  const key = cwd.split("/tree/")[0]!.replace(/\/+$/, "");
+  const parts = key.split("/");
+  return { key, label: parts.slice(-2).join("/") || key };
+}
+
+const home = "/Users/";
+function shortCwd(cwd: string): string {
+  // ~/ws/snomiao/agent-yes/tree/rgui → …/agent-yes/tree/rgui
+  const parts = cwd.replace(/^\/(Users|home)\/[^/]+\//, "~/").split("/");
+  return parts.length > 4 ? "…/" + parts.slice(-3).join("/") : cwd.replace(home, "~/");
+}
+
+function ago(ts?: number): string {
+  if (!ts) return "";
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
+}
+
+// A short node title: prefer the agent's OSC terminal title (what the console
+// shows — e.g. the current task), else fall back to cli + branch.
+function nodeTitle(r: AgentRecord): string {
+  const osc = (r.title ?? "").replace(/[⠁-⣿]/g, "").trim(); // drop braille spinner glyphs
+  if (osc) return osc.length > 52 ? osc.slice(0, 52) + "…" : osc;
+  return r.git?.branch ? `${r.cli} ⎇${r.git.branch}` : r.cli;
+}
+
+function nodeOf(r: AgentRecord): GraphNode {
+  const branch = r.git?.branch ?? null;
+  const prompt = (r.prompt ?? "").replace(/\s+/g, " ").trim();
+  const fields: [string, string][] = [
+    ["pid", String(r.pid)],
+    ["status", r.status],
+    ["cwd", shortCwd(r.cwd)],
+  ];
+  if (branch) fields.push(["branch", (r.git?.dirty ? "±" : "") + branch]);
+  if (r.last_active_at) fields.push(["active", ago(r.last_active_at) + " ago"]);
+  if (r.question) fields.push(["waiting", r.question.slice(0, 48)]);
+  else if (prompt) fields.push(["prompt", prompt.slice(0, 56) + (prompt.length > 56 ? "…" : "")]);
+  return {
+    id: String(r.pid),
+    title: nodeTitle(r),
+    category: CATEGORY[r.status] ?? r.status,
+    x: 0,
+    y: 0,
+    w: CARD_W,
+    // one in/out port so relationship wires (reads/sends) can anchor to the node
+    inputs: [{ id: "i", label: "", kind: "ctl" }],
+    outputs: [{ id: "o", label: "", kind: "ctl" }],
+    fields,
+  };
+}
+
+/**
+ * Build an rgui Graph from the agent records: parent linkage via
+ * `child.parent_pid === parent.wrapper_pid` → rgui `parent` (containment), then
+ * a simple recursive pack — leaves are cards, a node with children grows into a
+ * frame that wraps its children in a column. Roots tile left-to-right, wrapping
+ * into bands so a wide forest stays scannable.
+ */
+function buildGraph(records: AgentRecord[]): Graph {
+  const byPid = new Map<number, AgentRecord>();
+  for (const r of records) byPid.set(r.pid, r);
+  // wrapper_pid → the agent it belongs to, so a child's parent_pid resolves to a
+  // node id (the parent agent's own pid).
+  const ownerOfWrapper = new Map<number, number>();
+  for (const r of records) if (r.wrapper_pid != null) ownerOfWrapper.set(r.wrapper_pid, r.pid);
+
+  const nodes = new Map<string, GraphNode>();
+  const children = new Map<string, string[]>();
+  for (const r of records) {
+    const n = nodeOf(r);
+    nodes.set(n.id, n);
+    children.set(n.id, []);
+  }
+  // Spawn nesting is kept only WITHIN a cwd: a subagent whose parent is in the
+  // SAME worktree nests under it; a subagent whose parent works elsewhere becomes
+  // a root of its OWN cwd — so agents sharing a worktree snap together regardless
+  // of who spawned them (cross-cwd spawn links are dropped here, candidates for a
+  // future wire). cwd is the primary "workspace" unit; spawn is secondary.
+  const cwdRoots: string[] = [];
+  for (const r of records) {
+    const id = String(r.pid);
+    const parentPid = r.parent_pid != null ? ownerOfWrapper.get(r.parent_pid) : undefined;
+    const parentSameCwd =
+      parentPid != null &&
+      parentPid !== r.pid &&
+      nodes.has(String(parentPid)) &&
+      byPid.get(parentPid)!.cwd === r.cwd;
+    if (parentSameCwd) {
+      nodes.get(id)!.parent = String(parentPid);
+      children.get(String(parentPid))!.push(id);
+    } else {
+      cwdRoots.push(id);
+    }
+  }
+
+  // Snap agents together by cwd, then by repo. Agents in the SAME cwd cluster into
+  // a same-cwd container that surfaces their SHARED state (the loudest member —
+  // needs_input > stuck > active > idle); same-repo cwds then cluster into the
+  // repo container. A cwd/repo with a single member stays loose.
+  cwdGroups.clear();
+  const byRepo = new Map<string, string[]>();
+  for (const id of cwdRoots) {
+    const key = repoOf(byPid.get(Number(id))!.cwd).key;
+    (byRepo.get(key) ?? byRepo.set(key, []).get(key)!).push(id);
+  }
+  const topLevel: string[] = [];
+  for (const [repoKey, repoIds] of byRepo) {
+    // sub-group this repo's agents by EXACT cwd (same worktree)
+    const byCwd = new Map<string, string[]>();
+    for (const id of repoIds) {
+      const cwd = byPid.get(Number(id))!.cwd;
+      (byCwd.get(cwd) ?? byCwd.set(cwd, []).get(cwd)!).push(id);
+    }
+    const repoChildren: string[] = [];
+    for (const [cwd, cids] of byCwd) {
+      if (cids.length < 2) {
+        repoChildren.push(...cids);
+        continue;
+      }
+      const st = aggStateOf(cids);
+      const cwdId = `cwd:${cwd}`;
+      cwdGroups.set(cwdId, cids);
+      nodes.set(cwdId, {
+        id: cwdId,
+        title: cwd.slice(repoKey.length).replace(/^\/(tree\/)?/, "") || cwd,
+        category: `cwd-${st}`, // header colored by the group's shared state
+        x: 0,
+        y: 0,
+        w: CARD_W,
+        inputs: [],
+        outputs: [],
+        fields: [
+          ["agents", String(cids.length)],
+          ["shared", st],
+        ],
+      });
+      children.set(cwdId, cids);
+      for (const id of cids) nodes.get(id)!.parent = cwdId;
+      repoChildren.push(cwdId);
+    }
+    if (repoChildren.length < 2) {
+      topLevel.push(...repoChildren);
+      continue;
+    }
+    const repoId = `repo:${repoKey}`;
+    nodes.set(repoId, {
+      id: repoId,
+      title: repoOf(byPid.get(Number(repoIds[0]))!.cwd).label,
+      category: "repo",
+      x: 0,
+      y: 0,
+      w: CARD_W,
+      inputs: [],
+      outputs: [],
+      fields: [["worktrees", String(byCwd.size)]],
+    });
+    children.set(repoId, repoChildren);
+    for (const id of repoChildren) nodes.get(id)!.parent = repoId;
+    topLevel.push(repoId);
+  }
+
+  // Recursive shelf-pack. Children (which vary a lot in size — a leaf card vs a
+  // deep agent sub-tree) are SIZED first, then arranged left-to-right and wrapped
+  // to a target row width chosen for a roughly-landscape block, so a 20-branch
+  // repo becomes a compact grid instead of one very tall column.
+  function pack(id: string, x: number, y: number): { w: number; h: number } {
+    const node = nodes.get(id)!;
+    node.x = x;
+    node.y = y;
+    const kids = children.get(id) ?? [];
+    if (kids.length === 0) {
+      node.w = CARD_W;
+      node.h = CARD_H;
+      return { w: CARD_W, h: CARD_H };
+    }
+    const sizes = kids.map((k) => pack(k, 0, 0)); // measure subtrees (temp position)
+    const totalArea = sizes.reduce((a, s) => a + s.w * s.h, 0);
+    const maxChildW = Math.max(...sizes.map((s) => s.w));
+    const target = Math.max(maxChildW, Math.sqrt(totalArea) * 1.5); // ~1.5:1 landscape
+    let cx = x + PAD;
+    let cy = y + HEADER;
+    let rowH = 0;
+    let maxRight = x + PAD;
+    for (let i = 0; i < kids.length; i++) {
+      if (cx > x + PAD && cx + sizes[i]!.w > x + PAD + target) {
+        cx = x + PAD; // wrap to next shelf
+        cy += rowH + GAP;
+        rowH = 0;
+      }
+      pack(kids[i]!, cx, cy); // final placement (re-lays the subtree at cx,cy)
+      cx += sizes[i]!.w + GAP;
+      rowH = Math.max(rowH, sizes[i]!.h);
+      maxRight = Math.max(maxRight, cx - GAP);
+    }
+    node.w = Math.max(CARD_W, maxRight - x + PAD);
+    node.h = cy + rowH + PAD - y;
+    return { w: node.w, h: node.h };
+  }
+
+  // tile the top-level nodes (repo containers + loose agents) into bands
+  let x = 0;
+  let bandY = 0;
+  let bandH = 0;
+  for (const id of topLevel) {
+    const s = pack(id, x, bandY);
+    x += s.w + ROW_GAP;
+    bandH = Math.max(bandH, s.h);
+    if (x > WRAP_W) {
+      x = 0;
+      bandY += bandH + ROW_GAP;
+      bandH = 0;
+    }
+  }
+
+  // containers (nodes with children) render as frames around their kids — a
+  // terminal "over" them would cover the children, so only LEAF agents get a
+  // live terminal overlay.
+  isContainer = new Set([...children].filter(([, k]) => k.length > 0).map(([id]) => id));
+  // leaf agent nodes render via our LOD draw hook (terminal snapshot / identity),
+  // instead of rgui's default field card — see drawNode.
+  for (const n of nodes.values()) {
+    if (!isContainer.has(n.id) && !n.id.startsWith("repo:")) {
+      n.draw = (ctx, r) => drawNode(n.id, ctx, r);
+    }
+  }
+  return { nodes: [...nodes.values()], edges: [] };
+}
+
+// ── a baked sample forest (shown when no /api/ls is reachable) ────────────────
+function sampleRecords(): AgentRecord[] {
+  const now = Date.now();
+  const mk = (
+    pid: number,
+    cli: string,
+    status: AgentStatus,
+    cwd: string,
+    branch: string,
+    prompt: string,
+    extra: Partial<AgentRecord> = {},
+  ): AgentRecord => ({
+    pid,
+    cli,
+    status,
+    cwd,
+    prompt,
+    started_at: now - 600_000,
+    last_active_at: now - (extra.last_active_at ?? 30_000),
+    git: { branch },
+    ...extra,
+  });
+  return [
+    mk(1001, "claude", "active", "~/ws/acme/agent-yes/tree/rgui", "rgui", "impl /rgui + ship to pages", { wrapper_pid: 1001 }),
+    mk(1002, "claude", "idle", "~/ws/acme/rgui/tree/main", "main", "rgui heavy dev — org-chart containers", { wrapper_pid: 1002 }),
+    // a parent agent (wrapper 1003) with two subagents nested inside it
+    mk(1003, "claude", "active", "~/ws/acme/api/tree/main", "chore/pin-bump", "goal: pin bump wave", { wrapper_pid: 1003 }),
+    mk(1004, "claude", "idle", "~/ws/acme/api/tree/proxy", "proxy", "proxy work", { wrapper_pid: 1004, parent_pid: 1003 }),
+    mk(1005, "claude", "needs_input", "~/ws/acme/api/tree/main/lib/edge", "feat/force-h1", "force h1 land — awaiting review", { wrapper_pid: 1005, parent_pid: 1003, question: "Proceed with merge?" }),
+    mk(1006, "claude", "idle", "~/ws/acme/tools/tree/main", "main", "tooling", { wrapper_pid: 1006 }),
+    mk(1007, "claude", "stuck", "~/ws/acme/web/tree/main", "main", "resume web build", { wrapper_pid: 1007 }),
+  ];
+}
+
+// ─── per-node live terminals ──────────────────────────────────────────────────
+// Reuse the console's xterm.js (loaded from the same CDN in index.html) + its
+// raw tail protocol: each on-screen, large-enough LEAF node gets an xterm sized
+// to the agent's NATIVE cols/rows (from /api/size — we never push a resize, so
+// we don't fight the real user's PTY) and tails /api/tail/<pid>?raw=1. rgui glues
+// the panel over the node (scale:"fit"), so zoomed in you see the live terminal,
+// zoomed out the summary card. Virtualized + capped so we never run 40 terminals.
+let isContainer = new Set<string>();
+const recordsByPid = new Map<string, AgentRecord>();
+
+// relationship wires: recent agent→agent read/tail edges (from /api/edges).
+interface ReadEdge {
+  by: number;
+  target: number;
+  at: number;
+}
+let readEdges: ReadEdge[] = [];
+let showWires = true;
+
+// same-cwd groups (cwdId → member pids); their container surfaces the group's
+// SHARED state (the loudest member), refreshed on every content poll.
+const cwdGroups = new Map<string, string[]>();
+const STATE_RANK: AgentStatus[] = ["needs_input", "stuck", "active", "idle", "exited"];
+function aggStateOf(pids: string[]): AgentStatus {
+  const s = new Set(pids.map((p) => recordsByPid.get(p)?.status).filter(Boolean));
+  return STATE_RANK.find((x) => s.has(x)) ?? "idle";
+}
+
+const MAX_TERMS = 6; // cap concurrent xterms/SSE streams — `ay serve --http` gets
+// unresponsive under many concurrent /api/tail streams, and a stalled stream
+// auto-reconnects (re-sending a full snapshot = a repaint/flash)
+const TERM_MIN_W = 210; // node must be at least this wide on screen to earn a terminal
+const TERM_MIN_H = 120;
+const TERM_DROP_TICKS = 3; // ticks a terminal may stay unwanted before teardown
+
+type Xterm = {
+  write(d: string): void;
+  open(el: HTMLElement): void;
+  resize(cols: number, rows: number): void;
+  dispose(): void;
+  options: Record<string, unknown>;
+};
+const XTermCtor = (window as unknown as { Terminal?: new (o: unknown) => Xterm }).Terminal;
+
+// console's GitHub dark/light terminal palettes (kept legible on a white bg)
+const prefersLight = matchMedia("(prefers-color-scheme: light)");
+function isLight() {
+  return (document.documentElement.dataset.theme ?? (prefersLight.matches ? "light" : "dark")) === "light";
+}
+function termTheme() {
+  return isLight()
+    ? {
+        background: "#ffffff", foreground: "#1f2328", cursor: "#1f2328",
+        selectionBackground: "#b6d6ff", black: "#24292e", red: "#cf222e", green: "#116329",
+        yellow: "#4d2d00", blue: "#0969da", magenta: "#8250df", cyan: "#1b7c83", white: "#6e7781",
+        brightBlack: "#57606a", brightRed: "#a40e26", brightGreen: "#1a7f37", brightYellow: "#633c01",
+        brightBlue: "#218bff", brightMagenta: "#a475f9", brightCyan: "#3192aa", brightWhite: "#1f2328",
+      }
+    : { background: "#0d1117", foreground: "#c9d1d9", cursor: "#0d1117" };
+}
+
+interface TermEntry {
+  el: HTMLElement;
+  term: Xterm;
+  es: EventSource;
+  miss: number; // consecutive ticks unwanted (grace before teardown)
+  buf: string; // stream bytes deferred while the view moves (flushed on settle)
+}
+const terms = new Map<string, TermEntry>();
+
+// The rgui HTML-overlay layer (holds every terminal); cached once it exists.
+let overlayLayerEl: HTMLElement | null = null;
+function overlayLayer(): HTMLElement | null {
+  return (overlayLayerEl ??= document.querySelector<HTMLElement>(".rgui-overlay-layer"));
+}
+// Timestamp of the last view change — terminals are only reconciled once the view
+// has been still for a bit, so a zoom/pan never opens/closes SSE streams mid-
+// gesture (that churn leaks server-side FIFO watchers and triggers reconnect
+// repaints = flashing). Existing terminals stay put and just scale during motion.
+let lastViewChangeAt = 0;
+let prevK = 0;
+let prevX = 0;
+let prevY = 0;
+const SETTLE_MS = 180;
+let deferredWhileMoving = 0; // QA metric (see #qa): stream bytes deferred mid-gesture
+
+function makeTerm(pid: string): TermEntry | null {
+  const r = recordsByPid.get(pid);
+  if (!XTermCtor || !r) return null;
+  const el = document.createElement("div");
+  el.className = "ay-term";
+  el.dataset.rguiInteractive = "1"; // let scroll/select inside the terminal work
+  const bar = document.createElement("div");
+  bar.className = "ay-term-bar";
+  bar.innerHTML =
+    `<span class="dot ${r.status}"></span>` +
+    `<span class="t"></span><span class="pid">#${pid}</span>`;
+  (bar.querySelector(".t") as HTMLElement).textContent = nodeTitle(r);
+  const body = document.createElement("div");
+  body.className = "ay-term-body";
+  el.append(bar, body);
+
+  const term = new XTermCtor({
+    fontSize: 11, // smaller native canvas → cheaper to composite/scale during zoom
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    theme: termTheme(),
+    disableStdin: true, // read-only mirror
+    cursorBlink: false,
+    scrollback: 200,
+    convertEol: false,
+  });
+  term.open(body);
+  // render to a <canvas> bitmap so rgui's per-frame transform:scale() during zoom
+  // is a cheap GPU composite, not a full xterm char-remeasure + re-render (the
+  // DOM renderer re-measures because getBoundingClientRect includes the scale).
+  const CanvasAddon = (window as unknown as { CanvasAddon?: { CanvasAddon: new () => unknown } })
+    .CanvasAddon?.CanvasAddon;
+  if (CanvasAddon) {
+    try {
+      (term as unknown as { loadAddon(a: unknown): void }).loadAddon(new CanvasAddon());
+    } catch {
+      /* addon unavailable — fall back to the DOM renderer */
+    }
+  }
+
+  // #nostream (debug): skip the live SSE so the page reaches network-idle and rech
+  // can drive it; render a static pattern so the overlay still has content/size.
+  const noStream = location.hash.includes("nostream");
+  const es = noStream
+    ? ({ close() {} } as unknown as EventSource)
+    : new EventSource(`/api/tail/${encodeURIComponent(pid)}?raw=1`);
+  const entry: TermEntry = { el, term, es, miss: 0, buf: "" };
+  if (noStream) {
+    for (let i = 0; i < 20; i++) term.write(`row ${i} · #${pid} · nostream debug pattern\r\n`);
+  } else {
+    (es as EventSource).onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data) as string;
+        // While the view is moving, DEFER writes: repainting the xterm canvas
+        // while rgui is CSS-scaling it every frame re-rasters = the zoom flash.
+        // Buffer now, flush once the view settles (see the settle interval).
+        if (Date.now() - lastViewChangeAt < SETTLE_MS) {
+          entry.buf += data;
+          deferredWhileMoving++; // QA metric: stream bytes that arrived mid-gesture
+        } else term.write(data);
+      } catch {
+        /* non-JSON keepalive frame */
+      }
+    };
+  }
+
+  // size probe (only under #qa): log the overlay's natural px once xterm lays out
+  if (location.hash === "#qa")
+    requestAnimationFrame(() =>
+      console.log(
+        `[rgui-term] pid=${pid} el=${el.offsetWidth}x${el.offsetHeight}px ` +
+          `= ${((el.offsetWidth * el.offsetHeight) / 1e6).toFixed(2)}MPx`,
+      ),
+    );
+
+  // size to the agent's native grid so the absolute-cursor raw stream lands
+  // correctly; NO resize is pushed back to the PTY.
+  fetch(`/api/size/${encodeURIComponent(pid)}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((s: { cols?: number; rows?: number } | null) => {
+      if (s?.cols && s?.rows && terms.get(pid) === entry) term.resize(s.cols, s.rows);
+    })
+    .catch(() => {});
+
+  viewer.setNodeOverlay(pid, {
+    el,
+    anchor: "over",
+    scale: "fit",
+    // only reveal the terminal once it's big enough to read — agents with a large
+    // PTY (e.g. 160×50) would otherwise show as an illegible thumbnail; below this
+    // the node's summary card takes over (true semantic zoom: zoom in for the
+    // live terminal, out for the card).
+    minScale: 0.34,
+    // upscale past the terminal's native px to FILL a larger node (rgui caps at 1
+    // by default = crisp but the card shows around it at high zoom); 4× keeps it
+    // legible-ish while filling.
+    maxScale: 4,
+    clip: "node",
+    overflow: "hidden",
+    interactive: true,
+  });
+  // rgui leaves the <canvas> at z-index:1 (its GPU-underlay stacking) even after
+  // a WebGPU fallback tears the underlay down, which would bury the overlay layer
+  // (z-index:auto) — lift it above the canvas so the terminals show.
+  const layer = overlayLayer();
+  if (layer && layer.style.zIndex !== "2") layer.style.zIndex = "2";
+  return entry;
+}
+
+function dropTerm(pid: string) {
+  const e = terms.get(pid);
+  if (!e) return;
+  terms.delete(pid);
+  try {
+    e.es.close();
+  } catch {
+    /* */
+  }
+  try {
+    e.term.dispose();
+  } catch {
+    /* */
+  }
+  viewer.setNodeOverlay(pid, null);
+}
+
+// ── snapshot LOD + zoomed-out identity ────────────────────────────────────────
+// A leaf agent node's canvas content (rgui `node.draw`) is our own LOD ladder,
+// UNDER the live html-terminal overlay: zoomed in the overlay covers it; below
+// the overlay's readable scale we draw a SNAPSHOT of how the terminal looked
+// (grabbed off the canvas-renderer's <canvas> while it was live); zoomed out
+// small, just the identity+title row (like the console's left-side list).
+const DOT_COLOR: Record<string, string> = {
+  active: "#3fb950",
+  needs_input: "#d29922",
+  stuck: "#f85149",
+  exited: "#6e7781",
+  idle: "#8b949e",
+};
+const snapshots = new Map<string, HTMLCanvasElement>();
+
+// grab the live terminal's rendered pixels (canvas renderer → real <canvas>es)
+// into an offscreen canvas we keep after the live terminal is torn down.
+function captureSnapshot(id: string, entry: TermEntry) {
+  const cvs = entry.el.querySelectorAll("canvas");
+  if (!cvs.length) return;
+  let w = 0;
+  let h = 0;
+  cvs.forEach((c) => {
+    w = Math.max(w, (c as HTMLCanvasElement).width);
+    h = Math.max(h, (c as HTMLCanvasElement).height);
+  });
+  if (!w || !h) return;
+  let off = snapshots.get(id);
+  if (!off) {
+    off = document.createElement("canvas");
+    snapshots.set(id, off);
+  }
+  if (off.width !== w || off.height !== h) {
+    off.width = w;
+    off.height = h;
+  }
+  const octx = off.getContext("2d")!;
+  octx.fillStyle = isLight() ? "#ffffff" : "#0d1117";
+  octx.fillRect(0, 0, w, h);
+  cvs.forEach((c) => {
+    try {
+      octx.drawImage(c as HTMLCanvasElement, 0, 0);
+    } catch {
+      /* tainted/empty — skip */
+    }
+  });
+}
+
+// rgui node.draw for leaf agents (rgui still paints the border/selection). Title
+// bar (status dot + OSC title) + body = terminal snapshot when there's room, else
+// a compact identity block.
+function drawNode(
+  id: string,
+  ctx: CanvasRenderingContext2D,
+  rect: { width: number; height: number },
+) {
+  const r = recordsByPid.get(id);
+  const light = isLight();
+  const w = rect.width;
+  const h = rect.height;
+  const barH = Math.max(14, Math.min(26, h * 0.16));
+  ctx.fillStyle = light ? "#f3f1ea" : "#161b22";
+  ctx.fillRect(0, 0, w, barH);
+  if (r) {
+    ctx.beginPath();
+    ctx.arc(barH * 0.55, barH * 0.5, Math.max(2, barH * 0.16), 0, Math.PI * 2);
+    ctx.fillStyle = DOT_COLOR[r.status] ?? "#8b949e";
+    ctx.fill();
+    ctx.fillStyle = light ? "#22262b" : "#c9d1d9";
+    ctx.font = `600 ${Math.max(7, Math.min(14, barH * 0.6))}px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.textBaseline = "middle";
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(barH, 0, w - barH - 4, barH);
+    ctx.clip();
+    ctx.fillText(nodeTitle(r), barH * 1.05, barH * 0.56);
+    ctx.restore();
+  }
+  const bodyY = barH;
+  const bodyH = h - barH;
+  ctx.fillStyle = light ? "#ffffff" : "#0d1117";
+  ctx.fillRect(0, bodyY, w, bodyH);
+  const snap = snapshots.get(id);
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, bodyY, w, bodyH);
+  ctx.clip();
+  if (snap && snap.width && bodyH > 34) {
+    // fit width, show the BOTTOM of the terminal (the latest output) — a mini
+    // live-terminal thumbnail rather than the top of the scrollback.
+    const scale = w / snap.width;
+    const srcH = Math.min(snap.height, bodyH / scale);
+    ctx.drawImage(snap, 0, snap.height - srcH, snap.width, srcH, 0, bodyY, w, srcH * scale);
+  } else if (r && bodyH > 14) {
+    ctx.fillStyle = light ? "#69737d" : "#8b949e";
+    const fs = Math.max(7, Math.min(12, bodyH * 0.16));
+    ctx.font = `${fs}px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.textBaseline = "top";
+    const lines = [`#${id} · ${r.status}`, shortCwd(r.cwd) + (r.git?.branch ? ` ⎇${r.git.branch}` : "")];
+    if (r.question) lines.push(`⏳ ${r.question.slice(0, 40)}`);
+    lines.forEach((ln, i) => ctx.fillText(ln, 8, bodyY + 8 + i * (fs + 3)));
+  }
+  ctx.restore();
+}
+
+// Decide which nodes deserve a live terminal this frame (on-screen leaf nodes,
+// big enough, capped by area), create/tear down to match.
+let lastTermSync = 0;
+function syncTerminals(view: { x: number; y: number; k: number }) {
+  if (!XTermCtor) return;
+  const cw = canvas.clientWidth || innerWidth;
+  const ch = canvas.clientHeight || innerHeight;
+  const cand: { id: string; area: number }[] = [];
+  for (const n of viewer.graph.nodes) {
+    if (isContainer.has(n.id)) continue;
+    const sw = n.w * view.k;
+    const sh = (n.h ?? CARD_H) * view.k;
+    if (sw < TERM_MIN_W || sh < TERM_MIN_H) continue;
+    const sx = n.x * view.k + view.x;
+    const sy = n.y * view.k + view.y;
+    if (sx + sw < 0 || sx > cw || sy + sh < 0 || sy > ch) continue; // off-screen
+    cand.push({ id: n.id, area: sw * sh });
+  }
+  cand.sort((a, b) => b.area - a.area);
+  const wanted = new Set(cand.slice(0, MAX_TERMS).map((c) => c.id));
+
+  for (const id of wanted) if (!terms.has(id)) {
+    const e = makeTerm(id);
+    if (e) terms.set(id, e);
+  }
+  for (const [id, e] of terms) {
+    if (wanted.has(id)) e.miss = 0;
+    else if (++e.miss >= TERM_DROP_TICKS) dropTerm(id);
+  }
+}
+
+// Selected-node debug panel (#debug2): the selected node's rect and its live
+// terminal overlay's rect, in screen px. (rgui owns #debug and rewrites it every
+// frame, so we keep our extra readout in a panel we control.)
+const debug2El = document.getElementById("debug2");
+function updateNodeDebug() {
+  if (!debug2El) return;
+  const id = viewer.selection[0];
+  const node = id ? viewer.graph.nodes.find((n) => n.id === id) : undefined;
+  if (!node) {
+    debug2El.textContent = "";
+    return;
+  }
+  const v = viewer.view;
+  const h = nodeHeight(node); // rgui's effective height (rows-derived if h unset)
+  const R = (n: number) => Math.round(n);
+  const lines = [
+    `sel  #${id} · ${node.category}`,
+    `node world  ${R(node.x)},${R(node.y)}  ${R(node.w)}×${R(h)} wu`,
+    `node screen ${R(node.x * v.k + v.x)},${R(node.y * v.k + v.y)}  ${R(node.w * v.k)}×${R(h * v.k)} px`,
+  ];
+  const e = terms.get(id);
+  if (e) {
+    // the wrap is what rgui positions/scales (clip:"node"); its client rect is the
+    // overlay's actual on-screen box.
+    const box = (e.el.parentElement ?? e.el).getBoundingClientRect();
+    lines.push(
+      `ovl  natural ${e.el.offsetWidth}×${e.el.offsetHeight} px`,
+      `ovl  screen  ${R(box.x)},${R(box.y)}  ${R(box.width)}×${R(box.height)} px`,
+    );
+  } else {
+    lines.push(`ovl  (none — zoom in on a leaf)`);
+  }
+  debug2El.textContent = lines.join("\n");
+}
+
+// Browser tab title follows the selected agent (name + status glyph), like the
+// console's docTitle — else the fleet summary. This IS the "console title".
+const STATUS_GLYPH: Record<string, string> = {
+  active: "●",
+  needs_input: "⌨",
+  stuck: "■",
+  idle: "○",
+  exited: "✕",
+};
+function updateDocTitle() {
+  const id = viewer.selection[0];
+  const r = id ? recordsByPid.get(id) : undefined;
+  if (r) {
+    document.title = `${STATUS_GLYPH[r.status] ?? ""} ${nodeTitle(r)} · agent-yes`.trim();
+  } else {
+    const n = recordsByPid.size;
+    document.title = n ? `agent-yes · rgui · ${n} agents` : "agent-yes · rgui — live agent tree";
+  }
+}
+
+// ── bootstrap ────────────────────────────────────────────────────────────────
+const canvas = document.getElementById("viewer") as HTMLCanvasElement;
+const debug = document.getElementById("debug");
+const statusEl = document.getElementById("status")!;
+const statusLabel = statusEl.querySelector(".label")!;
+
+const initialTheme = (document.documentElement.dataset.theme as "dark" | "light") ?? "dark";
+
+const viewer: Rgui = createRgui(canvas, {
+  graph: { nodes: [], edges: [] },
+  theme: initialTheme,
+  debug,
+  onNodeClick: (id) => {
+    // focus the clicked agent — a real hook point for "open this agent's console"
+    viewer.setSelection([id]);
+  },
+  onNodeContextMenu: (id, screen) => {
+    // right-click → batch-send to the selection (or just this node); a selected
+    // container expands to its agent descendants.
+    const sel = viewer.selection;
+    const base = sel.includes(id) && sel.length > 0 ? [...sel] : [id];
+    if (!sel.includes(id)) viewer.setSelection(base);
+    const set = new Set<string>();
+    for (const t of base) {
+      if (recordsByPid.has(t)) set.add(t);
+      else for (const d of agentDescendants(t)) set.add(d);
+    }
+    const targets = [...set];
+    if (targets.length) openBatchMenu(screen.x, screen.y, targets);
+  },
+  onSelectionChange: () => {
+    updateNodeDebug();
+    updateDocTitle(); // tab title follows the selected agent
+  },
+  onFrame: (view) => {
+    updateNodeDebug(); // selected node's screen rect tracks pan/zoom every frame
+    const now = Date.now();
+    if (view.k !== prevK || view.x !== prevX || view.y !== prevY) {
+      prevK = view.k;
+      prevX = view.x;
+      prevY = view.y;
+      lastViewChangeAt = now;
+      return; // mid-gesture: leave terminals exactly as they are (rgui scales them)
+    }
+    // view is momentarily still — only reconcile once it has settled
+    if (now - lastViewChangeAt < SETTLE_MS) return;
+    if (now - lastTermSync < 200) return;
+    lastTermSync = now;
+    syncTerminals(view);
+  },
+});
+
+// expose for e2e/debugging (harmless): window.__rgui.viewer / .lastRecords
+(window as unknown as { __rgui: unknown }).__rgui = { viewer, get graph() { return viewer.graph; } };
+
+// Fit all agents, but never zoom out past a readable scale — a full forest fit
+// otherwise lands so far out that rgui's semantic-zoom LOD collapses the
+// edge-less, spread-out nodes below the draw threshold and the canvas looks
+// empty. Below MIN_FIT_K we hold MIN_FIT_K and keep the forest centered; the
+// user pans to explore (and zooms out further on purpose to renormalize).
+const MIN_FIT_K = 0.42;
+function fitReadable(pad = 80) {
+  viewer.fitView(pad);
+  const v = viewer.view;
+  if (v.k >= MIN_FIT_K) return;
+  const cw = canvas.clientWidth || window.innerWidth;
+  const ch = canvas.clientHeight || window.innerHeight;
+  const wcx = (cw / 2 - v.x) / v.k;
+  const wcy = (ch / 2 - v.y) / v.k;
+  const k = MIN_FIT_K;
+  viewer.setView({ k, x: cw / 2 - wcx * k, y: ch / 2 - wcy * k });
+}
+
+// The 43 live agents flip status/title constantly. A full setGraph re-layouts
+// and reshuffles every node (jumping them out from under the view and dropping
+// terminals), so split the record set into two signatures:
+//  - STRUCTURE (pid set + parent tree): a change here needs a real relayout.
+//  - CONTENT (status/title/branch/question): update the existing nodes IN PLACE
+//    and redraw — positions and terminals stay put.
+function structureSig(records: AgentRecord[]): string {
+  return records
+    .map((r) => `${r.pid}>${r.parent_pid ?? ""}`)
+    .sort()
+    .join("|");
+}
+function contentSig(records: AgentRecord[]): string {
+  return records
+    .map((r) => `${r.pid}:${r.status}:${r.question ?? ""}:${r.title ?? ""}:${r.git?.branch ?? ""}`)
+    .sort()
+    .join("|");
+}
+
+let firstPaint = true;
+let liveKnown = false;
+let lastStruct = "";
+let lastContent = "";
+
+// Refresh title/category/fields on the existing nodes (+ terminal title bars)
+// in place. We deliberately DON'T force a redraw here: a `setGraph` per poll
+// re-renders the whole canvas AND kicks rgui's frame-animation loop, which
+// re-glues every overlay for ~1-2s — the visible "flashing" every few seconds.
+// The mutated fields are picked up by the next natural frame (any pan/zoom), and
+// the cards are only readable when zoomed out anyway; the live terminals (the
+// thing you watch up close) update themselves via their own streams, and their
+// title bars/status dots are refreshed cheaply below.
+function updateContent(records: AgentRecord[]) {
+  const byId = new Map(records.map((r) => [String(r.pid), r] as const));
+  for (const n of viewer.graph.nodes) {
+    const r = byId.get(n.id);
+    if (r) {
+      const fresh = nodeOf(r);
+      n.title = fresh.title;
+      n.category = fresh.category;
+      n.fields = fresh.fields;
+    } else if (cwdGroups.has(n.id)) {
+      // same-cwd container: recompute the shared (loudest) state in place
+      const st = aggStateOf(cwdGroups.get(n.id)!);
+      n.category = `cwd-${st}`;
+      n.fields = [["agents", String(cwdGroups.get(n.id)!.length)], ["shared", st]];
+    }
+  }
+  for (const [pid, e] of terms) {
+    const r = byId.get(pid);
+    if (!r) continue;
+    const t = e.el.querySelector<HTMLElement>(".t");
+    if (t) t.textContent = nodeTitle(r);
+    const dot = e.el.querySelector<HTMLElement>(".dot");
+    if (dot) dot.className = `dot ${r.status}`;
+  }
+}
+
+function apply(records: AgentRecord[], live: boolean) {
+  recordsByPid.clear();
+  for (const r of records) recordsByPid.set(String(r.pid), r);
+  const struct = structureSig(records);
+  const content = contentSig(records);
+  if (struct !== lastStruct) {
+    lastStruct = struct;
+    lastContent = content;
+    // tear down terminals for agents that are gone (exited/removed)
+    for (const id of [...terms.keys()]) if (!recordsByPid.has(id)) dropTerm(id);
+    viewer.setGraph(buildGraph(records));
+    applyEdges(); // rebuild wires on the new node set
+    if (firstPaint) {
+      fitReadable();
+      firstPaint = false;
+    }
+  } else if (content !== lastContent) {
+    lastContent = content;
+    updateContent(records);
+  }
+  liveKnown = live;
+  statusEl.className = live ? "live" : "demo";
+  const n = records.length;
+  statusLabel.textContent = live
+    ? `live · ${n} agent${n === 1 ? "" : "s"}`
+    : "demo · no local ay serve";
+  updateDocTitle(); // keep the tab title's name/status/count fresh
+}
+
+// Rebuild the relationship wires (read/tail edges between present agent nodes) on
+// the current graph and redraw — cheap, no relayout. Called on structure change,
+// the edge poll, and the wire toggle.
+function applyEdges() {
+  const present = new Set(viewer.graph.nodes.map((n) => n.id));
+  const edges: Edge[] = showWires
+    ? readEdges
+        .filter((e) => e.by !== e.target && present.has(String(e.by)) && present.has(String(e.target)))
+        .map((e) => ({
+          from: { node: String(e.by), port: "o" },
+          to: { node: String(e.target), port: "i" },
+          dashed: true,
+          style: { color: "#58a6ff", width: 1.5, dash: [6, 4] },
+        }))
+    : [];
+  viewer.graph.edges.length = 0;
+  viewer.graph.edges.push(...edges);
+  viewer.setView(viewer.view); // schedule a redraw without a relayout
+}
+
+async function fetchEdges() {
+  try {
+    const res = await fetch("/api/edges", { headers: { accept: "application/json" } });
+    if (!res.ok || !(res.headers.get("content-type") ?? "").includes("json")) return;
+    readEdges = ((await res.json()) as { reads?: ReadEdge[] }).reads ?? [];
+    applyEdges();
+  } catch {
+    /* no /api/edges (static host / old daemon) — leave wires empty */
+  }
+}
+
+async function refresh() {
+  try {
+    const res = await fetch("/api/ls", { headers: { accept: "application/json" } });
+    if (!res.ok) throw new Error(String(res.status));
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("json")) throw new Error("not json"); // static host served HTML
+    const records = (await res.json()) as AgentRecord[];
+    apply(records, true);
+    void fetchEdges();
+  } catch {
+    // no reachable /api/ls → show the sample forest (only until live appears)
+    if (!liveKnown) apply(sampleRecords(), false);
+  }
+}
+
+refresh();
+setInterval(refresh, 3000);
+
+// QA (#qa): auto-zoom into a leaf so terminals spawn (the size probe in makeTerm
+// then logs each overlay's px), and run a slow zoom sweep logging how many times
+// the overlay layer toggles visibility — the "flash" signal — since rech's
+// idle-wait can't eval a page holding live SSE streams.
+if (location.hash.startsWith("#qa")) {
+  setTimeout(() => {
+    const parents = new Set(viewer.graph.nodes.map((n) => n.parent).filter(Boolean));
+    const leaf = viewer.graph.nodes.filter((n) => !parents.has(n.id) && !n.id.startsWith("repo:"))[6];
+    if (!leaf) return;
+    const cx = leaf.x + leaf.w / 2;
+    const cy = leaf.y + (leaf.h ?? CARD_H) / 2;
+    // The flash signal is a canvas REPAINT while the view is scaling. Count xterm
+    // content mutations that land WHILE the view is moving — with the defer-writes
+    // fix this should be ~0 even though stream bytes keep arriving (they're
+    // buffered). Also count overlay display-toggles + ay-term churn for good measure.
+    let xtermMutWhileMoving = 0;
+    let displayToggles = 0;
+    let termChurn = 0;
+    const mutSample = new Set<string>();
+    const seenDisplay = new WeakMap<Element, string>();
+    const moving = () => Date.now() - lastViewChangeAt < SETTLE_MS;
+    const obs = new MutationObserver((muts) => {
+      for (const m of muts) {
+        const t = m.target as Element;
+        if (t.closest?.(".xterm")) {
+          if (moving()) {
+            xtermMutWhileMoving++;
+            const el = (t.nodeType === 3 ? t.parentElement : t) as Element;
+            if (mutSample.size < 8)
+              mutSample.add(`${m.type}:${el?.tagName?.toLowerCase()}.${(el?.className || "").toString().slice(0, 24)}`);
+          }
+        } else if (m.type === "childList") {
+          for (const n of m.addedNodes) if ((n as Element).classList?.contains("ay-term")) termChurn++;
+          for (const n of m.removedNodes) if ((n as Element).classList?.contains("ay-term")) termChurn++;
+        } else if (m.type === "attributes" && m.attributeName === "style") {
+          const el = m.target as HTMLElement;
+          const d = el.style.display;
+          if (seenDisplay.get(el) !== d && (d === "none" || d === "")) {
+            if (seenDisplay.has(el)) displayToggles++;
+            seenDisplay.set(el, d);
+          }
+        }
+      }
+    });
+    // 1) zoom in and hold, so terminals actually spawn (the settle-gate blocks
+    //    creation during motion) and start streaming.
+    const k0 = 1.9;
+    viewer.setView({ k: k0, x: innerWidth / 2 - cx * k0, y: innerHeight / 2 - cy * k0 });
+    setTimeout(() => {
+      // 2) now WIGGLE the zoom (continuous motion) while terminals stream, and
+      //    measure xterm repaints landing mid-motion — the flash.
+      obs.observe(document.body, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        characterData: true,
+        attributeFilter: ["style"],
+      });
+      const deferBase = deferredWhileMoving;
+      let t = 0;
+      const iv = setInterval(() => {
+        t++;
+        const k = k0 * (1 + 0.18 * Math.sin(t * 0.6)); // oscillate around k0 (stays zoomed)
+        viewer.setView({ k, x: innerWidth / 2 - cx * k, y: innerHeight / 2 - cy * k });
+        if (t > 30) {
+          clearInterval(iv);
+          setTimeout(() => {
+            obs.disconnect();
+            console.log(
+              `[rgui-qa] zoom-wiggle: xterm-repaints-while-moving=${xtermMutWhileMoving} (THE FLASH — want ~0), ` +
+                `stream-bytes-deferred=${deferredWhileMoving - deferBase} (>0 proves streams were live during motion), ` +
+                `display-toggles=${displayToggles}, ay-term churn=${termChurn}, ` +
+                `mut-sample=[${[...mutSample].join(", ")}]`,
+            );
+          }, 400);
+        }
+      }, 90);
+    }, 1800);
+  }, 3500);
+}
+
+// Reconcile terminals on a steady tick too — onFrame alone can starve (a single
+// settle frame that lands inside the throttle window is skipped and never
+// retried until the next interaction), so this guarantees convergence to the
+// current view whether or not frames are flowing. Also gated on the view being
+// settled, so a zoom in progress never opens/closes streams mid-gesture.
+setInterval(() => {
+  if (Date.now() - lastViewChangeAt >= SETTLE_MS) {
+    syncTerminals(viewer.view);
+    // flush stream bytes that were deferred during the gesture (one repaint now,
+    // on a settled/non-scaling canvas — no flash)
+    for (const [id, e] of terms) {
+      if (e.buf) {
+        e.term.write(e.buf);
+        e.buf = "";
+      }
+      captureSnapshot(id, e); // keep a fresh thumbnail for the zoomed-out LOD
+    }
+  }
+  updateNodeDebug(); // refresh overlay rect once a terminal spins up after settle
+}, 350);
+
+// ── focus a single node ───────────────────────────────────────────────────────
+// node focus: fit the view to one node (center + zoom, capped). overlay focus:
+// the same, then focus the node's live terminal so you can scroll/select it.
+function focusNode(id: string, overlay = false) {
+  const n = viewer.graph.nodes.find((x) => x.id === id);
+  if (!n) return;
+  const h = nodeHeight(n);
+  const cw = canvas.clientWidth || innerWidth;
+  const ch = canvas.clientHeight || innerHeight;
+  const pad = 90;
+  const k = Math.min((cw - 2 * pad) / n.w, (ch - 2 * pad) / h, 2.6); // fit node, cap zoom-in
+  viewer.setView({ k, x: cw / 2 - (n.x + n.w / 2) * k, y: ch / 2 - (n.y + h / 2) * k });
+  viewer.setSelection([id]);
+  if (!overlay) return;
+  // the terminal spawns on settle (settle-gate) — poll for it, then focus it.
+  let tries = 14;
+  const grab = () => {
+    const e = terms.get(id);
+    if (e) {
+      for (const other of terms.values()) other.el.classList.remove("ay-term-focused");
+      e.el.classList.add("ay-term-focused");
+      try {
+        (e.term as unknown as { focus?: () => void }).focus?.();
+      } catch {
+        /* read-only xterm may not focus — the ring still marks it */
+      }
+    } else if (--tries > 0) setTimeout(grab, 130);
+  };
+  setTimeout(grab, 280);
+}
+
+// ── ⌘K command palette (go to / focus an agent) ───────────────────────────────
+const cmdk = document.getElementById("cmdk")!;
+const cmdkInput = document.getElementById("cmdk-input") as HTMLInputElement;
+const cmdkList = document.getElementById("cmdk-list")!;
+const escHtml = (s: string) =>
+  s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
+let cmdkSel = 0;
+let cmdkRows: { id: string; title: string; status: string; sub: string }[] = [];
+
+function cmdkData() {
+  const rows = [...recordsByPid.values()].map((r) => ({
+    id: String(r.pid),
+    title: nodeTitle(r),
+    status: r.status,
+    sub: shortCwd(r.cwd) + (r.git?.branch ? ` ⎇${r.git.branch}` : ""),
+  }));
+  rows.sort((a, b) => (a.status === "exited" ? 1 : 0) - (b.status === "exited" ? 1 : 0));
+  return rows;
+}
+function cmdkRender() {
+  const q = cmdkInput.value.trim().toLowerCase();
+  cmdkRows = cmdkData().filter(
+    (r) => !q || `${r.title} ${r.id} ${r.sub} ${r.status}`.toLowerCase().includes(q),
+  );
+  if (cmdkSel >= cmdkRows.length) cmdkSel = Math.max(0, cmdkRows.length - 1);
+  cmdkList.innerHTML = cmdkRows
+    .map(
+      (r, i) =>
+        `<div class="cmdk-row ${i === cmdkSel ? "sel" : ""}" data-i="${i}">` +
+        `<span class="dot ${r.status}"></span>` +
+        `<span class="cmdk-title">${escHtml(r.title)}</span>` +
+        `<span class="cmdk-pid">#${r.id}</span>` +
+        `<span class="cmdk-dim">${escHtml(r.sub)}</span></div>`,
+    )
+    .join("");
+  cmdkRows[cmdkSel] && viewer.setSelection([cmdkRows[cmdkSel]!.id]); // preview highlight
+  cmdkList.querySelector(".cmdk-row.sel")?.scrollIntoView({ block: "nearest" });
+}
+function cmdkOpen() {
+  cmdk.hidden = false;
+  cmdkInput.value = "";
+  cmdkSel = 0;
+  cmdkRender();
+  cmdkInput.focus();
+}
+function cmdkClose() {
+  cmdk.hidden = true;
+}
+function cmdkGo(overlay: boolean) {
+  const r = cmdkRows[cmdkSel];
+  if (r) focusNode(r.id, overlay);
+  cmdkClose();
+}
+addEventListener("keydown", (e) => {
+  if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+    e.preventDefault();
+    cmdk.hidden ? cmdkOpen() : cmdkClose();
+    return;
+  }
+  if (cmdk.hidden) return;
+  if (e.key === "Escape") (e.preventDefault(), cmdkClose());
+  else if (e.key === "ArrowDown") (e.preventDefault(), (cmdkSel = Math.min(cmdkRows.length - 1, cmdkSel + 1)), cmdkRender());
+  else if (e.key === "ArrowUp") (e.preventDefault(), (cmdkSel = Math.max(0, cmdkSel - 1)), cmdkRender());
+  else if (e.key === "Enter") (e.preventDefault(), cmdkGo(e.metaKey || e.ctrlKey));
+});
+cmdkInput.addEventListener("input", () => ((cmdkSel = 0), cmdkRender()));
+cmdkList.addEventListener("click", (e) => {
+  const row = (e.target as HTMLElement).closest<HTMLElement>(".cmdk-row");
+  if (!row) return;
+  cmdkSel = Number(row.dataset.i);
+  cmdkGo(e.metaKey || e.ctrlKey);
+});
+cmdk.addEventListener("click", (e) => {
+  if (e.target === cmdk) cmdkClose(); // click backdrop to close
+});
+
+// ── right-click batch send ────────────────────────────────────────────────────
+// agent descendants of a container node (repo/cwd/agent-with-subagents)
+function agentDescendants(containerId: string): string[] {
+  const parentOf = new Map(viewer.graph.nodes.map((n) => [n.id, n.parent]));
+  const out: string[] = [];
+  for (const n of viewer.graph.nodes) {
+    if (!recordsByPid.has(n.id)) continue;
+    let p = n.parent;
+    while (p) {
+      if (p === containerId) {
+        out.push(n.id);
+        break;
+      }
+      p = parentOf.get(p);
+    }
+  }
+  return out;
+}
+
+const ctxmenu = document.getElementById("ctxmenu")!;
+const ctxInput = document.getElementById("ctx-input") as HTMLTextAreaElement;
+let ctxTargets: string[] = [];
+function openBatchMenu(sx: number, sy: number, pids: string[]) {
+  ctxTargets = pids;
+  document.getElementById("ctx-count")!.textContent = String(pids.length);
+  document.getElementById("ctx-s")!.textContent = pids.length === 1 ? "" : "s";
+  ctxmenu.hidden = false;
+  ctxmenu.style.left = `${Math.min(sx, innerWidth - 348)}px`;
+  ctxmenu.style.top = `${Math.min(sy, innerHeight - 140)}px`;
+  ctxInput.value = "";
+  ctxInput.focus();
+}
+function closeBatchMenu() {
+  ctxmenu.hidden = true;
+}
+async function sendBatch() {
+  const msg = ctxInput.value;
+  const pids = [...ctxTargets];
+  if (!msg.trim() || !pids.length) return closeBatchMenu();
+  closeBatchMenu();
+  const results = await Promise.allSettled(
+    pids.map((pid) =>
+      fetch("/api/send", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ keyword: pid, msg }),
+      }).then((r) => (r.ok ? r : Promise.reject(r.status))),
+    ),
+  );
+  const ok = results.filter((r) => r.status === "fulfilled").length;
+  const prev = statusLabel.textContent;
+  statusLabel.textContent = `⌨ sent to ${ok}/${pids.length} agent${pids.length === 1 ? "" : "s"}`;
+  setTimeout(() => {
+    if (statusLabel.textContent?.startsWith("⌨")) statusLabel.textContent = prev;
+    void refresh();
+  }, 1500);
+}
+ctxInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
+    e.preventDefault();
+    void sendBatch();
+  } else if (e.key === "Escape") {
+    e.preventDefault();
+    closeBatchMenu();
+  }
+  e.stopPropagation();
+});
+document.getElementById("ctx-send")!.addEventListener("click", () => void sendBatch());
+addEventListener("mousedown", (e) => {
+  if (!ctxmenu.hidden && !ctxmenu.contains(e.target as Node)) closeBatchMenu();
+});
+
+// ── chrome controls ──────────────────────────────────────────────────────────
+document.getElementById("fit")!.addEventListener("click", () => fitReadable(80));
+const wiresBtn = document.getElementById("wires")!;
+function syncWiresBtn() {
+  wiresBtn.style.color = showWires ? "var(--accent)" : "";
+  wiresBtn.style.borderColor = showWires ? "var(--accent)" : "";
+}
+syncWiresBtn();
+wiresBtn.addEventListener("click", () => {
+  showWires = !showWires;
+  syncWiresBtn();
+  applyEdges();
+});
+document.getElementById("theme")!.addEventListener("click", () => {
+  const next = document.documentElement.dataset.theme === "light" ? "dark" : "light";
+  document.documentElement.dataset.theme = next;
+  localStorage.setItem("rgui-theme", next);
+  viewer.setTheme(next);
+  for (const e of terms.values()) e.term.options.theme = termTheme();
+});

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "build": "tsdown",
     "check:e2e": "bun scripts/check-e2e.ts",
     "cf": "bun scripts/cf.ts",
+    "build:rgui": "bun scripts/build-rgui.ts",
+    "dev:rgui": "bun lab/ui/rgui/dev.ts",
     "build:rs": "bun ./scripts/build-rs.ts",
     "postbuild": "bun ./ts/postbuild.ts",
     "demo": "bun run build && bun link && claude-yes -- demo",

--- a/scripts/build-rgui.ts
+++ b/scripts/build-rgui.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+// Build the /rgui page (lab/ui/rgui) — bundles main.ts + @snomiao/rgui into a
+// single browser module, then copies index.html beside it.
+//
+// rgui is consumed FROM SOURCE, never the npm package, so the page tracks rgui's
+// heavy dev. Source resolution order:
+//   1. $RGUI_LOCAL                         (explicit override)
+//   2. ~/ws/snomiao/rgui/tree/main         (the local dev worktree, if present)
+//   3. lib/rgui                            (the committed git submodule — CI/other machines)
+// The chosen dir's node_modules must have d3-selection/d3-zoom; we `bun install`
+// there once if missing (matters for the submodule / a fresh CI checkout).
+//
+// Usage:  bun scripts/build-rgui.ts [outdir]
+//   outdir defaults to lab/ui/rgui/dist
+import { existsSync } from "node:fs";
+import { cp, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { $ } from "bun";
+
+const root = path.join(import.meta.dir, "..");
+
+function resolveRguiDir(): string {
+  const candidates = [
+    process.env.RGUI_LOCAL,
+    path.join(homedir(), "ws/snomiao/rgui/tree/main"),
+    path.join(root, "lib/rgui"),
+  ].filter((d): d is string => !!d);
+  for (const d of candidates) {
+    if (existsSync(path.join(d, "src/index.ts"))) return d;
+  }
+  throw new Error(
+    "rgui source not found — run `git submodule update --init lib/rgui` " +
+      "(or set RGUI_LOCAL to a rgui checkout).",
+  );
+}
+
+const RGUI_DIR = resolveRguiDir();
+const isSubmodule = RGUI_DIR === path.join(root, "lib/rgui");
+console.log(`[build-rgui] rgui source: ${RGUI_DIR}${isSubmodule ? " (submodule)" : " (local)"}`);
+
+// rgui imports d3-selection/d3-zoom; ensure its deps exist (fresh submodule/CI)
+if (!existsSync(path.join(RGUI_DIR, "node_modules/d3-selection"))) {
+  console.log("[build-rgui] installing rgui deps…");
+  await $`bun install --cwd ${RGUI_DIR}`;
+}
+
+const outdir = process.argv[2] ? path.resolve(process.argv[2]) : path.join(root, "lab/ui/rgui/dist");
+await mkdir(outdir, { recursive: true });
+
+const result = await Bun.build({
+  entrypoints: [path.join(root, "lab/ui/rgui/main.ts")],
+  outdir,
+  target: "browser",
+  minify: true,
+  sourcemap: "linked",
+  naming: "[name].js",
+  plugins: [
+    {
+      // alias the bare "@snomiao/rgui" specifier to the resolved source entry so
+      // d3 (rgui's own dep) resolves from RGUI_DIR/node_modules, not agent-yes's.
+      name: "rgui-source-alias",
+      setup(b) {
+        b.onResolve({ filter: /^@snomiao\/rgui$/ }, () => ({
+          path: path.join(RGUI_DIR, "src/index.ts"),
+        }));
+      },
+    },
+  ],
+});
+
+if (!result.success) {
+  for (const m of result.logs) console.error(m);
+  throw new Error("[build-rgui] bundle failed");
+}
+
+await cp(path.join(root, "lab/ui/rgui/index.html"), path.join(outdir, "index.html"));
+console.log(`[build-rgui] → ${path.relative(root, outdir)}/ (index.html + main.js)`);

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -16,6 +16,7 @@ import {
   listRecords,
   readNotes,
   readPtysize,
+  recentReadEdges,
   renderRawLog,
   resolveOne,
   snapshotStatus,
@@ -1454,6 +1455,17 @@ export async function cmdServe(rest: string[]): Promise<number> {
       });
     }
 
+    // GET /api/edges — recent inter-agent relationship edges for the /rgui wire
+    // view. Currently the read/tail edges (agent `by` read agent `target` within
+    // the last minute, from ~/.agent-yes/reads.jsonl). Directional, ephemeral.
+    if (req.method === "GET" && p === "/api/edges") {
+      try {
+        return Response.json({ reads: await recentReadEdges() });
+      } catch (e) {
+        return new Response((e as Error).message, { status: 500 });
+      }
+    }
+
     // GET /api/whoami — this host's device label (user@host), so a remote
     // console can tag each agent with the machine it came from. Unlike codehost,
     // `ay serve --share` carries no per-agent device id; the viewer fetches this
@@ -1573,6 +1585,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
           return new Response(`pid ${record.pid}: no log_file`, { status: 404 });
         const logPath = record.log_file;
 
+        // Assigned inside start(); called by BOTH the stream's cancel() and the
+        // req.signal abort listener, so client-disconnect teardown can't leak.
+        let cleanup = () => {};
         const stream = new ReadableStream({
           async start(ctrl) {
             const enc = new TextEncoder();
@@ -1645,9 +1660,21 @@ export async function cmdServe(rest: string[]): Promise<number> {
             } catch {
               /* fs.watch unsupported — the fallback poll below still works */
             }
-            const poller = setInterval(() => void flush(), 60);
+            // When fs.watch is live it already gives instant echo, so the poll is
+            // only a safety net → 500ms. Without a watcher it IS the primary path
+            // → keep it at 60ms for low typing-echo latency. This matters when many
+            // /api/tail streams are open at once (the /rgui viewer opens one per
+            // node): N × a 60ms poll each was needless load on the event loop.
+            const poller = setInterval(() => void flush(), watcher ? 500 : 60);
 
-            req.signal.addEventListener("abort", () => {
+            // Tear down on client disconnect via BOTH the req.signal 'abort'
+            // listener and the stream's cancel() — whichever the runtime fires
+            // (Bun uses abort here; other runtimes/paths may only cancel). `closed`
+            // makes it idempotent so it runs exactly once and never leaks the
+            // heartbeat/poller/fs-watcher/fd, however many /api/tail streams churn
+            // (the /rgui viewer opens+drops one per node while panning/zooming).
+            cleanup = () => {
+              if (closed) return;
               closed = true;
               clearInterval(heartbeat);
               clearInterval(poller);
@@ -1662,7 +1689,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
               } catch {
                 /* already closed */
               }
-            });
+            };
+            req.signal.addEventListener("abort", cleanup);
+          },
+          cancel() {
+            cleanup();
           },
         });
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -171,6 +171,29 @@ async function lastReadAt(by: string, target: number): Promise<number | null> {
   return map.get(`${by}${READS_KEY_SEP}${target}`) ?? null;
 }
 
+/** Recent agent→agent read/tail edges (skips "human" readers), for the /rgui
+ * relationship-wire view. `by`/`target` are pids. */
+export interface ReadEdge {
+  by: number;
+  target: number;
+  at: number;
+}
+export async function recentReadEdges(windowMs = READ_WINDOW_MS): Promise<ReadEdge[]> {
+  const now = Date.now();
+  const map = await readReads();
+  const out: ReadEdge[] = [];
+  for (const [key, at] of map) {
+    if (now - at > windowMs) continue;
+    const i = key.indexOf(READS_KEY_SEP);
+    const by = key.slice(0, i);
+    if (!by.startsWith("agent:")) continue; // agent→agent only
+    const byPid = Number(by.slice("agent:".length));
+    const target = Number(key.slice(i + 1));
+    if (byPid && target && byPid !== target) out.push({ by: byPid, target, at });
+  }
+  return out;
+}
+
 // Identify the sender. An agent launched by `ay` inherits AGENT_YES_PID=<wrapper
 // pid>; the registered agent record carries that same wrapper_pid, so we map the
 // env value back to the agent's own canonical record. Falls back to a direct pid


### PR DESCRIPTION
## What

A `/rgui` page that renders the **live agent forest** with [`@snomiao/rgui`](https://github.com/snomiao/rgui)'s semantic-zoom node graph.

- Each agent from `GET /api/ls` → an rgui node. `child.parent_pid === parent.wrapper_pid` → rgui **containment**, so a parent agent frames its subagents and, zoomed out, renormalizes into one block.
- Falls back to a baked sample forest when no local `ay serve` is reachable (e.g. the static pages.dev preview).

## Linking rgui from source (not npm)

`lib/rgui` is a **git submodule**; `scripts/build-rgui.ts` bundles it via `Bun.build`, resolving the rgui source from `$RGUI_LOCAL` → the local dev worktree (`~/ws/snomiao/rgui/tree/main`) → the submodule, in that order. Heavy local dev flows through immediately; CI builds reproducibly from the pinned submodule.

## Serving — worker vs Pages

`agent-yes.com` is served by the `agent-yes-signal` **Worker** (it also runs the WebRTC-signaling Durable Objects on `s.agent-yes.com`), which is why it wasn't a Pages project. This PR adds a dedicated **`agent-yes` Cloudflare Pages project** as the dev domain (`*.agent-yes.pages.dev`), independent of the worker's custom domain.

- **Live now:** https://rgui.agent-yes.pages.dev/ (branch preview, deployed manually)
- **On merge:** the worker's `public/` sync also bundles `/rgui`, so `agent-yes.com/rgui/` serves it (deploy workflow now checks out submodules + bun).

## Verified

Rendered end-to-end in Chrome against real `/api/ls` (42 agents, containment intact) and the demo fallback; initial fit clamps to a readable scale (a full fit otherwise zooms past rgui's LOD threshold and looks empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)