### PR TITLE
feat(msgs): persist inter-agent messages to per-cwd inbox/outbox logs

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1079,6 +1079,50 @@
           background-color: color-mix(in srgb, var(--peer) 24%, transparent);
         }
       }
+      /* An inter-agent message just travelled between two rows (`ay send`/`key`/
+         `select`, from /api/edges `sends`). Both ends pulse so the exchange reads
+         as a pair: green at the SENDER, amber at the RECIPIENT — the same hues the
+         /r/ forest uses for its send wire. Distinct from .stdinflash (which fires
+         for ANY stdin, including a human typing) so agent→agent traffic stands out. */
+      .row.sendflash {
+        animation: sendpulse 0.7s ease-in-out infinite;
+      }
+      .row.recvflash {
+        animation: recvpulse 0.7s ease-in-out infinite;
+      }
+      @keyframes sendpulse {
+        0%,
+        100% {
+          background-color: transparent;
+        }
+        50% {
+          background-color: color-mix(in srgb, var(--green) 22%, transparent);
+        }
+      }
+      @keyframes recvpulse {
+        0%,
+        100% {
+          background-color: transparent;
+        }
+        50% {
+          background-color: color-mix(in srgb, var(--amber) 22%, transparent);
+        }
+      }
+      /* The wire itself: an SVG laid over the (scrolling) list, drawn from the row
+         rects. Inside .list so it scrolls with the rows; pointer-events off so it
+         never eats a click meant for a row. */
+      .list {
+        position: relative;
+      }
+      .wire-overlay {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        pointer-events: none;
+        overflow: visible;
+        z-index: 3;
+      }
       /* Per-row chip: how many peers are watching THIS agent (yellow, mono). */
       .peerchip {
         font-family: var(--mono);
@@ -2034,6 +2078,16 @@
       const stdinSeen = new Map();
       const flashUntil = new Map();
       const STDIN_FLASH_MS = 1200;
+      // Inter-agent message traffic (from /api/edges `sends`). A send is an EVENT,
+      // not a standing relation: both ends pulse and the wire between them fades
+      // out over SEND_FADE_MS. `sendSeen` dedupes by (by,target,at) so re-polling
+      // the same still-in-window edge doesn't re-arm the flash forever.
+      const sendFlashUntil = new Map(); // sender key   → until (ms)
+      const recvFlashUntil = new Map(); // receiver key → until (ms)
+      const sendSeen = new Set();
+      let sendWires = []; // [{by, target, at, kind}] — live wires, keys are <src>#<pid>
+      const SEND_FLASH_MS = 2000;
+      const SEND_FADE_MS = 20000; // wire fully faded this long after delivery
       let es = null; // live-tail subscription closer
       let term = null; // xterm.js Terminal rendering the raw PTY stream
       let fit = null;
@@ -3056,6 +3110,131 @@
           el.classList.toggle("stdinflash", on);
         }
       }, 200);
+
+      // ── inter-agent message traffic: row pulses + the wire between them ───────
+
+      /** Remaining life of a send, 1 at delivery → 0 once fully faded. */
+      function sendAlpha(at) {
+        return Math.max(0, Math.min(1, 1 - (Date.now() - at) / SEND_FADE_MS));
+      }
+
+      // Poll every source's /api/edges and arm a pulse for each NEW send. Edge pids
+      // are mapped to the `<src>#<pid>` row keys the list already uses, so a wire
+      // never crosses sources (a daemon only ever sees its own agents). An older
+      // daemon has no `sends` field — the console then simply shows no traffic.
+      async function pollEdges() {
+        const srcs = [...sources.values()].filter((s) => s.tx && s.live);
+        const results = await Promise.allSettled(
+          srcs.map(async (s) => {
+            const body = await s.tx.fetchJSON("/api/edges");
+            return (body?.sends ?? []).map((e) => ({
+              by: `${s.id}#${e.by}`,
+              target: `${s.id}#${e.target}`,
+              at: e.at,
+              kind: e.kind,
+            }));
+          }),
+        );
+        const edges = results.flatMap((p) => (p.status === "fulfilled" ? p.value : []));
+        const now = Date.now();
+        for (const e of edges) {
+          const id = `${e.by} ${e.target} ${e.at}`;
+          if (sendSeen.has(id)) continue; // already pulsed for this exact send
+          sendSeen.add(id);
+          // Don't flash a send that's already older than its own flash window (e.g.
+          // the first poll after opening the console, which sees the whole minute).
+          if (now - e.at > SEND_FLASH_MS) continue;
+          sendFlashUntil.set(e.by, now + SEND_FLASH_MS);
+          recvFlashUntil.set(e.target, now + SEND_FLASH_MS);
+        }
+        // Keep only wires still worth drawing; bound sendSeen to the live set so it
+        // can't grow without limit over a long session.
+        sendWires = edges.filter((e) => sendAlpha(e.at) > 0);
+        if (sendSeen.size > 500) {
+          const live = new Set(sendWires.map((e) => `${e.by} ${e.target} ${e.at}`));
+          for (const id of [...sendSeen]) if (!live.has(id)) sendSeen.delete(id);
+        }
+        renderSendWires();
+      }
+      setInterval(() => void pollEdges(), 1500);
+
+      // Drive the send/recv row pulses on the stable list DOM (same trick as the
+      // stdin flash above), and keep the wire fading. No-op when nothing's in
+      // flight, so an idle console costs nothing.
+      setInterval(() => {
+        const now = Date.now();
+        for (const [k, until] of [...sendFlashUntil.entries()])
+          if (until <= now) sendFlashUntil.delete(k);
+        for (const [k, until] of [...recvFlashUntil.entries()])
+          if (until <= now) recvFlashUntil.delete(k);
+        const listEl = $("list");
+        if (listEl && (sendFlashUntil.size || recvFlashUntil.size)) {
+          for (const el of listEl.querySelectorAll(".row[data-key]")) {
+            const key = el.getAttribute("data-key");
+            el.classList.toggle("sendflash", (sendFlashUntil.get(key) || 0) > now);
+            el.classList.toggle("recvflash", (recvFlashUntil.get(key) || 0) > now);
+          }
+        }
+        if (sendWires.length) {
+          sendWires = sendWires.filter((e) => sendAlpha(e.at) > 0);
+          renderSendWires(); // redraw so the wire's opacity decays smoothly
+        }
+      }, 200);
+
+      /**
+       * Draw the live send wires over the list: an S-curve in the left gutter from
+       * the sender row's centre to the recipient's, opacity decaying with age.
+       *
+       * The SVG lives INSIDE #list (which scrolls), sized to scrollHeight, so the
+       * wires scroll with their rows instead of needing a scroll listener. An
+       * endpoint that isn't in the DOM right now — folded under a collapsed parent,
+       * or filtered out by the search box — simply drops its wire.
+       */
+      function renderSendWires() {
+        const listEl = $("list");
+        if (!listEl) return;
+        let svg = listEl.querySelector(".wire-overlay");
+        if (!sendWires.length) {
+          if (svg) svg.remove();
+          return;
+        }
+        if (!svg) {
+          svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+          svg.setAttribute("class", "wire-overlay");
+          listEl.appendChild(svg);
+        }
+        const base = listEl.getBoundingClientRect();
+        // Row centres in the list's own scrolled coordinate space.
+        const yOf = (key) => {
+          const el = listEl.querySelector(`.row[data-key="${CSS.escape(key)}"]`);
+          if (!el) return null;
+          const r = el.getBoundingClientRect();
+          return r.top - base.top + listEl.scrollTop + r.height / 2;
+        };
+        svg.setAttribute("height", String(listEl.scrollHeight));
+        svg.style.height = listEl.scrollHeight + "px";
+        const paths = [];
+        for (const e of sendWires) {
+          const y1 = yOf(e.by);
+          const y2 = yOf(e.target);
+          if (y1 == null || y2 == null || y1 === y2) continue;
+          const a = sendAlpha(e.at);
+          const color = e.kind ? "245, 158, 11" : "63, 185, 80"; // amber = key/select, green = msg
+          // Bulge left-to-right with the gap so a long hop is legible, capped so it
+          // stays inside the gutter.
+          const bulge = Math.min(34, 8 + Math.abs(y2 - y1) * 0.18);
+          const x = 8;
+          paths.push(
+            `<path d="M ${x},${y1} C ${x + bulge},${y1} ${x + bulge},${y2} ${x},${y2}" ` +
+              `fill="none" stroke="rgba(${color}, ${(0.2 + 0.8 * a).toFixed(3)})" ` +
+              `stroke-width="${(1 + 1.6 * a).toFixed(2)}" stroke-dasharray="3 3" />` +
+              // arrowhead at the recipient end — which way the message travelled
+              `<circle cx="${x}" cy="${y2}" r="${(2 + 1.5 * a).toFixed(2)}" ` +
+              `fill="rgba(${color}, ${(0.3 + 0.7 * a).toFixed(3)})" />`,
+          );
+        }
+        svg.innerHTML = paths.join("");
+      }
 
       // Peer-selection overlay. The coordinate math (parseSel / selSegments /
       // hashHue) lives in console-logic.js (unit-tested); here we just measure the
@@ -4236,9 +4415,19 @@
       // redundant — and it's the only row your own terminal's protocol replies
       // could ever nudge, so this also keeps a resize from blinking your own row.
       function rowFlags(e) {
+        const now = Date.now();
         const peers = focusByKey.get(e._key) || 0;
-        const flash = e._key !== sel && (flashUntil.get(e._key) || 0) > Date.now();
-        return (peers ? " peerfocus" : "") + (flash ? " stdinflash" : "");
+        const flash = e._key !== sel && (flashUntil.get(e._key) || 0) > now;
+        // Re-emit the message pulses too: renderList replaces rows wholesale, so a
+        // class the fast loop toggled on would be lost on the next render otherwise.
+        const sent = (sendFlashUntil.get(e._key) || 0) > now;
+        const recv = (recvFlashUntil.get(e._key) || 0) > now;
+        return (
+          (peers ? " peerfocus" : "") +
+          (flash ? " stdinflash" : "") +
+          (sent ? " sendflash" : "") +
+          (recv ? " recvflash" : "")
+        );
       }
       // A yellow chip showing how many peers are watching this agent ("" if none).
       function peerChipHtml(e) {
@@ -4303,6 +4492,7 @@
         <span class="age">${age(e)}</span></div>`;
               })
               .join("") || `<div class="empty">no match</div>`;
+          renderSendWires(); // rows were replaced — re-draw the overlay (see below)
           return;
         }
         $("list").innerHTML =
@@ -4341,6 +4531,10 @@
       </div>`;
             })
             .join("") || `<div class="empty">no match</div>`;
+        // The innerHTML above replaced every row — and with them the wire overlay
+        // (a child of #list). Re-draw it against the fresh rects, or an in-flight
+        // wire would vanish on the next list render.
+        renderSendWires();
       }
 
       // Restore the last filter so a refresh (incl. the auto-reload on a new

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -782,6 +782,49 @@ interface ReadEdge {
 let readEdges: ReadEdge[] = [];
 let showWires = true;
 
+// message wires: recent agent→agent SENDS (`ay send`/`key`/`select`, from
+// /api/edges `sends`). Unlike a read edge — a standing "X watches Y" relation —
+// a send is an EVENT: it flashes bright at delivery and fades out over
+// SEND_FADE_MS, so the forest shows message traffic as it happens rather than a
+// permanent wire. Same node-KEY mapping; `kind` distinguishes a keystroke/menu
+// pick from a text message.
+interface SendEdge {
+  by: string;
+  target: string;
+  at: number;
+  kind?: "key" | "select";
+}
+let sendEdges: SendEdge[] = [];
+/** A send wire is fully opaque at delivery and gone this long after. */
+const SEND_FADE_MS = 20_000;
+/** Repaint cadence while any send wire is still fading (smooth decay). */
+const SEND_FADE_TICK_MS = 250;
+let sendFadeTimer: ReturnType<typeof setInterval> | null = null;
+
+/** Remaining life of a send edge, 1 at delivery → 0 once fully faded. */
+function sendAlpha(at: number): number {
+  return Math.max(0, Math.min(1, 1 - (Date.now() - at) / SEND_FADE_MS));
+}
+
+/**
+ * Keep repainting while any send wire is mid-fade, then stop. Without this the
+ * wires would only redraw on a structure change or the edge poll, so the decay
+ * would step coarsely instead of easing out.
+ */
+function ensureSendFadeTicker() {
+  const alive = sendEdges.some((e) => sendAlpha(e.at) > 0);
+  if (alive && !sendFadeTimer) {
+    sendFadeTimer = setInterval(() => {
+      if (!sendEdges.some((e) => sendAlpha(e.at) > 0)) {
+        sendEdges = [];
+        clearInterval(sendFadeTimer!);
+        sendFadeTimer = null;
+      }
+      applyEdges();
+    }, SEND_FADE_TICK_MS);
+  }
+}
+
 // same-cwd groups (cwdId → member pids); their container surfaces the group's
 // SHARED state (the loudest member), refreshed on every content poll.
 const cwdGroups = new Map<string, string[]>();
@@ -1781,30 +1824,83 @@ function applyEdges() {
           style: { color: "#58a6ff", width: 1.5, dash: [6, 4] },
         }))
     : [];
+
+  // Send wires point the way the MESSAGE travels: the sender drives the
+  // recipient's `prompt` input (the port that models "what you `ay send` it").
+  // Opposite direction from a read wire, which follows the information flowing
+  // BACK to the reader — so a two-way exchange reads as two arrows, not one.
+  // Alpha decays with age (see sendAlpha); a key/select event is styled apart
+  // from a text message since it's a keystroke, not a prompt.
+  const sends: Edge[] = showWires
+    ? sendEdges
+        .filter((e) => e.by !== e.target && present.has(e.by) && present.has(e.target))
+        .flatMap((e) => {
+          const a = sendAlpha(e.at);
+          if (a <= 0) return [];
+          const rgb = e.kind ? "245, 158, 11" : "63, 185, 80"; // amber = key/select, green = message
+          return [
+            {
+              from: { node: e.by, port: "status" },
+              to: { node: e.target, port: "prompt" },
+              dashed: true,
+              label: e.kind ?? "msg",
+              style: {
+                color: `rgba(${rgb}, ${(0.25 + 0.75 * a).toFixed(3)})`,
+                // fresh sends read as a thicker, brighter wire that thins as it fades
+                width: 1.5 + 2 * a,
+                dash: [2, 3],
+              },
+            } satisfies Edge,
+          ];
+        })
+    : [];
+
   viewer.graph.edges.length = 0;
   // env wires are structural (host → its top-level groups), not toggled with
   // the read/tail wires — always drawn, and few (one per root)
   viewer.graph.edges.push(
     ...edges,
+    ...sends,
     ...envEdges.filter((e) => present.has(e.from.node) && present.has(e.to.node)),
     ...fedEdges(present),
   );
   viewer.setView(viewer.view); // schedule a redraw without a relayout
 }
 
+type EdgesResponse = {
+  reads?: { by: number; target: number; at: number }[];
+  sends?: { by: number; target: number; at: number; kind?: "key" | "select" }[];
+};
+
 async function fetchEdges() {
   const results = await Promise.allSettled(
     [...wires.values()].filter(wireReady).map(async (w) => {
-      const raw =
-        (await apiJSON<{ reads?: { by: number; target: number; at: number }[] }>("/api/edges", w.id))
-          .reads ?? [];
-      return raw.map((e) => ({ by: `${w.id}#${e.by}`, target: `${w.id}#${e.target}`, at: e.at }));
+      const body = await apiJSON<EdgesResponse>("/api/edges", w.id);
+      const key = (pid: number) => `${w.id}#${pid}`;
+      return {
+        reads: (body.reads ?? []).map((e) => ({
+          by: key(e.by),
+          target: key(e.target),
+          at: e.at,
+        })),
+        // `sends` is absent on an older daemon — the send wires just stay empty.
+        sends: (body.sends ?? []).map((e) => ({
+          by: key(e.by),
+          target: key(e.target),
+          at: e.at,
+          kind: e.kind,
+        })),
+      };
     }),
   );
-  const merged = results.flatMap((p) => (p.status === "fulfilled" ? p.value : []));
-  if (merged.length || readEdges.length) {
-    readEdges = merged;
+  const ok = results.flatMap((p) => (p.status === "fulfilled" ? [p.value] : []));
+  const reads = ok.flatMap((r) => r.reads);
+  const sends = ok.flatMap((r) => r.sends);
+  if (reads.length || readEdges.length || sends.length || sendEdges.length) {
+    readEdges = reads;
+    sendEdges = sends;
     applyEdges();
+    ensureSendFadeTicker();
   }
 }
 

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -21,8 +21,8 @@ use std::env;
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
-    "send", "spawn", "attach", "stop", "exit", "restart", "note", "serve", "schedule", "remote",
-    "expose", "reap", "help",
+    "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "serve", "schedule",
+    "remote", "expose", "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -118,6 +118,23 @@ describe("messageLog", () => {
     expect(await readMailbox(from, "outbox")).toHaveLength(0);
   });
 
+  it("preserves the kind tag for key/select events", async () => {
+    const from = path.join(dir, "kfrom");
+    const to = path.join(dir, "kto");
+    await recordMessage(
+      makeRecord({
+        from: { pid: 1, cli: "bash", cwd: from, agent_id: "A" },
+        to: { pid: 2, cli: "bash", cwd: to, agent_id: "B" },
+        kind: "key",
+        body: "down down enter",
+        wrapped: false,
+      }),
+    );
+    const rec = (await readMailbox(to, "inbox"))[0]!;
+    expect(rec.kind).toBe("key");
+    expect(rec.body).toBe("down down enter");
+  });
+
   it("partyMatches prefers agent_id, falls back to pid", () => {
     const party = { pid: 5, cli: "c", cwd: "/x", agent_id: "stable" };
     expect(partyMatches(party, "stable", 999)).toBe(true); // agent_id wins across pid churn

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -6,7 +6,9 @@ import {
   mailboxPath,
   partyMatches,
   readMailbox,
+  recordInbox,
   recordMessage,
+  recordOutbox,
   type MessageRecord,
 } from "./messageLog.ts";
 
@@ -82,6 +84,38 @@ describe("messageLog", () => {
     await appendFile(p, "{ not json\n");
     expect(raw.trim().split("\n")).toHaveLength(1);
     expect(await readMailbox(from, "outbox")).toHaveLength(1);
+  });
+
+  it("recordOutbox writes only the sender's outbox (remote peer's cwd untouched)", async () => {
+    const from = path.join(dir, "local");
+    const to = path.join(dir, "remote");
+    await recordOutbox(
+      makeRecord({
+        from: { pid: 1, cli: "claude", cwd: from, agent_id: "A" },
+        to: { pid: 2, cli: "codex", cwd: to, agent_id: "B" },
+        remote: "http://host:8080",
+        wrapped: false,
+      }),
+    );
+    expect(await readMailbox(from, "outbox")).toHaveLength(1);
+    // The remote peer's cwd is on another host — nothing is written there.
+    expect(await readMailbox(to, "inbox")).toHaveLength(0);
+    expect((await readMailbox(from, "outbox"))[0]!.remote).toBe("http://host:8080");
+  });
+
+  it("recordInbox writes only the recipient's inbox (remote sender's cwd untouched)", async () => {
+    const from = path.join(dir, "remote-sender");
+    const to = path.join(dir, "local-recipient");
+    await recordInbox(
+      makeRecord({
+        from: { pid: 1, cli: "claude", cwd: from, agent_id: "A" },
+        to: { pid: 2, cli: "codex", cwd: to, agent_id: "B" },
+        remote: "wire",
+        wrapped: false,
+      }),
+    );
+    expect(await readMailbox(to, "inbox")).toHaveLength(1);
+    expect(await readMailbox(from, "outbox")).toHaveLength(0);
   });
 
   it("partyMatches prefers agent_id, falls back to pid", () => {

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import {
+  mailboxPath,
+  partyMatches,
+  readMailbox,
+  recordMessage,
+  type MessageRecord,
+} from "./messageLog.ts";
+
+function makeRecord(over: Partial<MessageRecord> = {}): MessageRecord {
+  return {
+    at: 1_000,
+    nonce: "abcd",
+    from: { pid: 11, cli: "claude", cwd: "/from", agent_id: "agent-A" },
+    to: { pid: 22, cli: "codex", cwd: "/to", agent_id: "agent-B" },
+    body: "hello",
+    confirmed: true,
+    wrapped: true,
+    ...over,
+  };
+}
+
+describe("messageLog", () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "msglog-"));
+    prevCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("mailboxPath colocates under <cwd>/.agent-yes", () => {
+    expect(mailboxPath("/x", "inbox")).toBe(path.join("/x", ".agent-yes", "inbox.jsonl"));
+    expect(mailboxPath("/x", "outbox")).toBe(path.join("/x", ".agent-yes", "outbox.jsonl"));
+  });
+
+  it("records to sender outbox and recipient inbox", async () => {
+    const from = path.join(dir, "sender");
+    const to = path.join(dir, "recipient");
+    const rec = makeRecord({
+      from: { pid: 11, cli: "claude", cwd: from, agent_id: "A" },
+      to: { pid: 22, cli: "codex", cwd: to, agent_id: "B" },
+    });
+    await recordMessage(rec);
+
+    const outbox = await readMailbox(from, "outbox");
+    const inbox = await readMailbox(to, "inbox");
+    expect(outbox).toHaveLength(1);
+    expect(inbox).toHaveLength(1);
+    expect(outbox[0]!.body).toBe("hello");
+    expect(inbox[0]!.to.agent_id).toBe("B");
+    // The sender's inbox and recipient's outbox stay empty.
+    expect(await readMailbox(from, "inbox")).toHaveLength(0);
+    expect(await readMailbox(to, "outbox")).toHaveLength(0);
+  });
+
+  it("writes a human sender's outbox under process.cwd()", async () => {
+    process.chdir(dir);
+    const to = path.join(dir, "recipient");
+    await recordMessage(makeRecord({ from: null, to: { pid: 22, cli: "codex", cwd: to } }));
+    const outbox = await readMailbox(dir, "outbox");
+    expect(outbox).toHaveLength(1);
+    expect(outbox[0]!.from).toBeNull();
+  });
+
+  it("readMailbox skips corrupt lines and returns empty for a missing file", async () => {
+    expect(await readMailbox(dir, "inbox")).toEqual([]);
+    const from = path.join(dir, "s");
+    await recordMessage(makeRecord({ from: { pid: 1, cli: "c", cwd: from } }));
+    // Corrupt the file with a partial line; the good record still parses.
+    const p = mailboxPath(from, "outbox");
+    const raw = await readFile(p, "utf-8");
+    const { appendFile } = await import("fs/promises");
+    await appendFile(p, "{ not json\n");
+    expect(raw.trim().split("\n")).toHaveLength(1);
+    expect(await readMailbox(from, "outbox")).toHaveLength(1);
+  });
+
+  it("partyMatches prefers agent_id, falls back to pid", () => {
+    const party = { pid: 5, cli: "c", cwd: "/x", agent_id: "stable" };
+    expect(partyMatches(party, "stable", 999)).toBe(true); // agent_id wins across pid churn
+    expect(partyMatches(party, "other", 5)).toBe(true); // pid fallback
+    expect(partyMatches(party, "other", 6)).toBe(false);
+    expect(partyMatches(null, "stable", 5)).toBe(false);
+  });
+});

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -37,7 +37,12 @@ export interface MessageRecord {
   from: MailParty | null;
   /** Recipient agent. */
   to: MailParty;
-  /** The message body (without the `[ay-msg …]` wrapper). */
+  /** What kind of stdin write this was. Omitted for a normal `ay send` text
+   * message; "key" for raw keystrokes (`ay key`), "select" for a menu pick
+   * (`ay select`). For key/select the `body` holds the key names / choice. */
+  kind?: "key" | "select";
+  /** The message body (without the `[ay-msg …]` wrapper), or — for a key/select
+   * record — the keystroke names / chosen option. */
   body: string;
   /** Trailing control code name (e.g. "enter", "ctrl-c") when not a plain submit. */
   code?: string;

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -1,0 +1,125 @@
+/**
+ * Durable inter-agent message log.
+ *
+ * Every `ay send` that carries a real body is recorded twice — from the two
+ * ends' points of view — as append-only JSONL colocated with each agent's
+ * project dir (the same `<cwd>/.agent-yes/` convention the session logs use):
+ *
+ *   - the SENDER's   `<from.cwd>/.agent-yes/outbox.jsonl`
+ *   - the RECIPIENT's `<to.cwd>/.agent-yes/inbox.jsonl`
+ *
+ * A single cwd may host several agents, so records carry the stable `agent_id`
+ * (falling back to `pid`) of each end; `ay msgs` filters a mailbox down to one
+ * agent by that key. Reading needs no lock (last line wins isn't relevant — a
+ * message log keeps every entry); writing is best-effort and never blocks or
+ * fails a send.
+ */
+
+import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { logger } from "./logger.ts";
+
+/** One end of a message: enough to attribute and to route a reply. */
+export interface MailParty {
+  pid: number;
+  cli: string;
+  cwd: string;
+  agent_id?: string | null;
+}
+
+/** A single delivered inter-agent message, stored verbatim in both mailboxes. */
+export interface MessageRecord {
+  /** Epoch ms the send was recorded. */
+  at: number;
+  /** The per-send nonce from the `[ay-msg …]` wrapper, when the body was wrapped. */
+  nonce?: string;
+  /** Sender; `null` when an interactive human shell sent it (no agent context). */
+  from: MailParty | null;
+  /** Recipient agent. */
+  to: MailParty;
+  /** The message body (without the `[ay-msg …]` wrapper). */
+  body: string;
+  /** Trailing control code name (e.g. "enter", "ctrl-c") when not a plain submit. */
+  code?: string;
+  /** Whether `ay send` confirmed the CLI acted on it. */
+  confirmed?: boolean;
+  /** Whether the body was wrapped in an `[ay-msg …]` attribution block. */
+  wrapped: boolean;
+}
+
+/** Keep at most this many lines per mailbox; older entries are compacted away. */
+const MAILBOX_MAX_LINES = 2000;
+
+export type Mailbox = "inbox" | "outbox";
+
+/** Path to a cwd's mailbox file (`<cwd>/.agent-yes/{inbox,outbox}.jsonl`). */
+export function mailboxPath(cwd: string, box: Mailbox): string {
+  return path.join(cwd, ".agent-yes", `${box}.jsonl`);
+}
+
+/** Whether a mail party is the agent identified by (agentId, pid). Prefers the
+ * stable agent_id (survives restart); falls back to pid for legacy records. */
+export function partyMatches(
+  party: MailParty | null,
+  agentId: string | null | undefined,
+  pid: number | null | undefined,
+): boolean {
+  if (!party) return false;
+  if (agentId && party.agent_id && party.agent_id === agentId) return true;
+  if (typeof pid === "number" && party.pid === pid) return true;
+  return false;
+}
+
+async function appendCapped(filePath: string, record: MessageRecord): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await appendFile(filePath, JSON.stringify(record) + "\n");
+  // Opportunistic compaction: keep the file bounded despite append-only writes.
+  const raw = await readFile(filePath, "utf-8").catch(() => "");
+  const lines = raw.split("\n").filter((l) => l.trim());
+  if (lines.length > MAILBOX_MAX_LINES) {
+    const kept = lines.slice(lines.length - MAILBOX_MAX_LINES).join("\n");
+    await writeFile(filePath, kept + "\n");
+  }
+}
+
+/**
+ * Record a delivered message in both mailboxes. Best-effort: any filesystem
+ * error is logged and swallowed so a persistence failure never breaks a send.
+ * The sender's outbox lives under `from.cwd`; a human sender (from === null)
+ * writes its outbox under `process.cwd()`.
+ */
+export async function recordMessage(record: MessageRecord): Promise<void> {
+  const outCwd = record.from?.cwd ?? process.cwd();
+  try {
+    await appendCapped(mailboxPath(outCwd, "outbox"), record);
+  } catch (err) {
+    logger.debug(`[messageLog] outbox append failed: ${err}`);
+  }
+  try {
+    await appendCapped(mailboxPath(record.to.cwd, "inbox"), record);
+  } catch (err) {
+    logger.debug(`[messageLog] inbox append failed: ${err}`);
+  }
+}
+
+/** Read and parse a cwd's mailbox, oldest first. Missing/corrupt lines skipped. */
+export async function readMailbox(cwd: string, box: Mailbox): Promise<MessageRecord[]> {
+  let raw: string;
+  try {
+    raw = await readFile(mailboxPath(cwd, box), "utf-8");
+  } catch {
+    return [];
+  }
+  const out: MessageRecord[] = [];
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const rec = JSON.parse(t) as MessageRecord;
+      if (rec && typeof rec.at === "number" && rec.to) out.push(rec);
+    } catch {
+      /* skip corrupt/partial line */
+    }
+  }
+  return out;
+}

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -45,6 +45,10 @@ export interface MessageRecord {
   confirmed?: boolean;
   /** Whether the body was wrapped in an `[ay-msg …]` attribution block. */
   wrapped: boolean;
+  /** The remote url/alias when this message crossed the wire (`ay send <remote>:<kw>`);
+   * absent for a same-host send. The two ends record their own mailbox on their
+   * own machine, so this marks that the peer's cwd is on another host. */
+  remote?: string;
 }
 
 /** Keep at most this many lines per mailbox; older entries are compacted away. */
@@ -83,23 +87,36 @@ async function appendCapped(filePath: string, record: MessageRecord): Promise<vo
 }
 
 /**
- * Record a delivered message in both mailboxes. Best-effort: any filesystem
- * error is logged and swallowed so a persistence failure never breaks a send.
- * The sender's outbox lives under `from.cwd`; a human sender (from === null)
- * writes its outbox under `process.cwd()`.
+ * Record the SENDER's view in its outbox. Best-effort — a filesystem error is
+ * logged and swallowed so persistence never breaks a send. The outbox lives
+ * under `from.cwd`; a human sender (from === null) writes under `process.cwd()`.
  */
-export async function recordMessage(record: MessageRecord): Promise<void> {
+export async function recordOutbox(record: MessageRecord): Promise<void> {
   const outCwd = record.from?.cwd ?? process.cwd();
   try {
     await appendCapped(mailboxPath(outCwd, "outbox"), record);
   } catch (err) {
     logger.debug(`[messageLog] outbox append failed: ${err}`);
   }
+}
+
+/** Record the RECIPIENT's view in its inbox (under `to.cwd`). Best-effort. */
+export async function recordInbox(record: MessageRecord): Promise<void> {
   try {
     await appendCapped(mailboxPath(record.to.cwd, "inbox"), record);
   } catch (err) {
     logger.debug(`[messageLog] inbox append failed: ${err}`);
   }
+}
+
+/**
+ * Record a same-host message in both mailboxes — the sender's outbox and the
+ * recipient's inbox both live on this machine. For a message that crossed the
+ * wire, each end calls `recordOutbox`/`recordInbox` on its own host instead.
+ */
+export async function recordMessage(record: MessageRecord): Promise<void> {
+  await recordOutbox(record);
+  await recordInbox(record);
 }
 
 /** Read and parse a cwd's mailbox, oldest first. Missing/corrupt lines skipped. */

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -16,6 +16,7 @@ import {
   listRecords,
   readNotes,
   readPtysize,
+  recentMessageEdges,
   recentReadEdges,
   renderLogTailLines,
   renderRawLog,
@@ -1724,12 +1725,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
       });
     }
 
-    // GET /api/edges — recent inter-agent relationship edges for the /rgui wire
-    // view. Currently the read/tail edges (agent `by` read agent `target` within
-    // the last minute, from ~/.agent-yes/reads.jsonl). Directional, ephemeral.
+    // GET /api/edges — recent inter-agent relationship edges for the /rgui + /w
+    // wire view. Two directional, ephemeral edge sets:
+    //   reads — agent `by` read/tailed agent `target` (from ~/.agent-yes/reads.jsonl)
+    //   sends — agent `by` sent `target` a message/key/select (from the per-cwd
+    //           outbox logs); carries the send `kind` so the UI can style it.
+    // Both are last-minute windows the client fades out by `at`.
     if (req.method === "GET" && p === "/api/edges") {
       try {
-        return Response.json({ reads: await recentReadEdges() });
+        const [reads, sends] = await Promise.all([recentReadEdges(), recentMessageEdges()]);
+        return Response.json({ reads, sends });
       } catch (e) {
         return new Response((e as Error).message, { status: 500 });
       }

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -26,6 +26,7 @@ import {
 } from "./subcommands.ts";
 import { TYPING_BADGE } from "./badges.ts";
 import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
+import { type MailParty, recordInbox } from "./messageLog.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { spawnRejectionReason } from "./spawnGate.ts";
 import { findSpawnHiddenLauncher } from "./rustBinary.ts";
@@ -2199,15 +2200,20 @@ export async function cmdServe(rest: string[]): Promise<number> {
       }
     }
 
-    // POST /api/send  body: {keyword, msg, code?}
+    // POST /api/send  body: {keyword, msg, code?, from?}
     if (req.method === "POST" && p === "/api/send") {
-      let body: { keyword: string; msg: string; code?: string };
+      let body: {
+        keyword: string;
+        msg: string;
+        code?: string;
+        from?: MailParty | null;
+      };
       try {
         body = (await req.json()) as typeof body;
       } catch {
         return new Response("invalid JSON body", { status: 400 });
       }
-      const { keyword, msg = "", code = "enter" } = body;
+      const { keyword, msg = "", code = "enter", from = null } = body;
       if (!keyword || typeof keyword !== "string") {
         return new Response("missing keyword", { status: 400 });
       }
@@ -2228,7 +2234,43 @@ export async function cmdServe(rest: string[]): Promise<number> {
         // over this same wire) is protocol noise, not input — stamp anyDaemonWriteAt
         // but not the "meaningful" time, so a resize/redraw can't trip the flash.
         await noteStdinWrite(record.pid, record.fifo_file, !isTerminalReply(msg));
-        return Response.json({ ok: true, pid: record.pid });
+        // Record the recipient's inbox on THIS host (the sender records its own
+        // outbox on its host). The sender crossed the wire, so `from.cwd` names a
+        // path on another machine — mark it remote so the peer's cwd isn't misread
+        // as local. Only real message bodies are logged. Best-effort.
+        if (msg) {
+          const senderParty: MailParty | null =
+            from && typeof from === "object" && typeof from.pid === "number"
+              ? {
+                  pid: from.pid,
+                  cli: String(from.cli ?? "?"),
+                  cwd: String(from.cwd ?? ""),
+                  agent_id: from.agent_id ?? undefined,
+                }
+              : null;
+          await recordInbox({
+            at: Date.now(),
+            from: senderParty,
+            to: {
+              pid: record.pid,
+              cli: record.cli,
+              cwd: record.cwd,
+              agent_id: record.agent_id,
+            },
+            body: msg,
+            code: code.toLowerCase() === "enter" ? undefined : code.toLowerCase(),
+            confirmed: true,
+            wrapped: false,
+            remote: senderParty ? "wire" : undefined,
+          });
+        }
+        return Response.json({
+          ok: true,
+          pid: record.pid,
+          cli: record.cli,
+          cwd: record.cwd,
+          agentId: record.agent_id ?? undefined,
+        });
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });
       }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -26,6 +26,7 @@ import {
   partyMatches,
   readMailbox,
   recordMessage,
+  recordOutbox,
 } from "./messageLog.ts";
 import { badgeDef, matchBadges, TYPING_BADGE } from "./badges.ts";
 import {
@@ -990,13 +991,48 @@ async function runRemoteSend(remote: ResolvedRemote, msg: string, code: string):
     process.stderr.write("remote send requires a keyword (e.g. token@host:port:keyword)\n");
     return 1;
   }
-  const res = await remotePost(remote, "/api/send", { keyword, msg, code });
+  // Attribute the send so the remote can record its recipient's inbox with a real
+  // sender (not an anonymous cross-wire write). Human shell → no `from`.
+  const sender = await senderContext();
+  const from = sender.agent
+    ? {
+        pid: sender.agent.pid,
+        cli: sender.agent.cli,
+        cwd: sender.agent.cwd,
+        agent_id: sender.agent.agent_id,
+      }
+    : null;
+  const res = await remotePost(remote, "/api/send", { keyword, msg, code, from });
   if (!res.ok) {
     process.stderr.write(`remote error ${res.status}: ${await res.text()}\n`);
     return 1;
   }
-  const data = (await res.json()) as any;
+  const data = (await res.json()) as {
+    pid: number;
+    cli?: string;
+    cwd?: string;
+    agentId?: string;
+  };
   process.stdout.write(`sent to remote pid ${data.pid} (${remote.url}  ${keyword})\n`);
+  // Record the sender's half of the exchange locally (the recipient's inbox is
+  // recorded on the remote host by its /api/send handler). Only real bodies.
+  if (msg && msg !== "-") {
+    await recordOutbox({
+      at: Date.now(),
+      from,
+      to: {
+        pid: data.pid,
+        cli: data.cli ?? keyword,
+        cwd: data.cwd ?? "",
+        agent_id: data.agentId,
+      },
+      body: msg,
+      code: code.toLowerCase() === "enter" ? undefined : code.toLowerCase(),
+      confirmed: true,
+      wrapped: false,
+      remote: remote.url,
+    });
+  }
   return 0;
 }
 
@@ -3204,9 +3240,10 @@ async function cmdMsgs(rest: string[]): Promise<number> {
       dir === "out"
         ? `→ ${rec.to.cli} #${rec.to.pid}`
         : `← ${rec.from ? `${rec.from.cli} #${rec.from.pid}` : "human"}`;
+    const via = rec.remote ? ` (via ${rec.remote})` : "";
     const flag = rec.confirmed === false ? " (unconfirmed)" : "";
     const line = truncate(rec.body.replace(/\s+/g, " "), 100);
-    process.stdout.write(`${when}  ${peer.padEnd(20)}${flag}  ${line}\n`);
+    process.stdout.write(`${when}  ${peer.padEnd(20)}${via}${flag}  ${line}\n`);
   }
   return 0;
 }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -3242,7 +3242,8 @@ async function cmdMsgs(rest: string[]): Promise<number> {
         : `← ${rec.from ? `${rec.from.cli} #${rec.from.pid}` : "human"}`;
     const via = rec.remote ? ` (via ${rec.remote})` : "";
     const flag = rec.confirmed === false ? " (unconfirmed)" : "";
-    const line = truncate(rec.body.replace(/\s+/g, " "), 100);
+    const tag = rec.kind ? `[${rec.kind}] ` : "";
+    const line = tag + truncate(rec.body.replace(/\s+/g, " "), 100);
     process.stdout.write(`${when}  ${peer.padEnd(20)}${via}${flag}  ${line}\n`);
   }
   return 0;
@@ -3258,6 +3259,36 @@ async function resolveWritableAgent(keyword: string, opts: CommonOpts): Promise<
     );
   }
   return record;
+}
+
+/**
+ * Record an `ay key` / `ay select` stdin write in the message log, same as a
+ * text send but tagged with its `kind` (and `body` = the keystroke names /
+ * chosen option). Key/select are local-only (no remote wire), so both mailboxes
+ * are on this host — recordMessage writes both. Best-effort.
+ */
+async function recordKeyEvent(
+  sender: { agent: GlobalPidRecord | null },
+  record: GlobalPidRecord,
+  kind: "key" | "select",
+  body: string,
+): Promise<void> {
+  await recordMessage({
+    at: Date.now(),
+    from: sender.agent
+      ? {
+          pid: sender.agent.pid,
+          cli: sender.agent.cli,
+          cwd: sender.agent.cwd,
+          agent_id: sender.agent.agent_id,
+        }
+      : null,
+    to: { pid: record.pid, cli: record.cli, cwd: record.cwd, agent_id: record.agent_id },
+    kind,
+    body,
+    confirmed: true,
+    wrapped: false,
+  });
 }
 
 async function cmdKey(rest: string[]): Promise<number> {
@@ -3307,10 +3338,11 @@ async function cmdKey(rest: string[]): Promise<number> {
   };
   const record = await resolveWritableAgent(keyword, opts);
   const force = Boolean(argv.force) || process.env.AGENT_YES_FORCE_SEND === "1";
-  await enforceSendGuards(record, force);
+  const sender = await enforceSendGuards(record, force);
 
   await writeKeysPaced(record.fifo_file!, byteSeqs, Math.max(0, argv.pace));
   process.stdout.write(`sent to pid ${record.pid} (${record.cli}): ${keyNames.join(" ")}\n`);
+  await recordKeyEvent(sender, record, "key", keyNames.join(" "));
   return 0;
 }
 
@@ -3367,7 +3399,7 @@ async function cmdSelect(rest: string[]): Promise<number> {
     );
   }
   const force = Boolean(argv.force) || process.env.AGENT_YES_FORCE_SEND === "1";
-  await enforceSendGuards(record, force);
+  const sender = await enforceSendGuards(record, force);
 
   const menu = await extractMenu(record.log_file, record.cli);
   if (!menu) {
@@ -3391,6 +3423,7 @@ async function cmdSelect(rest: string[]): Promise<number> {
   process.stdout.write(
     `pid ${record.pid} (${record.cli}): selected option ${n} (${moved} + enter)\n`,
   );
+  await recordKeyEvent(sender, record, "select", `option ${n}`);
 
   if (argv.wait) {
     const ok = await waitForNeedsInputClear(record, Math.max(1, argv.timeout) * 1000);

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -203,6 +203,49 @@ export async function recentReadEdges(windowMs = READ_WINDOW_MS): Promise<ReadEd
   return out;
 }
 
+/** Recent agent→agent MESSAGE edges (a delivered `ay send`/`key`/`select`), for
+ * the /rgui + /w wire view. Like {@link ReadEdge} but sourced from the per-cwd
+ * outbox logs and carrying the send `kind`. `by`/`target` are the sender/recipient
+ * pids AT SEND TIME (a restarted agent keeps a new pid — matched best-effort). */
+export interface MessageEdge {
+  by: number;
+  target: number;
+  at: number;
+  kind?: "key" | "select";
+}
+
+/**
+ * Scan every live agent's outbox for sends within `windowMs` and return them as
+ * directional edges (newest `at` per by→target pair wins). Bounded by the number
+ * of distinct agent cwds — the outbox is per-cwd, so each dir is read once.
+ */
+export async function recentMessageEdges(windowMs = READ_WINDOW_MS): Promise<MessageEdge[]> {
+  const now = Date.now();
+  const records = await listRecords(undefined, {
+    all: true,
+    active: false,
+    json: false,
+    latest: false,
+    cwdScope: null,
+  });
+  const cwds = [...new Set(records.map((r) => r.cwd).filter(Boolean))];
+  const best = new Map<string, MessageEdge>();
+  await Promise.all(
+    cwds.map(async (cwd) => {
+      for (const rec of await readMailbox(cwd, "outbox")) {
+        if (now - rec.at > windowMs) continue;
+        const by = rec.from?.pid;
+        const target = rec.to?.pid;
+        if (!by || !target || by === target) continue; // agent→agent only
+        const key = `${by}\0${target}`;
+        const prev = best.get(key);
+        if (!prev || rec.at > prev.at) best.set(key, { by, target, at: rec.at, kind: rec.kind });
+      }
+    }),
+  );
+  return [...best.values()];
+}
+
 // Identify the sender. An agent launched by `ay` inherits AGENT_YES_PID=<wrapper
 // pid>; the registered agent record carries that same wrapper_pid, so we map the
 // env value back to the agent's own canonical record. Falls back to a direct pid

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -20,6 +20,13 @@ import { type GlobalPidRecord, readGlobalPids, updateGlobalPidStatus } from "./g
 import { buildAgentForest, flattenForest } from "./agentTree.ts";
 import { parseTaskCounts, type TaskCounts } from "./todoParse.ts";
 import { agentYesHome } from "./agentYesHome.ts";
+import {
+  type MailParty,
+  type MessageRecord,
+  partyMatches,
+  readMailbox,
+  recordMessage,
+} from "./messageLog.ts";
 import { badgeDef, matchBadges, TYPING_BADGE } from "./badges.ts";
 import {
   classifyNeedsInput,
@@ -296,6 +303,7 @@ const SUBCOMMANDS = new Set([
   "tail",
   "head",
   "send",
+  "msgs",
   "key",
   "select",
   "spawn",
@@ -397,6 +405,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdRead(rest, { mode: "head" });
       case "send":
         return await cmdSend(rest);
+      case "msgs":
+        return await cmdMsgs(rest);
       case "key":
         return await cmdKey(rest);
       case "select":
@@ -534,6 +544,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay cat <keyword>                    full log\n` +
       `  ay head <keyword>                   first N lines\n` +
       `  ay send <keyword> <msg>             send a message\n` +
+      `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
       `  ay key <keyword> <key...>           send raw keystrokes (down/up/enter/esc/…) — drives menus\n` +
       `  ay select <keyword> <N>             pick option N of a needs_input selection menu\n` +
       `  ay attach <keyword>                 interactive attach (detach: Ctrl-\\)\n` +
@@ -2975,8 +2986,9 @@ async function cmdSend(rest: string[]): Promise<number> {
   const replyTarget = sender.agent?.agent_id || sender.agent?.pid;
   let prefix = "";
   let suffix = "";
+  let nonce: string | undefined;
   if (sender.agent && !isSlashCommand(body)) {
-    const nonce = randomBytes(4).toString("hex");
+    nonce = randomBytes(4).toString("hex");
     prefix = `<ay-msg ${nonce} from ${sender.agent.cli} #${sender.agent.pid} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${replyTarget} "...">\n`;
     suffix = `\n</ay-msg ${nonce}>`;
   }
@@ -3031,6 +3043,35 @@ async function cmdSend(rest: string[]): Promise<number> {
   process.stdout.write(
     `${status} to pid ${record.pid} (${record.cli}): ${truncate(payload, 80)}\n`,
   );
+
+  // Persist a durable record of the exchange from both ends' point of view (the
+  // sender's outbox + the recipient's inbox). Only real message bodies are
+  // logged — a bare control code (esc/ctrl-c with no body) isn't a "message".
+  // Best-effort: recordMessage swallows its own errors so it never breaks send.
+  if (body) {
+    await recordMessage({
+      at: Date.now(),
+      nonce,
+      from: sender.agent
+        ? {
+            pid: sender.agent.pid,
+            cli: sender.agent.cli,
+            cwd: sender.agent.cwd,
+            agent_id: sender.agent.agent_id,
+          }
+        : null,
+      to: {
+        pid: record.pid,
+        cli: record.cli,
+        cwd: record.cwd,
+        agent_id: record.agent_id,
+      },
+      body,
+      code: trailing === "\r" ? undefined : codeName,
+      confirmed,
+      wrapped: Boolean(nonce),
+    });
+  }
   if (!confirmed) {
     process.stderr.write(
       `\nwarning: couldn't confirm the CLI acted on it after ${SEND_SUBMIT_MAX_RETRIES + 1} attempt(s) — ` +
@@ -3057,6 +3098,117 @@ async function cmdSend(rest: string[]): Promise<number> {
     if (tip) process.stderr.write(tip);
   }
   return confirmed ? 0 : 1;
+}
+
+// ---------------------------------------------------------------------------
+// ay msgs — read the durable inter-agent message log
+// ---------------------------------------------------------------------------
+
+/** A mailbox record annotated with the direction it takes from the owner's POV. */
+interface DirectedMessage {
+  dir: "in" | "out";
+  rec: MessageRecord;
+}
+
+/**
+ * `ay msgs [keyword]` — show the inter-agent messages an agent sent and
+ * received. With no keyword it uses THIS caller's context (the agent running
+ * `ay msgs`, or the human shell's cwd); with a keyword it resolves one agent and
+ * reads that agent's mailboxes. Newest last, like a chat log.
+ */
+async function cmdMsgs(rest: string[]): Promise<number> {
+  const y = yargs(rest)
+    .usage("Usage: ay msgs [keyword] [--in|--out] [-n N] [--json]")
+    .option("in", { type: "boolean", default: false, description: "Only received messages" })
+    .option("out", { type: "boolean", default: false, description: "Only sent messages" })
+    .option("n", { type: "number", description: "Show the last N messages (default 50)" })
+    .option("json", { type: "boolean", default: false, description: "Emit raw JSONL records" })
+    .option("all", { type: "boolean", default: false, description: "Include exited agents" })
+    .option("latest", {
+      type: "boolean",
+      default: false,
+      description: "Use most recent match when multiple match",
+    })
+    .option("cwd", { type: "string", description: "Restrict to agents under this dir" })
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+
+  const argv = await y.parseAsync();
+  const keyword = argv._[0] !== undefined ? String(argv._[0]) : undefined;
+
+  // Whose mailbox: an explicit keyword names a target agent; otherwise the
+  // calling agent (or, for a human shell, its own cwd with no agent filter).
+  let ownerCwd: string;
+  let ownerAgentId: string | null | undefined;
+  let ownerPid: number | null | undefined;
+  let ownerLabel: string;
+  if (keyword) {
+    const opts: CommonOpts = {
+      all: argv.all,
+      active: false,
+      json: false,
+      latest: argv.latest,
+      cwdScope: typeof argv.cwd === "string" ? path.resolve(argv.cwd) : null,
+    };
+    const record = await resolveOne(keyword, opts);
+    ownerCwd = record.cwd;
+    ownerAgentId = record.agent_id;
+    ownerPid = record.pid;
+    ownerLabel = `pid ${record.pid} (${record.cli})`;
+  } else {
+    const sender = await senderContext();
+    ownerCwd = sender.agent?.cwd ?? process.cwd();
+    ownerAgentId = sender.agent?.agent_id;
+    ownerPid = sender.agent?.pid;
+    ownerLabel = sender.agent ? `pid ${sender.agent.pid} (${sender.agent.cli})` : "this shell";
+  }
+
+  const isOwner = (party: MailParty | null): boolean =>
+    // A human shell (no agent context) owns only the messages it sent, which
+    // carry `from: null`; match those so `ay msgs` in a plain terminal works.
+    ownerAgentId || ownerPid ? partyMatches(party, ownerAgentId, ownerPid) : party === null;
+
+  const messages: DirectedMessage[] = [];
+  if (!argv.in) {
+    for (const rec of await readMailbox(ownerCwd, "outbox")) {
+      if (isOwner(rec.from)) messages.push({ dir: "out", rec });
+    }
+  }
+  if (!argv.out) {
+    for (const rec of await readMailbox(ownerCwd, "inbox")) {
+      if (isOwner(rec.to)) messages.push({ dir: "in", rec });
+    }
+  }
+  messages.sort((a, b) => a.rec.at - b.rec.at);
+
+  const limit =
+    argv.n !== undefined && Number.isFinite(argv.n) && argv.n! > 0 ? Math.floor(argv.n!) : 50;
+  const shown = messages.slice(-limit);
+
+  if (argv.json) {
+    for (const { dir, rec } of shown) {
+      process.stdout.write(JSON.stringify({ dir, ...rec }) + "\n");
+    }
+    return 0;
+  }
+
+  if (shown.length === 0) {
+    process.stderr.write(`no messages for ${ownerLabel}.\n`);
+    return 0;
+  }
+
+  for (const { dir, rec } of shown) {
+    const when = new Date(rec.at).toLocaleTimeString();
+    const peer =
+      dir === "out"
+        ? `→ ${rec.to.cli} #${rec.to.pid}`
+        : `← ${rec.from ? `${rec.from.cli} #${rec.from.pid}` : "human"}`;
+    const flag = rec.confirmed === false ? " (unconfirmed)" : "";
+    const line = truncate(rec.body.replace(/\s+/g, " "), 100);
+    process.stdout.write(`${when}  ${peer.padEnd(20)}${flag}  ${line}\n`);
+  }
+  return 0;
 }
 
 // Resolve a keyword to one agent and return it with a writable FIFO, or throw


### PR DESCRIPTION
## What

Adds a durable log of inter-agent messages. Previously `ay send` wrote the body to the recipient's FIFO and it vanished — there was no record of who pinged whom or what an agent sent.

## How

Every `ay send` carrying a real body is now recorded from **both ends' point of view** as append-only JSONL, colocated with each project dir (the same `<cwd>/.agent-yes/` convention the session logs use):

- the sender's `<from.cwd>/.agent-yes/outbox.jsonl`
- the recipient's `<to.cwd>/.agent-yes/inbox.jsonl`

Records carry the stable `agent_id` (falling back to pid) of each end, so:
- a shared cwd hosting several agents can be filtered down to one, and
- the trail survives the sender restarting under a new pid.

Writing is **best-effort** — `recordMessage` swallows its own errors so a persistence failure never breaks a send. Files are compacted to the last 2000 lines despite append-only writes.

## New command

```
ay msgs [keyword] [--in|--out] [-n N] [--json]
```

- no keyword → the calling agent's own sent + received messages
- keyword → the resolved agent's messages
- newest last, like a chat log; `→` sent, `←` received

## Verification

- `ts/messageLog.spec.ts` (5 tests): both-mailbox write, human-sender outbox under cwd, corrupt-line skip, `partyMatches` agent_id-over-pid.
- End-to-end: launched two `ay bash` agents in separate cwds, had one read + send to the other, confirmed the record landed in both `inbox.jsonl`/`outbox.jsonl` with correct `agent_id`/`nonce`/`confirmed`, and that `ay msgs <pid>` rendered both directions and `--json`.
- `SUBCOMMANDS` mirrored in `rs/src/cli.rs`; Rust binary rebuilt (`build:rs`) so `ay msgs` delegates to the JS layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)