### PR TITLE
fix(share): allow xterm CSS from jsdelivr in console CSP (fixes blank terminal)

### DIFF
--- a/lab/ui/cf/_headers
+++ b/lab/ui/cf/_headers
@@ -9,4 +9,4 @@
 # same-origin /w/ assets (see sw.js), which 'self' allows, so the service worker
 # keeps working.
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; worker-src 'self'; manifest-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; worker-src 'self'; manifest-src 'self'

--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -44,7 +44,7 @@ const CSP = [
   "form-action 'self'",
   "img-src 'self' data:",
   "font-src 'self' data:",
-  "style-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
   "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
   "connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:",
   "worker-src 'self'",

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2413,7 +2413,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
     "form-action 'self'",
     "img-src 'self' data:",
     "font-src 'self' data:",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
     "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
     "connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:",
     "worker-src 'self'",


### PR DESCRIPTION
Hotfix. The CSP style-src omitted https://cdn.jsdelivr.net, so the browser blocked xterm's stylesheet (`<link rel=stylesheet>` in index.html). Result: the terminal screen didn't render and the hidden `.xterm-helper-textarea` showed as a stray input box. Adds jsdelivr to style-src in all three CSP copies. Verified live with rechrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)