### PR TITLE
fix(serve,setup): stock-Debian OOBE — unzip ensure, accurate PM msgs, truthful status

### DIFF
--- a/lab/ui/setup.sh
+++ b/lab/ui/setup.sh
@@ -18,6 +18,22 @@ elif command -v npm >/dev/null 2>&1; then
   RT="npm"
 else
   say "No bun or npm found — installing bun (https://bun.sh)…"
+  # bun's installer unpacks a .zip, so it hard-fails with "unzip is required to
+  # install bun" on a minimal image (e.g. stock Debian) that ships no unzip.
+  # Ensure it first via whatever package manager is present — best-effort, with
+  # sudo only when we aren't already root and sudo exists.
+  if ! command -v unzip >/dev/null 2>&1; then
+    say "Installing unzip (required by the bun installer)…"
+    if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo"; else SUDO=""; fi
+    if command -v apt-get >/dev/null 2>&1; then $SUDO apt-get update -qq && $SUDO apt-get install -y -qq unzip
+    elif command -v dnf >/dev/null 2>&1; then $SUDO dnf install -y -q unzip
+    elif command -v yum >/dev/null 2>&1; then $SUDO yum install -y -q unzip
+    elif command -v apk >/dev/null 2>&1; then $SUDO apk add --no-progress unzip
+    elif command -v pacman >/dev/null 2>&1; then $SUDO pacman -Sy --noconfirm unzip
+    elif command -v zypper >/dev/null 2>&1; then $SUDO zypper -q install -y unzip
+    fi
+    command -v unzip >/dev/null 2>&1 || err "couldn't install unzip automatically — install it and re-run (e.g. apt-get install unzip)."
+  fi
   curl -fsSL https://bun.sh/install | bash
   # Make bun available to the rest of this script.
   BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -374,6 +374,28 @@ async function managerRunnable(mgr: DaemonManager): Promise<boolean> {
   }
 }
 
+// Which manager is ACTUALLY running our daemon? `resolveDaemonManager` picks by
+// PATH order without a liveness check, so after a bootstrap oxmgr→pm2 fallback a
+// broken oxmgr shim (first on PATH) shadows the pm2 that really holds the daemon
+// — making `ay serve status` report `manager: oxmgr / installed: no` while pm2
+// serves. For reporting, probe each present manager and prefer the one that is
+// runnable AND has our daemon registered; fall back to the first runnable one,
+// else whatever resolveDaemonManager returns.
+async function resolveActiveManager(): Promise<DaemonManager | null> {
+  const oxmgr = Bun.which("oxmgr");
+  const pm2 = Bun.which("pm2");
+  const present: DaemonManager[] = [];
+  if (oxmgr) present.push({ id: "oxmgr", bin: oxmgr });
+  if (pm2) present.push({ id: "pm2", bin: pm2 });
+  let firstRunnable: DaemonManager | null = null;
+  for (const m of present) {
+    if (!(await managerRunnable(m))) continue;
+    firstRunnable ??= m;
+    if ((await readDaemonServeArgs(m)) !== null) return m; // this one holds the daemon
+  }
+  return firstRunnable ?? resolveDaemonManager();
+}
+
 // Install one PM package globally via the SAME JS package manager that installed
 // `ay` (bun preferred, npm fallback — no Rust toolchain required, so a fresh
 // Linux box with only bun from setup.sh works), then confirm the resulting
@@ -398,8 +420,15 @@ async function installAndVerify(pkg: "oxmgr" | "pm2"): Promise<DaemonManager | n
   if (!bin) return null;
   const mgr: DaemonManager = { id: pkg, bin };
   if (!(await managerRunnable(mgr))) {
+    // Name the actual reason: oxmgr ships a native binary (glibc), pm2 is a
+    // Node.js app that needs `node` on PATH — a bun-only box has neither by
+    // default, so a generic "glibc mismatch" would mislead for pm2.
+    const why =
+      pkg === "oxmgr"
+        ? "a native/glibc mismatch, e.g. glibc < 2.39"
+        : "pm2 needs a Node.js runtime and none was found";
     process.stderr.write(
-      `ay serve install: ${pkg} installed but can't exec here (likely a native/glibc mismatch)` +
+      `ay serve install: ${pkg} installed but can't exec here (${why})` +
         (pkg === "oxmgr" ? " — falling back to pm2\n" : "\n"),
     );
     return null;
@@ -597,8 +626,9 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
   if (!mgr) {
     process.stderr.write(
       "ay serve install: no usable process manager (need oxmgr or pm2)\n" +
-        "  install with:  bun add -g pm2\n" +
-        "             or: bun add -g oxmgr   (needs glibc ≥ 2.39 on Linux)\n",
+        "  - oxmgr: bun add -g oxmgr   (native binary; needs glibc ≥ 2.39 on Linux)\n" +
+        "  - pm2:   bun add -g pm2     (needs a Node.js runtime on PATH)\n" +
+        "  On a minimal bun-only box, install node (for pm2) or a newer glibc (for oxmgr).\n",
     );
     return 1;
   }
@@ -826,7 +856,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
 // Read-only: never mints a token or disturbs the daemon. `--json` for scripts.
 async function cmdServeStatus(args: string[]): Promise<number> {
   const json = args.includes("--json");
-  const mgr = resolveDaemonManager();
+  const mgr = await resolveActiveManager();
   const token = await loadTokenReadOnly();
   const shareLink = await readShareLink();
 


### PR DESCRIPTION
Follow-ups from a fresh **Debian 12 (t3.micro, glibc 2.36)** out-of-the-box test of the PM auto-bootstrap (#194). The fallback logic (oxmgr exec-fails → pm2) was confirmed correct; these fix the surrounding rough edges surfaced on a truly minimal image.

## 1. `setup.sh`: ensure `unzip` before installing bun
bun's installer unpacks a `.zip` and hard-fails with `error: unzip is required to install bun` on stock Debian minimal (no unzip). setup.sh now installs unzip first via whatever package manager is present (apt/dnf/yum/apk/pacman/zypper), using sudo only when not already root.

## 2. Accurate PM-failure messages
A bun-only box has neither glibc ≥ 2.39 (for oxmgr's native binary) nor node (for pm2). Previously pm2 failing for lack of node was reported as a `native/glibc mismatch`. Now each candidate names its real reason, and the final `no usable process manager` error spells out that **pm2 needs a Node.js runtime** and **oxmgr needs glibc ≥ 2.39**.

## 3. `ay serve status` reports the manager that actually runs the daemon
After an oxmgr→pm2 fallback, a broken oxmgr shim (first on PATH) shadowed the live pm2, so status printed `manager: oxmgr / installed: no` while pm2 was serving and HTTP was reachable. New `resolveActiveManager` probes each present manager and prefers one that is **runnable and has the daemon registered**, falling back to the first runnable, else `resolveDaemonManager`.

## Verification
- `bun run build` clean; serve.ts tsc error count unchanged (6 pre-existing, none in new code).
- `setup.sh` passes `sh -n`.
- No regression: on a box with working oxmgr, `ay serve status` still reports `manager: oxmgr / installed: yes`.
- Full stock-Debian re-validation (no unzip/node) offered by the reporter once merged/published.

## Owner-decision follow-up (not in this PR)
A truly minimal bun-only box has **no** working PM out of the box (oxmgr blocked by glibc, pm2 blocked by missing node). Closing that gap needs a design choice: ensure `node` in setup.sh, add a node-free fallback PM, or a bun-native supervisor. Flagging for a decision rather than picking one unilaterally.

Chain: #193 (send) → #194 (PM bootstrap) → #195 (http degrade) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)