### PR TITLE
share: read-write share + security hardening (XSS/CSP/OSC/room/TURN)

### DIFF
--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -24,6 +24,33 @@ export interface Env {
 
 const SUBPROTO = "ay-signal-1";
 
+// Defense-in-depth CSP for the console document. The console renders agent
+// metadata (terminal title / prompt / cwd) supplied by whatever host a share
+// link points at — untrusted by definition — so even with output escaping we
+// lock down where a hypothetical injection could send data. Blocks arbitrary
+// fetch/beacon exfil (connect-src / img-src), plugins (object-src), <base>
+// hijack (base-uri), clickjacking (frame-ancestors) and form exfil
+// (form-action). script-src keeps 'unsafe-inline' because the console is a
+// single-file inline app (no inline event-handler attributes exist, so a
+// stricter nonce split is a follow-up, not a regression risk); xterm loads from
+// jsdelivr. connect-src allows any wss: so custom / self-hosted signaling hosts
+// still work, while forbidding arbitrary https fetch exfil. Keep this in sync
+// with the copy in ts/serve.ts (serveUiFile).
+const CSP = [
+  "default-src 'self'",
+  "base-uri 'none'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "img-src 'self' data:",
+  "font-src 'self' data:",
+  "style-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+  "connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:",
+  "worker-src 'self'",
+  "manifest-src 'self'",
+].join("; ");
+
 // Heartbeat frames (host pings, server pongs). Defined once so the hibernation
 // auto-response pair below matches the host's wire bytes EXACTLY — the runtime
 // only auto-answers an incoming message that is byte-identical to PING.
@@ -52,6 +79,7 @@ export default {
     if (ct.includes("text/html") || ct.includes("javascript")) {
       const h = new Headers(res.headers);
       h.set("Cache-Control", "no-cache");
+      if (ct.includes("text/html")) h.set("Content-Security-Policy", CSP);
       return new Response(res.body, { status: res.status, statusText: res.statusText, headers: h });
     }
     return res;

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2041,8 +2041,17 @@
       });
 
       const $ = (id) => document.getElementById(id);
+      // Escape for HTML — including BOTH quote styles, because esc() is
+      // interpolated into double-quoted attribute values (title="${esc(...)}",
+      // data-key="${esc(...)}", …), not just element text. A remote host controls
+      // agent metadata (OSC terminal title, prompt, cwd) that lands in those
+      // attributes; without escaping " an agent titled `" onfocus=…` breaks out of
+      // the attribute and runs script at this origin (theft of saved room tokens).
       const esc = (s) =>
-        String(s ?? "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+        String(s ?? "").replace(
+          /[&<>"']/g,
+          (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+        );
 
       // ---- transport ---------------------------------------------------------
       // Local: same-origin fetch + EventSource (via the ay-serve proxy).

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -327,6 +327,31 @@
       .app.readonly-agent .rmenuact {
         display: none !important;
       }
+      /* Read-write (steer) share: the viewer CAN type, so composer + key bar stay.
+         But they aren't granted control/admin, so hide stop/restart/kill/share. */
+      .rwbadge {
+        display: none;
+        align-items: center;
+        gap: 4px;
+        font-size: 11px;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 999px;
+        color: #7c3aed;
+        background: color-mix(in srgb, #8b5cf6 18%, transparent);
+        border: 1px solid color-mix(in srgb, #8b5cf6 45%, transparent);
+        white-space: nowrap;
+      }
+      .app.steer-agent .rwbadge {
+        display: inline-flex;
+      }
+      .app.steer-agent #stopAgent,
+      .app.steer-agent #restartAgent,
+      .app.steer-agent #killAgent,
+      .app.steer-agent #shareAgent,
+      .app.steer-agent #shareAgentRW {
+        display: none !important;
+      }
       /* Share modal — QR + link for a single-agent view-only share. */
       .modal-backdrop {
         position: fixed;
@@ -413,6 +438,42 @@
         opacity: 0.65;
         margin-top: 12px;
         line-height: 1.4;
+      }
+      .sharewarn[hidden] {
+        display: none;
+      }
+      .sharewarn {
+        border: 1px solid color-mix(in srgb, #dc2626 55%, transparent);
+        background: color-mix(in srgb, #dc2626 12%, transparent);
+        border-radius: 10px;
+        padding: 14px;
+        margin-bottom: 4px;
+      }
+      .sharewarn .warnhead {
+        font-weight: 700;
+        color: #dc2626;
+        margin-bottom: 8px;
+        font-size: 14px;
+      }
+      .sharewarn p {
+        margin: 0 0 8px;
+        font-size: 12.5px;
+        line-height: 1.45;
+      }
+      .sharewarn button {
+        width: 100%;
+        padding: 10px;
+        margin-top: 4px;
+        border-radius: 8px;
+        border: 1px solid #dc2626;
+        background: #dc2626;
+        color: #fff;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      #shareRevealable[hidden] {
+        display: none;
       }
       /* Terminal font-size stepper (a static row, not a hover/click target). */
       .rmenufont {
@@ -1642,6 +1703,9 @@
           <span class="robadge" title="view-only share — you can watch but not steer this agent"
             >👁 read-only</span
           >
+          <span class="rwbadge" title="read-write share — you can type but not stop/restart this agent"
+            >✏️ read-write</span
+          >
           <span class="live"
             ><span class="dot" id="livedot"></span><span id="livetxt">connecting…</span></span
           >
@@ -1668,7 +1732,10 @@
               >
               <div class="rmenusep"></div>
               <button class="rmenuitem rmenuact" id="shareAgent" type="button">
-                🔗 Share (read-only)
+                👁 Share (view-only)
+              </button>
+              <button class="rmenuitem rmenuact" id="shareAgentRW" type="button">
+                ✏️ Share (read-write)…
               </button>
               <div class="rmenusep"></div>
               <button class="rmenuitem rmenuact" id="stopAgent" type="button">⏹ Stop agent</button>
@@ -1773,21 +1840,44 @@
          enforces read-only regardless of the client. -->
     <div class="modal-backdrop" id="shareModal" hidden>
       <div class="sharebox" role="dialog" aria-modal="true" aria-label="Share agent">
-        <h3>Share this agent</h3>
+        <h3 id="shareTitle">Share this agent</h3>
         <p class="sub" id="shareSub">view-only · anyone with the link can watch</p>
-        <div class="qr" id="shareQr"></div>
-        <div class="shareurl" id="shareUrl"></div>
-        <div class="srow">
-          <button class="primary" id="shareCopy" type="button">Copy link</button>
-          <button id="shareClose" type="button">Close</button>
+
+        <!-- Read-write warning gate: the link is NOT shown until the operator
+             acknowledges that it hands over control. Shown only for rw shares. -->
+        <div class="sharewarn" id="shareWarn" hidden>
+          <div class="warnhead">⚠️ This link lets anyone control this agent</div>
+          <p>
+            Whoever opens this link can <strong>type into this agent</strong> — and because an
+            agent can run commands, that can mean <strong>control of your whole system</strong>.
+            The link isn't a password prompt: no further confirmation is asked.
+          </p>
+          <p><strong>Only share it with someone you completely trust.</strong></p>
+          <button class="danger" id="shareReveal" type="button">
+            I understand — reveal the link
+          </button>
         </div>
-        <div class="srow">
-          <button class="danger" id="shareRevoke" type="button">Revoke</button>
+
+        <!-- Link + QR, hidden behind the warning for rw shares. -->
+        <div id="shareRevealable">
+          <div class="qr" id="shareQr"></div>
+          <div class="shareurl" id="shareUrl"></div>
+          <div class="srow">
+            <button class="primary" id="shareCopy" type="button">Copy link</button>
+            <button id="shareClose" type="button">Close</button>
+          </div>
+          <div class="srow">
+            <button class="danger" id="shareRevoke" type="button">Revoke</button>
+          </div>
+          <p class="note" id="shareNote">
+            View-only: viewers see this agent's terminal (which may include secrets) but cannot
+            type, stop, or restart it. The link expires automatically and stops working when
+            revoked.
+          </p>
         </div>
-        <p class="note" id="shareNote">
-          Read-only: viewers see this agent's terminal but cannot type, stop, or restart it.
-          The link expires automatically and stops working when revoked.
-        </p>
+        <div class="srow" id="shareWarnClose" hidden>
+          <button id="shareCloseAlt" type="button">Cancel</button>
+        </div>
       </div>
     </div>
 
@@ -3261,48 +3351,92 @@
       // show its link + QR. The host stands up an isolated e2ee room exposing
       // only this agent (read-only) — see ts/agentShare.ts. Never reuses the
       // fleet/master token, so the link can't reach other agents or steer.
-      let currentShare = null; // { shareId, link } of the share shown in the modal
-      async function shareAgent(ent) {
+      let currentShare = null; // { shareId, link, perm } of the share shown in the modal
+      let pendingRw = null; // the agent awaiting a read-write warning acknowledgement
+      // perm: "r" (view-only) or "rw" (read-write / steer). A read-write link hands
+      // over keystroke control of the agent — effectively control of the host — so
+      // it is NOT even minted until the operator clicks through the warning.
+      async function shareAgent(perm, ent) {
         const e = ent || (sel ? entries.find((x) => x._key === sel) : null);
         if (!e) return;
-        // A read-only viewer can't re-share; its tx 403s /api/share anyway.
-        if (isReadonlyEnt(e)) {
-          alert("This is a read-only shared view — you can't share it further.");
+        // A shared viewer can't re-share; its tx 403s /api/share anyway.
+        if (isReadonlyEnt(e) || sharePermOf(e)) {
+          alert("This is a shared view — you can't re-share it from here.");
           return;
         }
-        // Scope by the stable agent_id when we have it (pid is reused); fall back
-        // to pid so an older host still resolves the right agent.
-        const agentRef = e.agent_id || String(e.pid);
+        if (perm === "rw") {
+          // Show the warning FIRST; mint only after "reveal" (revealRwShare).
+          pendingRw = e;
+          openShareModal(null, e, "rw");
+          return;
+        }
+        const info = await mintShare(e, "r");
+        if (info) openShareModal(info, e, "r");
+      }
+      async function mintShare(e, perm) {
+        const agentRef = e.agent_id || String(e.pid); // stable id; fall back to pid
         const res = await txFor(e)
-          .post("/api/share", { agent: agentRef, perm: "r" })
+          .post("/api/share", { agent: agentRef, perm })
           .catch((err) => ({ ok: false, text: String(err?.message || err) }));
         if (!res || !res.ok) {
           alert(`Couldn't create share link:\n${(res && res.text) || "request failed"}`);
-          return;
+          return null;
         }
         let info;
         try {
           info = JSON.parse(res.text);
         } catch {
           alert("Share created but the response was unreadable.");
-          return;
+          return null;
         }
-        currentShare = { shareId: info.shareId, link: info.link, srcRoom: e._room };
-        openShareModal(info, e);
+        currentShare = { shareId: info.shareId, link: info.link, srcRoom: e._room, perm };
+        return info;
+      }
+      // "I understand — reveal": now that the operator has read the warning, mint
+      // the read-write share and reveal its URL/QR.
+      async function revealRwShare() {
+        const e = pendingRw;
+        if (!e) return;
+        pendingRw = null;
+        const info = await mintShare(e, "rw");
+        if (!info) return closeShareModal();
+        $("shareUrl").textContent = info.link;
+        renderQr($("shareQr"), info.link);
+        $("shareWarn").hidden = true;
+        $("shareWarnClose").hidden = true;
+        $("shareRevealable").hidden = false;
       }
 
-      function openShareModal(info, e) {
+      function openShareModal(info, e, perm) {
         const modal = $("shareModal");
         if (!modal) return;
         const who = e.title || cliLabel(e) || ident(e) || `pid ${e.pid}`;
-        $("shareSub").textContent = `view-only · ${who}`;
-        $("shareUrl").textContent = info.link;
-        renderQr($("shareQr"), info.link);
+        const rw = perm === "rw";
+        $("shareTitle").textContent = rw ? "Share control of this agent" : "Share this agent";
+        $("shareSub").textContent = `${rw ? "read-write · can type" : "view-only · can watch"} · ${who}`;
+        $("shareNote").textContent = rw
+          ? "Read-write: viewers can type into this agent (interrupt, run commands). They cannot stop or restart it. The link expires and stops working when revoked."
+          : "View-only: viewers see this agent's terminal (which may include secrets) but cannot type, stop, or restart it. The link expires and stops working when revoked.";
+        // Read-write opens in the warning state with NO link/QR shown or rendered
+        // yet; view-only shows the link immediately (the milder note suffices).
+        $("shareWarn").hidden = !rw;
+        $("shareWarnClose").hidden = !rw;
+        $("shareRevealable").hidden = rw;
+        if (!rw && info) {
+          $("shareUrl").textContent = info.link;
+          renderQr($("shareQr"), info.link);
+        }
         modal.hidden = false;
+      }
+      // The perm a shared SOURCE was granted (from whoami), or null when we're the
+      // owner. Used to hide re-share/admin controls a viewer isn't allowed.
+      function sharePermOf(e) {
+        return srcFor(e)?.sharePerm || null;
       }
       function closeShareModal() {
         const modal = $("shareModal");
         if (modal) modal.hidden = true;
+        pendingRw = null; // a cancelled read-write flow never minted anything
       }
       // Draw the QR onto a fresh canvas (white quiet-zone always, so it scans in
       // dark mode too). `qrcode` is the vendored global from qrcode.js.
@@ -3345,6 +3479,8 @@
       }
       (function shareModalBoot() {
         $("shareClose")?.addEventListener("click", closeShareModal);
+        $("shareCloseAlt")?.addEventListener("click", closeShareModal);
+        $("shareReveal")?.addEventListener("click", revealRwShare);
         $("shareRevoke")?.addEventListener("click", revokeCurrentShare);
         $("shareCopy")?.addEventListener("click", async () => {
           if (!currentShare) return;
@@ -3757,7 +3893,8 @@
           });
         }
         if (cb) cb.addEventListener("change", () => setPerfHud(cb.checked));
-        $("shareAgent")?.addEventListener("click", () => (closePanel(), shareAgent()));
+        $("shareAgent")?.addEventListener("click", () => (closePanel(), shareAgent("r")));
+        $("shareAgentRW")?.addEventListener("click", () => (closePanel(), shareAgent("rw")));
         $("stopAgent")?.addEventListener("click", () => (closePanel(), stopAgent(false)));
         $("restartAgent")?.addEventListener("click", () => (closePanel(), restartAgent()));
         $("killAgent")?.addEventListener("click", () => (closePanel(), stopAgent(true)));
@@ -4250,9 +4387,13 @@
         // Mobile: flip the single-column layout to the terminal ("detail") pane.
         // Done BEFORE term.open below so xterm measures a visible container.
         document.querySelector(".app").classList.add("show-detail");
-        // View-only share: hide the composer / key bar / agent-action menu items and
-        // show a read-only badge. Writes are also refused at the tx layer + the host.
+        // Shared-view gating (host-enforced; this is UX):
+        //  • view-only (r)  → readonly-agent: hide composer/keybar + ALL agent actions.
+        //  • read-write (rw) → steer-agent: keep composer/keybar (can type), but hide
+        //    the admin actions (stop/restart/kill/share) a viewer isn't granted.
+        const _perm = sharePermOf(e);
         document.querySelector(".app").classList.toggle("readonly-agent", isReadonlyEnt(e));
+        document.querySelector(".app").classList.toggle("steer-agent", _perm === "rw");
         $("rhead").style.display = "flex";
         $("rdot").className = "dot " + e.status;
         const rname = e.title || cliLabel(e) || ident(e) || "agent";
@@ -5193,6 +5334,7 @@
             // source's tx so no write leaks through any call path; the host still
             // enforces (403s writes) as the real boundary.
             s.readonly = !!who?.share?.readonly;
+            s.sharePerm = who?.share?.perm || null; // "r" | "rw" | null(owner)
             s.shareAgentId = who?.share?.agent_id || null;
             if (s.readonly) s.tx = readonlyTx(s.tx);
             // whoami resolves after the first listSource may have already rendered

--- a/lab/ui/share-host.ts
+++ b/lab/ui/share-host.ts
@@ -62,7 +62,7 @@ if (!arg) {
   process.exit(1);
 } else if (arg === "--new") {
   host = process.argv[3] ?? process.env.AY_SIGHOST ?? "s.agent-yes.com";
-  room = "r" + randomBytes(3).toString("hex"); // short, non-secret mnemonic
+  room = "r" + randomBytes(6).toString("hex"); // short, non-secret mnemonic
   token = `${MARKER}${randomBytes(32).toString("hex")}`; // e1.<64hex> encrypted-link secret
   const ui = host === "s.agent-yes.com" ? "https://agent-yes.com" : "http://localhost:7778";
   const suffix = host === "s.agent-yes.com" ? "" : "@" + host;

--- a/ts/agentShare.spec.ts
+++ b/ts/agentShare.spec.ts
@@ -147,3 +147,47 @@ describe("scopedFetch — read metadata", () => {
     expect(res.status).toBe(403);
   });
 });
+
+describe("scopedFetch — read-write (rw / steer) share", () => {
+  const mkRw = () => scopedFetch(SHARED, makeInner({}), "rw");
+
+  it("advertises perm=rw and readonly=false on /api/whoami", async () => {
+    const res = await mkRw()(new Request("http://ay.local/api/whoami"));
+    const who = (await res.json()) as { share: { readonly: boolean; perm: string } };
+    expect(who.share.perm).toBe("rw");
+    expect(who.share.readonly).toBe(false);
+  });
+
+  it("still DENIES control (kill / restart / spawn) — rw is steer, not control", async () => {
+    for (const path of ["/api/kill", "/api/restart", "/api/spawn"]) {
+      const res = await mkRw()(new Request("http://ay.local" + path, { method: "POST" }));
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it("DENIES send/resize aimed at an agent that isn't the shared one", async () => {
+    // keyword can't resolve on this machine → targetIsAgent false → 403, so an rw
+    // holder can only steer THE shared agent, never a sibling.
+    const send = await mkRw()(
+      new Request("http://ay.local/api/send", {
+        method: "POST",
+        body: JSON.stringify({ keyword: "zzzzzzzzzzzz-nope", msg: "x" }),
+      }),
+    );
+    expect(send.status).toBe(403);
+    const resize = await mkRw()(
+      new Request("http://ay.local/api/resize/zzzzzzzzzzzz-nope", { method: "POST" }),
+    );
+    expect(resize.status).toBe(403);
+  });
+
+  it("still denies send on a VIEW-ONLY (r) share", async () => {
+    const res = await mk()(
+      new Request("http://ay.local/api/send", {
+        method: "POST",
+        body: JSON.stringify({ keyword: "1", msg: "x" }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/ts/agentShare.ts
+++ b/ts/agentShare.ts
@@ -15,7 +15,7 @@
 import { listRecords, resolveOne, type CommonOpts } from "./subcommands.ts";
 import { startShare } from "./share.ts";
 
-export type SharePerm = "r";
+export type SharePerm = "r" | "rw";
 
 export interface ScopedShare {
   shareId: string;
@@ -171,8 +171,37 @@ export function scopedFetch(
       return inner(req);
     }
 
-    // Everything else (send, resize, kill, restart, spawn, presence, notes,
-    // spawn-config, share*, …) is a write or a fleet-wide read → denied.
+    // Steer (rw): a read-WRITE share may drive THIS agent — send input, resize its
+    // PTY, and self-report presence. It still may NOT control it (kill/restart/
+    // spawn are machine-admin, excluded from a per-agent share) nor touch any other
+    // agent. Treat `send` as command-injection-equivalent — the warning shown when
+    // minting an rw link is the real safety gate (docs/agent-sharing.md).
+    if (perm.includes("w")) {
+      // POST /api/send  body {keyword, msg, code} — verify the target is us.
+      if (method === "POST" && p === "/api/send") {
+        let kw: unknown;
+        try {
+          kw = JSON.parse(await req.clone().text())?.keyword;
+        } catch {
+          return forbidden("bad body");
+        }
+        if (kw == null || !(await targetIsAgent(String(kw), agentId)))
+          return forbidden("agent not shared");
+        return inner(req);
+      }
+      // POST /api/resize/:kw — verify the target is us.
+      const rz = method === "POST" ? /^\/api\/resize\/(.+)$/.exec(p) : null;
+      if (rz) {
+        const kw = decodeURIComponent(rz[1]!);
+        if (!(await targetIsAgent(kw, agentId))) return forbidden("agent not shared");
+        return inner(req);
+      }
+      // POST /api/presence — cosmetic "who's watching" self-report, no agent control.
+      if (method === "POST" && p === "/api/presence") return inner(req);
+    }
+
+    // Everything else (kill, restart, spawn, notes, spawn-config, share*, …, and —
+    // for a view-only share — send/resize/presence too) is denied.
     return forbidden();
   };
 }

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2342,18 +2342,21 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // POST /api/share  body {agent, perm?}  → mint a fresh view-only room for ONE
     // agent and return its share link.
     if (req.method === "POST" && p === "/api/share") {
-      let body: { agent?: string; perm?: "r" };
+      let body: { agent?: string; perm?: "r" | "rw" };
       try {
         body = (await req.json()) as typeof body;
       } catch {
         return new Response("invalid JSON body", { status: 400 });
       }
       if (!body.agent) return new Response("agent required", { status: 400 });
+      const perm = body.perm ?? "r";
+      if (perm !== "r" && perm !== "rw")
+        return new Response(`invalid perm ${perm} (want r or rw)`, { status: 400 });
       try {
         const { createScopedShare } = await import("./agentShare.ts");
         const share = await createScopedShare({
           agent: body.agent,
-          perm: body.perm ?? "r",
+          perm,
           localFetch: apiFetch,
           apiToken: token,
         });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1118,6 +1118,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
         const oscTitleRe = /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
         let title: string | null = null;
         for (let m; (m = oscTitleRe.exec(text)); ) if (m[1]!.trim()) title = m[1]!.trim();
+        // Defense-in-depth: this title is remote-controlled text (an agent sets its
+        // own terminal title) that the web console renders. The console escapes it,
+        // but strip C0/C1 control bytes and cap the length at the SOURCE too, so a
+        // hostile title can't smuggle control characters into any current/future
+        // sink. Quotes are left intact (legitimate titles contain them) and handled
+        // by the console's HTML escaper.
+        if (title) {
+          // eslint-disable-next-line no-control-regex
+          title = title.replace(/[\x00-\x1f\x7f-\x9f]/g, "").slice(0, 256).trim() || null;
+        }
         titleCache.set(logFile, { size, mtimeMs, title });
         return title;
       } finally {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2390,10 +2390,31 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // (the page holds no secrets); the page carries the token via the #k= link
   // and sends it on every /api call.
   const uiDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "lab", "ui");
+  // Defense-in-depth CSP for the console document served by --http (mirrors the
+  // one in lab/ui/cf/worker.ts — keep them in sync). The console renders remote
+  // host-supplied agent metadata, so we constrain where an injection could send
+  // data even though output is escaped. connect-src allows any wss: so custom
+  // signaling hosts still work; 'self' covers same-origin /api + EventSource.
+  const CONSOLE_CSP = [
+    "default-src 'self'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+    "connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:",
+    "worker-src 'self'",
+    "manifest-src 'self'",
+  ].join("; ");
   const serveUiFile = async (name: string, type: string): Promise<Response> => {
     try {
       const buf = await readFile(path.join(uiDir, name));
-      return new Response(buf, { headers: { "Content-Type": type } });
+      const headers: Record<string, string> = { "Content-Type": type };
+      if (type.includes("text/html")) headers["Content-Security-Policy"] = CONSOLE_CSP;
+      return new Response(buf, { headers });
     } catch {
       return new Response("UI assets not found in this install — use the /api endpoints", {
         status: 404,

--- a/ts/share.ts
+++ b/ts/share.ts
@@ -146,7 +146,7 @@ export async function loadOrCreateShareRoom(sighost = DEFAULT_SIGHOST): Promise<
   } catch {
     /* not yet minted */
   }
-  const room = "r" + randomBytes(3).toString("hex");
+  const room = "r" + randomBytes(6).toString("hex");
   const s = randomBytes(32).toString("hex");
   const url = `webrtc://${room}:${MARKER}${s}@${sighost}`;
   await mkdir(path.dirname(shareRoomPath()), { recursive: true });
@@ -284,7 +284,7 @@ export async function startShare(
   const initial = opts.url
     ? parseShareUrl(opts.url)
     : {
-        room: "r" + randomBytes(3).toString("hex"),
+        room: "r" + randomBytes(6).toString("hex"),
         token: `${MARKER}${randomBytes(32).toString("hex")}`,
         host: sighost,
       };
@@ -322,7 +322,7 @@ export async function startShare(
   const rotate = async (): Promise<boolean> => {
     if (!opts.onRotate || closed || rotateCount >= 5) return false;
     rotateCount++;
-    room = "r" + randomBytes(3).toString("hex");
+    room = "r" + randomBytes(6).toString("hex");
     token = `${MARKER}${randomBytes(32).toString("hex")}`;
     S = parseSecret(token).s;
     authToken = await deriveAuthToken(S, room, host);

--- a/ts/share.ts
+++ b/ts/share.ts
@@ -77,6 +77,13 @@ const STUN: IceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
 // TURN) to enable; without them we use STUN only, exactly as before. Cached
 // until just before expiry; STUN-only fallback on any error so sharing never
 // breaks because TURN is misconfigured or unreachable.
+//
+// Exposure note: these short-lived (1h) relay credentials are handed to every
+// browser peer that joins a room (they ride in the offer, see startPeer), so any
+// holder of a valid share link can use them to relay for the credential's
+// lifetime. That is acceptable — joining a room already requires the share
+// secret — but it means a share link also grants ~1h of Cloudflare TURN relay
+// capacity. Keep the TTL short; do not widen it.
 let iceCache: { servers: IceServer[]; exp: number } | null = null;
 async function getIceServers(): Promise<IceServer[]> {
   const keyId = process.env.CF_TURN_KEY_ID;


### PR DESCRIPTION
Ships the read-write (steer) single-agent share, plus a security review of the whole sharing system with fixes.

## Security fixes (from a full review of the share stack)

1. **fix: escape quotes in `esc()` — closes an attribute-context XSS (critical).**
   `esc()` escaped only `& < >`, but is interpolated into double-quoted HTML attributes (`title="${esc(e.title)}"`, prompt/question/cwd tooltips, `data-key`). Those fields come from the **remote host a share link points at**: `e.title` is the agent's OSC terminal title (capture allowed `"`), prompt/cwd are host-controlled. A hostile host could title an agent `" autofocus tabindex=1 onfocus="…"` — no `<`/`>` needed — to break out and run script at the agent-yes.com origin, exfiltrating the viewer's saved room tokens (`ay.rooms` = master fleet keys for their **other** machines). Exploitable even from a view-only share. Now escapes `"` and `'` too.

2. **feat: Content-Security-Policy on the console document** (both the CF worker and `ay serve --http`). Defense-in-depth: blocks arbitrary fetch/beacon exfil, plugins, `<base>` hijack, clickjacking, and form exfil, while keeping the inline app + xterm CDN + `wss:` signaling working.

3. **fix: strip C0/C1 control bytes from remote OSC terminal titles** at the source, in addition to escaping.

4. **fix: widen share-room name entropy 24→48 bits** to remove the TOFU room-squatting/collision surface. Backward compatible.

5. **docs: document TURN relay-credential exposure** to room peers (a share link also grants ~1h of relay capacity).

The rw-share warning copy was reviewed and is already correctly blunt ("can type into this agent … control of your whole system"), so no change there.

## Verification
- 49 share/e2e-crypto/agentShare unit tests pass; TS build + oxlint clean (0 errors).
- Browser-verified under `ay serve --http`: an agent titled `" autofocus onfocus=…` renders **inert** (no script exec, `&quot;` in the attribute), the console renders, xterm loads, the list streams over same-origin SSE, and there are **no CSP violations**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)