### PR TITLE
ci(release): push version bumps with RELEASE_TOKEN so required checks don't block releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,12 @@ jobs:
       # After this, we explicitly dispatch rust-build.yml below.
       - run: bunx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN (an admin PAT) instead of the default GITHUB_TOKEN:
+          # main now has required status checks, and @semantic-release/git's
+          # version-bump push would be rejected for the non-admin Actions token.
+          # Admin pushes bypass the checks (enforce_admins is off). Falls back
+          # to GITHUB_TOKEN if the secret is ever removed.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Disable husky hooks so @semantic-release/git's commit doesn't trigger
           # pre-commit (fmt/build/test), which races the rust rebuild against


### PR DESCRIPTION
main now carries required status checks (the 4 matrix-test jobs). The `@semantic-release/git` version-bump commit is a direct push to main, which the non-admin default `GITHUB_TOKEN` can no longer perform. Use the `RELEASE_TOKEN` admin secret (already set in repo secrets) for the semantic-release step — admin pushes bypass required checks under classic protection with `enforce_admins: off`. Falls back to `GITHUB_TOKEN` if the secret is ever removed.

Part of enabling CI-gated merges (see #229 discussion / harvest report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)