### PR TITLE
test(coverage): cover agentShare lifecycle + waitForFifo to restore the 90% gate

### DIFF
--- a/ts/agentShare.lifecycle.spec.ts
+++ b/ts/agentShare.lifecycle.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Lifecycle of scoped shares: mint / list / revoke / expire. The security filter
+// (scopedFetch) is driven with the REAL resolveOne in agentShare.spec.ts; here we
+// mock the registry and the WebRTC room so createScopedShare's bookkeeping can be
+// exercised hermetically (no signaling server, no live agents).
+
+const closeSpies: Array<ReturnType<typeof vi.fn>> = [];
+let roomSeq = 0;
+
+vi.mock("./share.ts", () => ({
+  startShare: vi.fn(async () => {
+    const close = vi.fn();
+    closeSpies.push(close);
+    const room = `room-${roomSeq++}`;
+    return { room, link: `https://agent-yes.com/w/#${room}:secret`, close };
+  }),
+}));
+
+const records = new Map<string, Record<string, unknown>>();
+vi.mock("./subcommands.ts", () => ({
+  listRecords: vi.fn(async () => [...records.values()]),
+  resolveOne: vi.fn(async (kw: string) => {
+    const rec = records.get(kw);
+    if (!rec) throw new Error(`no agent matches ${kw}`);
+    return rec;
+  }),
+}));
+
+import {
+  createScopedShare,
+  listShares,
+  revokeShare,
+  revokeAllShares,
+  MAX_SHARES,
+  DEFAULT_SHARE_TTL_MS,
+} from "./agentShare.ts";
+
+const localFetch = async () => new Response("ok");
+const baseOpts = { localFetch, apiToken: "tok" };
+
+beforeEach(() => {
+  records.clear();
+  closeSpies.length = 0;
+  records.set("1", { pid: 1, agent_id: "aaaaaaaaaaaa", cli: "claude", cwd: "/home/u/proj" });
+});
+
+afterEach(() => {
+  revokeAllShares();
+  vi.useRealTimers();
+});
+
+describe("createScopedShare", () => {
+  it("mints a view-only share with a fresh room and a cli · dir label", async () => {
+    const share = await createScopedShare({ ...baseOpts, agent: "1" });
+    expect(share.agentId).toBe("aaaaaaaaaaaa");
+    expect(share.perm).toBe("r"); // default
+    expect(share.room).toMatch(/^room-/);
+    expect(share.link).toContain(share.room);
+    expect(share.label).toBe("claude · proj");
+    expect(share.shareId).toMatch(/^s[0-9a-z]+$/);
+    expect(share.expiresAt - share.createdAt).toBe(DEFAULT_SHARE_TTL_MS);
+    expect("close" in share).toBe(false); // the close capability never leaves the host
+  });
+
+  it("labels a cwd-less agent with just the cli and honours perm/ttl overrides", async () => {
+    records.set("2", { pid: 2, agent_id: "cccccccccccc", cli: "codex", cwd: "" });
+    const share = await createScopedShare({ ...baseOpts, agent: "2", perm: "rw", ttlMs: 5000 });
+    expect(share.label).toBe("codex");
+    expect(share.perm).toBe("rw");
+    expect(share.expiresAt - share.createdAt).toBe(5000);
+  });
+
+  it("refuses an agent with no stable agent_id (pid alone is reused → unsafe)", async () => {
+    records.set("3", { pid: 3, agent_id: undefined, cli: "claude", cwd: "/x" });
+    await expect(createScopedShare({ ...baseOpts, agent: "3" })).rejects.toThrow(/agent_id/);
+  });
+
+  it("propagates an unresolvable keyword", async () => {
+    await expect(createScopedShare({ ...baseOpts, agent: "nope" })).rejects.toThrow(/no agent/);
+  });
+
+  it("caps concurrent shares at MAX_SHARES", async () => {
+    for (let i = 0; i < MAX_SHARES; i++) {
+      await createScopedShare({ ...baseOpts, agent: "1" });
+    }
+    await expect(createScopedShare({ ...baseOpts, agent: "1" })).rejects.toThrow(
+      /too many active shares/,
+    );
+  });
+});
+
+describe("listShares / revokeShare / revokeAllShares", () => {
+  it("lists newest-first without exposing close", async () => {
+    vi.useFakeTimers(); // control createdAt so the sort order is deterministic
+    const a = await createScopedShare({ ...baseOpts, agent: "1" });
+    vi.advanceTimersByTime(10);
+    const b = await createScopedShare({ ...baseOpts, agent: "1" });
+    const listed = listShares();
+    expect(listed.map((s) => s.shareId)).toEqual([b.shareId, a.shareId]);
+    for (const s of listed) expect("close" in s).toBe(false);
+  });
+
+  it("revokeShare closes the room and forgets the share; unknown id is a no-op", async () => {
+    const share = await createScopedShare({ ...baseOpts, agent: "1" });
+    expect(revokeShare(share.shareId)).toBe(true);
+    expect(closeSpies[0]).toHaveBeenCalledTimes(1);
+    expect(listShares()).toHaveLength(0);
+    expect(revokeShare(share.shareId)).toBe(false); // already gone
+    expect(revokeShare("s-unknown")).toBe(false);
+  });
+
+  it("revokeShare survives a close() that throws (room already torn down)", async () => {
+    const share = await createScopedShare({ ...baseOpts, agent: "1" });
+    closeSpies[0]!.mockImplementation(() => {
+      throw new Error("already closed");
+    });
+    expect(revokeShare(share.shareId)).toBe(true);
+    expect(listShares()).toHaveLength(0);
+  });
+
+  it("revokeAllShares closes every room", async () => {
+    await createScopedShare({ ...baseOpts, agent: "1" });
+    await createScopedShare({ ...baseOpts, agent: "1" });
+    revokeAllShares();
+    expect(listShares()).toHaveLength(0);
+    expect(closeSpies).toHaveLength(2);
+    for (const spy of closeSpies) expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("a share self-revokes when its TTL elapses", async () => {
+    vi.useFakeTimers();
+    const share = await createScopedShare({ ...baseOpts, agent: "1", ttlMs: 1000 });
+    expect(listShares().map((s) => s.shareId)).toContain(share.shareId);
+    vi.advanceTimersByTime(1001);
+    expect(listShares()).toHaveLength(0);
+    expect(closeSpies[0]).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ts/agentShare.spec.ts
+++ b/ts/agentShare.spec.ts
@@ -122,6 +122,51 @@ describe("scopedFetch — /api/ls/subscribe SSE is filtered", () => {
   });
 });
 
+describe("scopedFetch — /api/ls/subscribe remove + teardown", () => {
+  // Inner whose stream announces both agents, then removes them: only the removal
+  // of a pid we actually FORWARDED may cross; a never-forwarded sibling pid is
+  // information (its existence) and must be dropped.
+  function removalInner(): (req: Request) => Promise<Response> {
+    const enc = new TextEncoder();
+    return async () =>
+      new Response(
+        new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(
+              enc.encode(
+                `data: ${JSON.stringify({ full: true, upsert: [rec(1, SHARED), rec(2, OTHER)], remove: [] })}\n\n`,
+              ),
+            );
+            ctrl.enqueue(enc.encode(`data: ${JSON.stringify({ upsert: [], remove: [2] })}\n\n`));
+            ctrl.enqueue(enc.encode(`data: ${JSON.stringify({ upsert: [], remove: [1] })}\n\n`));
+            ctrl.close();
+          },
+        }),
+        { headers: { "Content-Type": "text/event-stream" } },
+      );
+  }
+
+  it("forwards removes only for pids it forwarded (sibling removals stay hidden)", async () => {
+    const res = await scopedFetch(SHARED, removalInner(), "r")(
+      new Request("http://ay.local/api/ls/subscribe"),
+    );
+    const events = (await sse(res))
+      .split("\n\n")
+      .filter((e) => e.startsWith("data:"))
+      .map((e) => JSON.parse(e.slice(5)) as { upsert: unknown[]; remove: number[] });
+    // Snapshot (shared only) + the remove of OUR pid; OTHER's removal is dropped.
+    expect(events).toHaveLength(2);
+    expect(events[0]!.upsert).toHaveLength(1);
+    expect(events[1]!.remove).toEqual([1]);
+  });
+
+  it("cancelling the filtered stream tears down the upstream reader", async () => {
+    const res = await mk()(new Request("http://ay.local/api/ls/subscribe"));
+    await res.body!.cancel(); // viewer went away — must not leak the inner stream
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("scopedFetch — read metadata", () => {
   it("passes /api/version through untouched", async () => {
     const res = await mk()(new Request("http://ay.local/api/version"));

--- a/ts/forkNested.spec.ts
+++ b/ts/forkNested.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { buildSpawnTutorial, shouldForkNested } from "./forkNested";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildSpawnTutorial, shouldForkNested, waitForFifo } from "./forkNested";
 
 describe("shouldForkNested", () => {
   it("forks when nested (AGENT_YES_PID set) and stdout is not a TTY", () => {
@@ -18,6 +21,40 @@ describe("shouldForkNested", () => {
 
   it("does NOT fork when attach opts out, regardless of context", () => {
     expect(shouldForkNested({ isTTY: false, ayPid: "1234", attach: true })).toBe(false);
+  });
+});
+
+describe("waitForFifo", () => {
+  let home: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(path.join(tmpdir(), "ay-forknested-"));
+    mkdirSync(path.join(home, "fifo"), { recursive: true });
+    prevHome = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = home;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("resolves true as soon as the wrapper's stdin FIFO is registered", async () => {
+    // Register the endpoint a poll-tick after the wait starts, like a real spawn.
+    setTimeout(() => writeFileSync(path.join(home, "fifo", "111.stdin"), ""), 60);
+    await expect(waitForFifo(111, 2000)).resolves.toBe(true);
+  });
+
+  it("times out false when the child never registers", async () => {
+    await expect(waitForFifo(222, 120)).resolves.toBe(false);
+  });
+
+  it("fails fast when aborted() reports the child already died", async () => {
+    const start = Date.now();
+    await expect(waitForFifo(333, 5000, () => true)).resolves.toBe(false);
+    expect(Date.now() - start).toBeLessThan(1000); // no full-timeout wait
   });
 });
 


### PR DESCRIPTION
## Why

The Matrix Test coverage gate has been red on every main push since Jul 8 — the share PRs (#200/#202) landed `agentShare.ts` with only its security filter (`scopedFetch`) tested. Global functions sat at **87.5%** and branches at **89.17%** against the 90% thresholds (statements/lines were fine), so all 4 matrix legs fail after 803 green tests.

## What

Adds the missing unit tests instead of loosening the gate:

- **`ts/agentShare.lifecycle.spec.ts`** (new): `createScopedShare` / `listShares` / `revokeShare` / `revokeAllShares` / TTL self-expiry / `MAX_SHARES` cap / no-`agent_id` refusal — with the WebRTC room (`startShare`) and registry (`resolveOne`) mocked so the bookkeeping runs hermetically (no signaling server, no live agents).
- **`ts/agentShare.spec.ts`**: SSE `remove`-event scoping (the removal of a never-forwarded sibling pid must not cross the channel) and viewer-cancel teardown of the filtered stream.
- **`ts/forkNested.spec.ts`**: `waitForFifo` — FIFO appears (true), timeout (false), `aborted()` fast-fail — via a temp `AGENT_YES_HOME`.

## Verification

Full `vitest run --coverage` locally (before = last red main run 29046945274, ubuntu/node leg):

| Metric | before (CI) | after (local) |
|---|---|---|
| Functions | 87.5% ❌ | **92.18%** ✅ |
| Branches | 89.17% ❌ | **91.23%** ✅ |
| Statements | 90.42% ✅ | 94.08% ✅ |
| Lines | 91.97% ✅ | 95.47% ✅ |

All 4 thresholds ≥ 90 again. The 40 tests in the three touched spec files pass in 0.6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)