### PR TITLE
feat(watchdog): reap wedged agents that repaint no working marker

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -18,6 +18,14 @@ clis:
     working:
       - esc to interrupt
       - to run in background
+    # Wedge watchdog: a frozen state that repaints no `working` marker at all
+    # (observed: claude wedged mid-"Compacting conversation…" at 0% CPU for
+    # days — screen matched neither ready, working nor needsInput). After this
+    # many seconds of total PTY silence in that no-marker state, recover via
+    # the same Esc → force-restart ladder as the spinner stall watchdog.
+    # Only enabled for CLIs whose ready markers reliably identify "parked at
+    # prompt"; 0/absent disables.
+    wedgeTimeoutSecs: 1800
     # needsInput: the agent is blocked on an interactive selection menu it did NOT
     # auto-resolve — an AskUserQuestion / a permission prompt whose options aren't
     # the auto-`enter`ed "Yes". The cursor `❯` sits on a numbered option. Surfaced
@@ -147,6 +155,9 @@ clis:
     working:
       - esc to interrupt
       - to run in background
+    # Same wedge watchdog as claude (this CLI runs the claude binary) — see
+    # the claude section for rationale.
+    wedgeTimeoutSecs: 1800
     needsInput:
       - pattern: '❯ ?\d+\.'
         flags: m
@@ -249,6 +260,9 @@ clis:
     working:
       - esc to interrupt
       - to run in background
+    # Same wedge watchdog as claude (this CLI runs the claude binary) — see
+    # the claude section for rationale.
+    wedgeTimeoutSecs: 1800
     needsInput:
       - pattern: '❯ ?\d+\.'
         flags: m

--- a/rs/src/config.rs
+++ b/rs/src/config.rs
@@ -78,6 +78,19 @@ pub struct CliConfig {
     /// `await` never resolved). On trip: send Esc to cancel; if still stalled,
     /// exit non-zero so a `--robust` run restarts with `--continue`. 0 disables.
     pub stall_timeout_secs: u64,
+    /// Wedge watchdog timeout (seconds). Complements `stall_timeout_secs`:
+    /// some frozen states repaint no `working` marker at all (observed: claude
+    /// wedged mid-"Compacting conversation…" at 0% CPU for days, its screen
+    /// matching neither `ready` nor `working` nor `needs_input`). When the
+    /// screen shows none of those and the PTY has been silent this long, the
+    /// CLI is treated as wedged and recovered via the same Esc → force-restart
+    /// ladder. 0 disables — the default, enabled per-CLI in
+    /// default.config.yaml only where the ready markers are trustworthy.
+    pub wedge_timeout_secs: u64,
+    /// Needs-input menu patterns: the agent is parked on an interactive
+    /// selection (AskUserQuestion / permission prompt) — a legitimate
+    /// indefinite wait for a human, exempt from the wedge watchdog.
+    pub needs_input: Vec<Regex>,
     /// Liveness window in ms: if we send stdin and the agent produces no PTY
     /// output within this window, mark it `unresponsive`. 0 = disabled.
     pub unresponsive_timeout_ms: u64,
@@ -176,6 +189,8 @@ fn build_cli_config(raw: CliConfigOverride) -> Result<CliConfig> {
         yes_args: raw.yes_args.unwrap_or_default(),
         no_eol: raw.no_eol.unwrap_or(false),
         stall_timeout_secs: raw.stall_timeout_secs.unwrap_or(DEFAULT_STALL_TIMEOUT_SECS),
+        wedge_timeout_secs: raw.wedge_timeout_secs.unwrap_or(0),
+        needs_input: compile_regex_list(raw.needs_input)?,
         unresponsive_timeout_ms: raw.unresponsive_timeout_ms.unwrap_or(0),
     })
 }
@@ -295,6 +310,11 @@ mod tests {
             .any(|rx| rx.is_match("Press Enter to continue")));
         assert!(!config.working.is_empty());
         assert!(config.working[0].is_match("esc to interrupt"));
+        // Wedge watchdog is armed for claude (its ready markers are
+        // trustworthy) and needsInput exempts menu-parked sessions.
+        assert_eq!(config.wedge_timeout_secs, 1800);
+        assert!(!config.needs_input.is_empty());
+        assert!(config.needs_input[0].is_match("❯ 1. Yes, apply this fix"));
         assert!(!config.fatal.is_empty());
         assert!(config.fatal[0].is_match("error: unknown option '--foo'"));
         // Usage-limit / overload are now auto-retried (typed "retry"), not fatal.

--- a/rs/src/config_loader.rs
+++ b/rs/src/config_loader.rs
@@ -106,6 +106,16 @@ pub struct CliConfigOverride {
     /// treated as silently stalled. 0 disables. Omitted → built-in default.
     #[serde(default)]
     pub stall_timeout_secs: Option<u64>,
+    /// Wedge watchdog timeout (seconds): screen matches neither ready, working
+    /// nor needsInput and the PTY has been silent this long → recover via the
+    /// stall ladder. 0 (or absent) disables. See config.rs.
+    #[serde(default)]
+    pub wedge_timeout_secs: Option<u64>,
+    /// Needs-input menu patterns (agent parked on an interactive selection —
+    /// exempt from the wedge watchdog; also surfaced by the TS side as the
+    /// `needs_input` state).
+    #[serde(default)]
+    pub needs_input: Option<Vec<RegexSource>>,
     /// Liveness window: if we send stdin to the agent and it produces no PTY
     /// output within this many ms, mark it `unresponsive`. 0 (or absent)
     /// disables the check — appropriate for CLIs that don't animate a spinner.
@@ -211,6 +221,8 @@ impl CliConfigOverride {
             restart_without_continue_arg,
             auto_retry,
             stall_timeout_secs,
+            wedge_timeout_secs,
+            needs_input,
             unresponsive_timeout_ms,
         } = other;
 
@@ -301,6 +313,12 @@ impl CliConfigOverride {
         }
         if stall_timeout_secs.is_some() {
             self.stall_timeout_secs = stall_timeout_secs;
+        }
+        if wedge_timeout_secs.is_some() {
+            self.wedge_timeout_secs = wedge_timeout_secs;
+        }
+        if needs_input.is_some() {
+            self.needs_input = needs_input;
         }
         if unresponsive_timeout_ms.is_some() {
             self.unresponsive_timeout_ms = unresponsive_timeout_ms;
@@ -678,6 +696,8 @@ logsDir: /custom/logs
                 restart_without_continue_arg: Some(vec![pattern("old-restart")]),
                 auto_retry: Some(vec![pattern("old-auto-retry")]),
                 stall_timeout_secs: Some(111),
+                wedge_timeout_secs: Some(1111),
+                needs_input: Some(vec![pattern("old-needs-input")]),
                 unresponsive_timeout_ms: Some(1000),
             },
         );
@@ -718,6 +738,8 @@ logsDir: /custom/logs
                 restart_without_continue_arg: Some(vec![pattern("new-restart")]),
                 auto_retry: Some(vec![pattern("new-auto-retry")]),
                 stall_timeout_secs: Some(222),
+                wedge_timeout_secs: Some(2222),
+                needs_input: Some(vec![pattern("new-needs-input")]),
                 unresponsive_timeout_ms: Some(2000),
             },
         );
@@ -771,6 +793,8 @@ logsDir: /custom/logs
         );
         assert_eq!(t.auto_retry, Some(vec![pattern("new-auto-retry")]));
         assert_eq!(t.stall_timeout_secs, Some(222));
+        assert_eq!(t.wedge_timeout_secs, Some(2222));
+        assert_eq!(t.needs_input, Some(vec![pattern("new-needs-input")]));
         assert_eq!(t.unresponsive_timeout_ms, Some(2000));
         assert!(t.typing_respond.as_ref().unwrap().contains_key("y"));
         assert!(t.typing_respond.as_ref().unwrap().contains_key("1"));

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -90,6 +90,30 @@ fn decide_stall_action(
     }
 }
 
+/// Whether the wedge detector trips. Complements the spinner-based stall
+/// detector above: some frozen states repaint no `working` marker at all
+/// (observed 2026-07: claude wedged mid-"Compacting conversation…" at 0% CPU
+/// for days, its screen matching neither `ready` nor `working` nor a
+/// needs-input menu). If the screen shows no ready prompt (parked/done), no
+/// working spinner (the stall detector's territory), and no interactive menu
+/// (a legitimate indefinite wait for a human), then `wedge_timeout_secs` of
+/// total PTY silence means the CLI is wedged. 0 disables — the default,
+/// enabled per-CLI in default.config.yaml only where the ready markers are
+/// trustworthy enough to tell "parked at prompt" from "frozen".
+fn is_wedged(
+    wedge_timeout_secs: u64,
+    working: bool,
+    ready: bool,
+    needs_input: bool,
+    idle_secs: u64,
+) -> bool {
+    wedge_timeout_secs > 0
+        && !working
+        && !ready
+        && !needs_input
+        && idle_secs >= wedge_timeout_secs
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum PanicAction {
     /// Gesture incomplete: fewer than `threshold` presses in the window.
@@ -985,13 +1009,31 @@ impl AgentContext {
         let working = self.cli_config.working.iter().any(|p| p.is_match(&screen));
         let idle_secs = self.idle_waiter.idle_time_ms() / 1000;
         let esc_elapsed = self.stall_esc_sent_at.map(|t| t.elapsed().as_secs());
-        let action = decide_stall_action(
-            timeout,
-            working,
-            idle_secs,
-            esc_elapsed,
-            STALL_ESC_GRACE_SECS,
-        );
+        // Wedge detector (see is_wedged): a frozen state that repaints no
+        // `working` marker. The extra ready/needs-input screen scans only run
+        // once the cheap conditions (enabled, spinner absent, long silence)
+        // already hold — never on a routine 50ms heartbeat.
+        let wedge_timeout = self.cli_config.wedge_timeout_secs;
+        let wedged = wedge_timeout > 0 && !working && idle_secs >= wedge_timeout && {
+            let ready = self.cli_config.ready.iter().any(|p| p.is_match(&screen));
+            let needs_input = self
+                .cli_config
+                .needs_input
+                .iter()
+                .any(|p| p.is_match(&screen));
+            is_wedged(wedge_timeout, working, ready, needs_input, idle_secs)
+        };
+        let action = if wedged {
+            // Reuse the stall ladder: `working: true` here just means "tripped".
+            decide_stall_action(wedge_timeout, true, idle_secs, esc_elapsed, STALL_ESC_GRACE_SECS)
+        } else {
+            decide_stall_action(timeout, working, idle_secs, esc_elapsed, STALL_ESC_GRACE_SECS)
+        };
+        let cause = if wedged {
+            "no ready prompt, no spinner, no menu"
+        } else {
+            "working spinner frozen"
+        };
         // Any non-Clear action means the "working" spinner is frozen → feed the
         // unified stuck flag. The stuck/recovered webhook is now emitted centrally
         // by update_unresponsive() (this used to fire its own "STUCK" notify); the
@@ -1004,9 +1046,11 @@ impl AgentContext {
             }
             StallAction::SendEsc => {
                 warn!(
-                    "No-output watchdog: spinner up with no visible output for {}s (>= {}s) — \
+                    "No-output watchdog: {} with no visible output for {}s (>= {}s) — \
                      stream looks stalled, sending Esc to cancel",
-                    idle_secs, timeout
+                    cause,
+                    idle_secs,
+                    if wedged { wedge_timeout } else { timeout }
                 );
                 // Esc cancels claude's in-flight request; harmless to other CLIs.
                 // Use send_esc (NOT send_text) so we don't ping the idle timer —
@@ -1018,9 +1062,9 @@ impl AgentContext {
             StallAction::Wait => {}
             StallAction::ForceRestart => {
                 warn!(
-                    "No-output watchdog: Esc did not recover the stream after {}s — forcing \
-                     restart (a --robust run resumes with --continue)",
-                    STALL_ESC_GRACE_SECS
+                    "No-output watchdog ({}): Esc did not recover the stream after {}s — \
+                     forcing restart (a --robust run resumes with --continue)",
+                    cause, STALL_ESC_GRACE_SECS
                 );
                 self.stall_force_restart = true;
             }
@@ -1467,6 +1511,23 @@ fn find_char_boundary(s: &str, at: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_is_wedged_trips_only_in_the_no_marker_state() {
+        // The real wedge: no ready, no spinner, no menu, long silence.
+        assert!(is_wedged(1800, false, false, false, 1800));
+        assert!(is_wedged(1800, false, false, false, 9999));
+        // Not yet silent long enough.
+        assert!(!is_wedged(1800, false, false, false, 1799));
+        // Disabled (the default for CLIs without trustworthy ready markers).
+        assert!(!is_wedged(0, false, false, false, 99999));
+        // Working spinner on screen — the stall detector's territory.
+        assert!(!is_wedged(1800, true, false, false, 9999));
+        // Parked at a ready prompt (idle/done) — a legitimate forever-wait.
+        assert!(!is_wedged(1800, false, true, false, 9999));
+        // Blocked on an interactive menu — waiting for a human, not wedged.
+        assert!(!is_wedged(1800, false, false, true, 9999));
+    }
 
     #[test]
     fn test_retry_backoff_secs_doubles_then_caps() {


### PR DESCRIPTION
## Problem

The spinner-based no-output watchdog (`stallTimeoutSecs`, #100) only trips while a `working` marker is on screen. Real wedges don't always leave one: on 2026-07-10 the machine had **117 stale agents (up to 8 days old, load average 139)**, and rendering their final screens from the raw logs showed a claude frozen mid-`Compacting conversation…` at 0% CPU whose screen matched **neither `ready`, `working` nor `needsInput`** — invisible to every detector.

## Fix

A wedge detector beside the stall detector, feeding the same Esc → 30s grace → force-restart ladder (exit 75; `--robust` resumes with `--continue`, and the resume-menu auto-`enter` already covers the restart path):

- trips when: no ready prompt + no working spinner + no needs-input menu + `wedgeTimeoutSecs` of total PTY silence
- `needsInput` menus (AskUserQuestion / permission prompts) are exempt — a human wait is legitimately unbounded
- `wedgeTimeoutSecs: 1800` enabled only for the claude-binary CLIs (claude / glm / openrouter) whose ready markers reliably identify "parked at prompt"; every other CLI defaults to 0 (off)
- `needsInput` is now parsed by the Rust config too (was TS-only)

## Verification

- Condition validated against the **real final screens** of three dead agents: compacting-wedge matches nothing (trips), finished-at-prompt matches `ready` (exempt), frozen-spinner matches `working` (existing detector's case).
- E2E sim (8s override, silent bash, unmatchable ready marker): Esc fired at exactly 8s with the wedge-specific message, force-restart at +30s, CLI relaunched, `unresponsive` flag published (`stuck` badge in `ay ls`).
- `cargo test`: 254 passed · `vitest`: 818 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)