### PR TITLE
feat(rgui): glide the camera on node focus (setView animate)

### DIFF
--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -1821,7 +1821,11 @@ function focusNode(id: string, overlay = false) {
   const ch = canvas.clientHeight || innerHeight;
   const pad = 90;
   const k = Math.min((cw - 2 * pad) / n.w, (ch - 2 * pad) / h, 2.6); // fit node, cap zoom-in
-  viewer.setView({ k, x: cw / 2 - (n.x + n.w / 2) * k, y: ch / 2 - (n.y + h / 2) * k });
+  // glide, don't hard-switch — the camera travel keeps spatial context (taku)
+  viewer.setView(
+    { k, x: cw / 2 - (n.x + n.w / 2) * k, y: ch / 2 - (n.y + h / 2) * k },
+    { animate: true },
+  );
   viewer.setSelection([id]);
   if (!overlay) return;
   // the terminal spawns on settle (settle-gate) — poll for it, then focus it.


### PR DESCRIPTION
Pairs with snomiao/rgui#4: `focusNode` (⌘K go-to / palette click) now glides the viewport to the target — easeInOut on the screen-center world point, log-space zoom, cancelled by any user wheel/drag — instead of hard-switching. Bumps `lib/rgui` to `7397646` (carries the feature; also picks up rgui main's lane auto-fold work already on their main).

Verified in the built page: sampled view trajectory eases over ~320ms and settles on the focused node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)