### PR TITLE
fix(serve): make serve-install work on bun-only boxes via a node→bun shim

### DIFF
--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { oxmgrVersionHasWindowsFix } from "./serve.ts";
+import { mkdtemp, readFile, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureNodeRuntime, isNoNodeExecError, oxmgrVersionHasWindowsFix } from "./serve.ts";
 
 // Guards the Windows daemon-manager selection: on Windows we only PREFER oxmgr
 // when the installed build carries the daemon-socket-inheritance fix. Stock
@@ -29,5 +32,85 @@ describe("oxmgrVersionHasWindowsFix", () => {
   it("returns false on unparseable output", () => {
     expect(oxmgrVersionHasWindowsFix("")).toBe(false);
     expect(oxmgrVersionHasWindowsFix("oxmgr (unknown)")).toBe(false);
+  });
+});
+
+// The bun-only-no-node path (sym003): pm2/oxmgr bins are `#!/usr/bin/env node`
+// scripts, so with no node on PATH they die at the shebang. ensureNodeRuntime
+// must bridge that with a node→bun shim in ay's own bin dir.
+describe("ensureNodeRuntime", () => {
+  let home: string;
+  let savedPath: string | undefined;
+  let savedHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-node-shim-"));
+    savedPath = process.env.PATH;
+    savedHome = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = home;
+  });
+
+  afterEach(async () => {
+    process.env.PATH = savedPath;
+    if (savedHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = savedHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const noNode = (cmd: string) => (cmd === "bun" ? "/fake/bin/bun" : null);
+
+  it.skipIf(process.platform === "win32")(
+    "writes an executable node→bun shim and prepends it to PATH when node is absent",
+    async () => {
+      const shim = await ensureNodeRuntime(noNode);
+      expect(shim).toBe(path.join(home, "bin", "node"));
+      const body = await readFile(shim!, "utf-8");
+      expect(body).toBe('#!/bin/sh\nexec "/fake/bin/bun" "$@"\n');
+      expect((await stat(shim!)).mode & 0o111).not.toBe(0); // executable
+      expect(process.env.PATH!.split(path.delimiter)[0]).toBe(path.join(home, "bin"));
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("does not duplicate the PATH entry", async () => {
+    await ensureNodeRuntime(noNode);
+    await ensureNodeRuntime(noNode);
+    const binDir = path.join(home, "bin");
+    const hits = process.env.PATH!.split(path.delimiter).filter((p) => p === binDir);
+    expect(hits).toHaveLength(1);
+  });
+
+  it("is a no-op when a real node exists", async () => {
+    expect(await ensureNodeRuntime(() => "/usr/bin/whatever")).toBeNull();
+  });
+
+  it("is a no-op when bun is missing too (nothing to shim to)", async () => {
+    expect(await ensureNodeRuntime(() => null)).toBeNull();
+  });
+});
+
+// Guards the serve-install diagnostic: a missing node runtime must be reported
+// as such, never as a "glibc mismatch" (glibc doesn't even exist on macOS).
+describe("isNoNodeExecError", () => {
+  it("matches macOS/BSD env output", () => {
+    expect(isNoNodeExecError("env: node: No such file or directory")).toBe(true);
+  });
+
+  it("matches GNU coreutils quoted env output", () => {
+    expect(isNoNodeExecError("env: 'node': No such file or directory")).toBe(true);
+  });
+
+  it("matches Windows cmd output", () => {
+    expect(
+      isNoNodeExecError("'node' is not recognized as an internal or external command"),
+    ).toBe(true);
+  });
+
+  it("does not match a real native/glibc failure", () => {
+    expect(
+      isNoNodeExecError(
+        "oxmgr: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found",
+      ),
+    ).toBe(false);
+    expect(isNoNodeExecError("")).toBe(false);
   });
 });

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -65,7 +65,7 @@ describe("ensureNodeRuntime", () => {
       const shim = await ensureNodeRuntime(noNode);
       expect(shim).toBe(path.join(home, "bin", "node"));
       const body = await readFile(shim!, "utf-8");
-      expect(body).toBe('#!/bin/sh\nexec "/fake/bin/bun" "$@"\n');
+      expect(body).toBe("#!/bin/sh\nexec '/fake/bin/bun' \"$@\"\n");
       expect((await stat(shim!)).mode & 0o111).not.toBe(0); // executable
       expect(process.env.PATH!.split(path.delimiter)[0]).toBe(path.join(home, "bin"));
     },
@@ -78,6 +78,29 @@ describe("ensureNodeRuntime", () => {
     const hits = process.env.PATH!.split(path.delimiter).filter((p) => p === binDir);
     expect(hits).toHaveLength(1);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "leaves an up-to-date shim untouched on repeat calls (read-only paths stay read-only)",
+    async () => {
+      const shim = (await ensureNodeRuntime(noNode))!;
+      const before = await stat(shim);
+      await new Promise((r) => setTimeout(r, 20));
+      await ensureNodeRuntime(noNode);
+      const after = await stat(shim);
+      expect(after.mtimeMs).toBe(before.mtimeMs); // not rewritten
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "single-quotes a bun path containing sh-special characters",
+    async () => {
+      const shim = await ensureNodeRuntime((cmd) =>
+        cmd === "bun" ? "/opt/we$ird `dir'/bun" : null,
+      );
+      const body = await readFile(shim!, "utf-8");
+      expect(body).toBe("#!/bin/sh\nexec '/opt/we$ird `dir'\\''/bun' \"$@\"\n");
+    },
+  );
 
   it("is a no-op when a real node exists", async () => {
     expect(await ensureNodeRuntime(() => "/usr/bin/whatever")).toBeNull();

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
+import { chmod, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
 import { renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -405,18 +405,69 @@ async function globalBinDir(installer: string[]): Promise<string | null> {
   return isBun ? out : path.join(out, "bin");
 }
 
+// Both oxmgr's and pm2's global bins are `#!/usr/bin/env node` JS scripts, so on
+// a bun-only box (setup.sh installs no node) exec dies with "env: node: No such
+// file or directory" — even though pm2 is pure JS and runs perfectly under bun.
+// When node is missing but bun exists, write a node→bun shim into ay's own bin
+// dir and prepend it to PATH so `env node` resolves. NOT solvable with
+// `bun add -g node`: that package (node-bin-gen) lands a broken arch-specific
+// stub and `Bun.which("node")` still finds nothing. POSIX-only — on Windows the
+// npm .cmd shims invoke node.exe directly and an sh script can't stand in.
+// Returns the shim path when the shim is in effect, null when unneeded/impossible.
+export async function ensureNodeRuntime(
+  which: (cmd: string) => string | null = Bun.which,
+): Promise<string | null> {
+  if (process.platform === "win32") return null;
+  if (which("node")) return null;
+  const bun = which("bun");
+  if (!bun) return null;
+  const binDir = path.join(agentYesHome(), "bin");
+  const shim = path.join(binDir, "node");
+  try {
+    await mkdir(binDir, { recursive: true });
+    await writeFile(shim, `#!/bin/sh\nexec "${bun}" "$@"\n`);
+    await chmod(shim, 0o755);
+    if (!(process.env.PATH ?? "").split(path.delimiter).includes(binDir)) {
+      process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+    }
+    return shim;
+  } catch {
+    return null; // best-effort: the exec probe will fail and name the reason
+  }
+}
+
+// Did an exec attempt die because `env` couldn't find a node runtime? macOS/BSD
+// env says `env: node: No such file or directory`, GNU coreutils quotes it
+// (`env: 'node': …`), Windows cmd says `'node' is not recognized`.
+export function isNoNodeExecError(stderr: string): boolean {
+  return (
+    /env: '?node'?: No such file or directory/.test(stderr) ||
+    /'node' is not recognized/.test(stderr)
+  );
+}
+
+// Probe one manager binary with `--version`, capturing stderr so a failure can
+// be diagnosed (glibc mismatch vs missing node runtime vs anything else).
+async function managerProbe(mgr: DaemonManager): Promise<{ ok: boolean; stderr: string }> {
+  try {
+    const p = Bun.spawn([mgr.bin, "--version"], { stdout: "ignore", stderr: "pipe" });
+    const [code, stderr] = await Promise.all([p.exited, new Response(p.stderr).text()]);
+    return { ok: (code ?? 1) === 0, stderr };
+  } catch (e) {
+    return { ok: false, stderr: String(e) };
+  }
+}
+
 // Does this manager's binary actually execute? A `bun add -g oxmgr` can succeed
 // yet leave a binary that can't run: oxmgr vendors a native binary requiring
 // GLIBC_2.39, which a box like Debian 12 (glibc 2.36) lacks, so exec dies with
-// "GLIBC_2.39 not found". Probe with `--version`: exit 0 means runnable; a
-// non-zero exit or spawn failure means the shim is on PATH but unusable.
+// "GLIBC_2.39 not found"; and on a node-less box the `env node` shebang itself
+// fails (see ensureNodeRuntime, applied here so every probe self-heals). Probe
+// with `--version`: exit 0 means runnable; a non-zero exit or spawn failure
+// means the shim is on PATH but unusable.
 async function managerRunnable(mgr: DaemonManager): Promise<boolean> {
-  try {
-    const p = Bun.spawn([mgr.bin, "--version"], { stdout: "ignore", stderr: "ignore" });
-    return ((await p.exited) ?? 1) === 0;
-  } catch {
-    return false;
-  }
+  await ensureNodeRuntime();
+  return (await managerProbe(mgr)).ok;
 }
 
 // Which manager is ACTUALLY running our daemon? `resolveDaemonManager` picks by
@@ -464,13 +515,18 @@ async function installAndVerify(pkg: "oxmgr" | "pm2"): Promise<DaemonManager | n
   const bin = Bun.which(pkg);
   if (!bin) return null;
   const mgr: DaemonManager = { id: pkg, bin };
-  if (!(await managerRunnable(mgr))) {
-    // Name the actual reason: oxmgr ships a native binary (glibc), pm2 is a
-    // Node.js app that needs `node` on PATH — a bun-only box has neither by
-    // default, so a generic "glibc mismatch" would mislead for pm2.
-    const why =
-      pkg === "oxmgr"
-        ? "a native/glibc mismatch, e.g. glibc < 2.39"
+  await ensureNodeRuntime();
+  const probe = await managerProbe(mgr);
+  if (!probe.ok) {
+    // Name the ACTUAL reason from the probe's stderr. A missing node runtime
+    // hits both managers identically (`env: node: No such file or directory` —
+    // their bins are `#!/usr/bin/env node` scripts), and reporting that as a
+    // "glibc mismatch" is nonsense on macOS where glibc doesn't exist. Only
+    // blame glibc for an oxmgr that got PAST the shebang and died natively.
+    const why = isNoNodeExecError(probe.stderr)
+      ? `${pkg} needs a Node.js runtime (its bin is a '#!/usr/bin/env node' script) and none was found`
+      : pkg === "oxmgr"
+        ? "likely a native binary mismatch, e.g. glibc < 2.39 on Linux"
         : "pm2 needs a Node.js runtime and none was found";
     process.stderr.write(
       `ay serve install: ${pkg} installed but can't exec here (${why})` +
@@ -670,7 +726,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
   let mgr = resolveDaemonManager();
   if (mgr && !(await managerRunnable(mgr))) {
     process.stderr.write(
-      `ay serve install: ${mgr.id} is on PATH but can't exec here (likely a native/glibc mismatch) — bootstrapping a working manager…\n`,
+      `ay serve install: ${mgr.id} is on PATH but can't exec here — bootstrapping a working manager…\n`,
     );
     mgr = null;
   }
@@ -679,8 +735,9 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
     process.stderr.write(
       "ay serve install: no usable process manager (need oxmgr or pm2)\n" +
         "  - oxmgr: bun add -g oxmgr   (native binary; needs glibc ≥ 2.39 on Linux)\n" +
-        "  - pm2:   bun add -g pm2     (needs a Node.js runtime on PATH)\n" +
-        "  On a minimal bun-only box, install node (for pm2) or a newer glibc (for oxmgr).\n",
+        "  - pm2:   bun add -g pm2     (pure JS; needs a node runtime — on a bun-only box\n" +
+        "           ay auto-writes a node→bun shim into ~/.agent-yes/bin, so if you still\n" +
+        "           see this, check that dir is writable or install node)\n",
     );
     return 1;
   }

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -413,6 +413,9 @@ async function globalBinDir(installer: string[]): Promise<string | null> {
 // `bun add -g node`: that package (node-bin-gen) lands a broken arch-specific
 // stub and `Bun.which("node")` still finds nothing. POSIX-only — on Windows the
 // npm .cmd shims invoke node.exe directly and an sh script can't stand in.
+// Called from managerRunnable, which read-only paths (`ay serve status`) also
+// reach: an up-to-date shim is left untouched there (a read, not a write), so
+// only the very first run on a node-less box materializes the file.
 // Returns the shim path when the shim is in effect, null when unneeded/impossible.
 export async function ensureNodeRuntime(
   which: (cmd: string) => string | null = Bun.which,
@@ -423,10 +426,15 @@ export async function ensureNodeRuntime(
   if (!bun) return null;
   const binDir = path.join(agentYesHome(), "bin");
   const shim = path.join(binDir, "node");
+  // Single-quote the bun path: inside sh double quotes `$`, backtick and `\`
+  // would still expand, corrupting the shim for a path containing them.
+  const body = `#!/bin/sh\nexec '${bun.replace(/'/g, `'\\''`)}' "$@"\n`;
   try {
-    await mkdir(binDir, { recursive: true });
-    await writeFile(shim, `#!/bin/sh\nexec "${bun}" "$@"\n`);
-    await chmod(shim, 0o755);
+    if ((await readFile(shim, "utf-8").catch(() => null)) !== body) {
+      await mkdir(binDir, { recursive: true });
+      await writeFile(shim, body);
+      await chmod(shim, 0o755);
+    }
     if (!(process.env.PATH ?? "").split(path.delimiter).includes(binDir)) {
       process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
     }
@@ -448,9 +456,15 @@ export function isNoNodeExecError(stderr: string): boolean {
 
 // Probe one manager binary with `--version`, capturing stderr so a failure can
 // be diagnosed (glibc mismatch vs missing node runtime vs anything else).
+// LC_ALL=C pins env(1)/libc error text to English so isNoNodeExecError's
+// patterns hold on localized systems.
 async function managerProbe(mgr: DaemonManager): Promise<{ ok: boolean; stderr: string }> {
   try {
-    const p = Bun.spawn([mgr.bin, "--version"], { stdout: "ignore", stderr: "pipe" });
+    const p = Bun.spawn([mgr.bin, "--version"], {
+      stdout: "ignore",
+      stderr: "pipe",
+      env: { ...process.env, LC_ALL: "C" },
+    });
     const [code, stderr] = await Promise.all([p.exited, new Response(p.stderr).text()]);
     return { ok: (code ?? 1) === 0, stderr };
   } catch (e) {
@@ -522,12 +536,16 @@ async function installAndVerify(pkg: "oxmgr" | "pm2"): Promise<DaemonManager | n
     // hits both managers identically (`env: node: No such file or directory` —
     // their bins are `#!/usr/bin/env node` scripts), and reporting that as a
     // "glibc mismatch" is nonsense on macOS where glibc doesn't exist. Only
-    // blame glibc for an oxmgr that got PAST the shebang and died natively.
+    // blame glibc for an oxmgr that got PAST the shebang and died natively;
+    // any other failure just gets the probe's own last stderr line — claiming
+    // "no node runtime" here would be false, ensureNodeRuntime just provided one.
+    const detailLine = probe.stderr.trim().split("\n").filter(Boolean).pop()?.slice(0, 160);
+    const detail = detailLine ? ` — ${detailLine}` : "";
     const why = isNoNodeExecError(probe.stderr)
       ? `${pkg} needs a Node.js runtime (its bin is a '#!/usr/bin/env node' script) and none was found`
       : pkg === "oxmgr"
-        ? "likely a native binary mismatch, e.g. glibc < 2.39 on Linux"
-        : "pm2 needs a Node.js runtime and none was found";
+        ? `likely a native binary mismatch, e.g. glibc < 2.39 on Linux${detail}`
+        : `exec probe failed${detail}`;
     process.stderr.write(
       `ay serve install: ${pkg} installed but can't exec here (${why})` +
         (pkg === "oxmgr" ? " — falling back to pm2\n" : "\n"),


### PR DESCRIPTION
## Bug (reported by qamac agent, root-caused live on sym003 — macOS arm64, bun-only, no node)

`ay serve install` fails with "no usable process manager": both oxmgr's and pm2's global bins are `#!/usr/bin/env node` JS scripts, so on a node-less box both die with `env: node: No such file or directory`. The failure was misreported as a glibc mismatch — on macOS, where glibc doesn't exist. `bun add -g node` does not help (node-bin-gen lands a broken arch-specific stub).

## Fix

- **`ensureNodeRuntime()`**: when `node` is absent but `bun` exists (POSIX only), write a `node→bun` shim into `~/.agent-yes/bin` and prepend it to PATH. Called from `managerRunnable()` so every probe self-heals — pm2 is pure JS and runs fully under bun (verified live on sym003: full `pm2 ls` table, v7.0.3).
- **Honest diagnostics**: `managerProbe()` now captures stderr and `isNoNodeExecError()` classifies the env-node ENOENT (macOS/BSD, GNU-quoted, and Windows forms), so the message says "needs a Node.js runtime" instead of blaming glibc; glibc is only blamed for an oxmgr that got past the shebang and died natively.
- Updated the final serve-install hint to mention the auto-shim.

## Tests

`ts/serve.spec.ts`: bun-only-no-node shim path (shim content, executable bit, PATH prepend, idempotency, no-op cases; skipped on win32) and the stderr classifier (positive + glibc-negative). 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)