### PR TITLE
feat(ui): /w/ ⇄ /r/ view switcher with a shared token-less room hash

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1685,6 +1685,9 @@
               <button id="foldbtn" class="viewbtn" title="fold subagent trees">⊞ subs</button>
               <button id="sortbtn" class="viewbtn" title="cycle sort order">⇅ state</button>
               <button id="viewbtn" class="viewbtn" title="toggle compact list">☰</button>
+              <button id="rguibtn" class="viewbtn" title="open the agent graph view (/r/) for this fleet">
+                ⌗ graph
+              </button>
               <button id="newbtn" class="newbtn" title="spawn a new agent on this fleet">
                 + New agent
               </button>
@@ -3962,6 +3965,10 @@
       }
 
       function renderList() {
+        // The graph view (/r/) only exists on the hosted origin — a local
+        // `ay serve --http` console (served at /) has no /r/ route, so the
+        // switcher would 404 there. Path-gate it to the hosted /w/ console.
+        $("rguibtn").hidden = !location.pathname.startsWith("/w");
         const toks = $("q").value.trim().split(/\s+/).filter(Boolean);
         // Build the full signalling-server > rooms > peers > agents > subagents
         // tree. Single-node room/peer layers fold away; ≥2 become ├ └ │ branches.
@@ -4505,6 +4512,20 @@
         foldSubs = !foldSubs;
         localStorage.setItem("ay.foldSubs", foldSubs ? "1" : "0");
         renderList();
+      });
+      // View switcher: same fleet, semantic-zoom graph rendering (/r/ = rgui).
+      // Prefer the selected agent's room (carrying its pid as a deep link),
+      // else the first live WebRTC room. Only the room mnemonic travels — /r/
+      // reconnects from the shared ay.rooms cache, so no token enters the URL.
+      // A pure-local console (no rooms) opens the local /r/ on the same wire.
+      $("rguibtn").addEventListener("click", () => {
+        const [selRoom, selPid] = sel ? sel.split("#") : [null, null];
+        let room = selRoom && selRoom !== LOCAL && loadRooms()[selRoom] ? selRoom : null;
+        if (!room)
+          room = [...sources.values()].find((s) => s.kind === "rtc" && s.live)?.id ?? null;
+        const frag =
+          room ? "#" + encodeURIComponent(room) + (room === selRoom && selPid ? ":" + selPid : "") : "";
+        location.href = "/r/" + frag;
       });
       // Cycle the sort order: state → created → identity → state.
       $("sortbtn").addEventListener("click", () => {

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -576,6 +576,7 @@
       <span id="status"><span class="dot"></span><span class="label">connecting…</span></span>
       <button id="fit" title="Fit all agents to view">fit</button>
       <button id="wires" title="Toggle read/tail relationship wires">⇢ wires</button>
+      <button id="console" title="Open the terminal console view (/w/) for this fleet">☰ console</button>
       <button id="theme" title="Toggle light/dark">◐</button>
     </div>
 

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -63,14 +63,59 @@ interface AgentRecord {
 // roomInfo is fixed at load from the hash. When a room IS configured we never
 // fall back to HTTP or the sample — you opened a share link, so we show that
 // room or its connection state.
-const roomInfo = parseRoomHash(location.hash) as
-  | { room: string; token: string; host: string }
-  | null;
+// "ay.rooms" is the console's saved-room credential cache (same origin, same
+// shape — see saveRoom in lab/ui/index.html). Sharing it makes /r/ ⇄ /w/
+// switching token-less: a share link opened on EITHER page caches the secret,
+// and after that a bare #<room> (or #<room>:<pid> deep link) reconnects on
+// both. Mirrors /w/'s SECURITY behavior: the token is eaten from the URL on
+// open so it never lingers in history/omnibox — only the room mnemonic stays.
+const ROOMS_KEY = "ay.rooms";
+function cachedRoom(name: string): { token: string; host: string } | null {
+  try {
+    const r = JSON.parse(localStorage.getItem(ROOMS_KEY) || "{}")[name];
+    return r?.token ? { token: r.token, host: r.host || "s.agent-yes.com" } : null;
+  } catch {
+    return null;
+  }
+}
+function saveRoom(name: string, token: string, host: string) {
+  try {
+    const r = JSON.parse(localStorage.getItem(ROOMS_KEY) || "{}");
+    r[name] = { token, host, ts: Date.now() };
+    localStorage.setItem(ROOMS_KEY, JSON.stringify(r));
+  } catch {
+    /* private mode / quota — the session still works, just not cached */
+  }
+}
+function resolveRoom(hash: string): { room: string; token: string; host: string } | null {
+  const p = parseRoomHash(hash) as { room: string; token: string; host: string } | null;
+  if (p) {
+    saveRoom(p.room, p.token, p.host);
+    history.replaceState(
+      null,
+      document.title,
+      location.pathname + location.search + "#" + p.room,
+    );
+    return p;
+  }
+  // #<room> or #<room>:<pid> — token-less forms; reconnect from the cache.
+  // (parseRoomHash already rejected these: bare room, or numeric ≤7-digit id.)
+  const h = decodeURIComponent(String(hash || "").replace(/^#/, ""));
+  const m = /^([A-Za-z0-9_-]+)(?::\d{1,7})?$/.exec(h);
+  if (m) {
+    const c = cachedRoom(m[1]!);
+    if (c) return { room: m[1]!, ...c };
+  }
+  return null;
+}
+const roomInfo = resolveRoom(location.hash);
 // #k=<token>: same-origin HTTP auth for a serve-hosted /r page (the console's
 // #k= convention) — appended to every /api call. #node=<pid>&embed: render ONLY
 // that agent's live terminal, full-viewport — the federation embed leg
 // (renderHints.embed): consumers iframe this page over the node rect, with the
 // TUI-preview card as their LOD fallback. See rgui docs/federation.md.
+// (Read AFTER resolveRoom: a share-link hash never carries k=/node= parts, and
+// resolveRoom's token-eating rewrite doesn't touch these forms.)
 const hashParts = location.hash.slice(1).split("&");
 const httpToken = hashParts.find((s) => s.startsWith("k="))?.slice(2) ?? null;
 // canonical form #node=<pid>&embed; #embed=<pid> accepted as an alias
@@ -2035,3 +2080,17 @@ document.getElementById("theme")!.addEventListener("click", () => {
   viewer.setTheme(next);
   for (const e of terms.values()) e.term.options.theme = termTheme();
 });
+// View switcher: same fleet, terminal-console rendering. The bare #<room> is
+// enough — the console reconnects from the shared ay.rooms cache (no token in
+// the URL). Path-gated to the hosted origin: the local dev:rgui server has no
+// /w/ route, so the button would 404 there — hide it.
+{
+  const consoleBtn = document.getElementById("console") as HTMLButtonElement;
+  if (/^\/(r|rgui)(\/|$)/.test(location.pathname)) {
+    consoleBtn.addEventListener("click", () => {
+      location.href = roomInfo ? "/w/#" + encodeURIComponent(roomInfo.room) : "/w/";
+    });
+  } else {
+    consoleBtn.hidden = true;
+  }
+}


### PR DESCRIPTION
## What

- **/w/ console header**: new `⌗ graph` button → opens `/r/#<room>[:pid]` for the selected agent's room (falls back to the first live WebRTC room).
- **/r/ rgui top bar**: new `☰ console` button → opens `/w/#<room>`.
- **Shared credentials**: /r/ now reads/writes the console's `ay.rooms` localStorage cache. A share link opened on either page caches the secret and eats the token from the URL (mirroring /w/'s SECURITY behavior); after that, bare `#<room>[:pid]` hashes reconnect on both pages — no token ever enters the URL on a switch.
- **Path-gated**: both buttons hide off the hosted origin (local `ay serve --http` has no /r/ route; dev:rgui has no /w/), so the switcher never 404s.

## Verified on production (agent-yes.com, deployed)

- /w/ → /r/: connects live (58 agents) from the token-less `#rc19085` hash
- /r/ → /w/: console restores with its persisted selection
- share link opened directly on /r/: token eaten to `#<room>`, connects live
- vitest: 818 passed / 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)