### PR TITLE
fix(share): apply console CSP via _headers on Cloudflare Static Assets

### DIFF
--- a/lab/ui/cf/_headers
+++ b/lab/ui/cf/_headers
@@ -1,0 +1,12 @@
+# Cloudflare Static Assets serves files directly, BEFORE the Worker runs, so the
+# Content-Security-Policy the Worker sets (worker.ts) never reaches the static
+# console document. This _headers file is the mechanism that actually applies the
+# CSP to the served assets (agent-yes.com/ and the console at /w/). Keep it in
+# sync with the CSP in lab/ui/cf/worker.ts and ts/serve.ts (serveUiFile).
+#
+# Applied to every path: CSP is only enforced by browsers on document (and worker)
+# responses, so setting it on JS/SVG/manifest is inert. sw.js only fetches
+# same-origin /w/ assets (see sw.js), which 'self' allows, so the service worker
+# keeps working.
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; worker-src 'self'; manifest-src 'self'

--- a/lab/ui/cf/wrangler.jsonc
+++ b/lab/ui/cf/wrangler.jsonc
@@ -19,7 +19,10 @@
     // ./public/blog/ (served at /blog/ — linked from the landing nav), and the
     // install scripts to ./public/ (agent-yes.com/setup.sh | setup.ps1). A glob
     // (../*.js) avoids silently breaking when the UI gains a new import.
-    "command": "mkdir -p ./public/w && cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/ && cp ../landing.html ./public/index.html && cp ../architecture.html ./public/architecture.html && rm -rf ./public/blog && cp -R ../blog ./public/blog && cp ../setup.sh ../setup.ps1 ./public/",
+    // The _headers file (copied to ./public/_headers) applies the console CSP to
+    // the STATIC assets — Cloudflare serves them before the Worker, so worker.ts's
+    // CSP never reaches the document; _headers is the mechanism that does.
+    "command": "mkdir -p ./public/w && cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/ && cp ../landing.html ./public/index.html && cp ../architecture.html ./public/architecture.html && rm -rf ./public/blog && cp -R ../blog ./public/blog && cp ../setup.sh ../setup.ps1 ./public/ && cp _headers ./public/_headers",
   },
   // Static console UI (served for every non-WebSocket request).
   "assets": { "directory": "./public", "binding": "ASSETS" },


### PR DESCRIPTION
Follow-up to #203. The CSP added to `worker.ts` never reached agent-yes.com: Cloudflare Static Assets serves `index.html` (and the console at `/w/`) **directly, before the Worker runs** — verified live, the document response carried neither the CSP nor the Worker's `no-cache` header. This adds a `_headers` file (copied into the assets root by the wrangler build) so the CSP actually lands on the served static documents. `worker.ts` keeps its CSP for the Worker-served fallback/404 path; `ts/serve.ts` still covers `ay serve --http`.

`sw.js` only fetches same-origin `/w/` assets, so the broad rule is safe for the service worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)