### PR TITLE
feat(rgui): cross-system graph federation (org.rgui.graph.v1)

### DIFF
--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -15,6 +15,9 @@
  */
 import createRgui, {
   annotationNode,
+  federatedDemoChain,
+  federatedGraphToRgui,
+  isFederatedGraphEnvelope,
   nodeHeight,
   type Edge,
   type Graph,
@@ -1237,6 +1240,97 @@ function reapplyMagnify() {
   for (const [id, s] of scaleByNode) if (present.has(id)) viewer.rescaleNode(id, s);
 }
 
+// ── federated mirrors (#feed=<url>[&feed=…] · #feddemo) ──────────────────────
+// Read-only subgraphs from OTHER rgui hosts (otoji.org etc.), as
+// org.rgui.graph.v1 envelopes (lib/rgui src/core/federation.ts). Each feed is
+// polled, converted via federatedGraphToRgui (clamped, remote:true = read-only
+// mirror) and merged under the local forest. Merge is id-based: the local graph
+// wins, then feeds in listed order — a feed carrying a STUB of another system's
+// node (e.g. otoji referencing ay://agent-yes/codex-agent) dedupes away when the
+// authoritative node is present, and its cross-system edges land on the real one.
+const FED_Y0 = 900; // world-y where the first federated subgraph mounts
+const FED_GAP = 300; // vertical gap between stacked federated subgraphs
+const fedHashParts = location.hash.slice(1).split("&");
+const fedFeeds = fedHashParts
+  .filter((s) => s.startsWith("feed="))
+  .map((s) => decodeURIComponent(s.slice(5)));
+const fedDemo = fedHashParts.includes("feddemo");
+const fedGraphs = new Map<string, Graph>(); // feed key -> converted subgraph
+const fedRevisions = new Map<string, string>();
+let lastLocalGraph: Graph = { nodes: [], edges: [] };
+
+function mergeFederated(local: Graph): Graph {
+  if (!fedGraphs.size) return local;
+  const nodes = [...local.nodes];
+  const edges = [...local.edges];
+  const seen = new Set(nodes.map((n) => n.id));
+  // stack subgraphs downward by MEASURED height (a big fleet mirror would
+  // otherwise run into the next subgraph); live feeds merge before the baked
+  // demo so an authoritative node (e.g. our codex-agent) beats the demo's stub
+  let cursor = Math.max(FED_Y0, ...local.nodes.map((n) => n.y + (n.h ?? CARD_H) + FED_GAP));
+  for (const key of [...fedFeeds, "demo"]) {
+    const g = fedGraphs.get(key);
+    if (!g?.nodes.length) continue;
+    const minX = Math.min(...g.nodes.map((n) => n.x));
+    const minY = Math.min(...g.nodes.map((n) => n.y));
+    let maxY = cursor;
+    for (const n of g.nodes) {
+      if (seen.has(n.id)) continue;
+      seen.add(n.id);
+      // clone with translated coords — the cached subgraph stays unshifted so a
+      // re-merge (feed update) can't drift it
+      const y = n.y - minY + cursor;
+      maxY = Math.max(maxY, y + (n.h ?? CARD_H));
+      nodes.push({ ...n, x: n.x - minX + 40, y });
+    }
+    edges.push(...g.edges);
+    cursor = maxY + FED_GAP;
+  }
+  return { nodes, edges: edges.filter((e) => seen.has(e.from.node) && seen.has(e.to.node)) };
+}
+
+// Feed edges survive applyEdges' wire rebuild (it truncates graph.edges).
+function fedEdges(present: Set<string>): Edge[] {
+  const out: Edge[] = [];
+  for (const g of fedGraphs.values())
+    out.push(...g.edges.filter((e) => present.has(e.from.node) && present.has(e.to.node)));
+  return out;
+}
+
+function refreshFedGraph() {
+  viewer.setGraph(mergeFederated(lastLocalGraph));
+  reapplyMagnify();
+  applyEdges();
+}
+
+async function pollFeeds() {
+  let changed = false;
+  for (let i = 0; i < fedFeeds.length; i++) {
+    const url = fedFeeds[i];
+    try {
+      const env = await (await fetch(url)).json();
+      if (!isFederatedGraphEnvelope(env)) continue;
+      const rev = String(env.revision);
+      if (fedRevisions.get(url) === rev) continue;
+      fedRevisions.set(url, rev);
+      fedGraphs.set(url, federatedGraphToRgui(env, { container: true }));
+      changed = true;
+    } catch {
+      /* feed unreachable — keep the last mirror (or none) */
+    }
+  }
+  if (changed) refreshFedGraph();
+}
+if (fedDemo) {
+  // offline showcase: the baked cross-system chain (plaintext → codex-agent →
+  // diff → filter → translate → tts) from rgui itself, no feed server needed
+  fedGraphs.set("demo", federatedGraphToRgui(federatedDemoChain(), { container: true }));
+}
+if (fedFeeds.length) {
+  void pollFeeds();
+  setInterval(() => void pollFeeds(), 5000);
+}
+
 function apply(records: AgentRecord[], live: boolean) {
   recordsByPid.clear();
   for (const r of records) recordsByPid.set(String(r.pid), r);
@@ -1247,7 +1341,8 @@ function apply(records: AgentRecord[], live: boolean) {
     lastContent = content;
     // tear down terminals for agents that are gone (exited/removed)
     for (const id of [...terms.keys()]) if (!recordsByPid.has(id)) dropTerm(id);
-    viewer.setGraph(buildGraph(records));
+    lastLocalGraph = buildGraph(records);
+    viewer.setGraph(mergeFederated(lastLocalGraph));
     reapplyMagnify(); // restore user magnify on the rebuilt nodes (ratio-safe)
     applyEdges(); // rebuild wires on the new node set
     if (firstPaint) {
@@ -1287,7 +1382,7 @@ function applyEdges() {
         }))
     : [];
   viewer.graph.edges.length = 0;
-  viewer.graph.edges.push(...edges);
+  viewer.graph.edges.push(...edges, ...fedEdges(present));
   viewer.setView(viewer.view); // schedule a redraw without a relayout
 }
 

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1600,6 +1600,81 @@ export async function cmdServe(rest: string[]): Promise<number> {
       }
     }
 
+    // GET /api/graph — the fleet as a read-only federated rgui graph envelope
+    // (org.rgui.graph.v1 — see lib/rgui src/core/federation.ts) so other rgui
+    // hosts (otoji.org etc.) can mirror it. A REDACTED projection of /api/ls:
+    // pid, cli type, status and the parent/subagent shape only — no cwd, prompt,
+    // question, or terminal bytes ever leave through this route. CORS-open on
+    // purpose: read-only + redacted, and the serve token still gates it like
+    // every /api route (hand out the feed URL with ?token=). The newest codex
+    // agent is ALSO exposed under the shared demo-chain id
+    // ay://agent-yes/codex-agent so cross-system edges have a stable target.
+    if (req.method === "GET" && p === "/api/graph") {
+      try {
+        const records = await listRecords(undefined, defaultOpts());
+        const origin = hostname();
+        const ns = `ay://${origin}`;
+        const textIn = { id: "text-in", label: "text", kind: "text" };
+        const textOut = { id: "text-out", label: "text", kind: "text" };
+        const byWrapper = new Map(records.map((r) => [r.wrapper_pid ?? r.pid, r.pid]));
+        const nid = (pid: number) => `${ns}/${pid}`;
+        const nodes = records.map((r, i) => ({
+          id: nid(r.pid),
+          app: "agent-yes",
+          type: `${r.cli}-agent`,
+          title: `${r.cli} #${r.pid}`,
+          category: "agent-yes",
+          owner: `agent-yes:${origin}`,
+          status: r.status,
+          parent: r.parent_pid && byWrapper.has(r.parent_pid) ? nid(byWrapper.get(r.parent_pid)!) : undefined,
+          pos: { x: (i % 8) * 320, y: Math.floor(i / 8) * 200 },
+          size: { w: 256, h: 128 },
+          inputs: [textIn],
+          outputs: [textOut],
+        }));
+        const codex = records
+          .filter((r) => r.cli === "codex")
+          .sort((a, b) => (b.last_active_at ?? 0) - (a.last_active_at ?? 0))[0];
+        nodes.push({
+          id: "ay://agent-yes/codex-agent",
+          app: "agent-yes",
+          type: "codex-agent",
+          title: "Codex Agent",
+          category: "agent-yes",
+          owner: `agent-yes:${origin}`,
+          status: codex?.status ?? "offline",
+          parent: undefined,
+          pos: { x: 0, y: -240 },
+          size: { w: 256, h: 128 },
+          inputs: [textIn],
+          outputs: [textOut],
+        });
+        const present = new Set(nodes.map((n) => n.id));
+        const edges = (await recentReadEdges())
+          .filter((e) => e.by !== e.target && present.has(nid(e.target)) && present.has(nid(e.by)))
+          .map((e) => ({
+            source: { node: nid(e.target), port: "text-out", type: "text" },
+            target: { node: nid(e.by), port: "text-in", type: "text" },
+            status: "readonly",
+            label: "reads",
+          }));
+        return Response.json(
+          {
+            kind: "rgui-federated-graph",
+            schema: "org.rgui.graph.v1",
+            producer: { app: "agent-yes", origin, label: `agent-yes fleet @ ${origin}` },
+            revision: Date.now(),
+            ts: Date.now(),
+            graph: { nodes, edges },
+            capabilities: { nodeTypes: [...new Set(nodes.map((n) => n.type))], portTypes: ["text"] },
+          },
+          { headers: { "Access-Control-Allow-Origin": "*" } },
+        );
+      } catch (e) {
+        return new Response((e as Error).message, { status: 500 });
+      }
+    }
+
     // GET /api/whoami — this host's device label (user@host), so a remote
     // console can tag each agent with the machine it came from. Unlike codehost,
     // `ay serve --share` carries no per-agent device id; the viewer fetches this


### PR DESCRIPTION
Part of the 3-repo federation demo (rgui × otoji × agent-yes). Chain target: plaintext (otoji) → **codex-agent (agent-yes)** → text-diff → filter → translator en→ja (otoji) → TTS (otoji).

## Expose — `GET /api/graph` on `ay serve`

Read-only federated rgui graph envelope (`org.rgui.graph.v1`, from lib/rgui `src/core/federation.ts`):
- **Redacted projection** of /api/ls: pid, cli type, status, parent/subagent shape only — no cwd, prompt, question, or terminal bytes.
- Every agent gets `text-in`/`text-out` ports; the newest codex agent is also published under the shared demo-chain id `ay://agent-yes/codex-agent` so cross-system edges land on a stable node.
- CORS-open (read-only + redacted), still token-gated like every /api route.

## Consume — /r/ read-only mirrors

- `#feed=<url>` (repeatable): poll 5s, revision-gated, converted via `federatedGraphToRgui` (clamped, `remote: true`), merged under the local forest.
- `#feddemo`: offline baked cross-system chain from rgui itself.
- Id-based dedupe — local graph wins, then feeds in listed order, baked demo last — so a feed's STUB of another system's node dedupes away to the authoritative one while its cross-system edges survive. Subgraphs stack by measured height.

## Verified (rech, local build + `bun ts/cli.ts serve --http --port 8877`)

- `/api/graph`: 55 nodes + codex-agent, 0 leak fields, `Access-Control-Allow-Origin: *`.
- Viewer `#feddemo&feed=…`: fleet mirror renders as remote (yellow) field cards; demo chain renders under its own container; `plaintext → codex-agent` edge reconnects to the LIVE codex node (status `active`) after stub dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)