### PR TITLE
feat(console): one source per machine — choose the peer to spawn on

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2215,6 +2215,7 @@
           this.room = window.__codehost.joinRoom({
             token: this.token,
             onStatus: (open) => {
+              if (this.orphaned()) return;
               this.live = open;
               // Keep the machines listed while the socket retries — room-client
               // self-heals, and dropping the rows would flicker the whole tree.
@@ -2229,6 +2230,7 @@
               renderRoomsIfOpen();
             },
             onPeers: (peers) => {
+              if (this.orphaned()) return;
               this.live = true;
               this.syncPeers(peers);
               firstPeers();
@@ -2241,10 +2243,18 @@
         close() {
           this.room?.close();
         }
+        // True once the room has been forgotten (removeRoom drops it from chRooms)
+        // or superseded by a re-add under the same name. joinRoom's callbacks can
+        // fire a queued peer broadcast AFTER that, and without this guard syncPeers
+        // would `sources.set` the machines back for a room the user just forgot.
+        orphaned() {
+          return chRooms.get(this.name) !== this;
+        }
         // Reconcile the fleet against the room's current server peers. Called on
         // every peer broadcast — including the frequent ones that only carry new
         // agent meta — so it must stay cheap when the peer SET hasn't changed.
         syncPeers(peers) {
+          if (this.orphaned()) return;
           const hosts = (peers || []).filter(isHostPeer);
           const seen = new Set();
           let changed = false;
@@ -3899,9 +3909,12 @@
         } catch {}
       }
 
-      // Match a stored/linked selection token against an entry: either the full
-      // composite key (room#pid) or a bare pid (?pid= deep links, legacy ay.sel).
-      const matchSel = (e, token) => e._key === token || String(e.pid) === String(token);
+      // Match a stored/linked selection token against an entry: the full composite
+      // key (`ay.sel` stores it verbatim), the `<room>#<pid>` deep-link form (the
+      // hash never names a machine — see the deep-link writer — so it resolves to
+      // whichever machine in the room owns that pid), or a bare pid (?pid= links).
+      const matchSel = (e, token) =>
+        e._key === token || e._room + "#" + e.pid === token || String(e.pid) === String(token);
 
       // Reconcile poll: refresh only the sources that aren't streaming (older
       // hosts, or ones whose stream hasn't delivered its first snapshot yet) and
@@ -5518,7 +5531,7 @@
         if (!m) return;
         const [, room, pid] = m;
         const key = room + "#" + pid;
-        const e = entries.find((x) => x._key === key);
+        const e = entries.find((x) => matchSel(x, key));
         if (e) {
           if (sel !== e._key) select(e._key);
           return;

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3271,7 +3271,17 @@
         // DELETE over the transport of the exact MACHINE that minted the share.
         // Keying by source id, not room, matters for a codehost room with several
         // machines — routing by room would revoke against the wrong host.
-        const tx = sources.get(currentShare.srcId)?.tx || localTx;
+        const src = sources.get(currentShare.srcId);
+        // Only fall back to localTx for a LOCAL share. If a remote machine's source
+        // has dropped (room/peer gone while the modal sat open), sending the DELETE
+        // to localhost would 404 yet still close the modal — the operator would
+        // think the share was killed while it stays live on the (now unreachable)
+        // host. Say so and keep the modal open instead.
+        const tx = src?.tx || (currentShare.srcId === LOCAL ? localTx : null);
+        if (!tx) {
+          alert("Can't revoke: the machine that owns this share is no longer connected.");
+          return;
+        }
         try {
           await tx.del("/api/share/" + encodeURIComponent(currentShare.shareId));
         } catch {}

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -789,6 +789,7 @@
         margin-bottom: 4px;
       }
       .lcard .nfield input,
+      .lcard .nfield select,
       .lcard .nfield textarea {
         width: 100%;
         background: var(--bg);
@@ -801,6 +802,7 @@
         resize: vertical;
       }
       .lcard .nfield input:focus,
+      .lcard .nfield select:focus,
       .lcard .nfield textarea:focus {
         border-color: var(--accent);
       }
@@ -2092,14 +2094,118 @@
       // A codehost room can hold several machines: every `codehost serve`
       // daemon advertises its live agents (PeerMeta.agents) and proxies the
       // local ay-serve API over its WebRTC tunnel at /__codehost/agent-yes/*.
-      // This wire aggregates all hosts' agents into one list, then routes each
-      // per-agent call to the host that owns the pid. Known v1 limitation:
-      // pids may collide across hosts (last listed wins); the host: tag keeps
-      // them tellable-apart visually.
+      //
+      // Every machine in the room is its own fleet source, id "<room>/<peerId>",
+      // sharing the room's one signaling/WebRTC connection. A source is therefore
+      // always exactly one machine — the invariant the rest of the console already
+      // assumes (`local` and each ay-share room are one machine too). v1 instead
+      // hid N machines behind one transport and picked a peer per request, which
+      // silently pinned `/api/spawn` and `/api/ls/subscribe` to whichever host was
+      // listed first, and let equal pids on two machines overwrite each other.
       const CH_API = "/__codehost/agent-yes";
-      class CodehostClient {
-        constructor(token) {
-          Object.assign(this, { token, room: null, byPid: new Map(), onstate: () => {} });
+
+      // Machines that can answer for agents: anything advertising agents, plus
+      // root daemons (their ay serve may know agents the broadcast hasn't picked
+      // up yet, and an idle root is still a valid spawn target).
+      const isHostPeer = (p) =>
+        !!p?.meta && ((p.meta.agents || []).length > 0 || p.meta.kind === "root");
+
+      // One codehost machine behind the standard transport shape. Every call is
+      // pinned to `peerId`, so a source built on this tx can never leak a request
+      // to a sibling machine in the same room. Both the room handle and the peer's
+      // meta are read at call time, never captured: the handle isn't assigned yet
+      // if the first peer broadcast lands during joinRoom, and the meta goes stale
+      // on every rebroadcast.
+      function chPeerTx(chRoom, peerId, getMeta) {
+        const req = (method, path, init) =>
+          chRoom.room.fetch(peerId, method, CH_API + path, init);
+        const ok = (res) => res.status >= 200 && res.status < 300;
+        // The daemon is in the room but its `ay serve` may be down. It still
+        // advertises the agents it knows, so degrade to that list rather than
+        // dropping the machine out of the fleet entirely.
+        const advertised = () =>
+          (getMeta()?.agents || []).map((a) => ({
+            pid: a.pid,
+            cli: a.tool,
+            title: a.title || null,
+            prompt: a.title || null,
+            cwd: a.cwd,
+            status: a.state,
+            started_at: a.startedAt,
+          }));
+        return {
+          async fetchJSON(path) {
+            let res;
+            try {
+              res = await req("GET", path);
+              if (!ok(res)) throw new Error("HTTP " + res.status);
+            } catch (err) {
+              if (path.startsWith("/api/ls")) return advertised();
+              throw err;
+            }
+            return res.json();
+          },
+          async fetchText(path) {
+            const res = await req("GET", path);
+            if (!ok(res)) throw new Error("HTTP " + res.status);
+            return res.text();
+          },
+          async post(path, bodyObj) {
+            const res = await req("POST", path, {
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify(bodyObj),
+            });
+            return { ok: ok(res), text: await res.text() };
+          },
+          subscribe(path, onText, onOpen, onError) {
+            let cancelled = false;
+            let reader = null;
+            (async () => {
+              try {
+                const res = await req("GET", path, { headers: { accept: "text/event-stream" } });
+                if (!ok(res) || !res.body) throw new Error("HTTP " + res.status);
+                onOpen && onOpen();
+                reader = res.body.getReader();
+                const dec = new TextDecoder();
+                let buf = "";
+                for (;;) {
+                  const { done, value } = await reader.read();
+                  if (done || cancelled) break;
+                  buf += dec.decode(value, { stream: true });
+                  let i;
+                  while ((i = buf.indexOf("\n\n")) >= 0) {
+                    const evt = buf.slice(0, i);
+                    buf = buf.slice(i + 2);
+                    for (const line of evt.split("\n"))
+                      if (line.startsWith("data:")) {
+                        try {
+                          onText(JSON.parse(line.slice(5).trim()));
+                        } catch {}
+                      }
+                  }
+                }
+                if (!cancelled) onError && onError();
+              } catch {
+                if (!cancelled) onError && onError();
+              }
+            })();
+            return () => {
+              cancelled = true;
+              try {
+                reader?.cancel();
+              } catch {}
+            };
+          },
+        };
+      }
+
+      // A joined codehost room. It owns the connection and keeps the fleet in sync
+      // with the room's server peers: a source appears when a machine joins and is
+      // dropped when it leaves. The room itself is never a source — only machines are.
+      class CodehostRoom {
+        constructor(name, token) {
+          Object.assign(this, { name, token, room: null, live: false, tried: false });
+          this.peers = new Map(); // peerId -> latest peer broadcast (meta included)
         }
         async connect() {
           if (!window.__codehost)
@@ -2109,10 +2215,22 @@
           this.room = window.__codehost.joinRoom({
             token: this.token,
             onStatus: (open) => {
-              if (!open) this.onstate("closed");
+              this.live = open;
+              // Keep the machines listed while the socket retries — room-client
+              // self-heals, and dropping the rows would flicker the whole tree.
+              // Drop their streams though: a stream that never errors would leave
+              // `streaming` set, the reconcile poll would skip the machine, and it
+              // would sit offline forever. syncPeers re-arms them on reconnect.
+              if (!open)
+                for (const s of roomSources(this.name)) {
+                  s.live = false;
+                  unsubscribeSource(s);
+                }
+              renderRoomsIfOpen();
             },
-            onPeers: () => {
-              this.onstate("open");
+            onPeers: (peers) => {
+              this.live = true;
+              this.syncPeers(peers);
               firstPeers();
             },
           });
@@ -2123,122 +2241,51 @@
         close() {
           this.room?.close();
         }
-        hosts() {
-          // Machines that can answer for agents: anything advertising agents,
-          // plus root daemons (their ay serve may know agents the broadcast
-          // hasn't picked up yet).
-          return (this.room?.peers || []).filter(
-            (p) => p.meta && ((p.meta.agents || []).length || p.meta.kind === "root"),
-          );
-        }
-        anyHost() {
-          const h = this.hosts();
-          return h.length ? h[0].peerId : null;
-        }
-        peerFor(path) {
-          const m = /^\/api\/(?:tail|size|resize|read|status)\/([^/?]+)/.exec(path);
-          const kw = m ? decodeURIComponent(m[1]) : null;
-          return (kw && this.byPid.get(kw)) || null;
-        }
-        async ls(path) {
-          const hosts = this.hosts();
-          const lists = await Promise.all(
-            hosts.map(async (p) => {
-              try {
-                const res = await this.room.fetch(p.peerId, "GET", CH_API + path);
-                if (!res.ok) throw new Error("HTTP " + res.status);
-                return (await res.json()).map((e) => ({ ...e, _host: p.meta?.host }));
-              } catch {
-                // ay serve down on that host — fall back to the daemon-advertised list.
-                return (p.meta?.agents || []).map((a) => ({
-                  pid: a.pid,
-                  cli: a.tool,
-                  title: a.title || null,
-                  prompt: a.title || null,
-                  cwd: a.cwd,
-                  status: a.state,
-                  started_at: a.startedAt,
-                  _host: p.meta?.host,
-                }));
-              }
-            }),
-          );
-          const byPid = new Map();
-          const merged = [];
-          lists.forEach((arr, i) => {
-            for (const e of arr) {
-              byPid.set(String(e.pid), hosts[i].peerId);
-              merged.push(e);
+        // Reconcile the fleet against the room's current server peers. Called on
+        // every peer broadcast — including the frequent ones that only carry new
+        // agent meta — so it must stay cheap when the peer SET hasn't changed.
+        syncPeers(peers) {
+          const hosts = (peers || []).filter(isHostPeer);
+          const seen = new Set();
+          let changed = false;
+          for (const p of hosts) {
+            seen.add(p.peerId);
+            this.peers.set(p.peerId, p);
+            const id = this.name + "/" + p.peerId;
+            let s = sources.get(id);
+            if (!s) {
+              s = {
+                id,
+                room: this.name,
+                peerId: p.peerId,
+                host: CH_HOST,
+                kind: "ch",
+                chRoom: this,
+                tx: chPeerTx(this, p.peerId, () => this.peers.get(p.peerId)?.meta),
+                client: null,
+                live: false,
+                tried: false,
+                devices: new Set(),
+                serverCount: 0,
+              };
+              sources.set(id, s);
+              changed = true;
             }
-          });
-          this.byPid = byPid;
-          return merged;
-        }
-        async fetchJSON(path) {
-          if (path.startsWith("/api/ls")) return this.ls(path);
-          const peer = this.peerFor(path) || this.anyHost();
-          if (!peer) throw new Error("no codehost peer");
-          const res = await this.room.fetch(peer, "GET", CH_API + path);
-          if (!res.ok) throw new Error("HTTP " + res.status);
-          return res.json();
-        }
-        async post(path, bodyObj) {
-          const kw = bodyObj && bodyObj.keyword != null ? String(bodyObj.keyword) : null;
-          const peer = (kw && this.byPid.get(kw)) || this.peerFor(path) || this.anyHost();
-          if (!peer) return { ok: false, text: "no codehost peer in the room" };
-          const res = await this.room.fetch(peer, "POST", CH_API + path, {
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify(bodyObj),
-          });
-          return { ok: res.status >= 200 && res.status < 300, text: await res.text() };
-        }
-        subscribe(path, onText, onOpen, onError) {
-          let cancelled = false;
-          let reader = null;
-          (async () => {
-            const peer = this.peerFor(path) || this.anyHost();
-            if (!peer) {
-              onError && onError();
-              return;
-            }
-            try {
-              const res = await this.room.fetch(peer, "GET", CH_API + path, {
-                headers: { accept: "text/event-stream" },
-              });
-              if (!res.ok || !res.body) throw new Error("HTTP " + res.status);
-              onOpen && onOpen();
-              reader = res.body.getReader();
-              const dec = new TextDecoder();
-              let buf = "";
-              for (;;) {
-                const { done, value } = await reader.read();
-                if (done || cancelled) break;
-                buf += dec.decode(value, { stream: true });
-                let i;
-                while ((i = buf.indexOf("\n\n")) >= 0) {
-                  const evt = buf.slice(0, i);
-                  buf = buf.slice(i + 2);
-                  for (const line of evt.split("\n"))
-                    if (line.startsWith("data:")) {
-                      try {
-                        onText(JSON.parse(line.slice(5).trim()));
-                      } catch {}
-                    }
-                }
-              }
-              if (!cancelled) onError && onError();
-            } catch {
-              if (!cancelled) onError && onError();
-            }
-          })();
-          return () => {
-            cancelled = true;
-            try {
-              reader?.cancel();
-            } catch {}
-          };
+            s.deviceLabel = p.meta?.host || "";
+            subscribeSource(s); // no-op while already streaming; re-arms after a drop
+          }
+          for (const peerId of [...this.peers.keys()]) {
+            if (seen.has(peerId)) continue;
+            this.peers.delete(peerId);
+            removeSource(this.name + "/" + peerId);
+            changed = true;
+          }
+          renderRoomsIfOpen();
+          if (changed) loadList(); // poll the newcomers until their stream opens
+          else mergeRender();
         }
       }
+      const chRooms = new Map(); // room name -> CodehostRoom
 
       // `ay serve --http` serves this page itself and prints a #k=<token> link;
       // boot() stores the token and local /api calls carry it as ?token= (query,
@@ -2253,7 +2300,7 @@
 
       // ---- transports: a uniform { fetchJSON, post, subscribe } over each wire ----
       // local (same-origin ay serve), an ay-share RTCClient, or a codehost room.
-      // CodehostClient already exposes this shape, so it's used as a tx directly.
+      // A codehost room builds one of these per machine in it (see chPeerTx).
       const localTx = {
         async fetchJSON(path) {
           return (await fetch(withTok(path))).json();
@@ -2311,13 +2358,27 @@
       }
 
       // ---- fleet: local + every saved room, all connected at once ------------
-      // Each source contributes its agents to one merged list (tagged with the
-      // owning source on `_room`/`_key`); per-agent ops route back via srcFor/txFor.
+      // A source is ONE machine. Each contributes its agents to one merged list,
+      // tagged with the owning source on `_src` (routing: srcFor/txFor) and with
+      // the room it belongs to on `_room` (display: the tree's room grouping).
+      // Those differ only for codehost rooms, where one room holds many machines.
       // Live counts in the rooms panel come from each source's serverCount/devices.
       const LOCAL = "local";
-      const sources = new Map(); // id -> { id, host, kind, tx, client, live, devices, serverCount }
-      const srcFor = (e) => (e && sources.get(e._room)) || sources.get(LOCAL) || null;
+      const sources = new Map(); // id -> { id, room, host, kind, tx, client, live, devices, serverCount }
+      const srcFor = (e) => (e && sources.get(e._src)) || sources.get(LOCAL) || null;
       const txFor = (e) => srcFor(e)?.tx || localTx;
+      // Every machine belonging to a room (for an ay-share room, the room itself).
+      const roomSources = (name) => [...sources.values()].filter((s) => (s.room || s.id) === name);
+      const roomLive = (name) =>
+        chRooms.has(name) ? chRooms.get(name).live : !!sources.get(name)?.live;
+      // How a machine names itself in a picker: "room · user@host", or just the
+      // room when its device label hasn't arrived yet.
+      const sourceLabel = (s) => {
+        if (!s) return "";
+        if (s.id === LOCAL) return "local";
+        const room = s.room || s.id;
+        return s.deviceLabel ? room + " · " + s.deviceLabel : room;
+      };
 
       // ---- connection-path classification (header [local/lan/wan/relay] pill) ----
       // Tells the user, at a glance, whether the terminal they're watching rides the
@@ -2403,33 +2464,23 @@
           return null;
         }
       }
-      // Resolve the live RTCPeerConnection that carries a SPECIFIC agent. A codehost
-      // room holds one peer per host (room.rtcs keyed by peerId); byPid maps the
-      // agent's pid to its peerId, so each agent resolves to ITS host's connection —
+      // Resolve the live RTCPeerConnection that carries a source. A codehost room
+      // holds one peer per machine (room.rtcs keyed by peerId) and a source pins
+      // exactly one of them, so each agent resolves to ITS machine's connection —
       // a VPS agent reads wan while a tak.local agent in the same room reads lan.
-      function pcForAgent(s, e) {
+      function pcForAgent(s) {
         if (!s) return null;
         if (s.kind === "rtc") return s.client?.pc || null; // share room: one host
-        if (s.kind === "ch") {
-          const peerId = s.client?.byPid?.get(String(e?.pid));
-          return (peerId && s.client?.room?.rtcs?.get(peerId)?.pc) || null;
-        }
+        if (s.kind === "ch") return s.chRoom?.room?.rtcs?.get(s.peerId)?.pc || null;
         return null; // local ay-serve has no peer connection
       }
       // Two cache views, both filled from one classification pass:
-      //  - connKinds keyed by the true PEER (room + peerId) drives the header badge,
-      //    so two machines that happen to share a hostname never collide.
+      //  - connKinds keyed by the source, i.e. the true PEER, drives the header
+      //    badge, so two machines that share a hostname never collide.
       //  - hostKinds keyed by (room, host) drives the peer-group header tags, which
       //    only ever render when hosts are already distinct.
       const hostKeyOf = (e) => (e?._room || "") + " " + (e?._host || "");
-      function peerKeyOf(s, e) {
-        if (!s || s.id === LOCAL || s.kind == null) return LOCAL;
-        if (s.kind === "ch") {
-          const peerId = s.client?.byPid?.get(String(e?.pid));
-          return s.id + " " + (peerId || e?._host || "");
-        }
-        return s.id; // rtc share: one peer per room
-      }
+      const peerKeyOf = (s) => (!s || s.id === LOCAL || s.kind == null ? LOCAL : s.id);
       const connKinds = new Map(); // peerKey -> "local" | "lan" | "wan" | "relay"
       const hostKinds = new Map(); // hostKey -> same (peer-header tags)
       const connInfo = new Map(); // peerKey -> full detail for the hover tooltip
@@ -2467,7 +2518,7 @@
         // Probe each distinct peer once (not once per agent), keyed by peerKey.
         const reps = new Map(); // peerKey -> a representative entry for that peer
         for (const e of entries) {
-          const k = peerKeyOf(srcFor(e), e);
+          const k = peerKeyOf(srcFor(e));
           if (!reps.has(k)) reps.set(k, e);
         }
         connKinds.clear();
@@ -2486,7 +2537,7 @@
               }
               return;
             }
-            const info = await inspectConn(pcForAgent(s, e));
+            const info = await inspectConn(pcForAgent(s));
             if (info) {
               connKinds.set(key, info.kind);
               connInfo.set(key, { ...info, signaling: signalingOf(s) });
@@ -2496,7 +2547,7 @@
         // Project peer kinds onto (room,host) keys for the tree's peer headers.
         hostKinds.clear();
         for (const e of entries) {
-          const kind = connKinds.get(peerKeyOf(srcFor(e), e));
+          const kind = connKinds.get(peerKeyOf(srcFor(e)));
           if (kind) hostKinds.set(hostKeyOf(e), kind);
         }
         paintHeaderBadge();
@@ -2519,7 +2570,7 @@
         const badge = $("ctype");
         if (!badge) return;
         const e = sel ? entries.find((x) => x._key === sel) : null;
-        const key = e ? peerKeyOf(srcFor(e), e) : null;
+        const key = e ? peerKeyOf(srcFor(e)) : null;
         const kind = key ? connKinds.get(key) : null;
         if (!kind) {
           badge.hidden = true;
@@ -3524,25 +3575,25 @@
         }
       }
 
-      // Pull one source's agent list, tagging each row with its origin + a
-      // composite key (pids can collide across rooms). Updates the source's live
-      // flag, device set, and server count for the rooms panel.
-      // Stamp a source's raw /api/ls records with their origin + composite key
-      // (pids collide across rooms) and recompute the source's device set + server
-      // count for the rooms panel. Pure transform of the source's current records.
+      // Stamp a source's raw /api/ls records with their machine (`_src`, how every
+      // per-agent op routes back), their room (`_room`, how the tree groups), and a
+      // composite key. `_key` is per-MACHINE, not per-room: two machines in one
+      // codehost room can each run pid 1234, and a room-scoped key would collide.
+      // Recomputes the source's device set + server count for the rooms panel.
+      // Pure transform of the source's current records.
       function stampAgents(s) {
         s.devices = new Set();
+        const room = s.room || s.id;
         const out = [...(s.byPid?.values() || [])].map((e) => {
-          // codehost stamps _host per agent; agent-yes share rooms fall back to
-          // the room's device label (from /api/whoami). Local stays unlabelled
-          // (no deviceLabel) so a single-machine view keeps its clean path-only
-          // identity instead of a blank "@:" prefix.
-          const host = e._host || s.deviceLabel || "";
+          // A source is one machine, so its device label (codehost peer meta, or
+          // /api/whoami on an ay-share room) labels every agent on it. Local stays
+          // unlabelled (no deviceLabel) so a single-machine view keeps its clean
+          // path-only identity instead of a blank "@:" prefix.
+          const host = s.deviceLabel || "";
           if (host) s.devices.add(host);
-          return { ...e, _room: s.id, _key: s.id + "#" + e.pid, _host: host };
+          return { ...e, _src: s.id, _room: room, _key: s.id + "#" + e.pid, _host: host };
         });
-        s.serverCount =
-          s.kind === "ch" ? s.client?.hosts().length || 0 : s.devices.size || (s.live ? 1 : 0);
+        s.serverCount = s.kind === "ch" ? (s.live ? 1 : 0) : s.devices.size || (s.live ? 1 : 0);
         s.agents = out;
       }
 
@@ -3582,6 +3633,10 @@
           // backoff reconnect (no-op if one's already queued or the room's gone).
           if (s.kind === "rtc") scheduleRtcReconnect(s);
           return [];
+        } finally {
+          // A codehost machine has no connect phase of its own — it becomes "tried"
+          // the first time we poll it, so the badge doesn't sit on "connecting…".
+          s.tried = true;
         }
       }
 
@@ -3874,16 +3929,20 @@
         for (const k of advanceStdinFlashes(entries, stdinSeen)) flashUntil.set(k, until);
         // Badge: total agents + how many rooms are live. Red only when nothing
         // at all is reachable (no source answered).
+        // Count ROOMS, not machines — a codehost room with three machines is still
+        // one room, and it can be connecting before any machine has appeared.
         const roomSrcs = srcs.filter((s) => s.id !== LOCAL);
-        const liveRooms = roomSrcs.filter((s) => s.live).length;
+        const liveRooms = new Set(roomSrcs.filter((s) => s.live).map((s) => s.room || s.id)).size;
         const anyLive = srcs.some((s) => s.live);
-        const connecting = roomSrcs.some((s) => !s.tried);
+        const connecting =
+          roomSrcs.some((s) => !s.tried) || [...chRooms.values()].some((r) => !r.tried);
+        const roomCount = roomSrcs.length || chRooms.size;
         const n = entries.length;
-        if (!srcs.length) {
+        if (!srcs.length && !chRooms.size) {
           setConn("● no fleet", "var(--muted)");
         } else if (!anyLive) {
           if (connecting) setConn("● connecting…", "var(--amber)");
-          else setConn(roomSrcs.length ? "● rooms offline" : "● ay serve down", "var(--red)");
+          else setConn(roomCount ? "● rooms offline" : "● ay serve down", "var(--red)");
         } else {
           const roomBit = liveRooms ? ` · ${liveRooms} room${liveRooms === 1 ? "" : "s"}` : "";
           setConn(`● ${n} agent${n === 1 ? "" : "s"}${roomBit}`, "var(--green)");
@@ -4437,7 +4496,7 @@
               srcBranch: src.git.branch,
               fromCwd: src.cwd,
               cli: src.cli,
-              room: src._room,
+              src: src._src,
             });
         }
         return rows;
@@ -4592,7 +4651,7 @@
               srcBranch: forkSrc.git.branch,
               fromCwd: forkSrc.cwd,
               cli: forkSrc.cli,
-              room: forkSrc._room,
+              src: forkSrc._src,
             });
           omniRows.push({ kind: "spawncwd" });
         }
@@ -4673,7 +4732,7 @@
           closeOmni(false); // committing — keep the bg as-is, spawnAndSelect takes over
           await spawnAndSelect(
             { cli: anchor?.cli || "claude", cwd: anchor?.cwd || undefined, prompt: q || undefined },
-            anchor?._room,
+            anchor?._src,
           );
           return;
         }
@@ -4692,7 +4751,7 @@
               prompt: q || undefined,
               fork: { fromCwd: row.fromCwd, branch: branch.trim() },
             },
-            row.room,
+            row.src,
           );
           return;
         }
@@ -4702,7 +4761,7 @@
           closeOmni(false);
           await spawnAndSelect(
             { cli: anchor?.cli || "claude", cwd: cwd.trim() || undefined, prompt: q || undefined },
-            anchor?._room,
+            anchor?._src,
           );
           return;
         }
@@ -4804,8 +4863,10 @@
         return "ch-" + (h >>> 0).toString(36).slice(0, 4).padStart(4, "0");
       }
 
-      function removeSource(room) {
-        const s = sources.get(room);
+      // Drop ONE machine from the fleet. A codehost machine shares its room's
+      // connection, so only the room may close it (see removeRoom).
+      function removeSource(id) {
+        const s = sources.get(id);
         if (!s) return;
         s.removed = true; // stop any pending exp-backoff reconnect (see below)
         clearTimeout(s.reconnectTimer);
@@ -4814,7 +4875,21 @@
           s.client?.close?.();
           s.client?.pc?.close?.();
         } catch {}
-        sources.delete(room);
+        sources.delete(id);
+      }
+
+      // Forget a whole room: every machine in it, plus the room's own connection.
+      function removeRoom(name) {
+        const ch = chRooms.get(name);
+        if (ch) {
+          chRooms.delete(name);
+          for (const peerId of ch.peers.keys()) removeSource(name + "/" + peerId);
+          try {
+            ch.close();
+          } catch {}
+          return;
+        }
+        removeSource(name); // an ay-share room IS its single machine
       }
 
       // Exponential-backoff reconnect for an agent-yes share room (the RTCClient
@@ -4915,11 +4990,29 @@
       async function addRoomSource(room, token, host) {
         host = host || SIG_DEFAULT;
         saveRoom(room, token, host); // cache so the badge can list & reconnect later
+        // A codehost room is a connection, not a machine: it contributes one source
+        // per machine as peers announce themselves (CodehostRoom.syncPeers).
+        if (host === CH_HOST) {
+          if (chRooms.has(room)) return;
+          const ch = new CodehostRoom(room, token);
+          chRooms.set(room, ch);
+          renderRoomsIfOpen();
+          try {
+            await ch.connect();
+          } catch {
+            ch.live = false;
+          }
+          ch.tried = true;
+          renderRoomsIfOpen();
+          loadList();
+          return;
+        }
         if (sources.has(room)) return;
         const s = {
           id: room,
+          room,
           host,
-          kind: host === CH_HOST ? "ch" : "rtc",
+          kind: "rtc",
           tx: null,
           client: null,
           live: false,
@@ -4930,25 +5023,12 @@
         sources.set(room, s);
         renderRoomsIfOpen();
         try {
-          if (host === CH_HOST) {
-            const c = new CodehostClient(token);
-            c.onstate = (st) => {
-              if (st === "closed") {
-                s.live = false;
-                renderRoomsIfOpen();
-              }
-            };
-            await c.connect();
-            s.client = c;
-            s.tx = c;
-          } else {
-            s.token = token;
-            await connectRtcSource(s);
-          }
+          s.token = token;
+          await connectRtcSource(s);
           s.live = true;
         } catch (e) {
           s.live = false;
-          if (s.kind === "rtc") scheduleRtcReconnect(s);
+          scheduleRtcReconnect(s);
         }
         s.tried = true;
         renderRoomsIfOpen();
@@ -4990,10 +5070,9 @@
       // in it right now". The signaling layer can't tell us the count until we've
       // connected, so we show the source's last-known serverCount.
       function roomStatus(n) {
-        const s = sources.get(n);
-        if (!s) return `<span class="rstat off">○</span>`;
-        if (!s.live) return `<span class="rstat off" title="offline">○</span>`;
-        const c = s.serverCount;
+        if (!sources.has(n) && !chRooms.has(n)) return `<span class="rstat off">○</span>`;
+        if (!roomLive(n)) return `<span class="rstat off" title="offline">○</span>`;
+        const c = roomSources(n).filter((s) => s.live).length;
         return `<span class="rstat on" title="${c} live ${c === 1 ? "server" : "servers"}">● ${c}</span>`;
       }
 
@@ -5003,7 +5082,7 @@
         const items = names.length
           ? names
               .map(
-                (n) => `<div class="ritem ${sources.get(n)?.live ? "cur" : ""}">
+                (n) => `<div class="ritem ${roomLive(n) ? "cur" : ""}">
           ${roomStatus(n)}
           <span class="rname" data-room="${esc(n)}">${esc(n)}</span>
           <span class="rhost">${esc(r[n].host)}</span>
@@ -5050,7 +5129,7 @@
         }
         const del = ev.target.closest(".rx");
         if (del) {
-          removeSource(del.dataset.del);
+          removeRoom(del.dataset.del);
           dropRoom(del.dataset.del);
           renderRooms();
           loadList();
@@ -5083,13 +5162,28 @@
       // The link carries only WHAT to run; the capability to run it is the viewer's
       // own connected fleet (cached room) + a y/N confirm on that host. So a public
       // launch link can never spawn on a machine the clicker doesn't already control.
-      function showLaunch(spec) {
+      // One button per MACHINE we can actually reach, so a codehost room with three
+      // machines offers three targets. A saved room with no live machine yet (boot
+      // race, or the room is down) still gets one button under its own name —
+      // launchOn connects it, and spawnTarget then resolves a machine inside it.
+      function fleetTargets() {
         const rooms = loadRooms();
-        const names = Object.keys(rooms).sort((a, b) => rooms[b].ts - rooms[a].ts);
+        return Object.keys(rooms)
+          .sort((a, b) => rooms[b].ts - rooms[a].ts)
+          .flatMap((n) => {
+            const live = roomSources(n).filter((s) => s.live);
+            return live.length
+              ? live.map((s) => ({ id: s.id, label: sourceLabel(s) }))
+              : [{ id: n, label: n }];
+          });
+      }
+
+      function showLaunch(spec) {
+        const names = fleetTargets();
         const cmd = "ay " + (spec.cli || "claude") + (spec.prompt ? ` -- "${spec.prompt}"` : "");
         const fleets = names.length
-          ? `<div class="lfleets">${names.map((n) => `<button class="lfleet" data-room="${esc(n)}">▷ ${esc(n)}</button>`).join("")}</div>
-         <div class="lhint">pick a fleet to run on</div>`
+          ? `<div class="lfleets">${names.map((t) => `<button class="lfleet" data-room="${esc(t.id)}">▷ ${esc(t.label)}</button>`).join("")}</div>
+         <div class="lhint">pick a machine to run on</div>`
           : `<div class="lwarn">No connected fleet on this device. Run <code>bunx agent-yes serve --share</code>, open its link once, then reopen this launch link.</div>`;
         $("launch").innerHTML = `<div class="lcard">
       <div class="ltitle">Launch agent</div>
@@ -5101,11 +5195,16 @@
         $("launch").style.display = "flex";
       }
 
-      // Pick the fleet to spawn on: an explicit roomId, else the selected agent's
-      // source, else local, else any live source.
-      function spawnTarget(roomId) {
+      // Pick the MACHINE to spawn on: an explicit source id, else any live machine
+      // in an explicitly named room (a launch link names a room, not a machine, and
+      // a machine that has since left the room degrades to its room), else the
+      // selected agent's machine, else local, else any live machine.
+      function spawnTarget(id) {
+        const room = id && id.includes("/") ? id.slice(0, id.indexOf("/")) : null;
         return (
-          sources.get(roomId) ||
+          sources.get(id) ||
+          (id && roomSources(id).find((s) => s.live)) ||
+          (room && roomSources(room).find((s) => s.live)) ||
           srcFor(entries.find((e) => e._key === sel)) ||
           sources.get(LOCAL) ||
           [...sources.values()].find((s) => s.live) ||
@@ -5126,7 +5225,7 @@
         }
         // Match by "newest agent that wasn't here before" ON THIS fleet — the
         // spawn returns the wrapper pid, but the agent registers under its own.
-        const before = new Set(entries.filter((e) => e._room === target.id).map((e) => e.pid));
+        const before = new Set(entries.filter((e) => e._src === target.id).map((e) => e.pid));
         const res = await target.tx.post("/api/spawn", {
           cli: spec.cli || "claude",
           from: spec.from || undefined,
@@ -5141,7 +5240,7 @@
         for (let i = 0; i < 14; i++) {
           await loadList();
           const fresh = entries
-            .filter((e) => e._room === target.id && !before.has(e.pid))
+            .filter((e) => e._src === target.id && !before.has(e.pid))
             .sort((a, b) => (b.started_at || 0) - (a.started_at || 0));
           if (fresh.length) {
             select(fresh[0]._key);
@@ -5152,12 +5251,17 @@
         return true;
       }
 
-      async function launchOn(room, spec) {
-        const r = loadRooms()[room];
-        if (!r) return;
-        $("launch").style.display = "none";
-        await connectRoom(room, r.token, r.host);
-        await spawnAndSelect(spec, room);
+      // `id` is a machine (source id) once its room is connected, or a bare room
+      // name when the launch link was opened before the room came up.
+      async function launchOn(id, spec) {
+        if (!sources.has(id)) {
+          const name = id.split("/")[0];
+          const r = loadRooms()[name];
+          if (!r) return;
+          $("launch").style.display = "none";
+          await connectRoom(name, r.token, r.host);
+        } else $("launch").style.display = "none";
+        await spawnAndSelect(spec, id);
       }
 
       $("launch").addEventListener("click", (ev) => {
@@ -5169,18 +5273,32 @@
         if (ev.target.closest(".lcancel")) $("launch").style.display = "none";
       });
 
-      // ---- "+ New agent": a spawn form for the CURRENTLY connected fleet ----
+      // ---- "+ New agent": a spawn form for one machine in the fleet ----------
       // Click → fill (cli defaults to claude, cwd prefilled from the selected agent
-      // when there is one, prompt optional) → POST /api/spawn on this connection.
+      // when there is one, prompt optional) → POST /api/spawn on that machine.
       // Always allowed: the console already controls every running agent's stdin.
+      //
+      // The Host row appears only when the fleet holds more than one machine. It
+      // defaults to spawnTarget()'s pick — the selected agent's machine — so the
+      // common "spawn next to what I'm looking at" flow needs no interaction.
       function showNew() {
         const here = entries.find((x) => x._key === sel);
         const cwd = here?.cwd || "";
         const target = spawnTarget();
-        const where = target ? (target.id === LOCAL ? "local" : target.id) : "local";
+        const hosts = [...sources.values()].filter((s) => s.live || s.id === target?.id);
         $("newform").dataset.room = target ? target.id : "";
+        const hostRow =
+          hosts.length > 1
+            ? `<div class="nfield"><label>Host</label><select id="nf-host">${hosts
+                .map(
+                  (s) =>
+                    `<option value="${esc(s.id)}"${s.id === target?.id ? " selected" : ""}>${esc(sourceLabel(s))}</option>`,
+                )
+                .join("")}</select></div>`
+            : "";
         $("newform").innerHTML = `<div class="lcard">
-      <div class="ltitle">New agent · ${esc(where)}</div>
+      <div class="ltitle">New agent · ${esc(sourceLabel(target) || "local")}</div>
+      ${hostRow}
       <div class="nfield"><label>CLI</label><input id="nf-cli" value="claude" spellcheck="false" autocapitalize="off" /></div>
       <div class="nfield"><label>Spawn from — optional</label><input id="nf-from" placeholder="github URL / owner/repo@branch — provisions a worktree" spellcheck="false" autocapitalize="off" /></div>
       <div class="nfield"><label>Working dir</label><input id="nf-cwd" value="${esc(cwd)}" placeholder="(host default — ignored when Spawn from is set)" spellcheck="false" autocapitalize="off" /></div>
@@ -5190,24 +5308,38 @@
         <button class="lcancel" id="nf-cancel">cancel</button>
       </div>
       <div id="nf-hook" class="lhint" style="display:none"></div>
-      <div class="lhint">POST /api/spawn on this fleet. ${IS_MAC ? "⌘" : "Ctrl"}+Enter to launch.</div></div>`;
+      <div class="lhint">POST /api/spawn on this machine. ${IS_MAC ? "⌘" : "Ctrl"}+Enter to launch.</div></div>`;
         $("newform").style.display = "flex";
         setTimeout(() => $("nf-prompt")?.focus(), 0);
-        // Surface whether this host runs a spawn hook (a trusted local command run
-        // before every launch — provisions env/cwd; see ~/.agent-yes/config.json).
-        // Read-only: /api/spawn-config discloses only the boolean, never the body.
-        if (target?.tx?.fetchJSON) {
-          target.tx
-            .fetchJSON("/api/spawn-config")
-            .then((c) => {
-              const el = $("nf-hook");
-              if (el && c && c.hasSpawnHook) {
-                el.textContent = "⚙ this host runs a spawn hook before launch";
-                el.style.display = "";
-              }
-            })
-            .catch(() => {});
-        }
+        // Retarget the form when the user picks another machine — the spawn-hook
+        // hint below is per-machine, so it has to be re-read too.
+        $("nf-host")?.addEventListener("change", (ev) => {
+          $("newform").dataset.room = ev.target.value;
+          showHook(sources.get(ev.target.value));
+        });
+        showHook(target);
+      }
+
+      // Surface whether the target host runs a spawn hook (a trusted local command
+      // run before every launch — provisions env/cwd; see ~/.agent-yes/config.json).
+      // Read-only: /api/spawn-config discloses only the boolean, never the body.
+      function showHook(target) {
+        const el = $("nf-hook");
+        if (el) el.style.display = "none";
+        if (!target?.tx?.fetchJSON) return;
+        const forId = target.id;
+        target.tx
+          .fetchJSON("/api/spawn-config")
+          .then((c) => {
+            // A slow answer for a host the user has since switched away from must
+            // not paint the new host's hint.
+            if (!el || $("newform").dataset.room !== forId) return;
+            if (c && c.hasSpawnHook) {
+              el.textContent = "⚙ this host runs a spawn hook before launch";
+              el.style.display = "";
+            }
+          })
+          .catch(() => {});
       }
 
       async function submitNew() {
@@ -5229,7 +5361,7 @@
           const norm = (p) => (p || "").replace(/\/+$/, "");
           const busy = entries.some(
             (e) =>
-              (room ? e._room === room : true) &&
+              (room ? e._src === room : true) &&
               e.exit_code == null &&
               norm(e.cwd) === norm(spec.cwd),
           );
@@ -5396,7 +5528,7 @@
         autoPid = key;
         autoPidExplicit = true;
         const r = loadRooms()[room];
-        if (r && !sources.get(room)) connectRoom(room, r.token, r.host);
+        if (r && !sources.has(room) && !chRooms.has(room)) connectRoom(room, r.token, r.host);
       });
 
       // ---- activity-gated polling + auto-reload on new deploy ----------------

--- a/tests/ui-dom/console-peer-spawn.test.ts
+++ b/tests/ui-dom/console-peer-spawn.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Deterministic DOM test of multi-machine (codehost) rooms in the REAL console
+ * (lab/ui/index.html), driven against a stubbed codehost room that holds TWO
+ * machines.
+ *
+ * It pins the two properties that a single-machine room can never exercise:
+ *   1. identity — the machines run agents with the SAME pid, and both must show
+ *      up as distinct rows. (v1 keyed agents by room+pid, so one silently won.)
+ *   2. routing — `+ New agent` spawns on the machine the user picked, not on
+ *      whichever peer the room happened to list first.
+ *
+ * The codehost transport module is replaced wholesale (window.__codehost comes
+ * from `import * as codehost from "./room-client.js"`), so no WebRTC, no
+ * signaling, no network. Every call the console makes through the room is
+ * recorded on window.__chCalls with the peer it was addressed to.
+ */
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { startServer } from "./server.ts";
+
+const TERMINAL_STUB =
+  "window.Terminal=class{constructor(){this.cols=80;this.rows=24;this.element=null;}" +
+  "loadAddon(){}open(el){this.element=el;}focus(){}onTitleChange(){}onResize(){}onScroll(){}" +
+  "onData(f){window.__onData=f;}onBinary(){}write(){}resize(c,r){this.cols=c;this.rows=r;}" +
+  "hasSelection(){return false;}getSelection(){return '';}getSelectionPosition(){return null;}" +
+  "clearSelection(){}dispose(){}};";
+const FITADDON_STUB = "window.FitAddon={FitAddon:class{activate(){}dispose(){}fit(){}}};";
+
+const ROOM = "ch-test";
+const PEER_A = "peer-a";
+const PEER_B = "peer-b";
+// Both machines run pid 4242 — the collision the per-machine key has to survive.
+const DUP_PID = 4242;
+
+// A fake codehost room with two server peers. Mirrors the shape the console uses:
+// joinRoom({token,onStatus,onPeers}) -> { peers, rtcs, close, fetch(peerId,…) }.
+const ROOM_CLIENT_STUB = `
+const T0 = 1700000000000;
+const agents = {
+  "${PEER_A}": [{ pid: ${DUP_PID}, cli: "claude", cwd: "/srv/alice/tree/main", title: "alice agent", prompt: "", status: "active", started_at: T0 }],
+  "${PEER_B}": [{ pid: ${DUP_PID}, cli: "claude", cwd: "/srv/bob/tree/main", title: "bob agent", prompt: "", status: "active", started_at: T0 }],
+};
+window.__chCalls = [];
+let nextPid = 9000;
+const resp = (status, payload) => {
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload);
+  return { status, ok: status >= 200 && status < 300, body: null, json: async () => JSON.parse(text), text: async () => text };
+};
+export function joinRoom({ onStatus, onPeers }) {
+  const peers = [
+    { peerId: "${PEER_A}", role: "server", meta: { host: "alice@boxA", kind: "root", agents: [] } },
+    { peerId: "${PEER_B}", role: "server", meta: { host: "bob@boxB", kind: "root", agents: [] } },
+  ];
+  const room = {
+    peers,
+    rtcs: new Map(),
+    close() {},
+    async fetch(peerId, method, url, init) {
+      const path = url.replace("/__codehost/agent-yes", "");
+      window.__chCalls.push({ peerId, method, path, body: init && init.body });
+      if (method === "GET" && path.startsWith("/api/ls/subscribe")) return resp(404, "no stream");
+      if (method === "GET" && path.startsWith("/api/ls")) return resp(200, agents[peerId]);
+      if (method === "GET" && path.startsWith("/api/spawn-config")) return resp(200, { hasSpawnHook: false });
+      if (method === "GET" && path.startsWith("/api/size")) return resp(200, { cols: 80, rows: 24 });
+      if (method === "GET" && path.startsWith("/api/tail")) return resp(404, "no stream");
+      if (method === "POST" && path === "/api/spawn") {
+        agents[peerId].push({ pid: ++nextPid, cli: "claude", cwd: "/srv/new", title: "spawned", prompt: "", status: "active", started_at: T0 + 1000 });
+        return resp(200, "ok");
+      }
+      return resp(200, {});
+    },
+  };
+  setTimeout(() => {
+    onStatus && onStatus(true);
+    onPeers && onPeers(peers);
+  }, 0);
+  return room;
+}
+export const DEFAULT_SIGNAL_URL = "wss://signal.codehost.dev";
+`;
+
+async function openConsole(
+  browser: Browser,
+  url: string,
+): Promise<{ ctx: BrowserContext; page: Page }> {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  await ctx.route(/cdn\.jsdelivr\.net/, (route) => {
+    const body = route.request().url().includes("addon-fit") ? FITADDON_STUB : TERMINAL_STUB;
+    route.fulfill({ status: 200, contentType: "application/javascript", body });
+  });
+  await ctx.route(/room-client\.js$/, (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript", body: ROOM_CLIENT_STUB }),
+  );
+  const page = await ctx.newPage();
+  await page.addInitScript(
+    ({ room }) => {
+      Object.defineProperty(navigator, "platform", { get: () => "Linux x86_64" });
+      // A saved codehost room, so connectAllRooms() joins it on boot.
+      localStorage.setItem(
+        "ay.rooms",
+        JSON.stringify({ [room]: { token: "tok", host: "codehost", ts: Date.now() } }),
+      );
+    },
+    { room: ROOM },
+  );
+  page.on("dialog", (d) => d.accept()); // the "already an agent in this cwd" confirm
+  await page.goto(url);
+  // 3 local fixture agents + 1 per machine.
+  await page.waitForFunction(() => document.querySelectorAll(".list .row").length >= 5, undefined, {
+    timeout: 15_000,
+  });
+  return { ctx, page };
+}
+
+const spawnCalls = (page: Page) =>
+  page.evaluate(() =>
+    (
+      (window as never as { __chCalls: { peerId: string; method: string; path: string }[] })
+        .__chCalls || []
+    ).filter((c) => c.method === "POST" && c.path === "/api/spawn"),
+  );
+
+describe("codehost room with two machines", () => {
+  let browser: Browser;
+  let url: string;
+  let close: () => void;
+
+  beforeAll(async () => {
+    ({ url, close } = await startServer());
+    browser = await chromium.launch({ headless: true });
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    close?.();
+  });
+
+  it("keeps agents with the same pid on different machines apart", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      // Both survive: the row key is per-machine, not per-room.
+      expect(await page.locator(`.row[data-key="${ROOM}/${PEER_A}#${DUP_PID}"]`).count()).toBe(1);
+      expect(await page.locator(`.row[data-key="${ROOM}/${PEER_B}#${DUP_PID}"]`).count()).toBe(1);
+      const list = await page.locator("#list").innerText();
+      expect(list).toContain("alice@boxA");
+      expect(list).toContain("bob@boxB");
+      // Each machine is polled for its OWN list — not one host answering for both.
+      const lsPeers = await page.evaluate(() =>
+        [
+          ...new Set(
+            ((window as never as { __chCalls: { peerId: string; path: string }[] }).__chCalls || [])
+              .filter(
+                (c) => c.path.startsWith("/api/ls") && !c.path.startsWith("/api/ls/subscribe"),
+              )
+              .map((c) => c.peerId),
+          ),
+        ].sort(),
+      );
+      expect(lsPeers).toEqual([PEER_A, PEER_B]);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("spawns on the selected agent's machine by default", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      await page.click(`.row[data-key="${ROOM}/${PEER_B}#${DUP_PID}"]`);
+      await page.click("#newbtn");
+      await page.waitForSelector("#nf-host");
+      // Host picker offers every machine in the fleet: local + boxA + boxB.
+      expect(await page.locator("#nf-host option").count()).toBe(3);
+      expect(await page.locator("#nf-host").inputValue()).toBe(`${ROOM}/${PEER_B}`);
+
+      await page.click("#nf-go");
+      await page.waitForFunction(
+        () =>
+          (
+            (window as never as { __chCalls: { method: string; path: string }[] }).__chCalls || []
+          ).some((c) => c.method === "POST" && c.path === "/api/spawn"),
+        undefined,
+        { timeout: 15_000 },
+      );
+      const spawns = await spawnCalls(page);
+      expect(spawns).toHaveLength(1);
+      expect(spawns[0].peerId).toBe(PEER_B); // NOT peer-a, the room's first peer
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("spawns on the machine chosen in the Host picker", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      // Start from boxB selected, then deliberately retarget to boxA.
+      await page.click(`.row[data-key="${ROOM}/${PEER_B}#${DUP_PID}"]`);
+      await page.click("#newbtn");
+      await page.waitForSelector("#nf-host");
+      await page.selectOption("#nf-host", `${ROOM}/${PEER_A}`);
+      await page.click("#nf-go");
+      await page.waitForFunction(
+        () =>
+          (
+            (window as never as { __chCalls: { method: string; path: string }[] }).__chCalls || []
+          ).some((c) => c.method === "POST" && c.path === "/api/spawn"),
+        undefined,
+        { timeout: 15_000 },
+      );
+      const spawns = await spawnCalls(page);
+      expect(spawns).toHaveLength(1);
+      expect(spawns[0].peerId).toBe(PEER_A);
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/tests/ui-dom/console-peer-spawn.test.ts
+++ b/tests/ui-dom/console-peer-spawn.test.ts
@@ -70,10 +70,13 @@ export function joinRoom({ onStatus, onPeers }) {
       return resp(200, {});
     },
   };
-  setTimeout(() => {
+  // Let a test replay a peer broadcast on demand — exercises the "late callback
+  // after the room was forgotten" race that the orphaned() guard closes.
+  window.__chRefire = () => {
     onStatus && onStatus(true);
     onPeers && onPeers(peers);
-  }, 0);
+  };
+  setTimeout(() => window.__chRefire(), 0);
   return room;
 }
 export const DEFAULT_SIGNAL_URL = "wss://signal.codehost.dev";
@@ -209,6 +212,45 @@ describe("codehost room with two machines", () => {
       const spawns = await spawnCalls(page);
       expect(spawns).toHaveLength(1);
       expect(spawns[0].peerId).toBe(PEER_A);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  // A #room:pid deep link never names a machine, so it must resolve to whichever
+  // machine in the room owns that pid. The per-machine `_key` broke exact-key
+  // matching, so this used to select nothing.
+  it("resolves a #room:pid deep link into the room to a machine", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      await page.evaluate((hash) => {
+        location.hash = hash;
+      }, `#${ROOM}:${DUP_PID}`);
+      await page.waitForSelector(".row.sel", { timeout: 10_000 });
+      const key = await page.locator(".row.sel").getAttribute("data-key");
+      expect(key).toMatch(new RegExp(`^${ROOM}/peer-[ab]#${DUP_PID}$`));
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  // Forgetting a room while joinRoom still has a queued peer broadcast must not
+  // resurrect its machines. Without the orphaned() guard the late onPeers would
+  // sources.set them back for a room the user just removed.
+  it("a late peer broadcast can't resurrect a forgotten room", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      await page.click("#conn"); // open the rooms panel
+      await page.click(`.rx[data-del="${ROOM}"]`); // forget the room
+      await page.waitForFunction(
+        () => document.querySelectorAll('.row[data-key^="ch-test/"]').length === 0,
+        undefined,
+        { timeout: 10_000 },
+      );
+      // Replay the broadcast the forgotten room's callback might still fire.
+      await page.evaluate(() => (window as never as { __chRefire: () => void }).__chRefire());
+      await page.waitForTimeout(300);
+      expect(await page.locator('.row[data-key^="ch-test/"]').count()).toBe(0);
     } finally {
       await ctx.close();
     }


### PR DESCRIPTION
## Problem

A codehost room can hold several machines, but the console modelled the whole room as **one** fleet source behind **one** transport that picked a peer per request (`CodehostClient.post` → `peerFor(path) || anyHost()`).

`/api/spawn` carries no pid and doesn't match `peerFor`'s regex, so it fell through to `anyHost()` — literally `hosts()[0].peerId`. **There was no way to choose the machine, and new agents always landed on whichever peer the room listed first.** `/api/ls/subscribe` had the same fallthrough, so only that one machine's deltas ever streamed; the rest refreshed on poll.

The same conflation broke identity. Agents were keyed `<room>#<pid>`, so two machines each running pid 1234 collided: one agent silently vanished from the list, and `byPid` (pid → peerId) resolved tail/resize/send to the wrong machine. `lab/ui/index.html` called this out as a known v1 limitation.

## Fix

Make a **source mean exactly one machine** — the invariant `local` and every `ay serve --share` room already satisfied. A codehost room becomes a connection that contributes one source per machine (`<room>/<peerId>`), each with its own peer-pinned transport.

Everything per-fleet then becomes per-machine correct with no new concept:

| | before | after |
|---|---|---|
| spawn target | room's first peer | the chosen machine |
| delta stream | first peer only | every machine |
| agent key | `<room>#<pid>` | `<room>/<peerId>#<pid>` |
| spawn-hook hint | first peer | the target machine |

`_src` routes; `_room` still groups the tree, so the rendered forest is unchanged.

## UI

The New-agent modal gains a **Host** picker, shown only when the fleet holds more than one machine. It defaults to `spawnTarget()`'s pick — the selected agent's machine — so "spawn next to what I'm looking at" needs no interaction. Launch links now list machines rather than rooms.

## Verification

New `tests/ui-dom/console-peer-spawn.test.ts` drives the real page against a stubbed two-machine codehost room (no WebRTC, no signaling) and asserts both colliding-pid agents render, each machine is polled for its own list, and spawn lands on the machine the user picked.

Both bugs were confirmed empirically against the old code:
- routing: with bob's agent on `peer-b` selected, the old code spawned on **`peer-a`** (`expected 'peer-a' to be 'peer-b'`).
- identity: only **4 of 5** agents rendered — the colliding pid dropped one.

`test:ui-dom` 19/19, `ui-logic` 109/109. `typecheck` reports the same 25 pre-existing errors as `main` (all in `ts/`, none from this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)