### PR TITLE
fix(setup): open /dev/tty in a subshell so a dash fatal-redirect cant kill the installer

### DIFF
--- a/lab/ui/setup.sh
+++ b/lab/ui/setup.sh
@@ -110,10 +110,16 @@ EOF
 # The guard actually OPENS /dev/tty rather than testing `[ -r /dev/tty ]`: on a
 # headless host (SSM, CI, cron) the device node exists and `-r` passes, yet
 # open() fails with ENXIO ("cannot create /dev/tty: No such device or address"),
-# which then leaks to the log. `{ : < /dev/tty; }` performs the real open and is
-# false exactly when the terminal is unusable. `[ -t 0 ]` won't do — under
-# curl | sh stdin is the pipe, so it's false even on an interactive box.
-if command -v ay >/dev/null 2>&1 && { : < /dev/tty; } 2>/dev/null; then
+# which then leaks to the log. `[ -t 0 ]` won't do either — under curl | sh
+# stdin is the pipe, so it's false even on an interactive box.
+#
+# The open-test runs in a SUBSHELL `( : < /dev/tty )`, not a brace group: POSIX
+# makes a redirection error fatal to a non-interactive shell, and dash (Debian's
+# /bin/sh) enforces it — a `{ : < /dev/tty; }` that fails to open would kill the
+# whole script (exit 2), even inside this `if` and even with the error muted by
+# `2>/dev/null`. The subshell confines that fatal exit; the parent just reads its
+# non-zero status and skips the prompt cleanly.
+if command -v ay >/dev/null 2>&1 && ( : < /dev/tty ) 2>/dev/null; then
   printf '\n\033[36m▸\033[0m Start sharing now and get a console link? [Y/n] ' > /dev/tty
   read -r ans < /dev/tty || ans=""
   case "$ans" in
@@ -121,3 +127,10 @@ if command -v ay >/dev/null 2>&1 && { : < /dev/tty; } 2>/dev/null; then
     *)     exec ay serve --share < /dev/tty ;;
   esac
 fi
+
+# The install itself is done and successful by here. Exit 0 explicitly so the
+# script's status isn't inherited from the trailing `if` — on a non-tty host the
+# guard's `{ : < /dev/tty; }` is false, which would otherwise leave `curl … | sh`
+# exiting non-zero (2) and read as a failure by CI despite a clean install. Real
+# failures above already `exit 1` before reaching here, so this never masks them.
+exit 0


### PR DESCRIPTION
Corrects #198. On a headless host `curl … | sh` exited **2** on a fully successful install (CI reads it as failure).

## Real root cause
POSIX makes a **redirection error fatal to a non-interactive shell**, and dash (Debian `/bin/sh`) enforces it strictly. #198 tested tty-usability with `{ : < /dev/tty; }` — a brace group that runs in the *current* shell. When `/dev/tty` cannot be opened (SSM/CI/cron), that failed redirect **terminates the whole script with exit 2** — inside the `if`, with `set -e` off, and even with the message muted by `2>/dev/null`. So #198 removed the visible `cannot create /dev/tty` noise but the script still died at the redirect (never reaching the end), leaving exit 2. Our earlier "trailing-if inherits the false condition" theory was wrong — a trailing `exit 0` does **not** help because execution never reaches it.

## Fix
Run the open-test in a **subshell** `( : < /dev/tty )`. The fatal exit is confined to the subshell; the parent reads its non-zero status, skips the prompt, and falls through to a clean `exit 0` (also added explicitly).

## Verified (dash + bash)
- brace-group `{ … }` → `exit 2`, script dies at the redirect (never reaches EOF).
- subshell `( … )` → prompt skipped, reaches EOF, `exit 0`, no `/dev/tty` error.

Deploys to agent-yes.com/setup.sh on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)