### PR TITLE
test(idleWaiter): tolerate CI timer coarseness in the elapsed-time assertion

### DIFF
--- a/ts/idleWaiter.spec.ts
+++ b/ts/idleWaiter.spec.ts
@@ -65,7 +65,9 @@ describe("IdleWaiter", () => {
     expect(waiter.idleTimeMs()).toBeLessThan(20);
 
     await new Promise((r) => setTimeout(r, 50));
-    expect(waiter.idleTimeMs()).toBeGreaterThanOrEqual(50);
+    // 45, not 50: setTimeout(50) can fire with the monotonic clock reading
+    // ~49ms on CI (timer coarseness), which flaked this exact assertion.
+    expect(waiter.idleTimeMs()).toBeGreaterThanOrEqual(45);
 
     waiter.ping();
     expect(waiter.idleTimeMs()).toBeLessThan(20);


### PR DESCRIPTION
setTimeout(50) can fire with the monotonic clock reading ~49ms on CI (timer coarseness), which failed `expected 49 to be greater than or equal to 50` on the merge commit of #229 (ubuntu/bun job). Loosen the lower bound to 45ms — the assertion still proves idleTimeMs tracks elapsed time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)