### PR TITLE
fix(share): read-only viewer first-frame width (settle whoami before sizing)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -303,6 +303,117 @@
         background: var(--line);
         margin: 4px 2px;
       }
+      /* View-only share: read-only badge in the header + hiding write controls. */
+      .robadge {
+        display: none;
+        align-items: center;
+        gap: 4px;
+        font-size: 11px;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 999px;
+        color: #b45309;
+        background: color-mix(in srgb, #f59e0b 18%, transparent);
+        border: 1px solid color-mix(in srgb, #f59e0b 45%, transparent);
+        white-space: nowrap;
+      }
+      .app.readonly-agent .robadge {
+        display: inline-flex;
+      }
+      /* A viewer can't steer/share — hide the composer, key bar and every agent
+         action in the ⋯ menu (Share/Stop/Restart/Kill). View prefs stay. */
+      .app.readonly-agent .composer,
+      .app.readonly-agent .keybar,
+      .app.readonly-agent .rmenuact {
+        display: none !important;
+      }
+      /* Share modal — QR + link for a single-agent view-only share. */
+      .modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 60;
+        padding: 16px;
+      }
+      .modal-backdrop[hidden] {
+        display: none;
+      }
+      .sharebox {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        max-width: 380px;
+        width: 100%;
+        padding: 20px;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+      }
+      .sharebox h3 {
+        margin: 0 0 4px;
+        font-size: 15px;
+      }
+      .sharebox .sub {
+        margin: 0 0 14px;
+        font-size: 12px;
+        opacity: 0.7;
+      }
+      .sharebox .qr {
+        display: flex;
+        justify-content: center;
+        padding: 12px;
+        background: #fff;
+        border-radius: 8px;
+        margin: 0 auto 14px;
+        width: fit-content;
+      }
+      .sharebox .qr canvas {
+        display: block;
+        image-rendering: pixelated;
+      }
+      .sharebox .shareurl {
+        width: 100%;
+        box-sizing: border-box;
+        font: 11px var(--mono);
+        padding: 8px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--bg2, var(--bg));
+        color: var(--fg);
+        word-break: break-all;
+      }
+      .sharebox .srow {
+        display: flex;
+        gap: 8px;
+        margin-top: 12px;
+      }
+      .sharebox button {
+        flex: 1;
+        padding: 9px;
+        border-radius: 8px;
+        border: 1px solid var(--line);
+        background: var(--bg2, var(--bg));
+        color: var(--fg);
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .sharebox button.primary {
+        background: #2563eb;
+        border-color: #2563eb;
+        color: #fff;
+      }
+      .sharebox button.danger {
+        color: #dc2626;
+        border-color: color-mix(in srgb, #dc2626 45%, transparent);
+      }
+      .sharebox .note {
+        font-size: 11px;
+        opacity: 0.65;
+        margin-top: 12px;
+        line-height: 1.4;
+      }
       /* Terminal font-size stepper (a static row, not a hover/click target). */
       .rmenufont {
         justify-content: space-between;
@@ -1460,6 +1571,10 @@
     <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js"></script>
+    <!-- QR generator (MIT, Kazuhiko Arase) — vendored locally so single-agent
+         share QR codes render offline under `ay serve --http`. Classic script:
+         defines the global `qrcode`. -->
+    <script src="./qrcode.js"></script>
     <script type="module">
       // codehost room transport — vendored from codehost's `bun run build:lib`.
       // Loaded as a module (deferred), so the classic script below awaits the
@@ -1524,6 +1639,9 @@
           <span class="dot" id="rdot"></span>
           <span class="name" id="rname"></span>
           <span class="badge" id="rpid"></span>
+          <span class="robadge" title="view-only share — you can watch but not steer this agent"
+            >👁 read-only</span
+          >
           <span class="live"
             ><span class="dot" id="livedot"></span><span id="livetxt">connecting…</span></span
           >
@@ -1548,6 +1666,10 @@
               <label class="rmenuitem"
                 ><input type="checkbox" id="perfToggle" /> <span>Perf HUD</span></label
               >
+              <div class="rmenusep"></div>
+              <button class="rmenuitem rmenuact" id="shareAgent" type="button">
+                🔗 Share (read-only)
+              </button>
               <div class="rmenusep"></div>
               <button class="rmenuitem rmenuact" id="stopAgent" type="button">⏹ Stop agent</button>
               <button class="rmenuitem rmenuact" id="restartAgent" type="button">
@@ -1645,6 +1767,29 @@
 
     <div class="launchoverlay" id="launch" style="display: none"></div>
     <div class="launchoverlay" id="newform" style="display: none"></div>
+
+    <!-- Single-agent view-only share: QR + link a viewer can open to watch (not
+         steer) just this agent. The link opens a read-only console; the host
+         enforces read-only regardless of the client. -->
+    <div class="modal-backdrop" id="shareModal" hidden>
+      <div class="sharebox" role="dialog" aria-modal="true" aria-label="Share agent">
+        <h3>Share this agent</h3>
+        <p class="sub" id="shareSub">view-only · anyone with the link can watch</p>
+        <div class="qr" id="shareQr"></div>
+        <div class="shareurl" id="shareUrl"></div>
+        <div class="srow">
+          <button class="primary" id="shareCopy" type="button">Copy link</button>
+          <button id="shareClose" type="button">Close</button>
+        </div>
+        <div class="srow">
+          <button class="danger" id="shareRevoke" type="button">Revoke</button>
+        </div>
+        <p class="note" id="shareNote">
+          Read-only: viewers see this agent's terminal but cannot type, stop, or restart it.
+          The link expires automatically and stops working when revoked.
+        </p>
+      </div>
+    </div>
 
     <!-- Cmd/Ctrl+K omnibox: search agents by title (instant) then output (tail),
          or spawn a new agent in the highlighted agent's cwd with the typed prompt. -->
@@ -2269,6 +2414,10 @@
           });
           return { ok: r.ok, text: await r.text() };
         },
+        async del(path) {
+          const r = await fetch(withTok(path), { method: "DELETE" });
+          return { ok: r.ok, text: await r.text() };
+        },
         subscribe(path, onText, onOpen, onError) {
           const ev = new EventSource(withTok(path));
           ev.onopen = () => onOpen && onOpen();
@@ -2287,6 +2436,10 @@
           },
           async post(path, bodyObj) {
             const r = await rtc.req("POST", path, JSON.stringify(bodyObj));
+            return { ok: r.status >= 200 && r.status < 300, text: r.text };
+          },
+          async del(path) {
+            const r = await rtc.req("DELETE", path);
             return { ok: r.status >= 200 && r.status < 300, text: r.text };
           },
           subscribe(path, onText, onOpen, onError) {
@@ -2318,6 +2471,26 @@
       const sources = new Map(); // id -> { id, host, kind, tx, client, live, devices, serverCount }
       const srcFor = (e) => (e && sources.get(e._room)) || sources.get(LOCAL) || null;
       const txFor = (e) => srcFor(e)?.tx || localTx;
+      // True when the agent lives in a view-only share room (the host advertises
+      // this via /api/whoami → share.readonly and 403s every write regardless).
+      const isReadonlyEnt = (e) => !!srcFor(e)?.readonly;
+      // Wrap a source tx so every write (POST) is refused client-side on a
+      // read-only share — reads (fetchJSON/fetchText/subscribe) pass through. The
+      // host is the real boundary; this just stops the UI from firing doomed
+      // writes (send / resize / presence / kill / restart / share).
+      function readonlyTx(tx) {
+        if (!tx || tx._ro) return tx;
+        return {
+          ...tx,
+          _ro: true,
+          async post() {
+            return { ok: false, text: "read-only share" };
+          },
+          async del() {
+            return { ok: false, text: "read-only share" };
+          },
+        };
+      }
 
       // ---- connection-path classification (header [local/lan/wan/relay] pill) ----
       // Tells the user, at a glance, whether the terminal they're watching rides the
@@ -3083,6 +3256,113 @@
           alert(`Restart failed for ${who}:\n${(res && res.text) || "request failed"}`);
       }
 
+      // ---- Single-agent view-only share (QR + link) -----------------------
+      // Ask THIS agent's host to mint a fresh, scoped, read-only share room and
+      // show its link + QR. The host stands up an isolated e2ee room exposing
+      // only this agent (read-only) — see ts/agentShare.ts. Never reuses the
+      // fleet/master token, so the link can't reach other agents or steer.
+      let currentShare = null; // { shareId, link } of the share shown in the modal
+      async function shareAgent(ent) {
+        const e = ent || (sel ? entries.find((x) => x._key === sel) : null);
+        if (!e) return;
+        // A read-only viewer can't re-share; its tx 403s /api/share anyway.
+        if (isReadonlyEnt(e)) {
+          alert("This is a read-only shared view — you can't share it further.");
+          return;
+        }
+        // Scope by the stable agent_id when we have it (pid is reused); fall back
+        // to pid so an older host still resolves the right agent.
+        const agentRef = e.agent_id || String(e.pid);
+        const res = await txFor(e)
+          .post("/api/share", { agent: agentRef, perm: "r" })
+          .catch((err) => ({ ok: false, text: String(err?.message || err) }));
+        if (!res || !res.ok) {
+          alert(`Couldn't create share link:\n${(res && res.text) || "request failed"}`);
+          return;
+        }
+        let info;
+        try {
+          info = JSON.parse(res.text);
+        } catch {
+          alert("Share created but the response was unreadable.");
+          return;
+        }
+        currentShare = { shareId: info.shareId, link: info.link, srcRoom: e._room };
+        openShareModal(info, e);
+      }
+
+      function openShareModal(info, e) {
+        const modal = $("shareModal");
+        if (!modal) return;
+        const who = e.title || cliLabel(e) || ident(e) || `pid ${e.pid}`;
+        $("shareSub").textContent = `view-only · ${who}`;
+        $("shareUrl").textContent = info.link;
+        renderQr($("shareQr"), info.link);
+        modal.hidden = false;
+      }
+      function closeShareModal() {
+        const modal = $("shareModal");
+        if (modal) modal.hidden = true;
+      }
+      // Draw the QR onto a fresh canvas (white quiet-zone always, so it scans in
+      // dark mode too). `qrcode` is the vendored global from qrcode.js.
+      function renderQr(container, text) {
+        container.textContent = "";
+        try {
+          const qr = qrcode(0, "M"); // type 0 = smallest version that fits; EC level M
+          qr.addData(text);
+          qr.make();
+          const n = qr.getModuleCount();
+          const cell = 5,
+            margin = 4;
+          const px = (n + margin * 2) * cell;
+          const cv = document.createElement("canvas");
+          cv.width = cv.height = px;
+          const ctx = cv.getContext("2d");
+          ctx.fillStyle = "#fff";
+          ctx.fillRect(0, 0, px, px);
+          ctx.fillStyle = "#000";
+          for (let r = 0; r < n; r++)
+            for (let c = 0; c < n; c++)
+              if (qr.isDark(r, c))
+                ctx.fillRect((c + margin) * cell, (r + margin) * cell, cell, cell);
+          container.appendChild(cv);
+        } catch (err) {
+          container.textContent = "QR unavailable";
+        }
+      }
+      async function revokeCurrentShare() {
+        if (!currentShare) return closeShareModal();
+        // DELETE over whichever transport owns the agent's host (local or the
+        // room the agent lives in) — the same host that minted the share.
+        const e = entries.find((x) => x._room === currentShare.srcRoom) || null;
+        const tx = (e ? srcFor(e)?.tx : null) || localTx;
+        try {
+          await tx.del("/api/share/" + encodeURIComponent(currentShare.shareId));
+        } catch {}
+        currentShare = null;
+        closeShareModal();
+      }
+      (function shareModalBoot() {
+        $("shareClose")?.addEventListener("click", closeShareModal);
+        $("shareRevoke")?.addEventListener("click", revokeCurrentShare);
+        $("shareCopy")?.addEventListener("click", async () => {
+          if (!currentShare) return;
+          try {
+            await navigator.clipboard.writeText(currentShare.link);
+            const b = $("shareCopy");
+            const t = b.textContent;
+            b.textContent = "Copied ✓";
+            setTimeout(() => (b.textContent = t), 1200);
+          } catch {
+            alert("Copy failed — select the link manually.");
+          }
+        });
+        $("shareModal")?.addEventListener("click", (ev) => {
+          if (ev.target === $("shareModal")) closeShareModal(); // backdrop click
+        });
+      })();
+
       // ---- Terminal right-click menu: copy + customizable quick commands ----
       // A right-click on the terminal used to copy the selection outright. Now it
       // opens a small menu: Copy, Paste, and user-defined quick commands. A quick
@@ -3477,6 +3757,7 @@
           });
         }
         if (cb) cb.addEventListener("change", () => setPerfHud(cb.checked));
+        $("shareAgent")?.addEventListener("click", () => (closePanel(), shareAgent()));
         $("stopAgent")?.addEventListener("click", () => (closePanel(), stopAgent(false)));
         $("restartAgent")?.addEventListener("click", () => (closePanel(), restartAgent()));
         $("killAgent")?.addEventListener("click", () => (closePanel(), stopAgent(true)));
@@ -3969,6 +4250,9 @@
         // Mobile: flip the single-column layout to the terminal ("detail") pane.
         // Done BEFORE term.open below so xterm measures a visible container.
         document.querySelector(".app").classList.add("show-detail");
+        // View-only share: hide the composer / key bar / agent-action menu items and
+        // show a read-only badge. Writes are also refused at the tx layer + the host.
+        document.querySelector(".app").classList.toggle("readonly-agent", isReadonlyEnt(e));
         $("rhead").style.display = "flex";
         $("rdot").className = "dot " + e.status;
         const rname = e.title || cliLabel(e) || ident(e) || "agent";
@@ -4053,6 +4337,12 @@
         let suppressPush = true;
         const pushSize = () => {
           if (term && sel === e._key && !suppressPush) {
+            // Read-only viewer: we can't drive the agent's PTY, so a pane resize
+            // just re-letterboxes the agent's fixed grid to fit — never a SIGWINCH.
+            if (isReadonlyEnt(e)) {
+              applyCanvasScale();
+              return;
+            }
             lastDroveAt = Date.now(); // we're driving the size now (lease the grid)
             tx.post("/api/resize/" + encodeURIComponent(pid), {
               cols: term.cols,
@@ -4094,6 +4384,16 @@
         const fitAndSync = (sz) => {
           if (sel !== selKey || !term) return;
           if (sz && sz.cols && sz.rows) agentSize = sz; // remember for the badge tooltip
+          // Read-only viewer: don't reflow the agent to our pane (we can't resize
+          // it, and shouldn't). Adopt the AGENT's own grid and CSS-scale it to fit,
+          // exactly like a shared-canvas watcher — otherwise the raw stream (emitted
+          // at the agent's width) wraps at the wrong column in our terminal.
+          if (isReadonlyEnt(e)) {
+            if (sz && sz.cols && sz.rows) followAgentSize(sz);
+            else applyCanvasScale();
+            suppressPush = false;
+            return;
+          }
           try {
             fit.fit();
           } catch {}
@@ -4868,12 +5168,20 @@
           // and tag this room's agents with it in listSource. Best-effort: an older
           // host with no /api/whoami just leaves rows device-less.
           try {
-            s.deviceLabel = (await s.tx.fetchJSON("/api/whoami"))?.host || "";
+            const who = await s.tx.fetchJSON("/api/whoami");
+            s.deviceLabel = who?.host || "";
+            // A single-agent view-only share advertises its capability here so the
+            // console enters read-only mode (hide + refuse writes). Wrap this
+            // source's tx so no write leaks through any call path; the host still
+            // enforces (403s writes) as the real boundary.
+            s.readonly = !!who?.share?.readonly;
+            s.shareAgentId = who?.share?.agent_id || null;
+            if (s.readonly) s.tx = readonlyTx(s.tx);
             // whoami resolves after the first listSource may have already rendered
             // this room's rows device-less (and activity-gated polling might not
             // re-fire soon on a backgrounded tab). Re-render now so the host label
-            // lands immediately instead of lagging a poll.
-            if (s.deviceLabel) loadList();
+            // (and any read-only state) lands immediately instead of lagging a poll.
+            if (s.deviceLabel || s.readonly) loadList();
           } catch {
             s.deviceLabel = "";
           }

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -4413,7 +4413,18 @@
         // inside fitAndSync keeps an already-matching agent from a redundant SIGWINCH.
         // Returns the in-flight sync promise so the initial open can await it
         // before starting the tail (below); tab-reactivation callers ignore it.
-        resyncTerm = () => {
+        resyncTerm = async () => {
+          if (sel !== selKey || !term) return;
+          // Settle the source's read-only state first (bounded) so fitAndSync picks
+          // the right sizing path on the FIRST render: a read-only viewer must
+          // adopt the agent's grid, not fit-to-pane — the raw snapshot can't be
+          // re-wrapped later. Bounded so an older host without whoami never wedges.
+          const src = srcFor(e);
+          if (src?.whoamiReady) {
+            try {
+              await Promise.race([src.whoamiReady, new Promise((r) => setTimeout(r, 1500))]);
+            } catch {}
+          }
           if (sel !== selKey || !term) return;
           return tx
             .fetchJSON("/api/size/" + encodeURIComponent(pid))
@@ -5167,6 +5178,13 @@
           // every machine's rows would be unlabelled. Ask the host who it is once
           // and tag this room's agents with it in listSource. Best-effort: an older
           // host with no /api/whoami just leaves rows device-less.
+          // Expose whoami as an awaitable so the terminal can settle the read-only
+          // state BEFORE it sizes/renders — otherwise a fast selection races the
+          // fetch and the initial raw snapshot lands on a fit-to-pane grid that a
+          // later resize can't un-wrap (a read-only viewer must render at the
+          // AGENT's grid). Re-created on every (re)connect.
+          let resolveWhoami;
+          s.whoamiReady = new Promise((r) => (resolveWhoami = r));
           try {
             const who = await s.tx.fetchJSON("/api/whoami");
             s.deviceLabel = who?.host || "";
@@ -5184,6 +5202,11 @@
             if (s.deviceLabel || s.readonly) loadList();
           } catch {
             s.deviceLabel = "";
+            // No whoami (older host / error): treat as writable, don't wedge the
+            // terminal — resolve so any awaiter proceeds immediately.
+            s.readonly = s.readonly || false;
+          } finally {
+            resolveWhoami();
           }
         } finally {
           s.reconnecting = false;

--- a/lab/ui/qrcode.js
+++ b/lab/ui/qrcode.js
@@ -1,0 +1,2297 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));

--- a/lab/ui/sw.js
+++ b/lab/ui/sw.js
@@ -6,13 +6,14 @@
 // fallback when offline, which is what makes the installed app launchable with no
 // network. WebSocket signaling and cross-origin CDN scripts are not GET fetches we
 // own, so they pass straight through.
-const CACHE = "agent-yes-w-v1";
+const CACHE = "agent-yes-w-v2";
 const SHELL = [
   "./",
   "./index.html",
   "./room-client.js",
   "./console-logic.js",
   "./e2e.js",
+  "./qrcode.js",
   "./manifest.webmanifest",
   "./icon.svg",
 ];

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lab/ui/index.html",
     "lab/ui/landing.html",
     "lab/ui/manifest.webmanifest",
+    "lab/ui/qrcode.js",
     "lab/ui/room-client.js",
     "lab/ui/sw.js",
     "lab/ui/blog/**"

--- a/ts/agentShare.spec.ts
+++ b/ts/agentShare.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { scopedFetch } from "./agentShare.ts";
+
+// The security core of single-agent view-only sharing: scopedFetch wraps the full
+// `ay serve` API and must DEFAULT-DENY, exposing only reads scoped to ONE agent_id.
+// These drive the real filter with a mock inner handler (no WebRTC / no registry).
+
+const SHARED = "aaaaaaaaaaaa"; // the shared agent's stable id
+const OTHER = "bbbbbbbbbbbb"; // a sibling on the same host — must never leak
+
+function rec(pid: number, agent_id: string) {
+  return { pid, agent_id, cli: "claude", cwd: "/x", status: "running", title: "t" };
+}
+
+// A stand-in for the master apiFetch. Records what it was asked and answers a few
+// endpoints; the scoped wrapper is what we're testing.
+function makeInner(seen: { url?: string }) {
+  return async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    seen.url = req.method + " " + url.pathname + url.search;
+    const p = url.pathname;
+    if (p === "/api/ls") {
+      // The real handler honours ?keyword=; emulate that so we can assert the
+      // wrapper both narrows via keyword AND post-filters by exact agent_id.
+      const kw = url.searchParams.get("keyword");
+      const all = [rec(1, SHARED), rec(2, OTHER)];
+      const out = kw ? all.filter((r) => r.agent_id === kw || r.cwd.includes(kw)) : all;
+      return Response.json(out);
+    }
+    if (p === "/api/whoami") return Response.json({ host: "me@box" });
+    if (p === "/api/version") return new Response("1.2.3");
+    if (p === "/api/ls/subscribe") {
+      const enc = new TextEncoder();
+      const body = new ReadableStream({
+        start(ctrl) {
+          // Initial full snapshot with BOTH agents, then a delta touching each.
+          ctrl.enqueue(
+            enc.encode(
+              `data: ${JSON.stringify({ full: true, upsert: [rec(1, SHARED), rec(2, OTHER)], remove: [] })}\n\n`,
+            ),
+          );
+          ctrl.enqueue(enc.encode(`: ping\n\n`));
+          ctrl.enqueue(
+            enc.encode(`data: ${JSON.stringify({ upsert: [rec(2, OTHER)], remove: [] })}\n\n`),
+          );
+          ctrl.enqueue(
+            enc.encode(`data: ${JSON.stringify({ upsert: [rec(1, SHARED)], remove: [] })}\n\n`),
+          );
+          ctrl.close();
+        },
+      });
+      return new Response(body, { headers: { "Content-Type": "text/event-stream" } });
+    }
+    // read/tail/status/size land here only if the wrapper allowed them through.
+    return new Response("inner-ok");
+  };
+}
+
+const mk = (seen: { url?: string } = {}) => scopedFetch(SHARED, makeInner(seen), "r");
+
+async function sse(res: Response): Promise<string> {
+  return await res.text();
+}
+
+describe("scopedFetch — default-deny writes", () => {
+  for (const [method, path] of [
+    ["POST", "/api/send"],
+    ["POST", "/api/resize/1"],
+    ["POST", "/api/kill"],
+    ["POST", "/api/restart"],
+    ["POST", "/api/spawn"],
+    ["POST", "/api/presence"],
+    ["GET", "/api/presence"],
+    ["POST", "/api/share"],
+    ["GET", "/api/notes"],
+    ["GET", "/api/spawn-config"],
+  ] as const) {
+    it(`403s ${method} ${path}`, async () => {
+      const res = await mk()(new Request("http://ay.local" + path, { method }));
+      expect(res.status).toBe(403);
+    });
+  }
+});
+
+describe("scopedFetch — /api/ls is narrowed and post-filtered", () => {
+  it("injects keyword=agentId and returns ONLY the shared agent", async () => {
+    const seen: { url?: string } = {};
+    const res = await mk(seen)(new Request("http://ay.local/api/ls"));
+    expect(seen.url).toContain("keyword=" + SHARED); // narrowed server-side
+    const out = (await res.json()) as { agent_id: string }[];
+    expect(out).toHaveLength(1);
+    expect(out[0]!.agent_id).toBe(SHARED);
+  });
+
+  it("post-filters even if the inner handler over-matches (fuzzy keyword)", async () => {
+    // Inner that ignores keyword and returns everyone — the wrapper must still cut
+    // it down to the shared agent by EXACT agent_id.
+    const leaky = scopedFetch(
+      SHARED,
+      async () => Response.json([rec(1, SHARED), rec(2, OTHER)]),
+      "r",
+    );
+    const out = (await (await leaky(new Request("http://ay.local/api/ls"))).json()) as {
+      agent_id: string;
+    }[];
+    expect(out.map((r) => r.agent_id)).toEqual([SHARED]);
+  });
+});
+
+describe("scopedFetch — /api/ls/subscribe SSE is filtered", () => {
+  it("keeps only the shared agent across snapshot + deltas", async () => {
+    const res = await mk()(new Request("http://ay.local/api/ls/subscribe"));
+    const text = await sse(res);
+    expect(text).toContain('"full":true');
+    expect(text).toContain(SHARED);
+    expect(text).not.toContain(OTHER); // sibling never crosses the channel
+    expect(text).toContain(": ping"); // heartbeat passes through
+    // The delta that touched only OTHER must be dropped entirely.
+    const dataEvents = text.split("\n\n").filter((e) => e.startsWith("data:"));
+    // full snapshot (shared only) + the shared-agent delta = 2 data events.
+    expect(dataEvents).toHaveLength(2);
+  });
+});
+
+describe("scopedFetch — read metadata", () => {
+  it("passes /api/version through untouched", async () => {
+    const res = await mk()(new Request("http://ay.local/api/version"));
+    expect(await res.text()).toBe("1.2.3");
+  });
+
+  it("advertises read-only capability on /api/whoami", async () => {
+    const res = await mk()(new Request("http://ay.local/api/whoami"));
+    const who = (await res.json()) as {
+      host: string;
+      share: { readonly: boolean; agent_id: string; perm: string };
+    };
+    expect(who.host).toBe("me@box");
+    expect(who.share.readonly).toBe(true);
+    expect(who.share.agent_id).toBe(SHARED);
+    expect(who.share.perm).toBe("r");
+  });
+
+  it("403s a read of an agent that is not the shared one (unknown keyword)", async () => {
+    // resolveOne throws for an unknown keyword → targetIsAgent false → 403. Uses a
+    // keyword that cannot resolve on this machine, so it never leaks a real agent.
+    const res = await mk()(new Request("http://ay.local/api/read/zzzzzzzzzzzz-nope"));
+    expect(res.status).toBe(403);
+  });
+});

--- a/ts/agentShare.ts
+++ b/ts/agentShare.ts
@@ -1,0 +1,301 @@
+// Single-agent, view-only shares (Option X from docs/agent-sharing.md).
+//
+// A scoped share stands up its OWN e2ee WebRTC room (via startShare, minted
+// fresh — never the persisted master fleet room) that exposes exactly ONE agent,
+// read-only. The room's host bridge wraps the full `ay serve` API handler in a
+// `scopedFetch` that DEFAULT-DENIES and permits only read paths, each verified to
+// resolve to the shared `agent_id` (the stable per-process id, not the reusable
+// pid). Read-only is enforced here on the host — the browser hiding controls is
+// only UX (design principle #1: host-enforced capability, not client-side hiding).
+//
+// Link format: agent-yes.com/w/#room:grantSecret — the pid is NOT in the URL; the
+// scope lives in this host-side share record. Shares are ephemeral (no disk
+// persistence): a daemon restart drops them, and a restarted agent mints a fresh
+// agent_id, so the holder re-shares (a deliberate NON-GOAL per the design).
+import { listRecords, resolveOne, type CommonOpts } from "./subcommands.ts";
+import { startShare } from "./share.ts";
+
+export type SharePerm = "r";
+
+export interface ScopedShare {
+  shareId: string;
+  agentId: string;
+  perm: SharePerm;
+  room: string;
+  link: string;
+  label: string; // human hint: cli · cwd basename
+  createdAt: number;
+  expiresAt: number;
+  close: () => void;
+}
+
+// Bound concurrent shares: each is its own signaling WS + WebRTC host peer with a
+// process.exit self-heal on repeated native peer-setup failure (see ts/share.ts),
+// so a fleet of rooms multiplies that risk and the signaling-DO cost. A handful is
+// plenty for the intended "show someone this one agent" use.
+export const MAX_SHARES = 8;
+export const DEFAULT_SHARE_TTL_MS = 24 * 60 * 60 * 1000; // 24h — design "short expiration"
+
+const shares = new Map<string, ScopedShare>();
+
+function lsOpts(all = false): CommonOpts {
+  return { all, active: false, json: true, latest: true, cwdScope: null };
+}
+
+export function listShares(): Omit<ScopedShare, "close">[] {
+  return [...shares.values()]
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .map(({ close: _close, ...s }) => s);
+}
+
+export function revokeShare(shareId: string): boolean {
+  const s = shares.get(shareId);
+  if (!s) return false;
+  try {
+    s.close();
+  } catch {
+    /* already closed */
+  }
+  shares.delete(shareId);
+  return true;
+}
+
+export function revokeAllShares(): void {
+  for (const id of [...shares.keys()]) revokeShare(id);
+}
+
+/** Resolve a keyword to a live agent and mint a fresh view-only share room for it. */
+export async function createScopedShare(opts: {
+  agent: string; // any keyword: pid, agent_id, cwd/cli/prompt substring
+  perm?: SharePerm;
+  localFetch: (req: Request) => Promise<Response>;
+  apiToken: string;
+  sighost?: string;
+  ttlMs?: number;
+}): Promise<Omit<ScopedShare, "close">> {
+  if (shares.size >= MAX_SHARES) {
+    throw new Error(`too many active shares (max ${MAX_SHARES}) — revoke one first`);
+  }
+  const record = await resolveOne(opts.agent, lsOpts(true)); // throws if none match
+  const agentId = record.agent_id;
+  if (!agentId) {
+    // Only agents registered with a stable id can be scoped safely; pid alone is
+    // reused and unsafe as the security key.
+    throw new Error(`agent ${record.pid} has no stable agent_id — cannot share (restart it)`);
+  }
+  const label = `${record.cli}${record.cwd ? " · " + record.cwd.split("/").filter(Boolean).pop() : ""}`;
+
+  const scoped = scopedFetch(agentId, opts.localFetch, opts.perm ?? "r");
+  const { room, link, close } = await startShare({
+    localFetch: scoped,
+    apiToken: opts.apiToken,
+    sighost: opts.sighost,
+    // no `url` → startShare mints a fresh, unpersisted room (never the master room)
+  });
+
+  const shareId = "s" + Math.abs(hashStr(room + agentId + link)).toString(36);
+  const createdAt = Date.now();
+  const ttl = opts.ttlMs ?? DEFAULT_SHARE_TTL_MS;
+  const expiresAt = createdAt + ttl;
+
+  const stop = () => close();
+  const expiryTimer = setTimeout(() => revokeShare(shareId), ttl);
+  expiryTimer.unref?.();
+
+  const share: ScopedShare = {
+    shareId,
+    agentId,
+    perm: opts.perm ?? "r",
+    room,
+    link,
+    label,
+    createdAt,
+    expiresAt,
+    close: () => {
+      clearTimeout(expiryTimer);
+      stop();
+    },
+  };
+  shares.set(shareId, share);
+  const { close: _c, ...pub } = share;
+  return pub;
+}
+
+function hashStr(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  return h;
+}
+
+function forbidden(msg = "read-only share"): Response {
+  return new Response(msg, { status: 403 });
+}
+
+// Wrap the master API handler so a scoped viewer can ONLY read, and only THIS
+// agent. Default-deny: an endpoint not explicitly allowed below is 403.
+export function scopedFetch(
+  agentId: string,
+  inner: (req: Request) => Promise<Response>,
+  perm: SharePerm = "r",
+): (req: Request) => Promise<Response> {
+  return async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    const p = url.pathname;
+    const method = req.method;
+
+    // Static host metadata, no agent data.
+    if (method === "GET" && p === "/api/version") return inner(req);
+    if (method === "GET" && p === "/api/whoami")
+      return withShareFlag(await inner(req), agentId, perm);
+
+    // Agent list: force keyword=agentId (cheap server-side narrowing) then
+    // post-filter by EXACT agent_id — matchKeyword can fuzzy-match a sibling whose
+    // cwd/prompt contains the hex, so the keyword hint is not a boundary on its own.
+    if (method === "GET" && (p === "/api/ls" || p === "/api/ls/subscribe")) {
+      const scopedUrl = new URL(url);
+      scopedUrl.searchParams.set("keyword", agentId);
+      scopedUrl.searchParams.delete("all"); // never widen to other/exited agents
+      const scopedReq = new Request(scopedUrl.toString(), req);
+      const res = await inner(scopedReq);
+      return p === "/api/ls" ? filterLsJson(res, agentId) : filterLsSse(res, agentId);
+    }
+
+    // Per-agent reads — verify the target resolves to OUR agent_id (403 otherwise).
+    const m =
+      /^\/api\/(read|tail|status|size)\/(.+)$/.exec(p) && method === "GET"
+        ? /^\/api\/(read|tail|status|size)\/(.+)$/.exec(p)
+        : null;
+    if (m) {
+      const kw = decodeURIComponent(m[2]!);
+      if (!(await targetIsAgent(kw, agentId))) return forbidden("agent not shared");
+      return inner(req);
+    }
+
+    // Everything else (send, resize, kill, restart, spawn, presence, notes,
+    // spawn-config, share*, …) is a write or a fleet-wide read → denied.
+    return forbidden();
+  };
+}
+
+async function targetIsAgent(keyword: string, agentId: string): Promise<boolean> {
+  try {
+    const rec = await resolveOne(keyword, lsOpts(true));
+    return rec.agent_id === agentId;
+  } catch {
+    return false;
+  }
+}
+
+// Add a self-describing read-only capability to /api/whoami so the viewer console
+// can enter read-only UI. The host stays the real boundary (writes are 403'd
+// regardless); this is a UX hint the browser can trust because it comes from the
+// host over the same e2ee channel.
+async function withShareFlag(res: Response, agentId: string, perm: SharePerm): Promise<Response> {
+  if (!res.ok) return res;
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return res;
+  }
+  const obj = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  return Response.json({ ...obj, share: { perm, agent_id: agentId, readonly: perm === "r" } });
+}
+
+async function filterLsJson(res: Response, agentId: string): Promise<Response> {
+  if (!res.ok) return res;
+  let arr: unknown;
+  try {
+    arr = await res.json();
+  } catch {
+    return res;
+  }
+  const kept = Array.isArray(arr)
+    ? arr.filter(
+        (r) => r && typeof r === "object" && (r as { agent_id?: string }).agent_id === agentId,
+      )
+    : [];
+  return Response.json(kept, { status: res.status });
+}
+
+// Filter the /api/ls/subscribe SSE so only the shared agent's deltas cross the
+// channel. Each event is `{full?, upsert:[records], remove:[pids]}`; keep only
+// upserts whose agent_id matches, and only removes for pids we actually forwarded.
+function filterLsSse(res: Response, agentId: string): Response {
+  if (!res.ok || !res.body) return res;
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  const enc = new TextEncoder();
+  const forwarded = new Set<number>();
+  let buf = "";
+
+  const stream = new ReadableStream({
+    async pull(ctrl) {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          ctrl.close();
+          return;
+        }
+        buf += dec.decode(value, { stream: true });
+        // Emit each complete SSE event (blank-line separated).
+        let sep: number;
+        let emittedSomething = false;
+        while ((sep = buf.indexOf("\n\n")) !== -1) {
+          const rawEvent = buf.slice(0, sep);
+          buf = buf.slice(sep + 2);
+          const out = transformEvent(rawEvent, agentId, forwarded);
+          if (out !== null) {
+            ctrl.enqueue(enc.encode(out + "\n\n"));
+            emittedSomething = true;
+          }
+        }
+        if (emittedSomething) return; // yield to the consumer; resume on next pull
+      }
+    },
+    cancel() {
+      reader.cancel().catch(() => {});
+    },
+  });
+  return new Response(stream, {
+    status: res.status,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+// Returns the rewritten SSE event text, or null to drop it entirely. Passes
+// through comment lines (": ping" heartbeats) and non-data frames unchanged.
+function transformEvent(rawEvent: string, agentId: string, forwarded: Set<number>): string | null {
+  const trimmed = rawEvent.replace(/\r/g, "");
+  if (!trimmed.trim()) return null;
+  if (!/^data:/m.test(trimmed)) return trimmed; // comments/heartbeats pass through
+  // Reassemble the `data:` payload (SSE allows multiple data: lines per event).
+  const dataLines = trimmed
+    .split("\n")
+    .filter((l) => l.startsWith("data:"))
+    .map((l) => l.slice(5).replace(/^ /, ""));
+  const payload = dataLines.join("\n");
+  let obj: {
+    full?: boolean;
+    upsert?: { pid: number; agent_id?: string }[];
+    remove?: number[];
+  };
+  try {
+    obj = JSON.parse(payload);
+  } catch {
+    return null; // malformed — drop rather than leak
+  }
+  const upsert = (obj.upsert ?? []).filter((r) => r && r.agent_id === agentId);
+  for (const r of upsert) forwarded.add(r.pid);
+  const remove = (obj.remove ?? []).filter((pid) => forwarded.has(pid));
+  for (const pid of remove) forwarded.delete(pid);
+  // On the first snapshot always emit (even if empty) so the viewer knows it's
+  // connected; later ticks only when something relevant changed.
+  if (!obj.full && upsert.length === 0 && remove.length === 0) return null;
+  const next = obj.full ? { full: true, upsert, remove } : { upsert, remove };
+  return "data: " + JSON.stringify(next);
+}

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2210,6 +2210,51 @@ export async function cmdServe(rest: string[]): Promise<number> {
       }
     }
 
+    // ---- Single-agent view-only shares (docs/agent-sharing.md, Option X) ------
+    // Mint / list / revoke scoped share rooms. Reachable by whoever already holds
+    // full control of this host (the local token or the master fleet room) — a
+    // scoped viewer can't reach these (its scopedFetch 403s /api/share*).
+
+    // POST /api/share  body {agent, perm?}  → mint a fresh view-only room for ONE
+    // agent and return its share link.
+    if (req.method === "POST" && p === "/api/share") {
+      let body: { agent?: string; perm?: "r" };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      if (!body.agent) return new Response("agent required", { status: 400 });
+      try {
+        const { createScopedShare } = await import("./agentShare.ts");
+        const share = await createScopedShare({
+          agent: body.agent,
+          perm: body.perm ?? "r",
+          localFetch: apiFetch,
+          apiToken: token,
+        });
+        return Response.json(share);
+      } catch (e) {
+        const msg = (e as Error).message;
+        const status = /too many active shares/.test(msg) ? 409 : /no agent matched|no stable/.test(msg) ? 404 : 500;
+        return new Response(msg, { status });
+      }
+    }
+
+    // GET /api/shares  → active scoped shares (for the manage/revoke UI).
+    if (req.method === "GET" && p === "/api/shares") {
+      const { listShares } = await import("./agentShare.ts");
+      return Response.json(listShares());
+    }
+
+    // DELETE /api/share/:shareId  → revoke (close the room).
+    const revokeM = /^\/api\/share\/([^/]+)$/.exec(p);
+    if (req.method === "DELETE" && revokeM) {
+      const { revokeShare } = await import("./agentShare.ts");
+      const ok = revokeShare(decodeURIComponent(revokeM[1]!));
+      return new Response(ok ? "revoked" : "no such share", { status: ok ? 200 : 404 });
+    }
+
     return new Response("Not Found", { status: 404 });
   };
 
@@ -2238,6 +2283,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return serveUiFile("console-logic.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/e2e.js")
       return serveUiFile("e2e.js", "text/javascript; charset=utf-8");
+    if (req.method === "GET" && p === "/qrcode.js")
+      return serveUiFile("qrcode.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/favicon.ico") return new Response(null, { status: 204 });
     return apiFetch(req);
   };
@@ -2388,6 +2435,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
   const shutdown = (resolve: () => void) => {
     if (heartbeat) clearInterval(heartbeat);
     closeShare?.();
+    // Close any scoped single-agent share rooms so viewers get an immediate drop.
+    void import("./agentShare.ts").then((m) => m.revokeAllShares()).catch(() => {});
     server?.stop();
     resolve();
   };


### PR DESCRIPTION
Follow-up to #200. Fixes the reported bug: a read-only viewer's terminal rendered its **first few frames at the wrong width**, and since xterm had already laid out the raw snapshot on a wrong-size grid, a later resize couldn't repair it.

**Root cause:** the read-only sizing path (adopt the agent's grid + CSS-scale, never drive a resize) only engaged after `whoami` set `s.readonly`. A fast selection raced that fetch → `fitAndSync` took the read-write path → fit-to-pane → the absolute-positioned raw tail snapshot landed on a wrong-size grid.

**Fix:** expose `whoami` as an awaitable (`s.whoamiReady`); `resyncTerm` settles the read-only state (bounded 1.5s) **before** the first size sync + tail replay, so the correct grid is chosen on the first render. Older hosts without `whoami` resolve immediately (treated writable).

Verified: unit tests still green; local console loads without regression. Live re-test to follow after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)