### PR TITLE
fix(setup): guard the share prompt by actually opening /dev/tty

### DIFF
--- a/lab/ui/setup.sh
+++ b/lab/ui/setup.sh
@@ -106,7 +106,14 @@ EOF
 # silently and let the user run `ay serve --share` themselves. We redirect the
 # spawned server's stdin from /dev/tty too, so its own "open the console in your
 # browser?" prompt has a terminal to read from.
-if command -v ay >/dev/null 2>&1 && [ -r /dev/tty ]; then
+#
+# The guard actually OPENS /dev/tty rather than testing `[ -r /dev/tty ]`: on a
+# headless host (SSM, CI, cron) the device node exists and `-r` passes, yet
+# open() fails with ENXIO ("cannot create /dev/tty: No such device or address"),
+# which then leaks to the log. `{ : < /dev/tty; }` performs the real open and is
+# false exactly when the terminal is unusable. `[ -t 0 ]` won't do — under
+# curl | sh stdin is the pipe, so it's false even on an interactive box.
+if command -v ay >/dev/null 2>&1 && { : < /dev/tty; } 2>/dev/null; then
   printf '\n\033[36m▸\033[0m Start sharing now and get a console link? [Y/n] ' > /dev/tty
   read -r ans < /dev/tty || ans=""
   case "$ans" in


### PR DESCRIPTION
Final polish in the stock-Debian OOBE chain (#194–#197). On a headless host (SSM, CI, cron), `setup.sh` leaked `sh: cannot create /dev/tty: No such device or address` at the end.

**Cause**: the interactive "start sharing?" prompt was guarded by `[ -r /dev/tty ]`. The `/dev/tty` device node exists and `-r` passes, but `open()` then fails with ENXIO on a host with no controlling terminal — and the subsequent `> /dev/tty` leaks the error.

**Fix**: guard by actually opening it — `{ : < /dev/tty; } 2>/dev/null` is false exactly when the terminal is unusable, so the prompt is skipped cleanly and no error reaches the log. `[ -t 0 ]` is not a substitute: under `curl | sh` stdin is the pipe, so it is false even on an interactive box and would suppress the prompt for everyone.

**Verified**: `sh -n` passes; with piped stdin the open-test returns false (graceful skip, no ENXIO), whereas `[ -r /dev/tty ]` returns true (the old buggy path). Deploys to agent-yes.com/setup.sh on merge.

Chain: #193 → #194 → #195 → #196 → #197 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)