### PR TITLE
feat(preview): P2P in-console preview of an exposed port (no edge relay)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -392,6 +392,60 @@
         padding-bottom: 10px;
         margin-bottom: 4px;
       }
+      /* P2P preview overlay — full-window iframe of the exposed app. */
+      .preview-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 70;
+        display: flex;
+        flex-direction: column;
+        background: var(--bg);
+      }
+      .preview-overlay[hidden] {
+        display: none;
+      }
+      .preview-bar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--line);
+        background: var(--panel, var(--bg));
+        flex: 0 0 auto;
+      }
+      .preview-bar .preview-badge {
+        font-size: 11px;
+        font-weight: 600;
+        color: #3fb950;
+        border: 1px solid #3fb95055;
+        border-radius: 6px;
+        padding: 2px 7px;
+        white-space: nowrap;
+      }
+      .preview-bar .preview-title {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        opacity: 0.8;
+        font-size: 13px;
+      }
+      .preview-bar button {
+        border: 1px solid var(--line);
+        background: transparent;
+        color: var(--fg);
+        border-radius: 6px;
+        padding: 3px 9px;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .preview-frame {
+        flex: 1 1 auto;
+        border: 0;
+        width: 100%;
+        background: #fff;
+      }
       /* Share modal — QR + link for a single-agent view-only share. */
       .modal-backdrop {
         position: fixed;
@@ -1960,6 +2014,19 @@
       </div>
     </div>
 
+    <!-- P2P preview: the exposed app rendered in-console over the machine's
+         WebRTC tunnel (Service Worker proxies /w/p/<src>/<port>/*, no relay). -->
+    <div class="preview-overlay" id="previewOverlay" hidden>
+      <div class="preview-bar">
+        <span class="preview-badge" title="served over a direct P2P WebRTC tunnel — traffic does not go through agent-yes.com">⚡ P2P · no relay</span>
+        <span class="preview-title" id="previewTitle"></span>
+        <button id="previewReload" type="button" title="reload">↻</button>
+        <button id="previewPop" type="button" title="open in a new tab">↗</button>
+        <button id="previewClose" type="button" title="close">✕</button>
+      </div>
+      <iframe class="preview-frame" id="previewFrame" title="preview"></iframe>
+    </div>
+
     <!-- Cmd/Ctrl+K omnibox: search agents by title (instant) then output (tail),
          or spawn a new agent in the highlighted agent's cwd with the typed prompt. -->
     <div class="omni" id="omni" style="display: none">
@@ -2176,6 +2243,15 @@
             started_at: a.startedAt,
           }));
         return {
+          // Marker + raw tunnel access for the P2P preview: only a codehost
+          // (`ch`) source can proxy a local port over its WebRTC DataChannel via
+          // the daemon's `preview` plugin (/__codehost/port/<PORT>/*), so the
+          // viewer's preview traffic stays peer-to-peer, off the edge relay.
+          ch: true,
+          peerId,
+          previewFetch(port, method, path, init) {
+            return chRoom.room.fetch(peerId, method, "/__codehost/port/" + port + path, init || {});
+          },
           async fetchJSON(path) {
             let res;
             try {
@@ -2432,6 +2508,43 @@
       const sources = new Map(); // id -> { id, room, host, kind, tx, client, live, devices, serverCount }
       const srcFor = (e) => (e && sources.get(e._src)) || sources.get(LOCAL) || null;
       const txFor = (e) => srcFor(e)?.tx || localTx;
+
+      // Preview bridge: the Service Worker (which can't own the RTCPeerConnection)
+      // forwards each /w/p/<src>/<port>/* request here; we run it over that
+      // source's codehost tunnel (previewFetch → the daemon's `preview` plugin →
+      // 127.0.0.1:<port>) and stream the response back through the message port.
+      // This keeps the viewer's preview traffic peer-to-peer, off the edge relay.
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.addEventListener("message", (event) => {
+          const msg = event.data;
+          if (!msg || msg.type !== "ay-preview-fetch") return;
+          const port = event.ports[0];
+          const tx = sources.get(msg.src)?.tx;
+          if (!tx || !tx.ch || !tx.previewFetch) {
+            port.postMessage({ type: "error", message: "no P2P preview for this machine" });
+            return;
+          }
+          const init = { headers: msg.headers };
+          if (msg.body) init.body = new Uint8Array(msg.body);
+          tx.previewFetch(msg.port, msg.method, msg.path, init)
+            .then(async (res) => {
+              const headers = {};
+              res.headers.forEach((v, k) => (headers[k] = v));
+              port.postMessage({ type: "head", status: res.status, statusText: res.statusText, headers });
+              if (res.body) {
+                const reader = res.body.getReader();
+                for (;;) {
+                  const { done, value } = await reader.read();
+                  if (done) break;
+                  const buf = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+                  port.postMessage({ type: "body", chunk: buf }, [buf]);
+                }
+              }
+              port.postMessage({ type: "end" });
+            })
+            .catch((err) => port.postMessage({ type: "error", message: String(err) }));
+        });
+      }
       // Every machine belonging to a room (for an ay-share room, the room itself).
       const roomSources = (name) => [...sources.values()].filter((s) => (s.room || s.id) === name);
       const roomLive = (name) =>
@@ -3397,6 +3510,23 @@
           btn.textContent = orig;
         }, 1200);
       }
+      // In-console P2P preview: an iframe served from /w/p/<src>/<port>/, which
+      // the Service Worker proxies over the machine's WebRTC tunnel (no relay).
+      function openPreview(src, port) {
+        // Scope-relative so it works at both /w/ (agent-yes.com) and / (ay serve).
+        const url = new URL("p/" + encodeURIComponent(src) + "/" + port + "/", location.href).pathname;
+        const frame = $("previewFrame");
+        if (!frame) return window.open(url, "_blank");
+        $("previewTitle").textContent = "localhost:" + port;
+        frame.src = url;
+        $("previewOverlay").hidden = false;
+      }
+      function closePreview() {
+        const ov = $("previewOverlay");
+        if (ov) ov.hidden = true;
+        const frame = $("previewFrame");
+        if (frame) frame.src = "about:blank"; // tear down the app + its tunnel
+      }
       async function doExpose() {
         const tx = exposePendingTx || localTx;
         const port = exposePendingPort;
@@ -3435,7 +3565,7 @@
               return;
             }
             if (Array.isArray(arr))
-              for (const ex of arr) rows.push({ ...ex, _srcName: s.name || s.id, _tx: tx });
+              for (const ex of arr) rows.push({ ...ex, _srcName: s.name || s.id, _src: s.id, _tx: tx });
           }),
         );
         list.textContent = "";
@@ -3470,8 +3600,19 @@
         meta.appendChild(host);
         row.appendChild(meta);
 
+        // Preview here: render the app P2P over this machine's WebRTC tunnel
+        // (no edge relay), in an in-console iframe. Only offered for a codehost
+        // (ch) source, which has the `preview` plugin.
+        if (ex._tx && ex._tx.ch) {
+          const preview = document.createElement("button");
+          preview.className = "primary";
+          preview.textContent = "Preview";
+          preview.title = "view in-console over a direct P2P tunnel (no relay)";
+          preview.onclick = () => openPreview(ex._src, ex.port);
+          row.appendChild(preview);
+        }
+
         const openBtn = document.createElement("button");
-        openBtn.className = "primary";
         openBtn.textContent = "Open";
         // Re-mint a fresh claim so the owner (or a guest) gets a usable link.
         openBtn.onclick = async () => {
@@ -3573,6 +3714,15 @@
         $("exposeClose")?.addEventListener("click", closeExposeModal);
         $("exposeModal")?.addEventListener("click", (e) => {
           if (e.target === $("exposeModal")) closeExposeModal();
+        });
+        $("previewClose")?.addEventListener("click", closePreview);
+        $("previewReload")?.addEventListener("click", () => {
+          const f = $("previewFrame");
+          if (f) f.src = f.src;
+        });
+        $("previewPop")?.addEventListener("click", () => {
+          const f = $("previewFrame");
+          if (f && f.src && f.src !== "about:blank") window.open(f.src, "_blank");
         });
       })();
       (function shareModalBoot() {

--- a/lab/ui/sw.js
+++ b/lab/ui/sw.js
@@ -6,7 +6,60 @@
 // fallback when offline, which is what makes the installed app launchable with no
 // network. WebSocket signaling and cross-origin CDN scripts are not GET fetches we
 // own, so they pass straight through.
-const CACHE = "agent-yes-w-v2";
+const CACHE = "agent-yes-w-v3";
+// Preview proxy: <scope>p/<encSrc>/<port>/* renders a machine's local dev
+// server INSIDE the console's existing WebRTC tunnel (peer-to-peer, off the
+// edge relay). We can't own the RTCPeerConnection here, so we forward each
+// request to the controlling page (which does), streaming the response back.
+// Scope-relative so it works at both /w/ (agent-yes.com) and / (ay serve --http).
+const BASE = new URL("./", self.location.href).pathname; // "/w/" or "/"
+const PREVIEW = new RegExp("^" + BASE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "p/([^/]+)/(\\d{1,5})(/.*)?$");
+
+async function pickClient() {
+  const all = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  // Prefer a real console tab (not the preview iframe itself).
+  return all.find((c) => !new URL(c.url).pathname.startsWith(BASE + "p/")) || all[0] || null;
+}
+
+async function proxyPreview(request, src, port, rest) {
+  const client = await pickClient();
+  if (!client) return new Response("open the agent-yes console to preview", { status: 502 });
+  const headers = {};
+  request.headers.forEach((v, k) => (headers[k] = v));
+  const body =
+    request.method === "GET" || request.method === "HEAD"
+      ? undefined
+      : new Uint8Array(await request.arrayBuffer());
+  return new Promise((resolve) => {
+    const mc = new MessageChannel();
+    let resolved = false;
+    mc.port1.onmessage = (ev) => {
+      const msg = ev.data;
+      if (msg.type === "head") {
+        const stream = new ReadableStream({
+          start(controller) {
+            mc.port1.onmessage = (e2) => {
+              const m2 = e2.data;
+              if (m2.type === "body") controller.enqueue(new Uint8Array(m2.chunk));
+              else if (m2.type === "end") controller.close();
+              else if (m2.type === "error") controller.error(new Error(m2.message));
+            };
+          },
+        });
+        resolved = true;
+        resolve(new Response(stream, { status: msg.status, statusText: msg.statusText, headers: msg.headers }));
+      } else if (msg.type === "error" && !resolved) {
+        resolved = true;
+        resolve(new Response("preview tunnel error: " + msg.message, { status: 502 }));
+      }
+    };
+    client.postMessage(
+      { type: "ay-preview-fetch", src, port: Number(port), method: request.method, path: rest, headers, body },
+      [mc.port2, ...(body ? [body.buffer] : [])],
+    );
+  });
+}
+
 const SHELL = [
   "./",
   "./index.html",
@@ -35,23 +88,52 @@ self.addEventListener("activate", (e) => {
 
 self.addEventListener("fetch", (e) => {
   const req = e.request;
-  if (req.method !== "GET") return;
   const url = new URL(req.url);
-  // Only the same-origin /w/ shell; let everything else (CDN, signaling) be.
-  if (url.origin !== self.location.origin || !url.pathname.startsWith("/w/")) return;
-  e.respondWith(
-    (async () => {
-      try {
-        const res = await fetch(req);
-        if (res && res.ok) {
-          const c = await caches.open(CACHE);
-          c.put(req, res.clone());
-        }
-        return res;
-      } catch {
-        const cached = await caches.match(req);
-        return cached || (await caches.match("./index.html")) || Response.error();
-      }
-    })(),
-  );
+  if (url.origin !== self.location.origin) return; // CDN / signaling pass through
+  // Preview proxy (any method): a request is a preview request if its own path
+  // is under <base>p/<src>/<port>/ (the iframe navigation + relative URLs), OR
+  // it comes from a preview-iframe CLIENT (an app's absolute-path subresource
+  // like Vite's /@vite/client — which resolves to the origin root, not our
+  // prefix). Either way we proxy it to that machine's port over the tunnel.
+  const own = PREVIEW.exec(url.pathname);
+  if (own) {
+    const rest = (own[3] || "/") + url.search;
+    e.respondWith(proxyPreview(req, decodeURIComponent(own[1]), own[2], rest));
+    return;
+  }
+  e.respondWith(maybePreviewFromClient(e, req, url));
 });
+
+// If the request came from a preview iframe, proxy it to that iframe's port
+// (appPath = the request's own path); otherwise fall back to the shell handler.
+async function maybePreviewFromClient(e, req, url) {
+  const clientId = e.clientId || e.resultingClientId;
+  if (clientId) {
+    const client = await self.clients.get(clientId).catch(() => null);
+    const cm = client && PREVIEW.exec(new URL(client.url).pathname);
+    if (cm) {
+      return proxyPreview(req, decodeURIComponent(cm[1]), cm[2], url.pathname + url.search);
+    }
+  }
+  return shellFetch(req, url);
+}
+
+async function shellFetch(req, url) {
+  const p = url.pathname;
+  // Pass through non-GET, the API (SSE/POST — never cache), and anything off the
+  // shell. Only cache the static console shell for offline launch.
+  const isApi = p === "/api" || p.startsWith("/api/");
+  if (req.method !== "GET" || isApi || !p.startsWith(BASE)) return fetch(req);
+  // Network-first for the same-origin shell; cache is the offline fallback.
+  try {
+    const res = await fetch(req);
+    if (res && res.ok) {
+      const c = await caches.open(CACHE);
+      c.put(req, res.clone());
+    }
+    return res;
+  } catch {
+    const cached = await caches.match(req);
+    return cached || (await caches.match("./index.html")) || Response.error();
+  }
+}

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2887,6 +2887,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return serveUiFile("e2e.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/qrcode.js")
       return serveUiFile("qrcode.js", "text/javascript; charset=utf-8");
+    // The PWA / preview Service Worker. Without it, --http never registers a SW
+    // (so the in-console P2P preview can't proxy). Served at the console root so
+    // its scope covers /p/<src>/<port>/*.
+    if (req.method === "GET" && p === "/sw.js")
+      return serveUiFile("sw.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/manifest.webmanifest")
       return serveUiFile("manifest.webmanifest", "application/manifest+json");
     if (req.method === "GET" && p === "/icon.svg")


### PR DESCRIPTION
Option **B** from the relay-vs-P2P decision: view an exposed `localhost:<port>` **in the console**, rendered over the machine's existing **codehost WebRTC tunnel** — the viewer's traffic stays peer-to-peer and never touches the agent-yes.com edge relay. Public Open/Copy links keep using the relay (so curl/anyone can reach them).

## How it works

```
preview iframe  ──/p/<src>/<port>/…──▶  Service Worker
                                          └▶ postMessage ─▶ console page (owns the RTC)
                                                              └▶ chRoom.room.fetch → codehost tunnel (P2P)
                                                                   └▶ daemon `preview` plugin → 127.0.0.1:<port>
```

- **`lab/ui/sw.js`** — proxies `<scope>p/<src>/<port>/*` to the controlling page and streams the response back. Absolute-path subresources (Vite's `/@vite/client`, `/src/main.tsx`) resolve to the origin root, so they're attributed to the preview via the **requesting iframe client** — arbitrary dev servers render, not just relative-path apps.
- **`index.html`** — a page↔SW bridge (`ay-preview-fetch` → `chRoom.room.fetch`), a `previewFetch`/`ch` capability on the codehost tx, a **Preview** button in the ports manager (codehost sources only), and a full-window preview overlay with a **⚡ P2P · no relay** badge.
- **`ts/serve.ts`** — serve `/sw.js` (like `rtc.js`; a 401 there meant `ay serve --http` never registered a SW).

Daemon half = codehost's `preview` plugin ([codehost#7](https://github.com/snomiao/codehost/pull/7), merged + live). WebSocket (Vite HMR) is a follow-up (plugins are HTTP-only).

## Verified end-to-end (rech, real browser)

A real Vite app (**otoji**) renders **fully** in the preview iframe over the P2P tunnel: the HTML, `/@vite/client`, `/src/main.tsx`, and all React components load through the codehost DataChannel; `#root` mounts; the app is interactive. No agent-yes.com relay involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)