### PR TITLE
feat(rgui): renderHints.embed — live single-agent terminal embeds

### DIFF
--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -65,6 +65,21 @@ interface AgentRecord {
 const roomInfo = parseRoomHash(location.hash) as
   | { room: string; token: string; host: string }
   | null;
+// #k=<token>: same-origin HTTP auth for a serve-hosted /r page (the console's
+// #k= convention) — appended to every /api call. #node=<pid>&embed: render ONLY
+// that agent's live terminal, full-viewport — the federation embed leg
+// (renderHints.embed): consumers iframe this page over the node rect, with the
+// TUI-preview card as their LOD fallback. See rgui docs/federation.md.
+const hashParts = location.hash.slice(1).split("&");
+const httpToken = hashParts.find((s) => s.startsWith("k="))?.slice(2) ?? null;
+// canonical form #node=<pid>&embed; #embed=<pid> accepted as an alias
+const embedPid =
+  hashParts.find((s) => s.startsWith("node="))?.slice(5) ??
+  hashParts.find((s) => s.startsWith("embed="))?.slice(6) ??
+  null;
+const embedMode = !!embedPid && hashParts.some((s) => s === "embed" || s.startsWith("embed="));
+const withTok = (path: string) =>
+  httpToken ? `${path}${path.includes("?") ? "&" : "?"}token=${encodeURIComponent(httpToken)}` : path;
 let room: InstanceType<typeof RTCClient> | null = null; // connected client (or null)
 let roomConnected = false;
 const usingRoom = () => !!roomInfo;
@@ -76,7 +91,7 @@ async function apiJSON<T>(path: string): Promise<T> {
     if (!roomReady()) throw new Error("room not connected");
     return JSON.parse((await room!.req("GET", path)).text) as T;
   }
-  const res = await fetch(path, { headers: { accept: "application/json" } });
+  const res = await fetch(withTok(path), { headers: { accept: "application/json" } });
   if (!res.ok) throw new Error(String(res.status));
   const ct = res.headers.get("content-type") ?? "";
   if (!ct.includes("json")) throw new Error("not json"); // static host served HTML
@@ -90,7 +105,7 @@ async function apiPost(path: string, body: unknown): Promise<{ ok: boolean; text
     const r = await room!.req("POST", path, JSON.stringify(body));
     return { ok: r.status >= 200 && r.status < 300, text: r.text };
   }
-  const r = await fetch(path, {
+  const r = await fetch(withTok(path), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -129,7 +144,7 @@ function subscribeRaw(path: string, onData: (v: unknown) => void): Sub {
     });
     return { close: unsub };
   }
-  const ev = new EventSource(path);
+  const ev = new EventSource(withTok(path));
   ev.onmessage = (e) => {
     try {
       onData(JSON.parse(e.data));
@@ -1250,7 +1265,7 @@ function reapplyMagnify() {
 // authoritative node is present, and its cross-system edges land on the real one.
 const FED_Y0 = 900; // world-y where the first federated subgraph mounts
 const FED_GAP = 300; // vertical gap between stacked federated subgraphs
-const fedHashParts = location.hash.slice(1).split("&");
+const fedHashParts = hashParts;
 const fedFeeds = fedHashParts
   .filter((s) => s.startsWith("feed="))
   .map((s) => decodeURIComponent(s.slice(5)));
@@ -1467,8 +1482,62 @@ if (roomInfo) {
   void connectOnce();
 }
 
-refresh();
-setInterval(refresh, 3000);
+// ── embed mode: ONE agent's live terminal, full viewport (renderHints.embed) ──
+// No forest, no polling loops — just the raw tail into an xterm sized to the
+// agent's native PTY grid, scaled down to fit the (usually iframe) viewport.
+function initEmbed(pid: string) {
+  document.title = `agent-yes · #${pid}`;
+  // the forest page booted underneath — drop its chrome entirely (incl. chrome
+  // mounted LATER, e.g. the theme toggle); the embed IS the whole document now
+  const css = document.createElement("style");
+  css.textContent = "body.ay-embed > *:not(.ay-embed-wrap){display:none!important}";
+  document.head.appendChild(css);
+  document.body.classList.add("ay-embed");
+  const wrap = document.createElement("div");
+  wrap.className = "ay-embed-wrap";
+  wrap.style.cssText = "position:fixed;inset:0;z-index:99;background:#0d1117;overflow:hidden";
+  const inner = document.createElement("div");
+  inner.style.cssText = "transform-origin:0 0"; // scaled to fit; wrap bg stays full-viewport
+  wrap.appendChild(inner);
+  document.body.appendChild(wrap);
+  if (!XTermCtor) {
+    wrap.textContent = "xterm failed to load";
+    return;
+  }
+  const term = new XTermCtor({
+    fontSize: 14,
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    theme: termTheme(),
+    disableStdin: true, // read-only mirror, same as the forest terminals
+    cursorBlink: false,
+    scrollback: 1000,
+    convertEol: false,
+  });
+  term.open(inner);
+  // scale the native-grid terminal to FIT the viewport (never upscale) — the
+  // iframe consumer sizes us to the node rect, so this is the whole fit story
+  const fit = () => {
+    const el = inner.querySelector(".xterm") as HTMLElement | null;
+    if (!el || !el.offsetWidth || !el.offsetHeight) return;
+    const s = Math.min(1, innerWidth / el.offsetWidth, innerHeight / el.offsetHeight);
+    inner.style.transform = `scale(${s})`;
+  };
+  addEventListener("resize", fit);
+  apiJSON<{ cols?: number; rows?: number }>(`/api/size/${encodeURIComponent(pid)}`)
+    .then((sz) => {
+      if (sz?.cols && sz?.rows) term.resize(sz.cols, sz.rows);
+    })
+    .catch(() => {})
+    .finally(() => requestAnimationFrame(fit));
+  subscribeRaw(`/api/tail/${encodeURIComponent(pid)}?raw=1`, (d) => term.write(d as string));
+}
+
+if (embedMode) {
+  initEmbed(embedPid!);
+} else {
+  refresh();
+  setInterval(refresh, 3000);
+}
 
 // QA (#qa): auto-zoom into a leaf so terminals spawn (the size probe in makeTerm
 // then logs each overlay's px), and run a slow zoom sweep logging how many times

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1649,11 +1649,19 @@ export async function cmdServe(rest: string[]): Promise<number> {
         // renderHints.preview: the REAL agent TUI tail (redacted in
         // logPreviewLines), drawn by rgui's federatedTerminalPreview as a live
         // terminal card on the mirroring host
-        const previewOf = async (r: (typeof records)[number]) => {
+        // renderHints.embed: the publisher's own single-agent live view — the
+        // consumer iframes it over the node rect (preview stays the LOD
+        // fallback). Carries the serve token: the feed itself is gated by the
+        // same token, so its consumers hold it already.
+        const embedBase = `${url.protocol}//${url.host}`;
+        const hintsOf = async (r: (typeof records)[number]) => {
+          const embed = {
+            url: `${embedBase}/r/#node=${r.pid}&embed&k=${encodeURIComponent(token)}`,
+          };
           const lines = await logPreviewLines(r.log_file);
-          if (!lines?.length) return undefined;
+          if (!lines?.length) return { embed };
           const title = (await logTitle(r.log_file)) ?? `${r.cli} #${r.pid}`;
-          return { preview: { kind: "terminal", title, status: r.status, lines } };
+          return { embed, preview: { kind: "terminal", title, status: r.status, lines } };
         };
         const nodes = await Promise.all(
           records.map(async (r, i) => ({
@@ -1669,7 +1677,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
             size: { w: 256, h: 128 },
             inputs: [textIn],
             outputs: [textOut],
-            renderHints: await previewOf(r),
+            renderHints: await hintsOf(r),
           })),
         );
         const codex = records
@@ -1688,7 +1696,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
           size: { w: 256, h: 128 },
           inputs: [textIn],
           outputs: [textOut],
-          renderHints: codex ? await previewOf(codex) : undefined,
+          renderHints: codex ? await hintsOf(codex) : undefined,
         });
         const present = new Set(nodes.map((n) => n.id));
         const edges = (await recentReadEdges())
@@ -2606,11 +2614,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
     "worker-src 'self'",
     "manifest-src 'self'",
   ].join("; ");
-  const serveUiFile = async (name: string, type: string): Promise<Response> => {
+  // The /r (rgui) page is embeddable: its #node=<pid>&embed view is the
+  // federation renderHints.embed target, iframed by OTHER rgui hosts over the
+  // node rect — so frame-ancestors opens up, unlike the console's 'none'.
+  const RGUI_CSP = CONSOLE_CSP.replace("frame-ancestors 'none'", "frame-ancestors *");
+  const serveUiFile = async (name: string, type: string, csp = CONSOLE_CSP): Promise<Response> => {
     try {
       const buf = await readFile(path.join(uiDir, name));
       const headers: Record<string, string> = { "Content-Type": type };
-      if (type.includes("text/html")) headers["Content-Security-Policy"] = CONSOLE_CSP;
+      if (type.includes("text/html")) headers["Content-Security-Policy"] = csp;
       return new Response(buf, { headers });
     } catch {
       return new Response("UI assets not found in this install — use the /api endpoints", {
@@ -2622,6 +2634,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
     const p = new URL(req.url).pathname;
     if (req.method === "GET" && (p === "/" || p === "/index.html"))
       return serveUiFile("index.html", "text/html; charset=utf-8");
+    // /r — the rgui forest page (built to lab/ui/rgui/dist by scripts/build-rgui.ts),
+    // served here so renderHints.embed URLs work with no extra host. Relative
+    // asset paths need the trailing slash, so bare /r redirects.
+    if (req.method === "GET" && p === "/r") return Response.redirect("/r/", 302);
+    if (req.method === "GET" && (p === "/r/" || p === "/r/index.html"))
+      return serveUiFile("rgui/dist/index.html", "text/html; charset=utf-8", RGUI_CSP);
+    if (req.method === "GET" && p === "/r/main.js")
+      return serveUiFile("rgui/dist/main.js", "text/javascript; charset=utf-8");
+    if (req.method === "GET" && p === "/r/main.js.map")
+      return serveUiFile("rgui/dist/main.js.map", "application/json");
     if (req.method === "GET" && p === "/room-client.js")
       return serveUiFile("room-client.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/console-logic.js")


### PR DESCRIPTION
Top rung of the federation preview ladder (rgui docs/federation.md): fields → TUI-card preview → **live iframe embed**.

- `GET /api/graph` nodes now carry `renderHints.embed = { url }` → the publisher's own single-agent live view; consumers (otoji) iframe it over the node rect (rgui overlay `scale:'fit'`), falling back to the `renderHints.preview` TUI card when hidden/small.
- `/r/#node=<pid>&embed` (alias `#embed=<pid>`): renders ONLY that agent's live xterm — raw `/api/tail` at native PTY grid, scaled to fit the viewport, all chrome hidden (including late-mounted). `#k=<token>` authenticates every HTTP /api call from the page.
- `ay serve --http` now serves the built /r page (`lab/ui/rgui/dist`) so embed URLs need no extra host; /r gets `frame-ancestors *` (console stays `'none'`).
- Embed URLs carry the serve token — the feed handing them out is gated by the same token.

Verified via rech: embed URL renders a real live claude TUI full-viewport; feed serves embed+preview per node; CSP header confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)