### PR TITLE
feat(expose): ay expose <port> — private edge-relay port proxy (MVP 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@types/yargs": "^17.0.35",
         "@typescript/native-preview": "^7.0.0-dev.20260124.1",
         "@vitest/coverage-v8": "4.1.0",
+        "codehost": "^0.32.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "node-pty": "^1.1.0",
@@ -230,6 +231,34 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@1.41.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dVBXkZ6MGLd3owV7jvuqJsZwiF3qw7kEkDVsYVpS/O96eEvlHcxVbaPjJjrTBgikXqyC22vg3dxBU7MW0utGfw=="],
 
+    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
     "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
@@ -329,6 +358,8 @@
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@snomiao/bun-pty": ["@snomiao/bun-pty@0.3.4", "", {}, "sha512-7eVzv+fNQrELScC6vmza52rXAxfHJnPiUSi6k2i1C0NS/xCB4+baEfH4tdRaEpGNrsI2DP6rnppNXQu+6kUWFA=="],
+
+    "@snomiao/daemon-kit": ["@snomiao/daemon-kit@0.2.0", "", {}, "sha512-Ymp6S/7C3cTGkakXqeYcVzieAN9O0uTmk7GxIeOEi7k2j3pX8mPVxZ5VgCQTSWmZjpNjUKR8zhb2dEkENOS+OQ=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
 
@@ -474,7 +505,19 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
 
+    "@xterm/addon-clipboard": ["@xterm/addon-clipboard@0.2.0", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-search": ["@xterm/addon-search@0.15.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg=="],
+
+    "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
+
+    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.11.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q=="],
+
     "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 
@@ -579,6 +622,8 @@
     "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
+
+    "codehost": ["codehost@0.32.0", "", { "dependencies": { "@parcel/watcher": "^2.5.6", "@snomiao/daemon-kit": "^0.2.0", "@xterm/addon-clipboard": "^0.2.0", "@xterm/addon-fit": "^0.11.0", "@xterm/addon-search": "^0.15.0", "@xterm/addon-unicode11": "^0.9.0", "@xterm/addon-web-links": "^0.11.0", "@xterm/headless": "^6.0.0", "@xterm/xterm": "^6.0.0", "bun-pty": "^0.4.8", "hono": "^4.12.16", "node-datachannel": "^0.32.3", "oxmgr": "^0.4.0", "react": "^19.1.1", "react-dom": "^19.1.1", "yaml": "^2.9.0", "yargs": "^17.7.2" }, "bin": { "codehost": "src/cli/index.ts", "ch": "src/cli/index.ts" } }, "sha512-sv/5Y/VMZg9Cu8vungcLs0c7kgHO9lxKL+J4AMAAYdavr2Pnboyo9ChgdulbxumQIw5jxk6EYNUUIJBvZqeGxw=="],
 
     "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
 
@@ -904,6 +949,8 @@
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
+    "hono": ["hono@4.12.29", "", {}, "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="],
+
     "hook-std": ["hook-std@4.0.0", "", {}, "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ=="],
 
     "hookable": ["hookable@6.0.1", "", {}, "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw=="],
@@ -966,11 +1013,15 @@
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
@@ -1037,6 +1088,8 @@
     "jest-regex-util": ["jest-regex-util@30.0.1", "", {}, "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA=="],
 
     "jest-util": ["jest-util@30.0.2", "", { "dependencies": { "@jest/types": "30.0.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.2" } }, "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg=="],
+
+    "js-base64": ["js-base64@3.8.1", "", {}, "sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
@@ -1198,6 +1251,8 @@
 
     "oxlint": ["oxlint@1.41.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.41.0", "@oxlint/darwin-x64": "1.41.0", "@oxlint/linux-arm64-gnu": "1.41.0", "@oxlint/linux-arm64-musl": "1.41.0", "@oxlint/linux-x64-gnu": "1.41.0", "@oxlint/linux-x64-musl": "1.41.0", "@oxlint/win32-arm64": "1.41.0", "@oxlint/win32-x64": "1.41.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.11.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-Dyaoup82uhgAgp5xLNt4dPdvl5eSJTIzqzL7DcKbkooUE4PDViWURIPlSUF8hu5a+sCnNIp/LlQMDsKoyaLTBA=="],
 
+    "oxmgr": ["oxmgr@0.4.0", "", { "bin": { "oxmgr": "bin/oxmgr.js" } }, "sha512-cxfOoW2UhjHhA0y6b1DLUxB8unXFF6J3U0yBDKKKi05WzaEHs7FUey7xlI/R3UlSkcYfnyvvagPAELrQ2bavOA=="],
+
     "p-each-series": ["p-each-series@3.0.0", "", {}, "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="],
 
     "p-filter": ["p-filter@4.1.0", "", { "dependencies": { "p-map": "^7.0.1" } }, "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw=="],
@@ -1284,7 +1339,9 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
-    "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "react-hook-form": ["react-hook-form@7.59.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-kmkek2/8grqarTJExFNjy+RXDIP8yM+QTl3QL6m6Q8b2bih4ltmiXxH7T9n+yXNK477xPh5yZT/6vD8sYGzJTA=="],
 
@@ -1341,6 +1398,8 @@
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semantic-release": ["semantic-release@25.0.2", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "semver-diff": "^5.0.0", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g=="],
 
@@ -1663,6 +1722,10 @@
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cli-truncate/string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+
+    "codehost/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "codehost/yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
 
@@ -2230,6 +2293,12 @@
 
     "cli-table3/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "codehost/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "codehost/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "codehost/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
     "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "conventional-changelog-core/conventional-changelog-writer/conventional-commits-filter": ["conventional-commits-filter@2.0.7", "", { "dependencies": { "lodash.ismatch": "^4.4.0", "modify-values": "^1.0.0" } }, "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA=="],
@@ -2402,6 +2471,14 @@
 
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "codehost/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "codehost/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "codehost/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "codehost/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "conventional-changelog-core/normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "conventional-changelog-core/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@2.8.9", "", {}, "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="],
@@ -2513,6 +2590,12 @@
     "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cli-highlight/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "codehost/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "codehost/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "codehost/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "dotgitignore/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/lab/ui/cf/exposure.ts
+++ b/lab/ui/cf/exposure.ts
@@ -1,0 +1,430 @@
+// Exposure Durable Object: the edge-relay leg of `ay expose <port>`.
+//
+// One DO per exposure id. The daemon dials IN with an outbound WebSocket
+// (wss://agent-yes.com/_ay/tunnel/<id>) and keeps it open; visitors hit
+// https://<id>.agent-yes.com/* and their HTTP requests / WebSockets are
+// multiplexed onto that daemon socket using the codehost tunnel protocol
+// (binary frames, streamId-multiplexed — see codehost/tunnel). The daemon
+// runs TunnelHost against 127.0.0.1:<port>; this DO runs the TunnelClient.
+//
+// Auth model (MVP, private-by-default):
+// - Daemon leg: first WS message is a JSON hello carrying a random key. The
+//   first hello pins the key (TOFU, like the signaling Room); a reconnect must
+//   present the same key or is closed 1008. The key is never logged/echoed.
+// - Visitor leg: the daemon's hello also carries SHA-256 hashes of single-use
+//   claim tokens. A visitor opens /_ay/claim?t=<token> once: the token hashes
+//   to a stored claim, which is consumed and swapped for an HttpOnly session
+//   cookie (8h). Every other request needs that cookie. No cookie → 403.
+//   Unauthenticated bytes NEVER reach the daemon.
+
+import { TunnelClient } from "codehost/tunnel";
+import type { TunnelTransport } from "codehost/tunnel";
+
+export interface ExposureEnv {}
+
+/** Visitor request bodies are buffered before tunneling — cap them. */
+const MAX_BODY = 25 * 1024 * 1024;
+/** Session cookie lifetime. */
+const SESSION_MS = 8 * 60 * 60 * 1000;
+/** An unclaimed token self-expires after this, so a leaked link is short-lived. */
+const CLAIM_TTL_MS = 24 * 60 * 60 * 1000;
+/** Sweep cadence for expired sess:/claim: keys (also self-reschedules). */
+const SWEEP_MS = 60 * 60 * 1000;
+/** Keep at most this many unclaimed tokens (re-runs of `ay expose` add one each). */
+const MAX_CLAIMS = 8;
+/** Hard cap on concurrent sockets per exposure — bounds a daemon-leg flood. */
+const MAX_SOCKETS = 16;
+/** A daemon socket that never authenticates is closed after this. */
+const UNAUTH_MS = 15 * 1000;
+/** Daemon keepalive: text frames answered at the edge without waking the DO. */
+const PING = "ping";
+const PONG = "pong";
+
+const COOKIE = "__ay_sess";
+
+type Attach = { role: "daemon"; authed: boolean; at: number };
+
+interface Hello {
+  t: "hello";
+  key: string;
+  port?: number;
+  claims?: string[]; // sha256 hex of unused claim tokens
+  v?: number;
+}
+
+export class Exposure {
+  // In-memory tunnel client over the live daemon socket. Rebuilt lazily after
+  // hibernation — any stream that was in flight kept the DO awake, so a fresh
+  // client on wake only ever starts from zero pending streams.
+  private tunnel: TunnelClient | null = null;
+  private tunnelWs: WebSocket | null = null;
+  private frameCb: ((data: Uint8Array) => void) | null = null;
+  private closeCb: (() => void) | null = null;
+
+  constructor(private state: DurableObjectState) {
+    this.state.setWebSocketAutoResponse(new WebSocketRequestResponsePair(PING, PONG));
+  }
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    // Daemon leg. The Worker sets the /_daemon path EXCLUSIVELY for the apex
+    // `ay expose` tunnel route, so a visitor can never reach it (their requests
+    // always arrive under /_visit). Still key-gated in webSocketMessage.
+    if (url.pathname === "/_daemon") {
+      if (req.headers.get("Upgrade") !== "websocket") {
+        return new Response("expected websocket", { status: 426 });
+      }
+      // Bound a flood of unauthenticated daemon-leg sockets (the id is public,
+      // so anyone can dial the apex tunnel path): cap concurrency and let the
+      // sweep alarm reap any that never authenticate.
+      if (this.state.getWebSockets().length >= MAX_SOCKETS) {
+        return new Response("too many connections", { status: 503 });
+      }
+      const { 0: client, 1: server } = new WebSocketPair();
+      this.state.acceptWebSocket(server);
+      server.serializeAttachment({ role: "daemon", authed: false, at: Date.now() } satisfies Attach);
+      await this.ensureSweep(UNAUTH_MS);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    // Visitor leg: the Worker prefixes the real path with /_visit.
+    const path = url.pathname.startsWith("/_visit") ? url.pathname.slice("/_visit".length) || "/" : url.pathname;
+
+    // Visitor claim: swap a single-use token for a session cookie.
+    if (path === "/_ay/claim") {
+      return this.claim(url);
+    }
+
+    // Everything else is a visitor request → session gate, then tunnel.
+    if (!(await this.hasSession(req))) {
+      return new Response(lockedPage(url.hostname), {
+        status: 403,
+        headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+      });
+    }
+
+    const daemon = this.daemonSocket();
+    if (!daemon) {
+      return new Response("This exposure's daemon is offline (ay expose is not running).\n", {
+        status: 502,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+    const tunnel = this.tunnelFor(daemon);
+
+    if (req.headers.get("Upgrade") === "websocket") {
+      return this.visitorWebSocket(tunnel, url.hostname, path + url.search, req);
+    }
+    return this.visitorHttp(tunnel, url.hostname, path + url.search, req);
+  }
+
+  // ---- daemon socket / tunnel plumbing ----
+
+  private daemonSocket(): WebSocket | null {
+    for (const ws of this.state.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Attach | null;
+      if (a?.authed) return ws;
+    }
+    return null;
+  }
+
+  private tunnelFor(ws: WebSocket): TunnelClient {
+    if (this.tunnel && this.tunnelWs === ws) return this.tunnel;
+    const transport: TunnelTransport = {
+      // Copy into a fresh ArrayBuffer-backed view — the protocol's WS
+      // fragmentation emits subarray views (byteOffset > 0) that some
+      // WebSocket.send implementations mishandle.
+      send: (frame) => {
+        const copy = new Uint8Array(frame.byteLength);
+        copy.set(frame);
+        ws.send(copy);
+      },
+      isOpen: () => ws.readyState === WebSocket.READY_STATE_OPEN,
+      bufferedAmount: () => 0,
+      onFrame: (cb) => {
+        this.frameCb = cb;
+      },
+      onClose: (cb) => {
+        this.closeCb = cb;
+      },
+    };
+    this.tunnelWs = ws;
+    this.tunnel = new TunnelClient(transport);
+    return this.tunnel;
+  }
+
+  async webSocketMessage(ws: WebSocket, msg: string | ArrayBuffer): Promise<void> {
+    const a = ws.deserializeAttachment() as Attach | null;
+    if (a?.role !== "daemon") return;
+
+    if (!a.authed) {
+      if (typeof msg !== "string") return ws.close(1008, "expected hello");
+      let hello: Hello;
+      try {
+        hello = JSON.parse(msg);
+      } catch {
+        return ws.close(1008, "expected hello");
+      }
+      if (hello.t !== "hello" || typeof hello.key !== "string" || hello.key.length < 32) {
+        return ws.close(1008, "expected hello");
+      }
+      const stored = await this.state.storage.get<string>("key");
+      if (stored === undefined) {
+        await this.state.storage.put("key", hello.key);
+        await this.state.storage.put("createdAt", Date.now());
+      } else if (stored !== hello.key) {
+        return ws.close(1008, "forbidden"); // key never echoed
+      }
+      // Register fresh claim tokens (bounded: drop oldest beyond MAX_CLAIMS).
+      // claim: values are expiry timestamps, and TTL is constant, so ascending
+      // value == oldest-first — evict the truly oldest, not a random hash.
+      const claims = (hello.claims ?? []).filter((c) => /^[a-f0-9]{64}$/.test(c)).slice(0, MAX_CLAIMS);
+      if (claims.length) {
+        const existing = [...(await this.state.storage.list<number>({ prefix: "claim:" }))].sort((a, b) => a[1] - b[1]);
+        const excess = existing.length + claims.length - MAX_CLAIMS;
+        for (const [k] of existing.slice(0, Math.max(0, excess))) await this.state.storage.delete(k);
+        const expires = Date.now() + CLAIM_TTL_MS;
+        for (const c of claims) await this.state.storage.put(`claim:${c}`, expires);
+        await this.ensureSweep();
+      }
+      // One daemon at a time: drop any previous socket.
+      for (const other of this.state.getWebSockets()) {
+        if (other !== ws) other.close(1012, "replaced");
+      }
+      ws.serializeAttachment({ role: "daemon", authed: true, at: a.at } satisfies Attach);
+      this.tunnel = null; // next visitor request binds to this socket
+      this.tunnelWs = null;
+      ws.send(JSON.stringify({ t: "ready" }));
+      return;
+    }
+
+    if (typeof msg === "string") {
+      if (msg === PING) ws.send(PONG); // auto-response fallback
+      return;
+    }
+    // Binary tunnel frame from the daemon → the in-memory client (if any).
+    // After hibernation there may be no client yet; frames for dead streams
+    // are dropped by the client core anyway.
+    if (this.tunnelWs === ws) this.frameCb?.(new Uint8Array(msg));
+  }
+
+  webSocketClose(ws: WebSocket): void {
+    if (this.tunnelWs === ws) {
+      this.closeCb?.(); // fails pending visitor streams
+      this.tunnel = null;
+      this.tunnelWs = null;
+    }
+  }
+
+  // ---- visitor session ----
+
+  private async claim(url: URL): Promise<Response> {
+    const token = url.searchParams.get("t") ?? "";
+    const denied = new Response(
+      "Invalid or already-used claim link. Ask the owner for a fresh one (re-run `ay expose`).\n",
+      { status: 403, headers: { "cache-control": "no-store" } },
+    );
+    if (token.length < 16) return denied;
+
+    const key = `claim:${await sha256hex(token)}`;
+    const exp = await this.state.storage.get<number>(key);
+    if (exp === undefined) return denied;
+    // Consume the token whether or not it's expired (strictly single-use).
+    await this.state.storage.delete(key);
+    if (Date.now() > exp) return denied;
+
+    const sess = randHex(32);
+    await this.state.storage.put(`sess:${sess}`, Date.now() + SESSION_MS);
+    await this.ensureSweep();
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: "/",
+        "set-cookie": `${COOKIE}=${sess}; Max-Age=${SESSION_MS / 1000}; Path=/; Secure; HttpOnly; SameSite=Lax`,
+        "referrer-policy": "no-referrer",
+        "cache-control": "no-store",
+      },
+    });
+  }
+
+  private async hasSession(req: Request): Promise<boolean> {
+    const sess = cookieValue(req.headers.get("cookie") ?? "", COOKIE);
+    if (!sess) return false;
+    const exp = await this.state.storage.get<number>(`sess:${sess}`);
+    if (exp === undefined) return false;
+    if (Date.now() > exp) {
+      await this.state.storage.delete(`sess:${sess}`);
+      return false;
+    }
+    return true;
+  }
+
+  // Schedule the sweep alarm so expired sess:/claim: keys and stale unauthed
+  // sockets can't pile up. `withinMs` pulls an existing later alarm earlier
+  // (e.g. a 15s unauth reap vs the hourly key sweep).
+  private async ensureSweep(withinMs: number = SWEEP_MS): Promise<void> {
+    const at = Date.now() + withinMs;
+    const cur = await this.state.storage.getAlarm();
+    if (cur === null || cur > at) await this.state.storage.setAlarm(at);
+  }
+
+  async alarm(): Promise<void> {
+    const now = Date.now();
+    let live = 0;
+    for (const prefix of ["sess:", "claim:"] as const) {
+      const entries = await this.state.storage.list<number>({ prefix });
+      for (const [k, exp] of entries) {
+        if (now > exp) await this.state.storage.delete(k);
+        else live++;
+      }
+    }
+    // Reap daemon-leg sockets that never authenticated within UNAUTH_MS.
+    let pendingUnauth = false;
+    for (const ws of this.state.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Attach | null;
+      if (a && !a.authed) {
+        if (now - a.at >= UNAUTH_MS) ws.close(1008, "auth timeout");
+        else pendingUnauth = true;
+      }
+    }
+    // Reschedule while anything still needs watching.
+    if (pendingUnauth) await this.state.storage.setAlarm(now + UNAUTH_MS);
+    else if (live > 0) await this.state.storage.setAlarm(now + SWEEP_MS);
+  }
+
+  // ---- visitor request paths ----
+
+  private async visitorHttp(tunnel: TunnelClient, hostname: string, pathAndQuery: string, req: Request): Promise<Response> {
+    const len = Number(req.headers.get("content-length") ?? 0);
+    if (len > MAX_BODY) return new Response("body too large", { status: 413 });
+
+    const headers: Record<string, string> = {};
+    req.headers.forEach((v, k) => {
+      if (k === "cookie") {
+        const rest = stripCookie(v, COOKIE); // the session is ours, not the app's
+        if (rest) headers[k] = rest;
+        return;
+      }
+      headers[k] = v;
+    });
+    // Overwritten AFTER copying visitor headers, so a visitor can't spoof them.
+    headers["x-forwarded-host"] = hostname;
+    headers["x-forwarded-proto"] = "https";
+
+    let body: Uint8Array | undefined;
+    if (req.method !== "GET" && req.method !== "HEAD" && req.body) {
+      const capped = await readCapped(req.body, MAX_BODY);
+      if (!capped) return new Response("body too large", { status: 413 });
+      body = capped;
+    }
+
+    try {
+      return await tunnel.fetch(req.method, pathAndQuery, headers, body);
+    } catch (err) {
+      return new Response(`upstream error: ${String(err)}\n`, { status: 502, headers: { "cache-control": "no-store" } });
+    }
+  }
+
+  private visitorWebSocket(tunnel: TunnelClient, _hostname: string, pathAndQuery: string, req: Request): Response {
+    const protoHeader = req.headers.get("Sec-WebSocket-Protocol");
+    const protocols = protoHeader ? protoHeader.split(",").map((s) => s.trim()) : undefined;
+    const { 0: client, 1: server } = new WebSocketPair();
+    server.accept(); // plain accept: an active visitor WS keeps the DO awake by design
+
+    const handle = tunnel.openWs(pathAndQuery, protocols, {
+      onOpenAck: (ok) => {
+        if (!ok) server.close(1011, "upstream refused");
+      },
+      onText: (text) => server.send(text),
+      onBin: (data) => server.send(data),
+      onClose: (code, reason) => {
+        try {
+          server.close(sanitizeCloseCode(code), reason.slice(0, 123));
+        } catch {
+          /* already closed */
+        }
+      },
+    });
+    server.addEventListener("message", (ev) => {
+      if (typeof ev.data === "string") handle.sendText(ev.data);
+      else handle.sendBin(new Uint8Array(ev.data as ArrayBuffer));
+    });
+    server.addEventListener("close", () => handle.close());
+    server.addEventListener("error", () => handle.close());
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+      ...(protocols?.[0] ? { headers: { "Sec-WebSocket-Protocol": protocols[0] } } : {}),
+    });
+  }
+}
+
+// ---- small pure helpers ----
+
+/** Read a stream into one buffer, aborting (→ null) once it exceeds `max`, so a
+ *  body without/with-a-lying Content-Length can't be buffered unboundedly. */
+async function readCapped(body: ReadableStream<Uint8Array>, max: number): Promise<Uint8Array | null> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > max) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.byteLength;
+  }
+  return out;
+}
+
+function cookieValue(header: string, name: string): string | null {
+  for (const part of header.split(";")) {
+    const [k, ...rest] = part.trim().split("=");
+    if (k === name) return rest.join("=");
+  }
+  return null;
+}
+
+function stripCookie(header: string, name: string): string {
+  return header
+    .split(";")
+    .map((s) => s.trim())
+    .filter((part) => part.split("=")[0] !== name)
+    .join("; ");
+}
+
+/** Close codes a server may pass to close(): 1000 or 3000-4999. */
+function sanitizeCloseCode(code: number): number {
+  return code === 1000 || (code >= 3000 && code <= 4999) ? code : 1000;
+}
+
+async function sha256hex(s: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function randHex(bytes: number): string {
+  const buf = crypto.getRandomValues(new Uint8Array(bytes));
+  return [...buf].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function lockedPage(host: string): string {
+  return `<!doctype html><meta charset="utf-8"><title>locked — ${host}</title>
+<meta name="robots" content="noindex">
+<body style="font-family:system-ui;max-width:34rem;margin:15vh auto;padding:0 1rem;color:#333">
+<h1 style="font-size:1.3rem">🔒 This preview is private</h1>
+<p><code>${host}</code> is a private port exposure served by <a href="https://agent-yes.com">agent-yes</a>.</p>
+<p>Access requires a one-time claim link from the machine's owner (printed by <code>ay expose</code>).</p>
+</body>`;
+}

--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -19,8 +19,16 @@
 
 export interface Env {
   ROOMS: DurableObjectNamespace;
+  EXPOSURES: DurableObjectNamespace;
   ASSETS: Fetcher;
 }
+
+export { Exposure } from "./exposure";
+
+// Exposure subdomains: <id>.agent-yes.com (wildcard route). Ids are generated
+// by `ay expose` and always start with "x", so they can never collide with
+// named subdomains (s., www., …). See exposure.ts for the relay itself.
+const EXPOSURE_HOST = /^(x[a-z0-9]{7,31})\.agent-yes\.com$/;
 
 const SUBPROTO = "ay-signal-1";
 
@@ -61,7 +69,31 @@ export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
 
+    // Route on the Host header (not url.hostname) so `wrangler dev` — where the
+    // URL is always localhost — still resolves via a spoofed Host; in
+    // production the two are identical.
+    const host = req.headers.get("host") ?? url.hostname;
+
+    // Visitor leg: EVERYTHING on an exposure subdomain belongs to its DO (so an
+    // exposed app owns its own /health, /_ay/*, etc.). The DO is addressed by a
+    // fixed internal /_visit path so a visitor can never reach the daemon leg
+    // (which the DO accepts only on the /_daemon path the Worker alone sets).
+    const exp = EXPOSURE_HOST.exec(host);
+    if (exp) {
+      const inner = new Request(new URL(`/_visit${url.pathname}${url.search}`, url), req);
+      return env.EXPOSURES.get(env.EXPOSURES.idFromName(exp[1]!)).fetch(inner);
+    }
+
     if (url.pathname === "/health") return new Response("ok\n");
+
+    // Daemon leg of a port exposure: `ay expose` dials this on the apex (the id
+    // rides the path). Reachable ONLY here — the DO trusts the /_daemon path,
+    // which the Worker sets exclusively for this route, never for a visitor.
+    const tun = /^\/_ay\/tunnel\/(x[a-z0-9]{7,31})$/.exec(url.pathname);
+    if (tun && req.headers.get("Upgrade") === "websocket") {
+      const inner = new Request(new URL("/_daemon", url), req);
+      return env.EXPOSURES.get(env.EXPOSURES.idFromName(tun[1]!)).fetch(inner);
+    }
 
     // WebSocket to /<room> → signaling DO (this is the s.agent-yes.com path).
     const m = /^\/([A-Za-z0-9_-]{1,64})$/.exec(url.pathname);

--- a/lab/ui/cf/wrangler.jsonc
+++ b/lab/ui/cf/wrangler.jsonc
@@ -28,17 +28,34 @@
     "command": "mkdir -p ./public/w && cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/ && cp ../landing.html ./public/index.html && cp ../architecture.html ./public/architecture.html && rm -rf ./public/blog && cp -R ../blog ./public/blog && cp ../setup.sh ../setup.ps1 ./public/ && cp _headers ./public/_headers && bun ../../../scripts/build-rgui.ts ./public/r && rm -rf ./public/rgui && cp -R ./public/r ./public/rgui",
   },
   // Static console UI (served for every non-WebSocket request).
-  "assets": { "directory": "./public", "binding": "ASSETS" },
+  // run_worker_first: the Worker must see the request BEFORE the asset server,
+  // otherwise a plain GET to an exposure subdomain (x*.agent-yes.com/) would be
+  // answered with the console's index.html asset and never reach the Exposure
+  // router. The Worker still delegates the main site to ASSETS.fetch, so
+  // agent-yes.com is unchanged (just always via the Worker now).
+  "assets": { "directory": "./public", "binding": "ASSETS", "run_worker_first": true },
   "durable_objects": {
-    "bindings": [{ "name": "ROOMS", "class_name": "Room" }],
+    "bindings": [
+      { "name": "ROOMS", "class_name": "Room" },
+      { "name": "EXPOSURES", "class_name": "Exposure" },
+    ],
   },
   // SQLite-backed DO classes (required on the free plan, fine on paid).
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Room"] }],
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["Room"] },
+    { "tag": "v2", "new_sqlite_classes": ["Exposure"] },
+  ],
   // One Worker, two custom domains: the UI on agent-yes.com, signaling on
   // s.agent-yes.com. Custom domains auto-provision DNS in the zone.
+  // The wildcard ROUTE serves `ay expose` subdomains (x*.agent-yes.com →
+  // Exposure DO). Custom domains win on their exact hostnames, so this only
+  // catches the rest. It needs a proxied wildcard DNS record in the zone
+  // (`*.agent-yes.com` AAAA 100::) which the deploy token can't create —
+  // one-time manual step in the dashboard.
   "routes": [
     { "pattern": "agent-yes.com", "custom_domain": true },
     { "pattern": "s.agent-yes.com", "custom_domain": true },
+    { "pattern": "*.agent-yes.com/*", "zone_name": "agent-yes.com" },
   ],
   "observability": { "enabled": true },
 }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
     "tsdown": "^0.20.3",
     "vitest": "4.1.0",
     "ws": "^8.20.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "codehost": "^0.32.0"
   },
   "peerDependencies": {
     "node-pty": "latest",

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -22,7 +22,7 @@ use std::env;
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
     "send", "spawn", "attach", "stop", "exit", "restart", "note", "serve", "schedule", "remote",
-    "reap", "help",
+    "expose", "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/expose.ts
+++ b/ts/expose.ts
@@ -1,0 +1,188 @@
+// `ay expose <port>` — share a local HTTP/WS server through the agent-yes edge
+// relay: https://<id>.agent-yes.com/* ⇄ Exposure DO ⇄ this daemon ⇄ 127.0.0.1:<port>.
+//
+// The daemon dials OUT (wss://<relay>/_ay/tunnel/<id>), so it works behind any
+// NAT, and runs the codehost tunnel protocol's host half against the local
+// port. Private by default: visitors need the single-use claim link printed
+// below (it swaps for an 8h HttpOnly cookie at the edge; unauthenticated
+// requests never reach this machine). See lab/ui/cf/exposure.ts for the edge.
+
+import { randomBytes, createHash } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { TunnelHost } from "codehost/tunnel";
+import type { TunnelTransport } from "codehost/tunnel";
+
+const DEFAULT_RELAY = "https://agent-yes.com";
+const PING_MS = 25_000;
+const RECONNECT_MIN_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+
+interface ExposureRecord {
+  id: string;
+  key: string;
+}
+
+function exposuresPath(): string {
+  const home = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
+  mkdirSync(home, { recursive: true });
+  return path.join(home, "exposures.json");
+}
+
+/** Stable id+key per (relay, port): re-running `ay expose 5173` keeps its URL. */
+function loadOrCreateExposure(relayHost: string, port: number): ExposureRecord {
+  const file = exposuresPath();
+  let all: Record<string, ExposureRecord> = {};
+  try {
+    all = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    /* first run */
+  }
+  const slot = `${relayHost}:${port}`;
+  const existing = all[slot];
+  if (existing?.id && existing.key) return existing;
+  const rec: ExposureRecord = {
+    // "x" prefix: exposure hostnames can never collide with named subdomains.
+    id: "x" + randomBytes(8).toString("hex").slice(0, 15),
+    key: randomBytes(32).toString("hex"),
+  };
+  all[slot] = rec;
+  const tmp = file + ".tmp";
+  writeFileSync(tmp, JSON.stringify(all, null, 2) + "\n");
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, file);
+  return rec;
+}
+
+/** Bun's browser-style WebSocket as a TunnelTransport. No bufferedAmountLow
+ *  event exists here — TunnelHost's 100ms safety poll covers drain resume. */
+function wsTransport(ws: WebSocket): TunnelTransport {
+  return {
+    // Copy into a fresh ArrayBuffer-backed view: Bun's ws.send mishandles a
+    // subarray view (byteOffset > 0), which the protocol's fragmentation emits.
+    send: (frame) => {
+      const copy = new Uint8Array(frame.byteLength);
+      copy.set(frame);
+      ws.send(copy);
+    },
+    isOpen: () => ws.readyState === WebSocket.OPEN,
+    bufferedAmount: () => ws.bufferedAmount,
+    onFrame: (cb) => {
+      ws.addEventListener("message", (ev) => {
+        if (typeof ev.data === "string") return;
+        const d = ev.data as ArrayBuffer | Uint8Array;
+        cb(d instanceof Uint8Array ? d : new Uint8Array(d));
+      });
+    },
+    onClose: (cb) => ws.addEventListener("close", () => cb()),
+  };
+}
+
+export async function cmdExpose(args: string[]): Promise<number> {
+  let relay = DEFAULT_RELAY;
+  let port = 0;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--relay") relay = args[++i] ?? relay;
+    else if (a.startsWith("--relay=")) relay = a.slice("--relay=".length);
+    else if (/^\d+$/.test(a)) port = Number(a);
+    else if (a === "-h" || a === "--help") {
+      console.log(
+        `Usage: ay expose <port> [--relay ${DEFAULT_RELAY}]\n\n` +
+          `Shares http://127.0.0.1:<port> at https://<id>.agent-yes.com (private:\n` +
+          `visitors need the printed one-time claim link, which sets an 8h cookie).\n` +
+          `The URL is stable per port on this machine. Ctrl-C stops sharing.`,
+      );
+      return 0;
+    }
+  }
+  if (!port || port < 1 || port > 65535) {
+    console.error("usage: ay expose <port> [--relay https://…]  (see ay expose --help)");
+    return 1;
+  }
+
+  const relayUrl = new URL(relay);
+  const rec = loadOrCreateExposure(relayUrl.host, port);
+  const wsProto = relayUrl.protocol === "http:" ? "ws:" : "wss:";
+  const tunnelUrl = `${wsProto}//${relayUrl.host}/_ay/tunnel/${rec.id}`;
+  // Public hostname: <id>.<zone> on the real relay; the relay host itself (with
+  // a Host-header spoof) when pointing at wrangler dev.
+  const publicHost = relayUrl.host === "agent-yes.com" ? `${rec.id}.agent-yes.com` : relayUrl.host;
+
+  // Fresh single-use claim token every run; only its hash goes to the edge.
+  const claimToken = randomBytes(18).toString("base64url");
+  const claimHash = createHash("sha256").update(claimToken).digest("hex");
+
+  let stopped = false;
+  let ws: WebSocket | null = null;
+  let backoff = RECONNECT_MIN_MS;
+  let announced = false;
+
+  const connect = () => {
+    if (stopped) return;
+    ws = new WebSocket(tunnelUrl);
+    ws.binaryType = "arraybuffer";
+    const sock = ws;
+    let ping: ReturnType<typeof setInterval> | null = null;
+
+    sock.addEventListener("open", () => {
+      sock.send(JSON.stringify({ t: "hello", key: rec.key, port, claims: [claimHash], v: 1 }));
+    });
+    sock.addEventListener("message", (ev) => {
+      if (typeof ev.data !== "string") return; // binary frames belong to the TunnelHost
+      let msg: { t?: string };
+      try {
+        msg = JSON.parse(ev.data);
+      } catch {
+        return;
+      }
+      if (msg.t === "ready") {
+        backoff = RECONNECT_MIN_MS;
+        new TunnelHost(wsTransport(sock), { port });
+        ping = setInterval(() => {
+          if (sock.readyState === WebSocket.OPEN) sock.send("ping");
+        }, PING_MS);
+        if (!announced) {
+          announced = true;
+          console.log(`[ay expose] sharing 127.0.0.1:${port}`);
+          console.log(`  url:    https://${publicHost}/`);
+          console.log(`  claim:  https://${publicHost}/_ay/claim?t=${claimToken}`);
+          console.log(`          (one-time link — opens access for 8h in that browser)`);
+        } else {
+          console.log(`[ay expose] reconnected`);
+        }
+      }
+    });
+    sock.addEventListener("close", (ev) => {
+      if (ping) clearInterval(ping);
+      if (stopped) return;
+      if (ev.code === 1008) {
+        console.error(`[ay expose] relay refused this exposure (${ev.reason || "forbidden"}) — giving up`);
+        process.exit(1);
+      }
+      console.log(`[ay expose] connection lost, retrying in ${Math.round(backoff / 1000)}s…`);
+      setTimeout(connect, backoff);
+      backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
+    });
+    sock.addEventListener("error", () => {
+      /* close fires right after; retry there */
+    });
+  };
+  connect();
+
+  const shutdown = () => {
+    stopped = true;
+    console.log("\n[ay expose] stopped — the URL now answers 502 until you expose again");
+    try {
+      ws?.close();
+    } catch {
+      /* ignore */
+    }
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  return new Promise<number>(() => {}); // runs until signal
+}

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -306,6 +306,7 @@ const SUBCOMMANDS = new Set([
   "serve",
   "schedule",
   "remote",
+  "expose",
   "reap",
   "help",
 ]);
@@ -427,6 +428,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         const { cmdRemote } = await import("./remotes.ts");
         return cmdRemote(rest);
       }
+      case "expose": {
+        const { cmdExpose } = await import("./expose.ts");
+        return cmdExpose(rest);
+      }
       case "reap": {
         const reaper = await import("./reaper.ts");
         await reaper.sweep();
@@ -546,6 +551,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay serve status                     show serve daemon/server status\n` +
       `  ay remote add <alias> http://<token>@<host>:<port>\n` +
       `  ay remote ls / rm <alias>           manage saved remotes\n` +
+      `  ay expose <port>                    share localhost:<port> at https://<id>.agent-yes.com (private link)\n` +
       `  ay ls   <token>@<host>:<port>       connect inline (no alias needed)\n` +
       `  ay send <token>@<host>:<port>:<kw> <msg>\n` +
       `\n` +

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
     "systray2",
     // codehost/provision is resolved at runtime (bun link) — never bundle it,
     // so a missing link degrades to a 501 instead of breaking the build.
-    /^codehost(\/|$)/,
+    // codehost/tunnel is the opposite: a pure-TS devDependency that MUST be
+    // bundled (ay expose runs on machines that never install codehost).
+    /^codehost\/provision(\/|$)/,
   ],
   format: "esm",
   outExtensions: () => ({ js: ".js" }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,11 @@ export default defineConfig({
         // isWebrtcSpec) are unit-tested in webrtcRemote.spec.ts; the connection
         // and HTTP bridge are integration-only (same rationale as share.ts).
         "ts/webrtcRemote.ts",
+        // Port-exposure daemon — dials the edge relay over a WebSocket and runs
+        // the codehost/tunnel host; needs a live relay + local server. Proven
+        // e2e (wrangler dev + real HTTP/SSE/WS), not unit-testable (same
+        // rationale as share.ts / webrtcRemote.ts).
+        "ts/expose.ts",
         // Guided onboarding — the workspace-setting path is unit-tested
         // (setup.spec.ts); the TTY prompt and the daemon install it delegates to
         // are integration-only.


### PR DESCRIPTION
## What

`ay expose <port>` shares a local `http://127.0.0.1:<port>` at `https://<id>.agent-yes.com` behind a **private, one-time claim link**. HTTP, SSE, and WebSocket all tunnel through. This is **MVP 1** of the [port-proxy plan](https://github.com/snomiao/codehost/pull/6) — it rides the transport-agnostic `codehost/tunnel` protocol extracted in MVP 0.

```
ay expose 5173
  url:    https://x1a2b3c….agent-yes.com/
  claim:  https://x1a2b3c….agent-yes.com/_ay/claim?t=…   (one-time → 8h cookie)
```

## Architecture

```
visitor ──https──▶ Worker (x*.agent-yes.com)
                     └▶ Exposure DO  ──one outbound WS──▶  ay expose daemon ──▶ 127.0.0.1:<port>
                        claim→cookie gate                  codehost/tunnel TunnelHost
                        codehost/tunnel TunnelClient
```

- **`ts/expose.ts`** — the daemon leg. Stable opaque `x…` id + 256-bit key per port (`~/.agent-yes/exposures.json`, `0600`), dials OUT `wss://agent-yes.com/_ay/tunnel/<id>` (works behind any NAT), runs `TunnelHost` against the local port, reconnects with backoff, prints a fresh single-use claim link each run.
- **`lab/ui/cf/exposure.ts`** — the `Exposure` Durable Object edge relay. TOFU-pinned daemon key, one-daemon-at-a-time, HTTP/WS multiplexed onto the daemon socket via `TunnelClient`. Visitors gated by a single-use claim token → `HttpOnly; Secure; SameSite=Lax` 8h session cookie; our cookie is stripped before forwarding; `x-forwarded-host/proto` overwritten (unspoofable).
- **`lab/ui/cf/worker.ts`** — routes `x*.agent-yes.com` visitor traffic (internal `/_visit` path) and the apex `/_ay/tunnel/<id>` daemon leg (internal `/_daemon` path) to the DO. The split guarantees a visitor can never reach the daemon leg.
- **`wrangler.jsonc`** — `EXPOSURES` DO + migration `v2`, wildcard route `*.agent-yes.com/*`, `run_worker_first` (the Worker must intercept subdomain requests before the static asset server).

## Security review (opus, adversarial)

No auth bypass, no SSRF, cookies host-scoped & unforgeable, claim single-use (atomic under the DO input gate). Findings fixed in this PR:
- **Unauthed daemon-socket flood** (the id is public) → `MAX_SOCKETS` cap + an alarm that reaps sockets that never authenticate within 15s.
- **Unbounded body buffering** when Content-Length is absent/spoofed → size-capped streaming read (413 past `MAX_BODY`).
- **Unbounded session/claim storage** → alarm sweep of expired keys.
- **Random claim eviction** beyond `MAX_CLAIMS` → oldest-first (by stored expiry).
- **`/health` route shadow** on exposure subdomains → exposure hosts now own every path.

TOFU key-squatting (pre-first-connect) is accepted for MVP (id is secret until shared; owner pins on first `ay expose`).

## Verification

Full local e2e through `wrangler dev` (a routes-disabled dev config avoids wrangler's Host normalization): locked 403 → claim 302+cookie → HTTP relay → app-owned `/health` tunneled → SSE stream → WebSocket echo → **200 KB WS message fragmented both ways, byte-exact** → claim reuse 403 → subdomain `/_ay/tunnel` rejected as a visitor (daemon leg unreachable) → apex console still 200, apex `/health` still edge-`ok`. `bun run build` + worker dry-run clean; `cargo build --release` clean.

## ⚠️ One manual step before subdomains resolve

The deploy token has no DNS scope, so add a **proxied wildcard DNS record** `*.agent-yes.com` (AAAA `100::` or CNAME → `agent-yes.com`, orange-cloud ON) in the Cloudflare dashboard once. Until then the worker deploys fine but `x*.agent-yes.com` won't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)