### PR TITLE
fix(release): stop actions/checkout credentials from overriding RELEASE_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # semantic-release needs full history to compute versions correctly
+          # Don't bake the workflow's GITHUB_TOKEN into git's http.extraheader:
+          # it overrides the RELEASE_TOKEN semantic-release embeds in the push
+          # URL, so the version-bump push authenticated as github-actions[bot]
+          # and was rejected by main's required checks (GH006, run 29158738669).
+          # The repo is public — the fetches below work unauthenticated.
+          persist-credentials: false
       - uses: actions/setup-node@v5
         with:
           node-version: "latest"


### PR DESCRIPTION
The @semantic-release/git version-bump push still failed branch protection after #232 (GH006 in run [29158738669](https://github.com/snomiao/agent-yes/actions/runs/29158738669)).

**Root cause**: `actions/checkout` defaults to `persist-credentials: true`, baking the workflow's `GITHUB_TOKEN` into `http.https://github.com/.extraheader`. That header takes precedence over the credential semantic-release embeds in the push URL — so the push authenticated as `github-actions[bot]` (not exempt from required checks) even though `RELEASE_TOKEN` was correctly wired into the step env.

**Fix**: `persist-credentials: false` on the checkout. All later steps (`gh workflow run`, `gh run watch`) already pass an explicit env token, and the repo is public so unauthenticated `git fetch --tags` keeps working.

This merge itself is a `fix:` commit, so the release run it triggers is the end-to-end verification of the RELEASE_TOKEN push path (it will also pick up the pending #233 feat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)