### PR TITLE
fix(serve): self-heal /api/tail when fs.watch silently dies (500ms typing echo)

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1767,23 +1767,32 @@ export async function cmdServe(rest: string[]): Promise<number> {
                 if (size < offset) offset = size; // truncated/rotated
                 if (size > offset) {
                   // The safety-net poll found appended bytes the watcher never
-                  // announced — the watcher is dead (a long-lived daemon can
-                  // reach a state where fs.watch callbacks stop firing
-                  // process-wide; observed alongside the node-datachannel
-                  // native-stack pathologies). Demote this stream to the fast
-                  // poll it would have used had watch() failed outright, or
-                  // every keystroke echo rides the slow poll (~500ms felt lag).
-                  // The 450ms grace absorbs the benign race where the poll tick
-                  // beats a healthy watcher to the same append by a few ms.
-                  if (viaPoll && watcher && Date.now() - lastWatcherFireAt > POLL_WATCHED - 50) {
-                    try {
-                      watcher.close();
-                    } catch {
-                      /* already dead */
-                    }
-                    watcher = null;
-                    clearInterval(poller);
-                    poller = setInterval(() => void flush(true), POLL_UNWATCHED);
+                  // announced — suspicious: the watcher may be dead (a
+                  // long-lived daemon can reach a state where fs.watch
+                  // callbacks stop firing process-wide; observed alongside the
+                  // node-datachannel native-stack pathologies), leaving every
+                  // keystroke echo riding the slow poll (~500ms felt lag). But
+                  // a HEALTHY watcher's callback may merely be queued behind
+                  // this very tick (sparse append landing just before the poll,
+                  // with lastWatcherFireAt stale from an idle stretch) — so
+                  // verify before demoting: give it 100ms to fire, and only
+                  // then demote this stream to the fast poll it would have used
+                  // had watch() failed outright.
+                  if (viaPoll && watcher && !demoteCheck && Date.now() - lastWatcherFireAt > POLL_WATCHED - 50) {
+                    const suspectAt = Date.now();
+                    demoteCheck = setTimeout(() => {
+                      demoteCheck = null;
+                      if (closed || !watcher) return;
+                      if (lastWatcherFireAt >= suspectAt) return; // fired since — healthy
+                      try {
+                        watcher.close();
+                      } catch {
+                        /* already dead */
+                      }
+                      watcher = null;
+                      clearInterval(poller);
+                      poller = setInterval(() => void flush(true), POLL_UNWATCHED);
+                    }, 100);
                   }
                   const len = size - offset;
                   const buf = Buffer.allocUnsafe(len);
@@ -1808,6 +1817,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
             };
 
             let lastWatcherFireAt = Date.now(); // grace at open — see demotion above
+            let demoteCheck: ReturnType<typeof setTimeout> | null = null;
             let watcher: ReturnType<typeof watch> | null = null;
             try {
               watcher = watch(logPath, () => {
@@ -1841,6 +1851,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
               closed = true;
               clearInterval(heartbeat);
               clearInterval(poller);
+              if (demoteCheck) clearTimeout(demoteCheck);
               try {
                 watcher?.close();
               } catch {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1759,13 +1759,32 @@ export async function cmdServe(rest: string[]): Promise<number> {
             // 300 ms full-file poll was the dominant typing-echo latency.
             const fh = await open(logPath, "r").catch(() => null);
             let reading = false;
-            const flush = async () => {
+            const flush = async (viaPoll = false) => {
               if (closed || reading || !fh) return;
               reading = true;
               try {
                 const { size } = await fh.stat();
                 if (size < offset) offset = size; // truncated/rotated
                 if (size > offset) {
+                  // The safety-net poll found appended bytes the watcher never
+                  // announced — the watcher is dead (a long-lived daemon can
+                  // reach a state where fs.watch callbacks stop firing
+                  // process-wide; observed alongside the node-datachannel
+                  // native-stack pathologies). Demote this stream to the fast
+                  // poll it would have used had watch() failed outright, or
+                  // every keystroke echo rides the slow poll (~500ms felt lag).
+                  // The 450ms grace absorbs the benign race where the poll tick
+                  // beats a healthy watcher to the same append by a few ms.
+                  if (viaPoll && watcher && Date.now() - lastWatcherFireAt > POLL_WATCHED - 50) {
+                    try {
+                      watcher.close();
+                    } catch {
+                      /* already dead */
+                    }
+                    watcher = null;
+                    clearInterval(poller);
+                    poller = setInterval(() => void flush(true), POLL_UNWATCHED);
+                  }
                   const len = size - offset;
                   const buf = Buffer.allocUnsafe(len);
                   const { bytesRead } = await fh.read(buf, 0, len, offset);
@@ -1788,9 +1807,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
               }
             };
 
+            let lastWatcherFireAt = Date.now(); // grace at open — see demotion above
             let watcher: ReturnType<typeof watch> | null = null;
             try {
-              watcher = watch(logPath, () => void flush());
+              watcher = watch(logPath, () => {
+                lastWatcherFireAt = Date.now();
+                void flush();
+              });
             } catch {
               /* fs.watch unsupported — the fallback poll below still works */
             }
@@ -1799,7 +1822,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
             // → keep it at 60ms for low typing-echo latency. This matters when many
             // /api/tail streams are open at once (the /rgui viewer opens one per
             // node): N × a 60ms poll each was needless load on the event loop.
-            const poller = setInterval(() => void flush(), watcher ? 500 : 60);
+            // (If the watcher turns out to be dead, flush() demotes to 60ms.)
+            const POLL_WATCHED = 500;
+            const POLL_UNWATCHED = 60;
+            let poller = setInterval(
+              () => void flush(true),
+              watcher ? POLL_WATCHED : POLL_UNWATCHED,
+            );
 
             // Tear down on client disconnect via BOTH the req.signal 'abort'
             // listener and the stream's cancel() — whichever the runtime fires


### PR DESCRIPTION
## Problem

Typing latency in the web console (agent-yes.com/w/) measured **25ms–1.1s, median ~300ms** while a fresh daemon delivers ~20ms. Bisected end-to-end:

- keydown → WebRTC → FIFO → pty → echo in log file: **14ms** ✅
- log append → browser frame arrival: **~350–500ms** ❌ (bun-peer probe showed flat ~500ms — the exact `/api/tail` fallback-poll interval)
- Fresh daemon, same code, same files: **13–15ms** ✅

So in a long-lived serve daemon, `fs.watch` callbacks **silently stop firing process-wide** (observed alongside the known node-datachannel native-stack pathologies), and every tail stream quietly rides the 500ms safety-net poll.

## Fix

Per-stream dead-watcher detection: when a poll-driven flush finds appended bytes and the watcher hasn't fired within the poll window, close the watcher and demote the stream to the 60ms poll it would have used had `watch()` failed outright. A grace stamp at stream open absorbs the benign race where a poll tick beats a healthy watcher to the same append.

## Verification

- Dead-watcher serve (fs.watch stubbed inert via preload): first echo ~506ms (one safety-poll ride triggers demotion), then **25–74ms** for the rest of the stream.
- Healthy serve, same bench: **12–23ms**, no false demotions.
- Full vitest suite: 818 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)