### PR TITLE
fix(expose): localhost Host for dev servers + Copy-link buttons

### DIFF
--- a/lab/ui/cf/exposure.ts
+++ b/lab/ui/cf/exposure.ts
@@ -320,9 +320,16 @@ export class Exposure {
       }
       headers[k] = v;
     });
-    // Overwritten AFTER copying visitor headers, so a visitor can't spoof them.
-    headers["x-forwarded-host"] = hostname;
+    // Do NOT send x-forwarded-host: the daemon's TunnelHost uses it AS the
+    // upstream Host, and the public subdomain trips dev-server host allow-lists
+    // (Vite/webpack/Next/Storybook → "host not allowed"). Omitting it makes
+    // TunnelHost default Host to 127.0.0.1:<port>, which every dev server
+    // accepts. The public host still reaches the app via x-forwarded-proto +
+    // x-original-host (forwarded through untouched, unlike x-forwarded-host).
+    // Drop any client-sent copies first so a visitor can't spoof them.
+    delete headers["x-forwarded-host"];
     headers["x-forwarded-proto"] = "https";
+    headers["x-original-host"] = hostname;
 
     let body: Uint8Array | undefined;
     if (req.method !== "GET" && req.method !== "HEAD" && req.body) {

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1947,6 +1947,7 @@
           </p>
           <div class="srow">
             <button class="primary" id="exposeGo" type="button">Expose &amp; open</button>
+            <button id="exposeCopy" type="button">Copy link</button>
             <button id="exposeCancel" type="button">Cancel</button>
           </div>
         </div>
@@ -3364,11 +3365,9 @@
 
       // Agree → mint the exposure on its host and open the claim link (which sets
       // the 8h cookie and redirects to the app), then refresh the manager list.
-      async function doExpose() {
-        const tx = exposePendingTx || localTx;
-        const port = exposePendingPort;
-        $("exposePrompt").hidden = true;
-        if (!port) return;
+      // Create (or reuse) the exposure and mint a fresh single-use claim link.
+      // Returns the {url, claim, …} info, or null on failure (with a message).
+      async function exposeNow(port, tx) {
         let info = null;
         try {
           const r = await tx.post("/api/expose", { port });
@@ -3377,9 +3376,46 @@
         if (!info || !info.claim) {
           $("exposeEmpty").hidden = false;
           $("exposeEmpty").textContent = "Couldn't expose port " + port + " (is `ay serve` reachable?).";
-          return;
+          return null;
         }
+        return info;
+      }
+      async function copyText(s) {
+        try {
+          await navigator.clipboard.writeText(s);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      // Briefly show "Copied!" on a button, then restore its label.
+      function flashCopied(btn) {
+        if (!btn) return;
+        const orig = btn.textContent;
+        btn.textContent = "Copied!";
+        setTimeout(() => {
+          btn.textContent = orig;
+        }, 1200);
+      }
+      async function doExpose() {
+        const tx = exposePendingTx || localTx;
+        const port = exposePendingPort;
+        $("exposePrompt").hidden = true;
+        if (!port) return;
+        const info = await exposeNow(port, tx);
+        if (!info) return;
         window.open(info.claim, "_blank", "noopener,noreferrer");
+        refreshExposeList();
+      }
+      async function doExposeCopy() {
+        const tx = exposePendingTx || localTx;
+        const port = exposePendingPort;
+        if (!port) return;
+        const info = await exposeNow(port, tx);
+        if (!info) return;
+        await copyText(info.claim);
+        flashCopied($("exposeCopy"));
+        $("exposePrompt").hidden = true;
         refreshExposeList();
       }
 
@@ -3449,6 +3485,21 @@
         };
         row.appendChild(openBtn);
 
+        const copyBtn = document.createElement("button");
+        copyBtn.textContent = "Copy";
+        // Mint a fresh single-use claim link and copy it (to share access).
+        copyBtn.onclick = async () => {
+          let link = ex.url;
+          try {
+            const r = await ex._tx.post("/api/expose", { port: ex.port });
+            const info = r.ok ? JSON.parse(r.text) : null;
+            if (info && info.claim) link = info.claim;
+          } catch {}
+          await copyText(link);
+          flashCopied(copyBtn);
+        };
+        row.appendChild(copyBtn);
+
         const revoke = document.createElement("button");
         revoke.className = "danger";
         revoke.textContent = "Revoke";
@@ -3514,6 +3565,7 @@
       (function exposeModalBoot() {
         $("portsbtn")?.addEventListener("click", () => openExposeManager(true));
         $("exposeGo")?.addEventListener("click", doExpose);
+        $("exposeCopy")?.addEventListener("click", doExposeCopy);
         $("exposeCancel")?.addEventListener("click", () => {
           $("exposePrompt").hidden = true;
           $("exposeTitle").textContent = "Exposed ports";


### PR DESCRIPTION
Two follow-ups to the console port-expose feature (#240), both deployed & verified.

## 1. Dev servers now work through the tunnel (Vite/webpack/Next/Storybook)

The daemon's `codehost` TunnelHost uses the `x-forwarded-host` header **as** the upstream `Host`. We were sending the public subdomain, which tripped dev-server host allow-lists:

> Blocked request. This host ("x…​.agent-yes.com") is not allowed. Add it to `server.allowedHosts` in vite.config.js.

Fix: the Exposure DO no longer sends `x-forwarded-host`, so TunnelHost defaults `Host` to `127.0.0.1:<port>` — the standard reverse-proxy behavior every dev server accepts. The public host still reaches the app via `x-forwarded-proto` + `x-original-host`.

**Verified**: exposing a real Vite dev server now returns `200` + the app's HTML through the tunnel (locally via `wrangler dev` and on the deployed relay), instead of the block page.

## 2. "Copy link" buttons

- Expose prompt: a **Copy link** button besides **Expose & open** — mints a fresh single-use claim link and copies it (to share) with a "Copied!" flash.
- Ports manager rows: a **Copy** button besides Open/Revoke, same behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)