### PR TITLE
fix(rgui): info-card double render when zoomed past 1×

### DIFF
--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -438,7 +438,11 @@ function buildGraph(records: AgentRecord[]): Graph {
       bg: isLight() ? "#ffffff" : "#0d1117",
       scale: "fit",
       minScale: 0.16, // readable at the default forest fit; hides only far out
-      maxScale: 1,
+      // uncapped: the card is world-space (natural px == world units), so the
+      // overlay must keep scaling past 1× to stay glued over its frame — capped
+      // at 1 it froze at 560×320 while the canvas LOD body kept growing behind
+      // it, showing both layers at once when zoomed in
+      maxScale: Infinity,
       clip: "node",
       overflow: "hidden",
     }),


### PR DESCRIPTION
## Why

Zooming into the "agent-yes · console" info card on agent-yes.com/r/ showed **two layers at once**: the crisp HTML overlay frozen at its natural 560×320 px in the card's top-left corner, with the canvas-drawn LOD body scaling up behind it.

| before (2×) | after (2×) |
|---|---|
| overlay stuck at 1×, canvas body at 2× behind it | one layer, overlay tracks the frame |

## Root cause

The card passes both `el` (HTML overlay, `scale: "fit"`) and `draw` (canvas LOD fallback) to `annotationNode`. rgui draws the canvas body **unconditionally**; that's normally invisible because the opaque overlay exactly covers the node. But the overlay's default `maxScale: 1` ("never upscale past natural size") caps its applied scale at 1×, while the node's screen rect keeps growing with zoom — at k>1 the canvas body peeks out around the frozen overlay.

## Fix

The card is world-space — its natural pixel size equals its world-unit size — so upscaling the overlay is exactly what should happen. Set `maxScale: Infinity`; the overlay now stays glued over its frame at every zoom-in level, and the canvas body remains the far-out fallback below `minScale`.

Verified in the built page at k=0.4 / 2× / 5× (single layer, copy buttons still work) and far-out (canvas LOD handoff unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)