### PR TITLE
fix(rgui): restore magnify ratio-safely via rescaleNode, not n.scale

### DIFF
--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -435,13 +435,6 @@ function buildGraph(records: AgentRecord[]): Graph {
       n.draw = (ctx, r) => drawNode(n.id, ctx, r);
     }
   }
-  // re-apply any user magnify (contentScale) after layout, so the node lenses in
-  // place — exactly where the live shift+drag rescale leaves it — instead of the
-  // manual zoom being lost on every structural rebuild.
-  for (const n of nodes.values()) {
-    const s = scaleByNode.get(n.id);
-    if (s && s !== 1) n.scale = s;
-  }
   return { nodes: [...nodes.values()], edges: [] };
 }
 
@@ -1103,7 +1096,11 @@ const viewer: Rgui = createRgui(canvas, {
     return viewer.graph;
   },
   scaleByNode, // e2e/debug: inspect persisted magnify
-  rebuild: () => viewer.setGraph(buildGraph([...recordsByPid.values()])), // e2e: force a structural rebuild
+  // e2e: force a structural rebuild THROUGH the real path (setGraph + magnify restore)
+  rebuild: () => {
+    viewer.setGraph(buildGraph([...recordsByPid.values()]));
+    reapplyMagnify();
+  },
 };
 
 // Fit all agents, but never zoom out past a readable scale — a full forest fit
@@ -1182,6 +1179,17 @@ function updateContent(records: AgentRecord[]) {
   }
 }
 
+// Restore each remembered user magnify onto the rebuilt nodes via rescaleNode —
+// the ratio-preserving path (it scales w and h by the SAME factor and sets
+// scale). Setting n.scale alone would leave a base-sized box inconsistent with
+// the scale, and a later snapGraph() snaps w/h independently and skews the ratio
+// (per rgui's resize-or-scale author).
+function reapplyMagnify() {
+  if (!scaleByNode.size) return;
+  const present = new Set(viewer.graph.nodes.map((n) => n.id));
+  for (const [id, s] of scaleByNode) if (present.has(id)) viewer.rescaleNode(id, s);
+}
+
 function apply(records: AgentRecord[], live: boolean) {
   recordsByPid.clear();
   for (const r of records) recordsByPid.set(String(r.pid), r);
@@ -1193,6 +1201,7 @@ function apply(records: AgentRecord[], live: boolean) {
     // tear down terminals for agents that are gone (exited/removed)
     for (const id of [...terms.keys()]) if (!recordsByPid.has(id)) dropTerm(id);
     viewer.setGraph(buildGraph(records));
+    reapplyMagnify(); // restore user magnify on the rebuilt nodes (ratio-safe)
     applyEdges(); // rebuild wires on the new node set
     if (firstPaint) {
       fitReadable();


### PR DESCRIPTION
Correctness fix on top of #213. The persist-magnify glue set `n.scale` directly on the rebuilt `buildGraph` node — but rgui's `contentScale` is a **content magnification, not a box size**: nothing multiplies `w`/`h`, so scale-alone leaves a base-sized box while the type doubles, `nodeMinHeight` then overrides the declared height, and the card's ratio skews (a 320×236 card would go taller-than-wide). Confirmed with rgui's resize-or-scale author, who ran both paths.

**Fix:** leave fresh nodes at scale 1 and re-apply the saved magnify with `viewer.rescaleNode(id, saved)` **after** `setGraph` (`reapplyMagnify`). `rescaleNode` is *relative* (`f = target / contentScale(n)`); from a fresh scale-1 node `f = saved`, so it scales `w` and `h` by the same factor — ratio-preserving. (Setting `n.scale` first *then* calling `rescaleNode` would make `f = saved/saved = 1`, a silent no-op — avoided.) The `__rgui.rebuild()` e2e hook now routes through `reapplyMagnify` so it exercises the real path.

## Verification
On rgui main: node 320×236 (ratio 1.356) magnified 2.5 + rebuild → scale 2.5, w **800** (=320×2.5), h **590** (=236×2.5), ratio **1.356 unchanged**, w grew by exactly the factor. Author signed off ("Ship it"). Visual: a magnified card keeps correct proportions (no cramped/tall drift). rgui main also hardened its docs+test for this (`c6f3622`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)