### PR TITLE
feat(env): environment nodes — host env node in /rgui + federation, spawn-here, new-agent modal UX

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -5531,16 +5531,56 @@
       });
 
       // ---- "+ New agent": a spawn form for one machine in the fleet ----------
-      // Click → fill (cli defaults to claude, cwd prefilled from the selected agent
-      // when there is one, prompt optional) → POST /api/spawn on that machine.
+      // Click → fill (cwd prefilled from the selected agent when there is one,
+      // prompt optional) → POST /api/spawn on that machine.
       // Always allowed: the console already controls every running agent's stdin.
       //
       // The Host row appears only when the fleet holds more than one machine. It
       // defaults to spawnTarget()'s pick — the selected agent's machine — so the
       // common "spawn next to what I'm looking at" flow needs no interaction.
+      // Working dir sits directly under Host (a cwd only means something on its
+      // machine) and autocompletes from that host's known agent cwds; CLI is a
+      // picker (options from /api/spawn-config `clis`), preselected from the
+      // chain: selected agent's cli → last used cli → explicit user pick.
+      const LAST_CLI_KEY = "ay.lastSpawnCli";
+      const CLI_FALLBACK = ["claude", "codex", "gemini", "copilot", "cursor-agent", "goose", "aider"];
+      function cliOptions(clis, preferred) {
+        const list = clis && clis.length ? clis : CLI_FALLBACK;
+        const has = preferred && list.includes(preferred);
+        return (
+          `<option value=""${has ? "" : " selected"} disabled>choose a CLI…</option>` +
+          list
+            .map((c) => `<option value="${esc(c)}"${c === preferred && has ? " selected" : ""}>${esc(c)}</option>`)
+            .join("")
+        );
+      }
+      // cwd suggestions: the target host's known agent cwds, live agents' first,
+      // deduped. Rendered into a <datalist> so the input stays free-text.
+      function cwdOptions(room) {
+        const seen = new Set();
+        const out = [];
+        const pool = entries
+          .filter((e) => (room ? e._src === room : true))
+          .sort((a, b) => (b.exit_code == null) - (a.exit_code == null));
+        for (const e of pool) {
+          const c = (e.cwd || "").replace(/\/+$/, "");
+          if (c && !seen.has(c)) {
+            seen.add(c);
+            out.push(`<option value="${esc(c)}"></option>`);
+          }
+        }
+        return out.join("");
+      }
       function showNew() {
         const here = entries.find((x) => x._key === sel);
         const cwd = here?.cwd || "";
+        // CLI preselect chain: current selected agent > last-used > none (forces
+        // an explicit pick — the Launch handler refuses an empty CLI).
+        let lastCli = "";
+        try {
+          lastCli = localStorage.getItem(LAST_CLI_KEY) || "";
+        } catch {}
+        const preferredCli = here?.cli || lastCli || "";
         const target = spawnTarget();
         const hosts = [...sources.values()].filter((s) => s.live || s.id === target?.id);
         $("newform").dataset.room = target ? target.id : "";
@@ -5556,9 +5596,9 @@
         $("newform").innerHTML = `<div class="lcard">
       <div class="ltitle">New agent · ${esc(sourceLabel(target) || "local")}</div>
       ${hostRow}
-      <div class="nfield"><label>CLI</label><input id="nf-cli" value="claude" spellcheck="false" autocapitalize="off" /></div>
+      <div class="nfield"><label>Working dir</label><input id="nf-cwd" list="nf-cwd-list" value="${esc(cwd)}" placeholder="(host default — ignored when Spawn from is set)" spellcheck="false" autocapitalize="off" /><datalist id="nf-cwd-list">${cwdOptions(target ? target.id : "")}</datalist></div>
+      <div class="nfield"><label>CLI</label><select id="nf-cli">${cliOptions(null, preferredCli)}</select></div>
       <div class="nfield"><label>Spawn from — optional</label><input id="nf-from" placeholder="github URL / owner/repo@branch — provisions a worktree" spellcheck="false" autocapitalize="off" /></div>
-      <div class="nfield"><label>Working dir</label><input id="nf-cwd" value="${esc(cwd)}" placeholder="(host default — ignored when Spawn from is set)" spellcheck="false" autocapitalize="off" /></div>
       <div class="nfield"><label>Prompt — optional</label><textarea id="nf-prompt" rows="3" placeholder="initial message to send the agent…"></textarea></div>
       <div class="lrow">
         <button class="lfleet" id="nf-go">▷ Launch</button>
@@ -5569,9 +5609,11 @@
         $("newform").style.display = "flex";
         setTimeout(() => $("nf-prompt")?.focus(), 0);
         // Retarget the form when the user picks another machine — the spawn-hook
-        // hint below is per-machine, so it has to be re-read too.
+        // hint and the cwd suggestions are per-machine, so both re-read.
         $("nf-host")?.addEventListener("change", (ev) => {
           $("newform").dataset.room = ev.target.value;
+          const dl = $("nf-cwd-list");
+          if (dl) dl.innerHTML = cwdOptions(ev.target.value);
           showHook(sources.get(ev.target.value));
         });
         showHook(target);
@@ -5590,10 +5632,17 @@
           .then((c) => {
             // A slow answer for a host the user has since switched away from must
             // not paint the new host's hint.
-            if (!el || $("newform").dataset.room !== forId) return;
-            if (c && c.hasSpawnHook) {
+            if ($("newform").dataset.room !== forId) return;
+            if (el && c && c.hasSpawnHook) {
               el.textContent = "⚙ this host runs a spawn hook before launch";
               el.style.display = "";
+            }
+            // spawn-config also discloses the CLIs this daemon accepts — swap
+            // the picker's options to the host's real list (keep the selection)
+            const cliSel = $("nf-cli");
+            if (cliSel && c && Array.isArray(c.clis) && c.clis.length) {
+              const cur = cliSel.value;
+              cliSel.innerHTML = cliOptions(c.clis, cur || null);
             }
           })
           .catch(() => {});
@@ -5602,8 +5651,18 @@
       async function submitNew() {
         const go = $("nf-go");
         if (!go || go.disabled) return;
+        const cli = ($("nf-cli").value || "").trim();
+        if (!cli) {
+          // no silent default — the user must pick a CLI (chain: selected agent's
+          // cli → last used → this explicit pick)
+          $("nf-cli").focus();
+          return;
+        }
+        try {
+          localStorage.setItem(LAST_CLI_KEY, cli);
+        } catch {}
         const spec = {
-          cli: ($("nf-cli").value || "claude").trim(),
+          cli,
           from: $("nf-from")?.value.trim() || "",
           cwd: $("nf-cwd").value.trim(),
           prompt: $("nf-prompt").value,

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -594,6 +594,9 @@
       ></textarea>
       <div class="ctx-foot">
         <span><b>⏎</b> send · <b>shift+⏎</b> newline · <b>esc</b> cancel</span>
+        <!-- environment nodes (host env / cwd / repo) double as launch targets:
+             the textarea becomes the new agent's initial prompt -->
+        <button id="ctx-spawn" hidden>▷ Spawn here</button>
         <button id="ctx-send">Send</button>
       </div>
       <div class="ctx-share" id="ctx-share" hidden>

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -52,6 +52,51 @@ interface AgentRecord {
   badges?: string[];
 }
 
+// ── host environment (otoji environment-node adoption) ───────────────────────
+// GET /api/host describes the machine the fleet runs on: identity + live health
+// (loadavg/mem) + capability flags. The viewer renders it as ONE host env node
+// that every top-level group wires into via `environment` edges — the worktree
+// (cwd) and repo containers are the finer-grained environments nested inside it.
+// A daemon too old to expose /api/host just 404s → no env node, nothing breaks.
+interface HostInfo {
+  host: string;
+  platform: string;
+  arch: string;
+  cpus: number;
+  loadavg: number[];
+  mem: { total: number; free: number };
+  uptime: number;
+  caps?: Record<string, boolean>;
+}
+const ENV_HOST_ID = "env:host";
+let hostInfo: HostInfo | null = null;
+// host-env → top-level-root wires, rebuilt by buildGraph, drawn by applyEdges
+const envEdges: Edge[] = [];
+function hostEnvFields(): [string, string][] {
+  const h = hostInfo;
+  if (!h) return [];
+  const recs = [...recordsByPid.values()];
+  const live = recs.filter((r) => r.status !== "exited");
+  const stuck = live.filter((r) => r.status === "stuck").length;
+  const load1 = h.loadavg?.[0] ?? 0;
+  const hot = load1 > h.cpus; // 1-min load above core count = saturated host
+  const usedPct = h.mem.total ? Math.round(((h.mem.total - h.mem.free) / h.mem.total) * 100) : 0;
+  const fields: [string, string][] = [
+    ["scope", "native-device"],
+    ["os", `${h.platform}/${h.arch} · ${h.cpus} cpus`],
+  ];
+  // Windows reports loadavg [0,0,0] — skip the row rather than show a lie
+  if (h.loadavg?.some((n) => n > 0))
+    fields.push([hot ? "⚠ load" : "load", h.loadavg.map((n) => n.toFixed(1)).join(" ")]);
+  fields.push(["mem", `${usedPct}% of ${(h.mem.total / 2 ** 30).toFixed(0)}G`]);
+  fields.push(["agents", `${live.length} live${stuck ? ` · ⚠ ${stuck} stuck` : ""}`]);
+  if (h.caps) {
+    const on = Object.entries(h.caps).filter(([, v]) => v).map(([k]) => k);
+    if (on.length) fields.push(["caps", on.join(" · ")]);
+  }
+  return fields;
+}
+
 // ── data source: room · HTTP · sample ────────────────────────────────────────
 // The viewer reads from ONE of three wires, in priority order:
 //   1. a WebRTC room — when the URL hash is a share link (#room:token[@host] or
@@ -287,6 +332,9 @@ function portsOf(r: AgentRecord): { inputs: Port[]; outputs: Port[] } {
   const inputs: Port[] = [
     { id: "prompt", label: "prompt", kind: "ctl" },
     { id: "deps", label: "reads", kind: "text" },
+    // env input (otoji environment-node parity): which environment this agent
+    // runs in. Fed by the host env node / its cwd container, metadata-only.
+    { id: "env", label: "env", kind: "environment" },
   ];
   // status output: kind = the status string so the port dot is color-coded per
   // state (stable hashed color); the label (shown zoomed in) is the state text.
@@ -398,12 +446,11 @@ function buildGraph(records: AgentRecord[]): Graph {
         x: 0,
         y: 0,
         w: CARD_W,
-        inputs: [],
+        // the cwd container IS the worktree environment node — env in from the
+        // host, and (metadata-only) it provides the env its members run in
+        inputs: [{ id: "env", label: "env", kind: "environment" }],
         outputs: [],
-        fields: [
-          ["agents", String(cids.length)],
-          ["shared", st],
-        ],
+        fields: cwdFields(cids),
       });
       children.set(cwdId, cids);
       for (const id of cids) nodes.get(id)!.parent = cwdId;
@@ -421,7 +468,8 @@ function buildGraph(records: AgentRecord[]): Graph {
       x: 0,
       y: 0,
       w: CARD_W,
-      inputs: [],
+      // env in from the host env node (the repo's worktrees live on that machine)
+      inputs: [{ id: "env", label: "env", kind: "environment" }],
       outputs: [],
       fields: [["worktrees", String(byCwd.size)]],
     });
@@ -466,6 +514,35 @@ function buildGraph(records: AgentRecord[]): Graph {
     node.w = Math.max(CARD_W, maxRight - x + PAD);
     node.h = cy + rowH + PAD - y;
     return { w: node.w, h: node.h };
+  }
+
+  // The host environment node (otoji environment-node adoption): the machine
+  // every top-level group runs on — identity, live load/mem, capability flags
+  // (see hostEnvFields). Absent until /api/host answers (old daemon: never).
+  envEdges.length = 0;
+  if (hostInfo) {
+    nodes.set(ENV_HOST_ID, {
+      id: ENV_HOST_ID,
+      title: `⬢ ${hostInfo.host}`,
+      category: "environment",
+      x: 0,
+      y: 0,
+      w: CARD_W,
+      inputs: [],
+      outputs: [{ id: "env", label: "env", kind: "environment" }],
+      fields: hostEnvFields(),
+    });
+    children.set(ENV_HOST_ID, []);
+    // host env → each top-level root (repo/cwd containers + loose agents);
+    // members nested inside a container inherit its environment visually
+    for (const id of topLevel)
+      envEdges.push({
+        from: { node: ENV_HOST_ID, port: "env" },
+        to: { node: id, port: "env" },
+        dashed: true,
+        style: { color: "#805ad5", width: 1.5, dash: [3, 5] },
+      });
+    topLevel.unshift(ENV_HOST_ID);
   }
 
   // tile the top-level nodes (repo containers + loose agents) into bands
@@ -520,7 +597,12 @@ function buildGraph(records: AgentRecord[]): Graph {
   // leaf agent nodes render via our LOD draw hook (terminal snapshot / identity),
   // instead of rgui's default field card — see drawNode.
   for (const n of nodes.values()) {
-    if (!isContainer.has(n.id) && !n.id.startsWith("repo:") && !n.id.startsWith("info:")) {
+    if (
+      !isContainer.has(n.id) &&
+      !n.id.startsWith("repo:") &&
+      !n.id.startsWith("info:") &&
+      !n.id.startsWith("env:") // env node has no terminal — default field card
+    ) {
       n.draw = (ctx, r) => drawNode(n.id, ctx, r);
     }
   }
@@ -587,6 +669,19 @@ const STATE_RANK: AgentStatus[] = ["needs_input", "stuck", "active", "idle", "ex
 function aggStateOf(pids: string[]): AgentStatus {
   const s = new Set(pids.map((p) => recordsByPid.get(p)?.status).filter(Boolean));
   return STATE_RANK.find((x) => s.has(x)) ?? "idle";
+}
+
+// Body rows of a cwd (worktree environment) container. 2+ LIVE agents in one
+// worktree share its branch, git index and bun-link targets — a real hazard
+// (they silently commit onto each other's branch), so it gets a ⚠ row.
+function cwdFields(pids: string[]): [string, string][] {
+  const live = pids.filter((p) => recordsByPid.get(p)?.status !== "exited").length;
+  const fields: [string, string][] = [
+    ["agents", String(pids.length)],
+    ["shared", aggStateOf(pids)],
+  ];
+  if (live >= 2) fields.push(["⚠", `${live} live agents share this worktree`]);
+  return fields;
 }
 
 const MAX_TERMS = 6; // cap concurrent xterms/SSE streams — `ay serve --http` gets
@@ -1178,6 +1273,16 @@ function updateSysPanel(records: AgentRecord[], live: boolean) {
     items.push({ id: "repos", label: "repos", value: String(repos.size) });
     items.push({ id: "worktrees", label: "worktrees", value: String(cwds.size) });
   }
+  if (hostInfo?.loadavg?.some((n) => n > 0)) {
+    const load1 = hostInfo.loadavg[0]!;
+    items.push({
+      id: "load",
+      label: "host load",
+      value: load1.toFixed(1),
+      // saturated host (1-min load past the core count) = the wedged-fleet smell
+      color: load1 > hostInfo.cpus ? "#f85149" : undefined,
+    });
+  }
   items.push({
     id: "conn",
     label: live ? (usingRoom() ? "live · room" : "live · local") : "demo · no ay serve",
@@ -1214,7 +1319,9 @@ const viewer: Rgui = createRgui(canvas, {
   },
   onNodeContextMenu: (id, screen) => {
     // right-click → batch-send to the selection (or just this node); a selected
-    // container expands to its agent descendants.
+    // container expands to its agent descendants. Environment-ish nodes (host
+    // env / cwd / repo) additionally offer "spawn here" — the env node as a
+    // launch target (the textarea doubles as the new agent's prompt).
     const sel = viewer.selection;
     const base = sel.includes(id) && sel.length > 0 ? [...sel] : [id];
     if (!sel.includes(id)) viewer.setSelection(base);
@@ -1224,7 +1331,8 @@ const viewer: Rgui = createRgui(canvas, {
       else for (const d of agentDescendants(t)) set.add(d);
     }
     const targets = [...set];
-    if (targets.length) openBatchMenu(screen.x, screen.y, targets);
+    const spawn = spawnSpecOf(id);
+    if (targets.length || spawn) openBatchMenu(screen.x, screen.y, targets, spawn);
   },
   onSelectionChange: () => {
     updateNodeDebug();
@@ -1330,9 +1438,10 @@ function updateContent(records: AgentRecord[]) {
       n.outputs = fresh.outputs; // status/ask/result track live state (no relayout)
     } else if (cwdGroups.has(n.id)) {
       // same-cwd container: recompute the shared (loudest) state in place
-      const st = aggStateOf(cwdGroups.get(n.id)!);
-      n.category = `cwd-${st}`;
-      n.fields = [["agents", String(cwdGroups.get(n.id)!.length)], ["shared", st]];
+      n.category = `cwd-${aggStateOf(cwdGroups.get(n.id)!)}`;
+      n.fields = cwdFields(cwdGroups.get(n.id)!);
+    } else if (n.id === ENV_HOST_ID) {
+      n.fields = hostEnvFields(); // live/stuck counts track the fresh records
     }
   }
   for (const [pid, e] of terms) {
@@ -1517,7 +1626,13 @@ function applyEdges() {
         }))
     : [];
   viewer.graph.edges.length = 0;
-  viewer.graph.edges.push(...edges, ...fedEdges(present));
+  // env wires are structural (host → its top-level groups), not toggled with
+  // the read/tail wires — always drawn, and few (one per root)
+  viewer.graph.edges.push(
+    ...edges,
+    ...envEdges.filter((e) => present.has(e.from.node) && present.has(e.to.node)),
+    ...fedEdges(present),
+  );
   viewer.setView(viewer.view); // schedule a redraw without a relayout
 }
 
@@ -1529,6 +1644,28 @@ async function fetchEdges() {
     /* no /api/edges (static host / old daemon / room down) — leave wires empty */
   }
 }
+
+// Poll the host environment (identity + load/mem/caps) every 30s. The first
+// answer adds the env node to the forest (structure change → force a rebuild);
+// later answers only refresh its fields in place — same no-flash philosophy as
+// updateContent. A 404 (older daemon) just means no env node.
+async function fetchHost() {
+  try {
+    const h = await apiJSON<HostInfo>("/api/host");
+    const first = !hostInfo;
+    hostInfo = h;
+    if (first) {
+      lastStruct = ""; // env node joins the graph on the next apply()
+      void refresh();
+    } else {
+      const n = viewer.graph.nodes.find((x) => x.id === ENV_HOST_ID);
+      if (n) n.fields = hostEnvFields(); // picked up by the next natural frame
+    }
+  } catch {
+    /* /api/host unavailable (old daemon / static host / room down) */
+  }
+}
+setInterval(() => void fetchHost(), 30_000);
 
 async function refresh() {
   try {
@@ -1594,6 +1731,7 @@ if (roomInfo) {
       roomConnected = true;
       delay = RTC_MIN; // a healthy connect resets the backoff
       void refresh(); // pull the first snapshot over the room immediately
+      void fetchHost(); // and the host env (the 30s interval keeps it fresh)
     } catch {
       setRoomLabel("room disconnected");
       schedule();
@@ -1702,6 +1840,7 @@ if (embedMode) {
 } else {
   refresh();
   setInterval(refresh, 3000);
+  if (!usingRoom()) void fetchHost(); // room mode fetches on connect instead
 }
 // The whole page is configured from the hash (room / feeds / embed target / k=),
 // all read once at boot — a hash-only navigation (e.g. an iframe consumer
@@ -1939,14 +2078,33 @@ function agentDescendants(containerId: string): string[] {
 const ctxmenu = document.getElementById("ctxmenu")!;
 const ctxInput = document.getElementById("ctx-input") as HTMLTextAreaElement;
 let ctxTargets: string[] = [];
-function openBatchMenu(sx: number, sy: number, pids: string[]) {
+let ctxSpawn: { cwd: string | null; cli: string } | null = null;
+
+// What "spawn here" means for a right-clicked node: an environment-ish node
+// (host env / cwd container / repo container) is a launch TARGET — the cwd the
+// new agent starts in; a plain agent spawns a sibling next to itself. The cli
+// follows the neighbours (spawn what already runs there), falling back to claude.
+function spawnSpecOf(id: string): { cwd: string | null; cli: string } | null {
+  const cliOf = (pids: string[]) => recordsByPid.get(pids[0] ?? "")?.cli ?? "claude";
+  if (id === ENV_HOST_ID) return { cwd: null, cli: cliOf([...recordsByPid.keys()]) };
+  if (id.startsWith("cwd:")) return { cwd: id.slice(4), cli: cliOf(cwdGroups.get(id) ?? []) };
+  if (id.startsWith("repo:")) return { cwd: id.slice(5), cli: cliOf(agentDescendants(id)) };
+  const r = recordsByPid.get(id);
+  return r ? { cwd: r.cwd, cli: r.cli } : null;
+}
+
+function openBatchMenu(sx: number, sy: number, pids: string[], spawn: typeof ctxSpawn = null) {
   ctxTargets = pids;
+  ctxSpawn = spawn;
   // "share this node" — single agent only (a share scopes to exactly one agent)
   ctxSharePid = pids.length === 1 ? pids[0]! : null;
   ctxShare.hidden = !ctxSharePid || usingRoom(); // a room viewer can't mint shares
   ctxShareOut.hidden = true;
   document.getElementById("ctx-count")!.textContent = String(pids.length);
   document.getElementById("ctx-s")!.textContent = pids.length === 1 ? "" : "s";
+  const spawnBtn = document.getElementById("ctx-spawn") as HTMLButtonElement;
+  spawnBtn.hidden = !spawn;
+  if (spawn) spawnBtn.title = `POST /api/spawn · ${spawn.cli} in ${spawn.cwd ?? "(host default dir)"}`;
   ctxmenu.hidden = false;
   ctxmenu.style.left = `${Math.min(sx, innerWidth - 348)}px`;
   ctxmenu.style.top = `${Math.min(sy, innerHeight - 140)}px`;
@@ -1976,10 +2134,31 @@ async function sendBatch() {
     void refresh();
   }, 1500);
 }
+// Launch a new agent in the right-clicked environment (host env / cwd / repo
+// node) — the textarea's content becomes the initial prompt (may be empty).
+async function spawnHere() {
+  const spec = ctxSpawn;
+  if (!spec) return;
+  const prompt = ctxInput.value;
+  closeBatchMenu();
+  statusLabel.textContent = `▷ spawning ${spec.cli}…`;
+  const r = await apiPost("/api/spawn", {
+    cli: spec.cli,
+    ...(spec.cwd ? { cwd: spec.cwd } : {}),
+    prompt,
+  });
+  statusLabel.textContent = r.ok ? "▷ spawned" : `spawn failed: ${r.text.slice(0, 80)}`;
+  setTimeout(() => void refresh(), 1200);
+  setTimeout(() => void refresh(), 4000); // and again once the wrapper registered
+}
+
 ctxInput.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
     e.preventDefault();
-    void sendBatch();
+    // Enter = send to the targeted agents; on a pure environment node (no agent
+    // targets) there is nothing to send to, so Enter launches instead.
+    if (ctxTargets.length) void sendBatch();
+    else if (ctxSpawn) void spawnHere();
   } else if (e.key === "Escape") {
     e.preventDefault();
     closeBatchMenu();
@@ -1987,6 +2166,7 @@ ctxInput.addEventListener("keydown", (e) => {
   e.stopPropagation();
 });
 document.getElementById("ctx-send")!.addEventListener("click", () => void sendBatch());
+document.getElementById("ctx-spawn")!.addEventListener("click", () => void spawnHere());
 addEventListener("mousedown", (e) => {
   if (!ctxmenu.hidden && !ctxmenu.contains(e.target as Node)) closeBatchMenu();
 });

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -497,6 +497,37 @@ describe("console DOM behaviour", () => {
       await ctx.close();
     }
   });
+
+  it("new-agent modal: Working dir sits under Host, autocompletes, CLI needs an explicit pick", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      await page.click("#newbtn");
+      await page.waitForSelector("#newform .lcard");
+      // Working dir leads (right under the Host row when one exists) — a cwd
+      // only means something on its machine; CLI and the rest follow.
+      const labels = await page.locator("#newform .nfield label").allTextContents();
+      const iCwd = labels.findIndex((l) => l.includes("Working dir"));
+      const iCli = labels.findIndex((l) => l.trim().startsWith("CLI"));
+      expect(iCwd).toBeGreaterThanOrEqual(0);
+      expect(iCli).toBeGreaterThan(iCwd);
+      // cwd autocompletes from the fleet's known agent cwds
+      expect(await page.locator("#nf-cwd").getAttribute("list")).toBe("nf-cwd-list");
+      expect(await page.locator("#nf-cwd-list option").count()).toBeGreaterThan(0);
+      // CLI is a picker (not free text) whose first option is a disabled
+      // "choose a CLI…" placeholder — no silent claude default.
+      expect(await page.locator("#nf-cli").evaluate((el) => el.tagName)).toBe("SELECT");
+      expect(await page.locator("#nf-cli option").first().getAttribute("disabled")).not.toBeNull();
+      // With no agent selected and no last-used cli, the value is empty and
+      // Launch refuses to submit (the form stays open, no /api/spawn fired).
+      if ((await page.locator("#nf-cli").inputValue()) === "") {
+        await page.click("#nf-go");
+        expect(await page.locator("#newform .lcard").count()).toBe(1);
+        expect(await page.locator("#nf-go").isDisabled()).toBe(false);
+      }
+    } finally {
+      await ctx.close();
+    }
+  });
 });
 
 // A nested fixture: root 201 with two subagents (202 active, 203 idle) and a

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -3,7 +3,7 @@ import { renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
-import { homedir, hostname, userInfo } from "os";
+import { arch, cpus, freemem, homedir, hostname, loadavg, platform, totalmem, uptime, userInfo } from "os";
 import path from "path";
 import yargs from "yargs";
 import {
@@ -1706,6 +1706,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
         const ns = `ay://${origin}`;
         const textIn = { id: "text-in", label: "text", kind: "text" };
         const textOut = { id: "text-out", label: "text", kind: "text" };
+        // otoji environment-node adoption: agents also carry an `env` input fed
+        // by ONE host environment node (below) — "this fleet runs on this
+        // machine". Only the HOST is published as an environment; worktree envs
+        // stay local-only (their cwd paths are exactly what this route redacts).
+        const envIn = { id: "env", label: "env", kind: "environment" };
+        const envOut = { id: "env", label: "env", kind: "environment" };
+        const envNodeId = `${ns}/env-${hostname()}`;
         const byWrapper = new Map(records.map((r) => [r.wrapper_pid ?? r.pid, r.pid]));
         const nid = (pid: number) => `${ns}/${pid}`;
         // renderHints.preview: the REAL agent TUI tail (redacted in
@@ -1746,11 +1753,33 @@ export async function cmdServe(rest: string[]): Promise<number> {
             parent: r.parent_pid && byWrapper.has(r.parent_pid) ? nid(byWrapper.get(r.parent_pid)!) : undefined,
             pos: { x: (i % 8) * (NODE_W + 64), y: Math.floor(i / 8) * 480 },
             size: await sizeOf(r.pid),
-            inputs: [textIn],
+            inputs: [textIn, envIn],
             outputs: [textOut],
             renderHints: await hintsOf(r),
           })),
         );
+        // The host environment node: identity + capability flags only (no cwd,
+        // no load numbers — health telemetry stays behind /api/host).
+        nodes.push({
+          id: envNodeId,
+          app: "agent-yes",
+          type: "environment",
+          title: `env @ ${hostname()}`,
+          category: "environment",
+          owner: `agent-yes:${hostname()}`,
+          status: "active",
+          parent: undefined,
+          pos: { x: -NODE_W - 96, y: 0 },
+          size: { w: NODE_W, h: 160 },
+          inputs: [],
+          outputs: [envOut],
+          renderHints: undefined,
+          configPublic: {
+            scope: "native-device",
+            runtime: "native",
+            caps: { send: true, kill: true, spawn: true, spawnHook: hasSpawnHook(), provision: hasProvisionHook() },
+          },
+        } as unknown as (typeof nodes)[number]); // configPublic is envelope-legal but absent from the agent-node literal type
         const codex = records
           .filter((r) => r.cli === "codex")
           .sort((a, b) => (b.last_active_at ?? 0) - (a.last_active_at ?? 0))[0];
@@ -1765,12 +1794,17 @@ export async function cmdServe(rest: string[]): Promise<number> {
           parent: undefined,
           pos: { x: 0, y: -560 },
           size: codex ? await sizeOf(codex.pid) : { w: NODE_W, h: 260 },
-          inputs: [textIn],
+          inputs: [textIn, envIn],
           outputs: [textOut],
           renderHints: codex ? await hintsOf(codex) : undefined,
         });
         const present = new Set(nodes.map((n) => n.id));
-        const edges = (await recentReadEdges())
+        const edges: {
+          source: { node: string; port: string; type: string };
+          target: { node: string; port: string; type: string };
+          status: string;
+          label?: string;
+        }[] = (await recentReadEdges())
           .filter((e) => e.by !== e.target && present.has(nid(e.target)) && present.has(nid(e.by)))
           .map((e) => ({
             source: { node: nid(e.target), port: "text-out", type: "text" },
@@ -1778,6 +1812,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
             status: "readonly",
             label: "reads",
           }));
+        // env wiring: host environment → each ROOT agent (children inherit the
+        // environment through containment — wiring every agent would be noise)
+        for (const n of nodes) {
+          if (n.id === envNodeId || n.parent) continue;
+          edges.push({
+            source: { node: envNodeId, port: "env", type: "environment" },
+            target: { node: n.id, port: "env", type: "environment" },
+            status: "readonly",
+          });
+        }
         return Response.json(
           {
             kind: "rgui-federated-graph",
@@ -1786,7 +1830,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
             revision: Date.now(),
             ts: Date.now(),
             graph: { nodes, edges },
-            capabilities: { nodeTypes: [...new Set(nodes.map((n) => n.type))], portTypes: ["text"] },
+            capabilities: { nodeTypes: [...new Set(nodes.map((n) => n.type))], portTypes: ["text", "environment"] },
           },
           { headers: { "Access-Control-Allow-Origin": "*" } },
         );
@@ -1842,6 +1886,33 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return Response.json({
         hasSpawnHook: hasSpawnHook(),
         hasProvisionHook: hasProvisionHook(),
+        // the CLIs /api/spawn accepts, so the console can render a picker
+        // instead of a free-text field (unknown values 400 anyway)
+        clis: SUPPORTED_CLIS,
+      });
+    }
+
+    // GET /api/host — this machine as an ENVIRONMENT: identity + live health
+    // (load, memory) + what the environment permits (capability flags, otoji
+    // environment-node style). The /rgui viewer renders it as the host env node
+    // every agent implicitly runs inside. Read-only, token-gated like the rest;
+    // loadavg is [0,0,0] on Windows — the viewer treats that as "n/a".
+    if (req.method === "GET" && p === "/api/host") {
+      return Response.json({
+        host: hostname(),
+        platform: platform(),
+        arch: arch(),
+        cpus: cpus().length,
+        loadavg: loadavg(),
+        mem: { total: totalmem(), free: freemem() },
+        uptime: uptime(),
+        caps: {
+          send: true, // the console can always drive agent stdin
+          kill: true,
+          spawn: true, // /api/spawn is always on; hooks below shape it
+          spawnHook: hasSpawnHook(),
+          provision: hasProvisionHook(),
+        },
       });
     }
 


### PR DESCRIPTION
Adopts otoji's **environment-node** concept (otoji PR #100) across agent-yes.

## What
- **`GET /api/host`** — the machine as an environment: identity (host/platform/arch/cpus), live health (loadavg, mem), and capability flags (send/kill/spawn/spawnHook/provision). 404 on older daemons degrades gracefully.
- **/api/graph federation** — publishes ONE host environment node (`type: environment`, `configPublic` scope/runtime/caps) wired `env →` into root agents; every agent gains an `env` input; `portTypes += environment`. Worktree envs stay local-only — their cwd paths are exactly what this route redacts.
- **/rgui viewer** — renders the host env node (`⬢ host`) with load/mem/agent/caps rows (⚠ when 1-min load exceeds core count — the wedged-fleet smell), env edges to top-level roots, agent `env` input ports, a `⚠ N live agents share this worktree` row on shared cwd containers (shared branch/bun-link hazard), and host load in the sys panel.
- **Spawn-here** — right-click a host-env / cwd / repo node → `▷ Spawn here` launches an agent in that environment via `POST /api/spawn` (textarea doubles as the initial prompt; Enter spawns when the node has no send targets). The env node is now a launch target, not just metadata.
- **Console new-agent modal UX** — Working dir moves directly under Host (a cwd only means something on its machine) and autocompletes from that host's known agent cwds via `<datalist>`; CLI becomes a picker fed by `/api/spawn-config`'s new `clis` field, preselected via selected-agent's cli → last-used (localStorage) → explicit pick (no silent `claude` default).

## Verified
- `bun run build` + `bun run build:rgui` clean; vitest 821 passed / 1 known flaky (`subcommands` confirm-window timing — passes on rerun 108/108); `test:ui-dom` 21/21.
- Live smoke on a scratch daemon: `/api/host` payload, `spawn-config.clis`, envelope env node + 37 env edges + agent env inputs all verified; /r/ in real Chrome shows `⬢ Mac` with `⚠ load`, caps row, and 10 env edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)