### PR TITLE
fix(rgui): input path on terminal-covered cards + /r-form share links

### DIFF
--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -603,6 +603,14 @@ function makeTerm(pid: string): TermEntry | null {
   const el = document.createElement("div");
   el.className = "ay-term";
   el.dataset.rguiInteractive = "1"; // let scroll/select inside the terminal work
+  // right-click on the live terminal = right-click on the node: open the send
+  // menu instead of the browser menu — without this a terminal-covered card has
+  // NO input path at all (the room/share view is exactly one such card)
+  el.addEventListener("contextmenu", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openBatchMenu(e.clientX, e.clientY, [pid]);
+  });
   const bar = document.createElement("div");
   bar.className = "ay-term-bar";
   bar.innerHTML =
@@ -1934,11 +1942,14 @@ ctxShareBtn.addEventListener("click", async () => {
     return;
   }
   const share = JSON.parse(r.text) as { link: string; agentId: string };
-  ctxShareLink.textContent = share.link;
+  // present the /r (viewer) form of the capability link — same room+secret,
+  // this surface; the holder can flip /r/# to /w/# for the full console
+  const link = share.link.replace("/w/#", "/r/#");
+  ctxShareLink.textContent = link;
   sharedIds.add(share.agentId);
   markShared();
   try {
-    await navigator.clipboard.writeText(share.link);
+    await navigator.clipboard.writeText(link);
   } catch {
     /* clipboard blocked — the link is still selectable */
   }


### PR DESCRIPTION
taku's QA feedback on shared nodes in /r:

1. **Couldn't input on the shared node in /r (while /w could).** Root cause: the live-terminal overlay swallows right-click (browser context menu), and a scoped-room view is exactly one terminal-covered card — so /r had no input affordance at all. The overlay now forwards `contextmenu` to the send menu for its agent, same as right-clicking the bare card. Verified e2e over a scoped **rw** room: right-click the terminal → send `echo QA-SHARE-INPUT-OK` → lands in the agent's PTY. (Read-only shares still deny host-side via scopedFetch.)
2. **Share links now present the /r (viewer) form** (`…/r/#room:secret`) instead of `/w` — same capability, current surface; flip the path for the full console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)