### PR TITLE
feat(expose): expose a clicked localhost URL from the console + ports manager

### DIFF
--- a/lab/ui/cf/exposure.ts
+++ b/lab/ui/cf/exposure.ts
@@ -176,18 +176,7 @@ export class Exposure {
       } else if (stored !== hello.key) {
         return ws.close(1008, "forbidden"); // key never echoed
       }
-      // Register fresh claim tokens (bounded: drop oldest beyond MAX_CLAIMS).
-      // claim: values are expiry timestamps, and TTL is constant, so ascending
-      // value == oldest-first — evict the truly oldest, not a random hash.
-      const claims = (hello.claims ?? []).filter((c) => /^[a-f0-9]{64}$/.test(c)).slice(0, MAX_CLAIMS);
-      if (claims.length) {
-        const existing = [...(await this.state.storage.list<number>({ prefix: "claim:" }))].sort((a, b) => a[1] - b[1]);
-        const excess = existing.length + claims.length - MAX_CLAIMS;
-        for (const [k] of existing.slice(0, Math.max(0, excess))) await this.state.storage.delete(k);
-        const expires = Date.now() + CLAIM_TTL_MS;
-        for (const c of claims) await this.state.storage.put(`claim:${c}`, expires);
-        await this.ensureSweep();
-      }
+      await this.registerClaims(hello.claims);
       // One daemon at a time: drop any previous socket.
       for (const other of this.state.getWebSockets()) {
         if (other !== ws) other.close(1012, "replaced");
@@ -200,7 +189,16 @@ export class Exposure {
     }
 
     if (typeof msg === "string") {
-      if (msg === PING) ws.send(PONG); // auto-response fallback
+      if (msg === PING) return void ws.send(PONG); // auto-response fallback
+      // A running daemon can register fresh claim tokens without reconnecting
+      // (the console mints one each time the owner re-opens an exposure).
+      let ctrl: { t?: string; claims?: string[] };
+      try {
+        ctrl = JSON.parse(msg);
+      } catch {
+        return;
+      }
+      if (ctrl.t === "claim") await this.registerClaims(ctrl.claims);
       return;
     }
     // Binary tunnel frame from the daemon → the in-memory client (if any).
@@ -258,6 +256,20 @@ export class Exposure {
       return false;
     }
     return true;
+  }
+
+  // Register fresh claim tokens (bounded: drop oldest beyond MAX_CLAIMS).
+  // claim: values are expiry timestamps, and TTL is constant, so ascending
+  // value == oldest-first — evict the truly oldest, not a random hash.
+  private async registerClaims(raw: string[] | undefined): Promise<void> {
+    const claims = (raw ?? []).filter((c) => /^[a-f0-9]{64}$/.test(c)).slice(0, MAX_CLAIMS);
+    if (!claims.length) return;
+    const existing = [...(await this.state.storage.list<number>({ prefix: "claim:" }))].sort((a, b) => a[1] - b[1]);
+    const excess = existing.length + claims.length - MAX_CLAIMS;
+    for (const [k] of existing.slice(0, Math.max(0, excess))) await this.state.storage.delete(k);
+    const expires = Date.now() + CLAIM_TTL_MS;
+    for (const c of claims) await this.state.storage.put(`claim:${c}`, expires);
+    await this.ensureSweep();
   }
 
   // Schedule the sweep alarm so expired sess:/claim: keys and stale unauthed

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -352,6 +352,46 @@
       .app.steer-agent #shareAgentRW {
         display: none !important;
       }
+      /* Expose modal — ports manager list rows. */
+      .exposeList {
+        margin: 10px 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        max-height: 40vh;
+        overflow-y: auto;
+      }
+      .exposerow {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 7px 9px;
+      }
+      .exposerow .exmeta {
+        flex: 1;
+        min-width: 0;
+      }
+      .exposerow .explabel {
+        font-weight: 600;
+      }
+      .exposerow .exurl {
+        font-size: 11px;
+        opacity: 0.7;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .exposerow .exhost {
+        font-size: 10px;
+        opacity: 0.55;
+      }
+      .exposePrompt {
+        border-bottom: 1px solid var(--line);
+        padding-bottom: 10px;
+        margin-bottom: 4px;
+      }
       /* Share modal — QR + link for a single-agent view-only share. */
       .modal-backdrop {
         position: fixed;
@@ -1685,6 +1725,9 @@
               <button id="foldbtn" class="viewbtn" title="fold subagent trees">⊞ subs</button>
               <button id="sortbtn" class="viewbtn" title="cycle sort order">⇅ state</button>
               <button id="viewbtn" class="viewbtn" title="toggle compact list">☰</button>
+              <button id="portsbtn" class="viewbtn" title="manage exposed localhost ports">
+                ⇄ ports
+              </button>
               <button id="rguibtn" class="viewbtn" title="open the agent graph view (/r/) for this fleet">
                 ⌗ graph
               </button>
@@ -1886,6 +1929,32 @@
         </div>
         <div class="srow" id="shareWarnClose" hidden>
           <button id="shareCloseAlt" type="button">Cancel</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Expose modal: prompt to publish a clicked localhost:PORT through
+         agent-yes.com, plus the ports manager (list + revoke active exposures). -->
+    <div class="modal-backdrop" id="exposeModal" hidden>
+      <div class="sharebox" role="dialog" aria-modal="true" aria-label="Expose localhost port">
+        <h3 id="exposeTitle">Exposed ports</h3>
+        <div class="exposePrompt" id="exposePrompt" hidden>
+          <p class="sub" id="exposePromptSub">Publish this local server on the internet?</p>
+          <p class="note">
+            A private link on <strong>agent-yes.com</strong> will tunnel to this port on the agent's
+            machine. Only someone who opens the one-time claim link (which opens automatically for
+            you) can reach it. Revoke anytime below.
+          </p>
+          <div class="srow">
+            <button class="primary" id="exposeGo" type="button">Expose &amp; open</button>
+            <button id="exposeCancel" type="button">Cancel</button>
+          </div>
+        </div>
+        <div class="exposeList" id="exposeList">
+          <p class="sub" id="exposeEmpty">No ports are exposed right now.</p>
+        </div>
+        <div class="srow">
+          <button id="exposeClose" type="button">Close</button>
         </div>
       </div>
     </div>
@@ -3242,6 +3311,157 @@
         if (modal) modal.hidden = true;
         pendingRw = null; // a cancelled read-write flow never minted anything
       }
+
+      // ---- Port exposure: publish a clicked localhost:PORT through agent-yes.com ----
+
+      // Recognise a local-loopback URL and pull its port (default 80). Only these
+      // are offered for exposure — a real public URL just opens normally.
+      function localhostPort(uri) {
+        let u;
+        try {
+          u = new URL(uri);
+        } catch {
+          return null;
+        }
+        if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+        const h = u.hostname;
+        if (h !== "localhost" && h !== "127.0.0.1" && h !== "0.0.0.0" && h !== "::1") return null;
+        const port = Number(u.port) || (u.protocol === "https:" ? 443 : 80);
+        return port >= 1 && port <= 65535 ? port : null;
+      }
+
+      // The tx the expose prompt should call (the daemon whose terminal was clicked).
+      let exposePendingTx = null;
+      let exposePendingPort = 0;
+
+      // Called by the terminal link handler when a localhost URL is clicked.
+      function promptExpose(port, tx) {
+        exposePendingTx = tx || localTx;
+        exposePendingPort = port;
+        $("exposeTitle").textContent = "Expose localhost:" + port + "?";
+        $("exposePromptSub").textContent =
+          "Publish this local server (port " + port + ") on the internet via agent-yes.com?";
+        $("exposePrompt").hidden = false;
+        openExposeManager(false);
+      }
+
+      // Open the ports manager (list of active exposures across every host).
+      function openExposeManager(resetPrompt) {
+        if (resetPrompt !== false) {
+          $("exposePrompt").hidden = true;
+          $("exposeTitle").textContent = "Exposed ports";
+        }
+        const modal = $("exposeModal");
+        if (modal) modal.hidden = false;
+        refreshExposeList();
+      }
+      function closeExposeModal() {
+        const modal = $("exposeModal");
+        if (modal) modal.hidden = true;
+        exposePendingTx = null;
+        exposePendingPort = 0;
+      }
+
+      // Agree → mint the exposure on its host and open the claim link (which sets
+      // the 8h cookie and redirects to the app), then refresh the manager list.
+      async function doExpose() {
+        const tx = exposePendingTx || localTx;
+        const port = exposePendingPort;
+        $("exposePrompt").hidden = true;
+        if (!port) return;
+        let info = null;
+        try {
+          const r = await tx.post("/api/expose", { port });
+          if (r.ok) info = JSON.parse(r.text);
+        } catch {}
+        if (!info || !info.claim) {
+          $("exposeEmpty").hidden = false;
+          $("exposeEmpty").textContent = "Couldn't expose port " + port + " (is `ay serve` reachable?).";
+          return;
+        }
+        window.open(info.claim, "_blank", "noopener,noreferrer");
+        refreshExposeList();
+      }
+
+      // Gather active exposures from every live host and render the manager rows.
+      async function refreshExposeList() {
+        const list = $("exposeList");
+        if (!list) return;
+        const rows = [];
+        await Promise.all(
+          [...sources.values()].map(async (s) => {
+            const tx = s.tx || (s.id === "local" ? localTx : null);
+            if (!tx) return;
+            let arr;
+            try {
+              arr = await tx.fetchJSON("/api/exposes");
+            } catch {
+              return;
+            }
+            if (Array.isArray(arr))
+              for (const ex of arr) rows.push({ ...ex, _srcName: s.name || s.id, _tx: tx });
+          }),
+        );
+        list.textContent = "";
+        if (!rows.length) {
+          const p = document.createElement("p");
+          p.className = "sub";
+          p.id = "exposeEmpty";
+          p.textContent = "No ports are exposed right now.";
+          list.appendChild(p);
+          return;
+        }
+        rows.sort((a, b) => b.createdAt - a.createdAt);
+        for (const ex of rows) list.appendChild(renderExposeRow(ex));
+      }
+
+      function renderExposeRow(ex) {
+        const row = document.createElement("div");
+        row.className = "exposerow";
+        const meta = document.createElement("div");
+        meta.className = "exmeta";
+        const label = document.createElement("div");
+        label.className = "explabel";
+        label.textContent = "localhost:" + ex.port;
+        const url = document.createElement("div");
+        url.className = "exurl";
+        url.textContent = ex.url;
+        const host = document.createElement("div");
+        host.className = "exhost";
+        host.textContent = ex._srcName;
+        meta.appendChild(label);
+        meta.appendChild(url);
+        meta.appendChild(host);
+        row.appendChild(meta);
+
+        const openBtn = document.createElement("button");
+        openBtn.className = "primary";
+        openBtn.textContent = "Open";
+        // Re-mint a fresh claim so the owner (or a guest) gets a usable link.
+        openBtn.onclick = async () => {
+          try {
+            const r = await ex._tx.post("/api/expose", { port: ex.port });
+            const info = r.ok ? JSON.parse(r.text) : null;
+            window.open(info && info.claim ? info.claim : ex.url, "_blank", "noopener,noreferrer");
+          } catch {
+            window.open(ex.url, "_blank", "noopener,noreferrer");
+          }
+        };
+        row.appendChild(openBtn);
+
+        const revoke = document.createElement("button");
+        revoke.className = "danger";
+        revoke.textContent = "Revoke";
+        revoke.onclick = async () => {
+          revoke.disabled = true;
+          try {
+            await ex._tx.del("/api/expose/" + ex.port);
+          } catch {}
+          refreshExposeList();
+        };
+        row.appendChild(revoke);
+        return row;
+      }
       // Draw the QR onto a fresh canvas (white quiet-zone always, so it scans in
       // dark mode too). `qrcode` is the vendored global from qrcode.js.
       function renderQr(container, text) {
@@ -3291,6 +3511,18 @@
         currentShare = null;
         closeShareModal();
       }
+      (function exposeModalBoot() {
+        $("portsbtn")?.addEventListener("click", () => openExposeManager(true));
+        $("exposeGo")?.addEventListener("click", doExpose);
+        $("exposeCancel")?.addEventListener("click", () => {
+          $("exposePrompt").hidden = true;
+          $("exposeTitle").textContent = "Exposed ports";
+        });
+        $("exposeClose")?.addEventListener("click", closeExposeModal);
+        $("exposeModal")?.addEventListener("click", (e) => {
+          if (e.target === $("exposeModal")) closeExposeModal();
+        });
+      })();
       (function shareModalBoot() {
         $("shareClose")?.addEventListener("click", closeShareModal);
         $("shareCloseAlt")?.addEventListener("click", closeShareModal);
@@ -4256,9 +4488,13 @@
         // new tab (noopener so the page can't be tampered with via window.opener).
         try {
           term.loadAddon(
-            new WebLinksAddon.WebLinksAddon((e, uri) =>
-              window.open(uri, "_blank", "noopener,noreferrer"),
-            ),
+            new WebLinksAddon.WebLinksAddon((ev, uri) => {
+              // A localhost URL isn't reachable from the viewer's browser — offer
+              // to publish it through agent-yes.com (on THIS agent's host: txFor(e)).
+              const port = localhostPort(uri);
+              if (port) return promptExpose(port, txFor(e));
+              window.open(uri, "_blank", "noopener,noreferrer");
+            }),
           );
         } catch {
           /* addon CDN blocked — terminal still works, just without auto-links */

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -645,6 +645,8 @@
          (the DOM renderer's getBoundingClientRect includes the ancestor scale
          transform → constant re-measure = the zoom flash) -->
     <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-canvas@0.7.0/lib/addon-canvas.min.js"></script>
+    <!-- clickable URLs in node terminals (localhost links offer to expose) -->
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js"></script>
 
     <script type="module" src="./main.js"></script>
   </body>

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -76,6 +76,16 @@ interface HostInfo {
 const envIdOf = (src: string) => `env:${src}`;
 // host-env → top-level-root wires, rebuilt by buildGraph, drawn by applyEdges
 const envEdges: Edge[] = [];
+
+// Active port exposures per source (GET /api/exposes), polled with the host
+// info and rendered as an "exposed" field on that machine's ⬢ env node.
+interface ExposureInfo {
+  id: string;
+  port: number;
+  url: string;
+  createdAt: number;
+}
+const exposedBySrc = new Map<string, ExposureInfo[]>();
 function hostEnvFields(src: string): [string, string][] {
   const h = wires.get(src)?.hostInfo;
   if (!h) return [];
@@ -99,6 +109,10 @@ function hostEnvFields(src: string): [string, string][] {
   if (h.caps) {
     const on = Object.entries(h.caps).filter(([, v]) => v).map(([k]) => k);
     if (on.length) fields.push(["caps", on.join(" · ")]);
+  }
+  const exposed = exposedBySrc.get(src) ?? [];
+  if (exposed.length) {
+    fields.push(["⇄ exposed", exposed.map((e) => e.port).sort((a, b) => a - b).join(" · ")]);
   }
   return fields;
 }
@@ -245,6 +259,43 @@ async function apiPost(
     body: JSON.stringify(body),
   });
   return { ok: r.ok, text: await r.text() };
+}
+
+// A local-loopback URL clicked in a node terminal isn't reachable from the
+// viewer's browser — recognise it so we can offer to publish it instead.
+function localhostPort(uri: string): number | null {
+  let u: URL;
+  try {
+    u = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+  const h = u.hostname;
+  if (h !== "localhost" && h !== "127.0.0.1" && h !== "0.0.0.0" && h !== "::1") return null;
+  const port = Number(u.port) || (u.protocol === "https:" ? 443 : 80);
+  return port >= 1 && port <= 65535 ? port : null;
+}
+
+// Ask, then publish 127.0.0.1:<port> on the clicked node's machine through
+// agent-yes.com and open the one-time claim link (sets the 8h cookie).
+async function exposeFromRgui(port: number, src: string): Promise<void> {
+  if (!confirm(`Expose localhost:${port} on agent-yes.com?\n\nA private link tunnels to this port on the agent's machine. Only someone with the one-time claim link (opens now) can reach it. Revoke from the /w/ console's ports manager.`))
+    return;
+  const r = await apiPost("/api/expose", { port }, src);
+  let info: ExposureInfo & { claim?: string };
+  try {
+    info = JSON.parse(r.text);
+  } catch {
+    alert(`Couldn't expose port ${port} — is the daemon reachable?`);
+    return;
+  }
+  if (r.ok && info.claim) {
+    window.open(info.claim, "_blank", "noopener,noreferrer");
+    void fetchHosts(); // refresh the env node's exposed row promptly
+  } else {
+    alert(`Couldn't expose port ${port}: ${r.text}`);
+  }
 }
 
 // Subscribe to an SSE-style stream over one wire. onData receives each parsed
@@ -898,6 +949,23 @@ function makeTerm(pid: string): TermEntry | null {
       (term as unknown as { loadAddon(a: unknown): void }).loadAddon(new CanvasAddon());
     } catch {
       /* addon unavailable — fall back to the DOM renderer */
+    }
+  }
+  // Clickable URLs. A localhost link offers to publish through agent-yes.com on
+  // THIS node's machine (src); any other URL just opens in a new tab.
+  const WebLinks = (window as unknown as { WebLinksAddon?: { WebLinksAddon: new (h: (e: MouseEvent, uri: string) => void) => unknown } })
+    .WebLinksAddon?.WebLinksAddon;
+  if (WebLinks) {
+    try {
+      (term as unknown as { loadAddon(a: unknown): void }).loadAddon(
+        new WebLinks((_e: MouseEvent, uri: string) => {
+          const port = localhostPort(uri);
+          if (port != null) void exposeFromRgui(port, src);
+          else window.open(uri, "_blank", "noopener,noreferrer");
+        }),
+      );
+    } catch {
+      /* addon CDN blocked — terminal still works, just without auto-links */
     }
   }
 
@@ -1768,6 +1836,13 @@ async function fetchHosts() {
         }
         if (!w.hostInfo) firstArrival = true;
         w.hostInfo = h;
+        // Best-effort: refresh this machine's active exposures for the env node.
+        try {
+          const ex = await apiJSON<ExposureInfo[]>("/api/exposes", w.id);
+          if (Array.isArray(ex)) exposedBySrc.set(w.id, ex);
+        } catch {
+          /* older daemon without /api/exposes — no exposed row */
+        }
         const n = viewer.graph.nodes.find((x) => x.id === envIdOf(w.id));
         if (n) n.fields = hostEnvFields(w.id); // picked up by the next natural frame
       } catch {

--- a/ts/expose.ts
+++ b/ts/expose.ts
@@ -3,9 +3,15 @@
 //
 // The daemon dials OUT (wss://<relay>/_ay/tunnel/<id>), so it works behind any
 // NAT, and runs the codehost tunnel protocol's host half against the local
-// port. Private by default: visitors need the single-use claim link printed
-// below (it swaps for an 8h HttpOnly cookie at the edge; unauthenticated
-// requests never reach this machine). See lab/ui/cf/exposure.ts for the edge.
+// port. Private by default: visitors need a single-use claim link (it swaps
+// for an 8h HttpOnly cookie at the edge; unauthenticated requests never reach
+// this machine). See lab/ui/cf/exposure.ts for the edge.
+//
+// Two front doors share one implementation:
+//   - the CLI (`cmdExpose`), which starts one exposure and blocks; and
+//   - the in-process manager (`ensureExposure` / `listExposures` /
+//     `stopExposure`), which `ay serve` drives from POST /api/expose so the web
+//     console can expose a clicked localhost port and revoke it later.
 
 import { randomBytes, createHash } from "node:crypto";
 import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
@@ -24,13 +30,41 @@ interface ExposureRecord {
   key: string;
 }
 
+/** Live handle for one exposed port. */
+export interface ExposureHandle {
+  /** Opaque exposure id (also the subdomain label). */
+  id: string;
+  /** Local loopback port being shared. */
+  port: number;
+  /** Public host, e.g. x….agent-yes.com (or the relay host for a dev relay). */
+  publicHost: string;
+  /** Public root URL. */
+  url: string;
+  /** Relay host this exposure is registered on. */
+  relayHost: string;
+  createdAt: number;
+  /** Mint a fresh single-use claim link and register it with the relay. The
+   *  visitor opening it gets an 8h session cookie for this exposure. */
+  mintClaim(): string;
+  /** Stop sharing (closes the relay socket; the URL then answers 502). */
+  stop(): void;
+}
+
+/** Serializable view of an active exposure (for the console's ports manager). */
+export interface ExposureInfo {
+  id: string;
+  port: number;
+  url: string;
+  createdAt: number;
+}
+
 function exposuresPath(): string {
   const home = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
   mkdirSync(home, { recursive: true });
   return path.join(home, "exposures.json");
 }
 
-/** Stable id+key per (relay, port): re-running `ay expose 5173` keeps its URL. */
+/** Stable id+key per (relay, port): re-exposing a port keeps its URL. */
 function loadOrCreateExposure(relayHost: string, port: number): ExposureRecord {
   const file = exposuresPath();
   let all: Record<string, ExposureRecord> = {};
@@ -79,6 +113,160 @@ function wsTransport(ws: WebSocket): TunnelTransport {
   };
 }
 
+/**
+ * Start (or fail) one exposure. Resolves once the relay has accepted the daemon
+ * and the tunnel is live; rejects if the relay refuses this exposure (bad key).
+ * Reconnects with backoff for the life of the handle.
+ */
+export function startExposure(opts: {
+  port: number;
+  relay?: string;
+  /** Log lifecycle transitions (CLI wants this; the manager stays quiet). */
+  log?: (msg: string) => void;
+}): Promise<ExposureHandle> {
+  const relay = opts.relay ?? DEFAULT_RELAY;
+  const port = opts.port;
+  const log = opts.log ?? (() => {});
+  const relayUrl = new URL(relay);
+  const rec = loadOrCreateExposure(relayUrl.host, port);
+  const wsProto = relayUrl.protocol === "http:" ? "ws:" : "wss:";
+  const tunnelUrl = `${wsProto}//${relayUrl.host}/_ay/tunnel/${rec.id}`;
+  // Public hostname: <id>.<zone> on the real relay; the relay host itself (with
+  // a Host-header spoof) when pointing at a dev relay (wrangler dev).
+  const publicHost = relayUrl.host === "agent-yes.com" ? `${rec.id}.agent-yes.com` : relayUrl.host;
+  const publicUrl = `https://${publicHost}/`;
+
+  let stopped = false;
+  let sock: WebSocket | null = null;
+  let ready = false;
+  let backoff = RECONNECT_MIN_MS;
+
+  const handle: ExposureHandle = {
+    id: rec.id,
+    port,
+    publicHost,
+    url: publicUrl,
+    relayHost: relayUrl.host,
+    createdAt: Date.now(),
+    mintClaim() {
+      const token = randomBytes(18).toString("base64url");
+      const hash = createHash("sha256").update(token).digest("hex");
+      if (sock && sock.readyState === WebSocket.OPEN) {
+        sock.send(JSON.stringify({ t: "claim", claims: [hash] }));
+      }
+      return `https://${publicHost}/_ay/claim?t=${token}`;
+    },
+    stop() {
+      stopped = true;
+      try {
+        sock?.close();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+
+  return new Promise<ExposureHandle>((resolve, reject) => {
+    const connect = () => {
+      if (stopped) return;
+      sock = new WebSocket(tunnelUrl);
+      sock.binaryType = "arraybuffer";
+      const ws = sock;
+      let ping: ReturnType<typeof setInterval> | null = null;
+
+      ws.addEventListener("open", () => {
+        ws.send(JSON.stringify({ t: "hello", key: rec.key, port, v: 1 }));
+      });
+      ws.addEventListener("message", (ev) => {
+        if (typeof ev.data !== "string") return; // binary frames belong to the TunnelHost
+        let msg: { t?: string };
+        try {
+          msg = JSON.parse(ev.data);
+        } catch {
+          return;
+        }
+        if (msg.t === "ready") {
+          backoff = RECONNECT_MIN_MS;
+          new TunnelHost(wsTransport(ws), { port });
+          ping = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) ws.send("ping");
+          }, PING_MS);
+          if (!ready) {
+            ready = true;
+            log(`sharing 127.0.0.1:${port} at ${publicUrl}`);
+            resolve(handle);
+          } else {
+            log(`reconnected`);
+          }
+        }
+      });
+      ws.addEventListener("close", (ev) => {
+        if (ping) clearInterval(ping);
+        if (stopped) return;
+        if (ev.code === 1008) {
+          const err = new Error(`relay refused exposure (${ev.reason || "forbidden"})`);
+          if (!ready) return reject(err);
+          log(err.message);
+          return;
+        }
+        log(`connection lost, retrying in ${Math.round(backoff / 1000)}s…`);
+        setTimeout(connect, backoff);
+        backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
+      });
+      ws.addEventListener("error", () => {
+        /* close fires right after; retry there */
+      });
+    };
+    connect();
+  });
+}
+
+// ---- in-process manager (driven by `ay serve` POST /api/expose) ----
+
+const active = new Map<number, ExposureHandle>();
+/** In-flight starts, so concurrent POSTs for the same port share one dial. */
+const starting = new Map<number, Promise<ExposureHandle>>();
+
+/** Start an exposure for `port` (or reuse a running one). Idempotent per port. */
+export async function ensureExposure(port: number, relay?: string): Promise<ExposureHandle> {
+  const existing = active.get(port);
+  if (existing) return existing;
+  const inflight = starting.get(port);
+  if (inflight) return inflight;
+  const p = startExposure({ port, relay })
+    .then((h) => {
+      active.set(port, h);
+      starting.delete(port);
+      return h;
+    })
+    .catch((e) => {
+      starting.delete(port);
+      throw e;
+    });
+  starting.set(port, p);
+  return p;
+}
+
+export function listExposures(): ExposureInfo[] {
+  return [...active.values()]
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .map((h) => ({ id: h.id, port: h.port, url: h.url, createdAt: h.createdAt }));
+}
+
+export function stopExposure(port: number): boolean {
+  const h = active.get(port);
+  if (!h) return false;
+  h.stop();
+  active.delete(port);
+  return true;
+}
+
+export function stopAllExposures(): void {
+  for (const port of [...active.keys()]) stopExposure(port);
+}
+
+// ---- CLI ----
+
 export async function cmdExpose(args: string[]): Promise<number> {
   let relay = DEFAULT_RELAY;
   let port = 0;
@@ -102,83 +290,21 @@ export async function cmdExpose(args: string[]): Promise<number> {
     return 1;
   }
 
-  const relayUrl = new URL(relay);
-  const rec = loadOrCreateExposure(relayUrl.host, port);
-  const wsProto = relayUrl.protocol === "http:" ? "ws:" : "wss:";
-  const tunnelUrl = `${wsProto}//${relayUrl.host}/_ay/tunnel/${rec.id}`;
-  // Public hostname: <id>.<zone> on the real relay; the relay host itself (with
-  // a Host-header spoof) when pointing at wrangler dev.
-  const publicHost = relayUrl.host === "agent-yes.com" ? `${rec.id}.agent-yes.com` : relayUrl.host;
-
-  // Fresh single-use claim token every run; only its hash goes to the edge.
-  const claimToken = randomBytes(18).toString("base64url");
-  const claimHash = createHash("sha256").update(claimToken).digest("hex");
-
-  let stopped = false;
-  let ws: WebSocket | null = null;
-  let backoff = RECONNECT_MIN_MS;
-  let announced = false;
-
-  const connect = () => {
-    if (stopped) return;
-    ws = new WebSocket(tunnelUrl);
-    ws.binaryType = "arraybuffer";
-    const sock = ws;
-    let ping: ReturnType<typeof setInterval> | null = null;
-
-    sock.addEventListener("open", () => {
-      sock.send(JSON.stringify({ t: "hello", key: rec.key, port, claims: [claimHash], v: 1 }));
-    });
-    sock.addEventListener("message", (ev) => {
-      if (typeof ev.data !== "string") return; // binary frames belong to the TunnelHost
-      let msg: { t?: string };
-      try {
-        msg = JSON.parse(ev.data);
-      } catch {
-        return;
-      }
-      if (msg.t === "ready") {
-        backoff = RECONNECT_MIN_MS;
-        new TunnelHost(wsTransport(sock), { port });
-        ping = setInterval(() => {
-          if (sock.readyState === WebSocket.OPEN) sock.send("ping");
-        }, PING_MS);
-        if (!announced) {
-          announced = true;
-          console.log(`[ay expose] sharing 127.0.0.1:${port}`);
-          console.log(`  url:    https://${publicHost}/`);
-          console.log(`  claim:  https://${publicHost}/_ay/claim?t=${claimToken}`);
-          console.log(`          (one-time link — opens access for 8h in that browser)`);
-        } else {
-          console.log(`[ay expose] reconnected`);
-        }
-      }
-    });
-    sock.addEventListener("close", (ev) => {
-      if (ping) clearInterval(ping);
-      if (stopped) return;
-      if (ev.code === 1008) {
-        console.error(`[ay expose] relay refused this exposure (${ev.reason || "forbidden"}) — giving up`);
-        process.exit(1);
-      }
-      console.log(`[ay expose] connection lost, retrying in ${Math.round(backoff / 1000)}s…`);
-      setTimeout(connect, backoff);
-      backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
-    });
-    sock.addEventListener("error", () => {
-      /* close fires right after; retry there */
-    });
-  };
-  connect();
+  let handle: ExposureHandle;
+  try {
+    handle = await startExposure({ port, relay, log: (m) => console.log(`[ay expose] ${m}`) });
+  } catch (e) {
+    console.error(`[ay expose] ${(e as Error).message} — giving up`);
+    return 1;
+  }
+  const claimUrl = handle.mintClaim();
+  console.log(`  url:    ${handle.url}`);
+  console.log(`  claim:  ${claimUrl}`);
+  console.log(`          (one-time link — opens access for 8h in that browser)`);
 
   const shutdown = () => {
-    stopped = true;
     console.log("\n[ay expose] stopped — the URL now answers 502 until you expose again");
-    try {
-      ws?.close();
-    } catch {
-      /* ignore */
-    }
+    handle.stop();
     process.exit(0);
   };
   process.on("SIGINT", shutdown);

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2729,6 +2729,42 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return new Response(ok ? "revoked" : "no such share", { status: ok ? 200 : 404 });
     }
 
+    // POST /api/expose  body {port}  → share 127.0.0.1:<port> through the edge
+    // relay and return {url, claim} (a fresh single-use claim link each call).
+    if (req.method === "POST" && p === "/api/expose") {
+      let body: { port?: number; relay?: string };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      const port = Number(body.port);
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        return new Response("valid port required", { status: 400 });
+      }
+      try {
+        const { ensureExposure } = await import("./expose.ts");
+        const h = await ensureExposure(port, body.relay);
+        return Response.json({ id: h.id, port: h.port, url: h.url, claim: h.mintClaim(), createdAt: h.createdAt });
+      } catch (e) {
+        return new Response(`expose failed: ${(e as Error).message}`, { status: 502 });
+      }
+    }
+
+    // GET /api/exposes  → active port exposures (for the console's ports manager).
+    if (req.method === "GET" && p === "/api/exposes") {
+      const { listExposures } = await import("./expose.ts");
+      return Response.json(listExposures());
+    }
+
+    // DELETE /api/expose/:port  → revoke (the URL then answers 502).
+    const unexposeM = /^\/api\/expose\/(\d+)$/.exec(p);
+    if (req.method === "DELETE" && unexposeM) {
+      const { stopExposure } = await import("./expose.ts");
+      const ok = stopExposure(Number(unexposeM[1]));
+      return new Response(ok ? "revoked" : "no such exposure", { status: ok ? 200 : 404 });
+    }
+
     return new Response("Not Found", { status: 404 });
   };
 
@@ -2793,10 +2829,18 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return serveUiFile("room-client.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/console-logic.js")
       return serveUiFile("console-logic.js", "text/javascript; charset=utf-8");
+    // rtc.js is a STATIC import of the console module (import { RTCClient }) — a
+    // 401 here fails the whole module link and the console never boots.
+    if (req.method === "GET" && p === "/rtc.js")
+      return serveUiFile("rtc.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/e2e.js")
       return serveUiFile("e2e.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/qrcode.js")
       return serveUiFile("qrcode.js", "text/javascript; charset=utf-8");
+    if (req.method === "GET" && p === "/manifest.webmanifest")
+      return serveUiFile("manifest.webmanifest", "application/manifest+json");
+    if (req.method === "GET" && p === "/icon.svg")
+      return serveUiFile("icon.svg", "image/svg+xml");
     if (req.method === "GET" && p === "/favicon.ico") return new Response(null, { status: 204 });
     return apiFetch(req);
   };


### PR DESCRIPTION
## What

Builds on [#239](https://github.com/snomiao/agent-yes/pull/239): **click a `http://localhost:PORT` link in an agent's terminal** (in `/w/` or `/r/`) → a panel offers to publish it through agent-yes.com → on agree the daemon stands up an edge-relay exposure and opens the one-time claim link. Active exposures are **visualized on the host env node in `/r/`** and **managed (list + revoke) from a `⇄ ports` panel in `/w/`**.

## Flow

```
terminal localhost link ──click──▶ "Expose localhost:5173?" panel
                                      └─agree─▶ POST /api/expose {port}
                                                 └─▶ ensureExposure() dials the relay
                                                     └─▶ open claim link → 8h cookie → app
```

## Backend

- **`ts/expose.ts`** — refactored the `ay expose` CLI daemon into a reusable in-process **manager**: `startExposure()` → handle (`mintClaim`/`stop`), `ensureExposure()` (idempotent per port), `listExposures()`, `stopExposure()`. Claims now ride a `{t:"claim"}` control message so a live exposure mints a fresh link without reconnecting. `cmdExpose()` is a thin CLI wrapper.
- **`ts/serve.ts`** — `POST /api/expose {port}` → `{url, claim}`, `GET /api/exposes`, `DELETE /api/expose/:port`. Also **fixes a pre-existing bug**: `rtc.js` (+ `manifest.webmanifest`, `icon.svg`) weren't in the `ay serve --http` static allowlist, and since `rtc.js` is a *static import* of the console module, a 401 there failed the whole module link — the console never booted under `ay serve --http`.
- **`lab/ui/cf/exposure.ts`** — the Exposure DO accepts `{t:"claim"}` from an authed daemon (`registerClaims()` extracted). Backward-compatible with the old hello-carried claims.

## /w/ console (`lab/ui/index.html`)

- WebLinksAddon handler intercepts localhost URLs → an **expose prompt modal**; on agree posts `/api/expose` and opens the claim link.
- a **`⇄ ports` toolbar button** opens a **ports manager** listing every host's active exposures with **Open** (re-mint a claim) and **Revoke** (DELETE) per row.

## /r/ rgui (`lab/ui/rgui/main.ts`, `rgui/index.html`)

- loads `addon-web-links`; per-node terminals intercept localhost URLs → confirm then `apiPost("/api/expose")` and open the claim.
- polls `/api/exposes` alongside host info and renders a **`⇄ exposed` field** (live port list) on each machine's ⬢ env node.

## Verification (rech, real browser, against the deployed relay)

- `/w/`: clicked `⇄ ports` → manager renders; created an exposure → it lists as `localhost:19000` with Open/Revoke; **Revoke removed it** (`/api/exposes` → `[]`). The expose prompt panel renders (`"Expose localhost:19000?"` + Expose & open / Cancel).
- **Full tunnel**: a browser-initiated `/api/expose` on the local daemon tunnels through the **production relay** to the real local dev server (`DEV SERVER ok /hello-from-prod`).
- `/r/`: the **Mac env node shows `⇄ exposed 19000`**; agent node wired via the env edge.
- `bun run build` + worker dry-run clean.

The relay worker (`{t:"claim"}` handler) is already deployed. This PR needs a console redeploy (built from `lab/ui/` by the worker `build.command`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)