### PR TITLE
feat(cli): bash/cmd/powershell as interactive shell CLIs

### DIFF
--- a/agent-yes.config.schema.json
+++ b/agent-yes.config.schema.json
@@ -131,8 +131,8 @@
         },
         "promptArg": {
           "type": "string",
-          "description": "How to pass the prompt: 'first-arg', 'last-arg', or a flag like '--prompt'",
-          "examples": ["first-arg", "last-arg", "--prompt", "-p"]
+          "description": "How to pass the prompt: 'first-arg', 'last-arg', a flag like '--prompt', or 'typed' to type it into an interactive session after the prompt is ready (shells)",
+          "examples": ["first-arg", "last-arg", "--prompt", "-p", "typed"]
         },
         "noEOL": {
           "type": "boolean",

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -479,3 +479,48 @@ clis:
       npm: "npm i -g opencode-ai"
     enter: []
     ready: []
+
+  # Bare interactive shells. Unlike the agent CLIs above, these aren't AI tools
+  # — they're a plain login shell you can drive from the console and launch
+  # other agents inside (e.g. `ay bash 'claude'`). `promptArg: typed` means any
+  # initial command is TYPED into the shell after its prompt is ready (see the
+  # run loop), rather than passed as an argv — so `bash -c` never runs-and-exits
+  # and the session stays interactive. No `working`/`enter` markers: a shell has
+  # no spinner and no auto-acceptable menus. The `ready` regex anchors on the
+  # prompt suffix so the typed command lands at the prompt instead of waiting on
+  # the force-ready fallback; with no match it still force-readies after 10s.
+  bash:
+    promptArg: typed
+    ready:
+      - pattern: '[$#] $'
+        flags: m
+    working: []
+    enter: []
+    fatal: []
+    exitCommands:
+      - exit
+
+  # Windows only (cmd.exe is absent on macOS/Linux, so `ay cmd` there just
+  # reports command-not-found). Prompt looks like `C:\Users\me>`.
+  cmd:
+    promptArg: typed
+    ready:
+      - pattern: '^[A-Za-z]:\\.*>'
+        flags: m
+    working: []
+    enter: []
+    fatal: []
+    exitCommands:
+      - exit
+
+  # Windows only (Windows PowerShell 5.1). Prompt looks like `PS C:\Users\me>`.
+  powershell:
+    promptArg: typed
+    ready:
+      - pattern: '^PS .*>'
+        flags: m
+    working: []
+    enter: []
+    fatal: []
+    exitCommands:
+      - exit

--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
     "openrouter-yes": "./dist/openrouter-yes.js",
     "orcy": "./dist/orcy.js",
     "pi-yes": "./dist/pi-yes.js",
-    "qwen-yes": "./dist/qwen-yes.js"
+    "qwen-yes": "./dist/qwen-yes.js",
+    "bash-yes": "./dist/bash-yes.js",
+    "cmd-yes": "./dist/cmd-yes.js",
+    "powershell-yes": "./dist/powershell-yes.js"
   },
   "directories": {
     "doc": "docs"

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -161,6 +161,9 @@ pub const SUPPORTED_CLIS: &[&str] = &[
     "auggie",
     "amp",
     "opencode",
+    "bash",
+    "cmd",
+    "powershell",
 ];
 
 // Most fields here are read elsewhere in the binary; the ones that aren't
@@ -701,7 +704,7 @@ mod tests {
 
     #[test]
     fn test_supported_clis_count() {
-        assert_eq!(SUPPORTED_CLIS.len(), 13);
+        assert_eq!(SUPPORTED_CLIS.len(), 16);
         // The claude-compatible providers (run the `claude` binary via env) must
         // be present, else their `*-yes` bins fail validation in the Rust runtime.
         for cli in ["glm", "openrouter", "pi"] {

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -249,6 +249,12 @@ pub struct AgentContext {
     poke_unresponsive: bool,
     watchdog_stalled: bool,
     unresponsive: bool,
+
+    // Shell "typed" prompt (promptArg: typed — bash/cmd/powershell). When set,
+    // this command is typed into the interactive session once the shell prompt
+    // is first ready, then the session stays live. None for every other CLI
+    // (they receive the prompt via argv instead). See run_with_fifo.
+    initial_input: Option<String>,
 }
 
 impl AgentContext {
@@ -263,6 +269,7 @@ impl AgentContext {
         term_rows: u16,
         term_cols: u16,
         render_plain: bool,
+        initial_input: Option<String>,
     ) -> Self {
         Self {
             cli,
@@ -308,6 +315,7 @@ impl AgentContext {
             poke_unresponsive: false,
             watchdog_stalled: false,
             unresponsive: false,
+            initial_input,
         }
     }
 
@@ -377,6 +385,27 @@ impl AgentContext {
         fifo_path: Option<std::path::PathBuf>,
     ) -> Result<i32> {
         let writer = pty.get_writer();
+
+        // Shell "typed" prompt: once the shell prompt is first ready, type the
+        // initial command and leave the session interactive. This is how
+        // bash/cmd/powershell (promptArg: typed) receive an initial command
+        // without `-c`'s run-and-exit, so you can e.g. `ay bash 'claude'` and
+        // then keep launching things inside the same shell. Runs in its own
+        // task so it never blocks the main loop; writes exactly once.
+        if let Some(input) = self.initial_input.clone() {
+            let writer = writer.clone();
+            let mut first_ready = self.stdin_first_ready.clone();
+            tokio::spawn(async move {
+                first_ready.wait().await;
+                // Small settle so the command lands at the prompt, not mid-banner.
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                if let Ok(mut w) = writer.lock() {
+                    let _ = w.write_all(input.as_bytes());
+                    let _ = w.write_all(b"\r");
+                    let _ = w.flush();
+                }
+            });
+        }
 
         // Create message context
         let mut msg_ctx = MessageContext::new(

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -151,7 +151,12 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
     // Build command arguments
     let mut cmd_args = args.cli_args.clone();
 
-    // Add prompt based on promptArg configuration
+    // Add prompt based on promptArg configuration.
+    //
+    // "typed" is the shell mode (bash/cmd/powershell): the prompt is NOT passed
+    // as an argv (that would run-and-exit, e.g. `bash -c`), it is typed into the
+    // interactive session after the shell prompt is ready — see `initial_input`
+    // below and its consumer in AgentContext::run_with_fifo.
     if let Some(ref prompt) = args.prompt {
         match cli_config.prompt_arg.as_str() {
             "first-arg" => {
@@ -160,6 +165,7 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
             "last-arg" => {
                 cmd_args.push(prompt.clone());
             }
+            "typed" => {}
             flag if flag.starts_with("--") || flag.starts_with("-") => {
                 cmd_args.push(flag.to_string());
                 cmd_args.push(prompt.clone());
@@ -167,6 +173,14 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
             _ => {}
         }
     }
+
+    // For "typed" (shell) CLIs, carry the prompt into the run loop so it is typed
+    // into the live session once ready; every other mode delivered it via argv.
+    let initial_input = if cli_config.prompt_arg == "typed" {
+        args.prompt.clone()
+    } else {
+        None
+    };
 
     // Add default args
     cmd_args.extend(cli_config.default_args.iter().cloned());
@@ -259,6 +273,7 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
             term_rows,
             term_cols,
             render_plain,
+            initial_input.clone(),
         );
 
         // Create per-pid FIFO for `cy send <keyword> <msg>`. Best-effort —

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -65,7 +65,7 @@ export type AgentCliConfig = {
   working?: RegExp[]; // regex matcher for working status
   updateAvailable?: RegExp[]; // regex matcher for update available banners
   exitCommands?: string[]; // commands to exit the cli gracefully
-  promptArg?: (string & {}) | "first-arg" | "last-arg"; // argument name to pass the prompt, e.g. --prompt, or first-arg for positional arg
+  promptArg?: (string & {}) | "first-arg" | "last-arg" | "typed"; // argument name to pass the prompt, e.g. --prompt, first-arg for positional arg, or "typed" to type it into an interactive session after ready (shells)
 
   // handle special format
   noEOL?: boolean; // if true, do not split lines by \n when handling inputs, e.g. for codex, which uses cursor-move csi code instead of \n to move lines
@@ -361,6 +361,10 @@ export default async function agentYes({
     } else if (cliConf.promptArg.startsWith("--")) {
       cliArgs = [cliConf.promptArg, prompt, ...cliArgs];
       prompt = undefined; // clear prompt to avoid sending later
+    } else if (cliConf.promptArg === "typed") {
+      // Shell mode (bash/cmd/powershell): don't pass an argv (that would
+      // run-and-exit). Leave `prompt` set so it's typed into the interactive
+      // session at onStart, keeping the shell alive afterwards.
     } else {
       logger.warn(`Unknown promptArg format: ${cliConf.promptArg}`);
     }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -3189,12 +3189,18 @@ export function stopTipForCli(cli: string, pid: number): string | null {
 ///   claude   — `/exit`
 ///   codex    — `/exit`
 ///   gemini   — `/quit`
+///   bash/cmd/powershell — `exit` (the shell builtin; closes the session at a
+///     bare prompt, far cleaner than Ctrl+C which would instead hit whatever
+///     app is running in the foreground).
 /// Other CLIs aren't in the table because their reliable graceful-exit
 /// command isn't well-known here; `ay stop` falls back to double Ctrl+C.
 export const GRACEFUL_EXIT_COMMANDS: Record<string, string> = {
   claude: "/exit",
   codex: "/exit",
   gemini: "/quit",
+  bash: "exit",
+  cmd: "exit",
+  powershell: "exit",
 };
 
 export function controlCodeFromName(name: string): string {


### PR DESCRIPTION
## What

Add bare shells — **bash**, plus Windows **cmd** / **powershell** — as first-class agent-yes CLIs. `ay bash` opens a plain interactive login shell you can drive from the console (`ay send`/`ay tail`) and **launch other agents inside** (`ay bash 'claude'`), all tracked in the subagent tree.

## How

New **`promptArg: "typed"`** mode. For a shell, argv delivery would mean `bash -c "<cmd>"` — which runs-and-exits, killing the session. Instead, `typed` carries the initial command into the run loop and **types it into the live session once the prompt is ready**, then leaves the shell interactive.

- `default.config.yaml`: `bash` / `cmd` / `powershell` entries — `promptArg: typed`, prompt-suffix `ready` markers, empty `working`/`enter` (a shell has no spinner and no auto-acceptable menus). cmd/powershell are Windows-only (their binaries are absent elsewhere, so `ay cmd` on macOS/Linux just reports command-not-found).
- Rust: added to `SUPPORTED_CLIS` (+ count test); new `"typed"` arm in `main.rs`; `AgentContext` types `initial_input` after `stdin_first_ready` fires, in its own task, writing exactly once.
- TS runtime: `"typed"` leaves `prompt` set so it's typed at `onStart`.
- Config schema + auto-generated `bash-yes`/`cmd-yes`/`powershell-yes` bin shims.

## Verified

- Full Rust suite (263 tests) green, including the `SUPPORTED_CLIS` count + config-existence checks.
- End-to-end with the built release binary: `ay bash 'echo …'` → `ay ls` shows a `bash` agent nested under its parent, `ay tail` shows the typed command ran and the shell **stayed at a live prompt**, and a follow-up `ay send` command also ran. Ready detection fires on the prompt (not the 10s force-ready fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)