### PR TITLE
fix(serve): pass a live env snapshot to daemon-manager spawns

### DIFF
--- a/ts/nodeRuntime.spec.ts
+++ b/ts/nodeRuntime.spec.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, readFile, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
+
+// process.platform is stubbed per test (instead of skipIf) so every branch of
+// ensureNodeRuntime is exercised on every CI OS — the win32 early-return on
+// POSIX runners and the POSIX shim path on Windows runners (mkdir/writeFile/
+// chmod all work there; the shim just isn't consulted by real spawns).
+const realPlatform = process.platform;
+function setPlatform(p: string) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+// The bun-only-no-node path (sym003): pm2/oxmgr bins are `#!/usr/bin/env node`
+// scripts, so with no node on PATH they die at the shebang. ensureNodeRuntime
+// must bridge that with a node→bun shim in ay's own bin dir.
+describe("ensureNodeRuntime", () => {
+  let home: string;
+  let savedPath: string | undefined;
+  let savedHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-node-shim-"));
+    savedPath = process.env.PATH;
+    savedHome = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = home;
+    setPlatform("linux");
+  });
+
+  afterEach(async () => {
+    setPlatform(realPlatform);
+    process.env.PATH = savedPath;
+    if (savedHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = savedHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const noNode = (cmd: string) => (cmd === "bun" ? "/fake/bin/bun" : null);
+
+  it("writes an executable node→bun shim and prepends it to PATH when node is absent", async () => {
+    const shim = await ensureNodeRuntime(noNode);
+    expect(shim).toBe(path.join(home, "bin", "node"));
+    const body = await readFile(shim!, "utf-8");
+    expect(body).toBe("#!/bin/sh\nexec '/fake/bin/bun' \"$@\"\n");
+    if (realPlatform !== "win32") {
+      expect((await stat(shim!)).mode & 0o111).not.toBe(0); // executable
+    }
+    expect(process.env.PATH!.split(path.delimiter)[0]).toBe(path.join(home, "bin"));
+  });
+
+  it("does not duplicate the PATH entry", async () => {
+    await ensureNodeRuntime(noNode);
+    await ensureNodeRuntime(noNode);
+    const binDir = path.join(home, "bin");
+    const hits = process.env.PATH!.split(path.delimiter).filter((p) => p === binDir);
+    expect(hits).toHaveLength(1);
+  });
+
+  it("leaves an up-to-date shim untouched on repeat calls (read-only paths stay read-only)", async () => {
+    const shim = (await ensureNodeRuntime(noNode))!;
+    const before = await stat(shim);
+    await new Promise((r) => setTimeout(r, 20));
+    await ensureNodeRuntime(noNode);
+    const after = await stat(shim);
+    expect(after.mtimeMs).toBe(before.mtimeMs); // not rewritten
+  });
+
+  it("single-quotes a bun path containing sh-special characters", async () => {
+    const shim = await ensureNodeRuntime((cmd) => (cmd === "bun" ? "/opt/we$ird `dir'/bun" : null));
+    const body = await readFile(shim!, "utf-8");
+    expect(body).toBe("#!/bin/sh\nexec '/opt/we$ird `dir'\\''/bun' \"$@\"\n");
+  });
+
+  it("is a no-op when a real node exists", async () => {
+    expect(await ensureNodeRuntime(() => "/usr/bin/whatever")).toBeNull();
+  });
+
+  it("is a no-op when bun is missing too (nothing to shim to)", async () => {
+    expect(await ensureNodeRuntime(() => null)).toBeNull();
+  });
+
+  it("is a no-op on Windows (npm .cmd shims invoke node.exe directly)", async () => {
+    setPlatform("win32");
+    expect(await ensureNodeRuntime(noNode)).toBeNull();
+  });
+});
+
+describe("liveEnv", () => {
+  it("carries post-startup process.env mutations (unlike Bun.spawn's implicit env)", () => {
+    process.env.AY_LIVE_ENV_TEST = "set-after-start";
+    try {
+      expect(liveEnv().AY_LIVE_ENV_TEST).toBe("set-after-start");
+    } finally {
+      delete process.env.AY_LIVE_ENV_TEST;
+    }
+  });
+});

--- a/ts/nodeRuntime.ts
+++ b/ts/nodeRuntime.ts
@@ -1,0 +1,58 @@
+import { chmod, mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { agentYesHome } from "./agentYesHome.ts";
+
+/**
+ * Snapshot of the CURRENT process.env for child spawns. Bun.spawn without an
+ * explicit `env` hands the child the environ captured at PROCESS STARTUP — not
+ * the live process.env — so post-startup mutations (ensureNodeRuntime's shim
+ * PATH prepend, installAndVerify's global-bin-dir prepend) silently never reach
+ * the child. That is exactly how `ay serve install` kept dying with
+ * `env: node: No such file or directory` at the `pm2 start` spawn on a bun-only
+ * box even though the probe (which passes env explicitly) had just succeeded.
+ * Every spawn of a process-manager binary must pass `env: liveEnv()`.
+ */
+export function liveEnv(): Record<string, string | undefined> {
+  return { ...process.env };
+}
+
+/**
+ * Both oxmgr's and pm2's global bins are `#!/usr/bin/env node` JS scripts, so on
+ * a bun-only box (setup.sh installs no node) exec dies with "env: node: No such
+ * file or directory" — even though pm2 is pure JS and runs perfectly under bun.
+ * When node is missing but bun exists, write a node→bun shim into ay's own bin
+ * dir and prepend it to PATH so `env node` resolves. NOT solvable with
+ * `bun add -g node`: that package (node-bin-gen) lands a broken arch-specific
+ * stub and `Bun.which("node")` still finds nothing. POSIX-only — on Windows the
+ * npm .cmd shims invoke node.exe directly and an sh script can't stand in.
+ * Read-only paths (`ay serve status`) also reach this via the manager probes:
+ * an up-to-date shim is left untouched there (a read, not a write), so only the
+ * very first run on a node-less box materializes the file.
+ * Returns the shim path when the shim is in effect, null when unneeded/impossible.
+ */
+export async function ensureNodeRuntime(
+  which: (cmd: string) => string | null = Bun.which,
+): Promise<string | null> {
+  if (process.platform === "win32") return null;
+  if (which("node")) return null;
+  const bun = which("bun");
+  if (!bun) return null;
+  const binDir = path.join(agentYesHome(), "bin");
+  const shim = path.join(binDir, "node");
+  // Single-quote the bun path: inside sh double quotes `$`, backtick and `\`
+  // would still expand, corrupting the shim for a path containing them.
+  const body = `#!/bin/sh\nexec '${bun.replace(/'/g, `'\\''`)}' "$@"\n`;
+  try {
+    if ((await readFile(shim, "utf-8").catch(() => null)) !== body) {
+      await mkdir(binDir, { recursive: true });
+      await writeFile(shim, body);
+      await chmod(shim, 0o755);
+    }
+    if (!(process.env.PATH ?? "").split(path.delimiter).includes(binDir)) {
+      process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+    }
+    return shim;
+  } catch {
+    return null; // best-effort: the exec probe will fail and name the reason
+  }
+}

--- a/ts/oxmgrService.ts
+++ b/ts/oxmgrService.ts
@@ -1,3 +1,4 @@
+import { liveEnv } from "./nodeRuntime.ts";
 // Register oxmgr's daemon with the platform init system (launchd on macOS,
 // systemd on Linux, Task Scheduler on Windows) so managed processes survive a
 // *reboot*, not just a crash.
@@ -18,8 +19,12 @@ export async function ensureBootAutostart(oxmgrBin: string): Promise<boolean> {
   try {
     // Already registered with the init system? Then we're done — don't bounce
     // the daemon (and all its children) just to re-assert what's already true.
+    // env: liveEnv() so the node→bun shim's PATH prepend reaches oxmgr's
+    // `#!/usr/bin/env node` launcher (implicit inheritance uses the startup
+    // environ, missing post-startup mutations).
     const status = Bun.spawn([oxmgrBin, "service", "status"], {
       stdio: ["ignore", "ignore", "ignore"],
+      env: liveEnv(),
     });
     if ((await status.exited) === 0) return true;
 
@@ -28,6 +33,7 @@ export async function ensureBootAutostart(oxmgrBin: string): Promise<boolean> {
     // so passing it after `install` is rejected.
     const svc = Bun.spawn([oxmgrBin, "service", "install"], {
       stdio: ["ignore", "ignore", "ignore"],
+      env: liveEnv(),
     });
     return (await svc.exited) === 0;
   } catch {

--- a/ts/schedule.ts
+++ b/ts/schedule.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { resolveSpawnCwd } from "./workspaceConfig.ts";
 import { ensureBootAutostart } from "./oxmgrService.ts";
+import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
 
 // `ay schedule` — run an agent on a recurring schedule via oxmgr's cron support.
 // A scheduled job runs once immediately AND on every cron tick (with
@@ -33,16 +34,23 @@ function schedName(explicit: string | undefined, cli: string, key: string): stri
 }
 
 async function run(cmd: string[], capture = false): Promise<{ code: number; out: string }> {
+  // env: liveEnv() — oxmgr's global bin is a `#!/usr/bin/env node` script, and
+  // ensureNodeRuntime's shim PATH prepend only reaches children given the LIVE
+  // process.env (Bun.spawn's implicit inheritance uses the startup environ).
   const p = Bun.spawn(cmd, {
     stdin: "ignore",
     stdout: capture ? "pipe" : "inherit",
     stderr: capture ? "pipe" : "inherit",
+    env: liveEnv(),
   });
   const out = capture ? await new Response(p.stdout).text() : "";
   return { code: (await p.exited) ?? 1, out };
 }
 
 export async function cmdSchedule(rest: string[]): Promise<number> {
+  // On a bun-only box oxmgr's `#!/usr/bin/env node` launcher needs the node→bun
+  // shim before ANY oxmgr call below can exec (same fix as serve-install).
+  await ensureNodeRuntime();
   const oxmgrBin = Bun.which("oxmgr");
   if (!oxmgrBin) {
     process.stderr.write(

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -160,7 +160,11 @@ describe("manager spawns pass a live env snapshot", () => {
     );
     expect(calls?.length).toBeGreaterThanOrEqual(7);
     for (const call of calls!) {
-      expect(call, `missing explicit env in: ${call.slice(0, 80)}`).toContain("env:");
+      // Require a real liveEnv() env option, not just the substring "env:"
+      // (which a comment inside the options object could satisfy).
+      expect(call, `missing explicit env in: ${call.slice(0, 80)}`).toMatch(
+        /env: (?:\{\s*(?:\.\.\.)?)?liveEnv\(\)/,
+      );
     }
   });
 });

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -1,8 +1,6 @@
-import { mkdtemp, readFile, rm, stat } from "fs/promises";
-import { tmpdir } from "os";
-import path from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ensureNodeRuntime, isNoNodeExecError, oxmgrVersionHasWindowsFix } from "./serve.ts";
+import { readFile } from "fs/promises";
+import { describe, expect, it } from "vitest";
+import { isNoNodeExecError, oxmgrVersionHasWindowsFix } from "./serve.ts";
 
 // Guards the Windows daemon-manager selection: on Windows we only PREFER oxmgr
 // when the installed build carries the daemon-socket-inheritance fix. Stock
@@ -32,82 +30,6 @@ describe("oxmgrVersionHasWindowsFix", () => {
   it("returns false on unparseable output", () => {
     expect(oxmgrVersionHasWindowsFix("")).toBe(false);
     expect(oxmgrVersionHasWindowsFix("oxmgr (unknown)")).toBe(false);
-  });
-});
-
-// The bun-only-no-node path (sym003): pm2/oxmgr bins are `#!/usr/bin/env node`
-// scripts, so with no node on PATH they die at the shebang. ensureNodeRuntime
-// must bridge that with a node→bun shim in ay's own bin dir.
-describe("ensureNodeRuntime", () => {
-  let home: string;
-  let savedPath: string | undefined;
-  let savedHome: string | undefined;
-
-  beforeEach(async () => {
-    home = await mkdtemp(path.join(tmpdir(), "ay-node-shim-"));
-    savedPath = process.env.PATH;
-    savedHome = process.env.AGENT_YES_HOME;
-    process.env.AGENT_YES_HOME = home;
-  });
-
-  afterEach(async () => {
-    process.env.PATH = savedPath;
-    if (savedHome === undefined) delete process.env.AGENT_YES_HOME;
-    else process.env.AGENT_YES_HOME = savedHome;
-    await rm(home, { recursive: true, force: true });
-  });
-
-  const noNode = (cmd: string) => (cmd === "bun" ? "/fake/bin/bun" : null);
-
-  it.skipIf(process.platform === "win32")(
-    "writes an executable node→bun shim and prepends it to PATH when node is absent",
-    async () => {
-      const shim = await ensureNodeRuntime(noNode);
-      expect(shim).toBe(path.join(home, "bin", "node"));
-      const body = await readFile(shim!, "utf-8");
-      expect(body).toBe("#!/bin/sh\nexec '/fake/bin/bun' \"$@\"\n");
-      expect((await stat(shim!)).mode & 0o111).not.toBe(0); // executable
-      expect(process.env.PATH!.split(path.delimiter)[0]).toBe(path.join(home, "bin"));
-    },
-  );
-
-  it.skipIf(process.platform === "win32")("does not duplicate the PATH entry", async () => {
-    await ensureNodeRuntime(noNode);
-    await ensureNodeRuntime(noNode);
-    const binDir = path.join(home, "bin");
-    const hits = process.env.PATH!.split(path.delimiter).filter((p) => p === binDir);
-    expect(hits).toHaveLength(1);
-  });
-
-  it.skipIf(process.platform === "win32")(
-    "leaves an up-to-date shim untouched on repeat calls (read-only paths stay read-only)",
-    async () => {
-      const shim = (await ensureNodeRuntime(noNode))!;
-      const before = await stat(shim);
-      await new Promise((r) => setTimeout(r, 20));
-      await ensureNodeRuntime(noNode);
-      const after = await stat(shim);
-      expect(after.mtimeMs).toBe(before.mtimeMs); // not rewritten
-    },
-  );
-
-  it.skipIf(process.platform === "win32")(
-    "single-quotes a bun path containing sh-special characters",
-    async () => {
-      const shim = await ensureNodeRuntime((cmd) =>
-        cmd === "bun" ? "/opt/we$ird `dir'/bun" : null,
-      );
-      const body = await readFile(shim!, "utf-8");
-      expect(body).toBe("#!/bin/sh\nexec '/opt/we$ird `dir'\\''/bun' \"$@\"\n");
-    },
-  );
-
-  it("is a no-op when a real node exists", async () => {
-    expect(await ensureNodeRuntime(() => "/usr/bin/whatever")).toBeNull();
-  });
-
-  it("is a no-op when bun is missing too (nothing to shim to)", async () => {
-    expect(await ensureNodeRuntime(() => null)).toBeNull();
   });
 });
 

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -128,6 +128,12 @@ describe("isNoNodeExecError", () => {
     ).toBe(true);
   });
 
+  it("matches localized-then-normalized output (probe pins LC_ALL=C)", () => {
+    // managerProbe spawns with LC_ALL=C precisely so this English form is what
+    // we always see; this test documents the coupling.
+    expect(isNoNodeExecError("env: node: No such file or directory")).toBe(true);
+  });
+
   it("does not match a real native/glibc failure", () => {
     expect(
       isNoNodeExecError(
@@ -135,5 +141,26 @@ describe("isNoNodeExecError", () => {
       ),
     ).toBe(false);
     expect(isNoNodeExecError("")).toBe(false);
+  });
+});
+
+// Bun.spawn without an explicit `env` hands the child the environ captured at
+// process startup, NOT the live process.env — so ensureNodeRuntime's shim PATH
+// prepend never reached children spawned that way (`pm2 start` died with
+// `env: node: No such file or directory` right after the probe passed). Guard
+// the fix pattern: every spawn of a daemon-manager binary in serve.ts must pass
+// an explicit env.
+describe("manager spawns pass a live env snapshot", () => {
+  it("every Bun.spawn of mgr.bin/startArgv/installer carries an env option", async () => {
+    const src = await readFile(new URL("./serve.ts", import.meta.url), "utf-8");
+    // Grab each Bun.spawn(...) call whose argv mentions a manager binary.
+    // Capture from the call opening through the options object's closing `})`.
+    const calls = src.match(
+      /Bun\.spawn\((?:\[[^\]]*mgr\.bin[^\]]*\]|startArgv|installer),[\s\S]*?\}\)/g,
+    );
+    expect(calls?.length).toBeGreaterThanOrEqual(7);
+    for (const call of calls!) {
+      expect(call, `missing explicit env in: ${call.slice(0, 80)}`).toContain("env:");
+    }
   });
 });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
+import { mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
 import { renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -25,6 +25,8 @@ import {
   type CommonOpts,
 } from "./subcommands.ts";
 import { TYPING_BADGE } from "./badges.ts";
+import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
+export { ensureNodeRuntime } from "./nodeRuntime.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { spawnRejectionReason } from "./spawnGate.ts";
 import { findSpawnHiddenLauncher } from "./rustBinary.ts";
@@ -406,45 +408,6 @@ async function globalBinDir(installer: string[]): Promise<string | null> {
   return isBun ? out : path.join(out, "bin");
 }
 
-// Both oxmgr's and pm2's global bins are `#!/usr/bin/env node` JS scripts, so on
-// a bun-only box (setup.sh installs no node) exec dies with "env: node: No such
-// file or directory" — even though pm2 is pure JS and runs perfectly under bun.
-// When node is missing but bun exists, write a node→bun shim into ay's own bin
-// dir and prepend it to PATH so `env node` resolves. NOT solvable with
-// `bun add -g node`: that package (node-bin-gen) lands a broken arch-specific
-// stub and `Bun.which("node")` still finds nothing. POSIX-only — on Windows the
-// npm .cmd shims invoke node.exe directly and an sh script can't stand in.
-// Called from managerRunnable, which read-only paths (`ay serve status`) also
-// reach: an up-to-date shim is left untouched there (a read, not a write), so
-// only the very first run on a node-less box materializes the file.
-// Returns the shim path when the shim is in effect, null when unneeded/impossible.
-export async function ensureNodeRuntime(
-  which: (cmd: string) => string | null = Bun.which,
-): Promise<string | null> {
-  if (process.platform === "win32") return null;
-  if (which("node")) return null;
-  const bun = which("bun");
-  if (!bun) return null;
-  const binDir = path.join(agentYesHome(), "bin");
-  const shim = path.join(binDir, "node");
-  // Single-quote the bun path: inside sh double quotes `$`, backtick and `\`
-  // would still expand, corrupting the shim for a path containing them.
-  const body = `#!/bin/sh\nexec '${bun.replace(/'/g, `'\\''`)}' "$@"\n`;
-  try {
-    if ((await readFile(shim, "utf-8").catch(() => null)) !== body) {
-      await mkdir(binDir, { recursive: true });
-      await writeFile(shim, body);
-      await chmod(shim, 0o755);
-    }
-    if (!(process.env.PATH ?? "").split(path.delimiter).includes(binDir)) {
-      process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
-    }
-    return shim;
-  } catch {
-    return null; // best-effort: the exec probe will fail and name the reason
-  }
-}
-
 // Did an exec attempt die because `env` couldn't find a node runtime? macOS/BSD
 // env says `env: node: No such file or directory`, GNU coreutils quotes it
 // (`env: 'node': …`), Windows cmd says `'node' is not recognized`.
@@ -453,18 +416,6 @@ export function isNoNodeExecError(stderr: string): boolean {
     /env: '?node'?: No such file or directory/.test(stderr) ||
     /'node' is not recognized/.test(stderr)
   );
-}
-
-// Snapshot of the CURRENT process.env for child spawns. Bun.spawn without an
-// explicit `env` hands the child the environ captured at PROCESS STARTUP — not
-// the live process.env — so post-startup mutations (ensureNodeRuntime's shim
-// PATH prepend, installAndVerify's global-bin-dir prepend) silently never reach
-// the child. That is exactly how `ay serve install` kept dying with
-// `env: node: No such file or directory` at the `pm2 start` spawn on a bun-only
-// box even though the probe (which passes env explicitly) had just succeeded.
-// Every spawn of a manager binary must pass `env: liveEnv()`.
-function liveEnv(): Record<string, string | undefined> {
-  return { ...process.env };
 }
 
 // Probe one manager binary with `--version`, capturing stderr so a failure can

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -26,7 +26,6 @@ import {
 } from "./subcommands.ts";
 import { TYPING_BADGE } from "./badges.ts";
 import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
-export { ensureNodeRuntime } from "./nodeRuntime.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { spawnRejectionReason } from "./spawnGate.ts";
 import { findSpawnHiddenLauncher } from "./rustBinary.ts";

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -359,6 +359,7 @@ function oxmgrHasWindowsFix(bin: string): boolean {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],
+      env: { ...process.env } as NodeJS.ProcessEnv,
     });
     oxmgrWinFixCache = oxmgrVersionHasWindowsFix(out);
   } catch {
@@ -454,6 +455,18 @@ export function isNoNodeExecError(stderr: string): boolean {
   );
 }
 
+// Snapshot of the CURRENT process.env for child spawns. Bun.spawn without an
+// explicit `env` hands the child the environ captured at PROCESS STARTUP — not
+// the live process.env — so post-startup mutations (ensureNodeRuntime's shim
+// PATH prepend, installAndVerify's global-bin-dir prepend) silently never reach
+// the child. That is exactly how `ay serve install` kept dying with
+// `env: node: No such file or directory` at the `pm2 start` spawn on a bun-only
+// box even though the probe (which passes env explicitly) had just succeeded.
+// Every spawn of a manager binary must pass `env: liveEnv()`.
+function liveEnv(): Record<string, string | undefined> {
+  return { ...process.env };
+}
+
 // Probe one manager binary with `--version`, capturing stderr so a failure can
 // be diagnosed (glibc mismatch vs missing node runtime vs anything else).
 // LC_ALL=C pins env(1)/libc error text to English so isNoNodeExecError's
@@ -463,7 +476,7 @@ async function managerProbe(mgr: DaemonManager): Promise<{ ok: boolean; stderr: 
     const p = Bun.spawn([mgr.bin, "--version"], {
       stdout: "ignore",
       stderr: "pipe",
-      env: { ...process.env, LC_ALL: "C" },
+      env: { ...liveEnv(), LC_ALL: "C" },
     });
     const [code, stderr] = await Promise.all([p.exited, new Response(p.stderr).text()]);
     return { ok: (code ?? 1) === 0, stderr };
@@ -517,7 +530,11 @@ async function installAndVerify(pkg: "oxmgr" | "pm2"): Promise<DaemonManager | n
   const installer = bun ? [bun, "add", "-g", pkg] : npm ? [npm, "install", "-g", pkg] : null;
   if (!installer) return null;
   process.stderr.write(`ay serve install: installing ${pkg}…\n`);
-  const code = (await Bun.spawn(installer, { stdio: ["ignore", "inherit", "inherit"] }).exited) ?? 1;
+  const code =
+    (await Bun.spawn(installer, {
+      stdio: ["ignore", "inherit", "inherit"],
+      env: liveEnv(),
+    }).exited) ?? 1;
   if (code !== 0) {
     process.stderr.write(`ay serve install: '${installer.join(" ")}' failed (exit ${code})\n`);
     return null;
@@ -662,7 +679,9 @@ async function ensureBootAutostart(mgr: DaemonManager): Promise<boolean> {
 
 async function spawnExit(cmd: string[]): Promise<number> {
   try {
-    return (await Bun.spawn(cmd, { stdio: ["ignore", "ignore", "ignore"] }).exited) ?? 1;
+    return (
+      (await Bun.spawn(cmd, { stdio: ["ignore", "ignore", "ignore"], env: liveEnv() }).exited) ?? 1
+    );
   } catch {
     return 1;
   }
@@ -675,7 +694,11 @@ async function spawnExit(cmd: string[]): Promise<number> {
 async function readDaemonServeArgs(mgr: DaemonManager): Promise<string[] | null> {
   try {
     if (mgr.id === "oxmgr") {
-      const p = Bun.spawn([mgr.bin, "status", DAEMON_NAME], { stdout: "pipe", stderr: "ignore" });
+      const p = Bun.spawn([mgr.bin, "status", DAEMON_NAME], {
+        stdout: "pipe",
+        stderr: "ignore",
+        env: liveEnv(),
+      });
       const out = await new Response(p.stdout).text();
       if ((await p.exited) !== 0) return null;
       const m = /Command:\s*(.+)/.exec(out);
@@ -683,7 +706,7 @@ async function readDaemonServeArgs(mgr: DaemonManager): Promise<string[] | null>
       const after = /\bserve\b\s*(.*)$/.exec(m[1]!.trim());
       return after ? after[1]!.split(/\s+/).filter(Boolean) : [];
     }
-    const p = Bun.spawn([mgr.bin, "jlist"], { stdout: "pipe", stderr: "ignore" });
+    const p = Bun.spawn([mgr.bin, "jlist"], { stdout: "pipe", stderr: "ignore", env: liveEnv() });
     const out = await new Response(p.stdout).text();
     if ((await p.exited) !== 0) return null;
     const list = JSON.parse(out) as Array<{ name?: string; pm2_env?: { args?: string[] } }>;
@@ -911,7 +934,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
             "--",
             ...managedArgv.slice(1),
           ];
-    const proc = Bun.spawn(startArgv, { stdio: ["ignore", "inherit", "inherit"] });
+    const proc = Bun.spawn(startArgv, { stdio: ["ignore", "inherit", "inherit"], env: liveEnv() });
     const code = await proc.exited;
     if (code === 0) {
       const onBoot = await ensureBootAutostart(mgr);
@@ -962,6 +985,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
   if (sub === "uninstall") {
     const proc = Bun.spawn([mgr.bin, "delete", DAEMON_NAME], {
       stdio: ["ignore", "inherit", "inherit"],
+      env: liveEnv(),
     });
     const code = (await proc.exited) ?? 1;
     if (mgr.id === "pm2" && code === 0) {
@@ -977,6 +1001,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
   if (sub === "logs") {
     const proc = Bun.spawn([mgr.bin, "logs", DAEMON_NAME, ...args], {
       stdio: ["ignore", "inherit", "inherit"],
+      env: liveEnv(),
     });
     return (await proc.exited) ?? 1;
   }


### PR DESCRIPTION
## Residual bug from #243 (qamac's sym003 clean-install verification)

On a bun-only box, `ay serve install` still died at the `pm2 start` spawn with exit 127 `env: node: No such file or directory` — right after the pm2 probe had passed. qamac's decisive observation: mutating PATH **in-process** fails, exporting the shim dir in the **login shell** succeeds.

## Root cause (reproduced locally)

`Bun.spawn` without an explicit `env` hands the child the **environ captured at process startup**, not the live `process.env`:

```
process.env.PATH = "/zz-mutated:" + process.env.PATH
implicit : /Users/sno/.bun/bin   ← mutation invisible
explicit : /zz-mutated           ← env: {...process.env} sees it
```

`managerProbe` spreads `process.env` explicitly → saw the shim → passed. The `pm2 start` spawn (and stop/delete/save/startup/status/jlist/logs/installer) passed no `env` → original environ → no shim → `env: node` at the shebang → 127.

## Fix

`liveEnv()` snapshots the live `process.env`; every spawn of a daemon-manager binary now passes it explicitly (plus the win32 `execFileSync` probe). A source-scan test asserts every `Bun.spawn` of `mgr.bin`/`startArgv`/`installer` carries an `env:` option so the pattern can't silently regress. 16/16 serve specs pass.

Side note from the same report: `bun add -g agent-yes@1.192.1` DependencyLoop was **not reproducible** in an isolated `BUN_INSTALL` prefix here — likely sym003-local linked-package state, not a package bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)