### PR TITLE
feat(preview): vite HMR WebSocket over the P2P preview tunnel

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2306,6 +2306,10 @@
           previewFetch(port, method, path, init) {
             return chRoom.room.fetch(peerId, method, "/__codehost/port/" + port + path, init || {});
           },
+          // Open a WS to the previewed port over the tunnel (Vite HMR etc.).
+          previewWs(port, path, protocols, handlers) {
+            return chRoom.room.openWs(peerId, "/__codehost/port/" + port + path, protocols, handlers);
+          },
           async fetchJSON(path) {
             let res;
             try {
@@ -2599,6 +2603,98 @@
             .catch((err) => port.postMessage({ type: "error", message: String(err) }));
         });
       }
+
+      // A window.WebSocket replacement, bound to a preview source+port, that
+      // tunnels over the codehost DataChannel (previewWs → the daemon's port WS)
+      // instead of the network. The preview iframe's injected bootstrap installs
+      // it as window.WebSocket so a dev server's HMR socket goes P2P too.
+      // previewWs is async (it dials the peer), so sends before open are queued.
+      window.__ayMakeWS = function (src, port) {
+        return class PreviewWebSocket {
+          static CONNECTING = 0;
+          static OPEN = 1;
+          static CLOSING = 2;
+          static CLOSED = 3;
+          CONNECTING = 0;
+          OPEN = 1;
+          CLOSING = 2;
+          CLOSED = 3;
+          constructor(url, protocols) {
+            this.url = String(url);
+            this.readyState = 0; // CONNECTING
+            this.binaryType = "blob";
+            this.protocol = "";
+            this._listeners = {};
+            this._handle = null;
+            this._queue = [];
+            const tx = sources.get(src)?.tx;
+            const u = new URL(this.url, location.href);
+            const protoList = protocols ? (Array.isArray(protocols) ? protocols : [protocols]) : undefined;
+            if (!tx || !tx.previewWs) return void this._fail();
+            tx.previewWs(port, u.pathname + u.search, protoList, {
+              onOpenAck: (ok, proto) => {
+                if (!ok) return this._fail();
+                this.readyState = 1;
+                this.protocol = proto || "";
+                this._dispatch("open", {});
+                for (const m of this._queue) this._rawSend(m);
+                this._queue = [];
+              },
+              onText: (t) => this._dispatch("message", { data: t }),
+              onBin: (d) => this._dispatch("message", { data: this._wrap(d) }),
+              onClose: (code, reason) => {
+                this.readyState = 3;
+                this._dispatch("close", { code, reason, wasClean: code === 1000 });
+              },
+            })
+              .then((h) => {
+                this._handle = h;
+                if (this.readyState === 3 && this._closeReq) h.close(this._closeReq.code, this._closeReq.reason);
+              })
+              .catch(() => this._fail());
+          }
+          _wrap(d) {
+            return this.binaryType === "arraybuffer"
+              ? d.buffer.slice(d.byteOffset, d.byteOffset + d.byteLength)
+              : new Blob([d]);
+          }
+          _rawSend(data) {
+            const h = this._handle;
+            if (!h) return;
+            if (typeof data === "string") h.sendText(data);
+            else if (data instanceof Blob) data.arrayBuffer().then((b) => h.sendBin(new Uint8Array(b)));
+            else if (ArrayBuffer.isView(data)) h.sendBin(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+            else h.sendBin(new Uint8Array(data));
+          }
+          send(data) {
+            if (this.readyState === 0) this._queue.push(data);
+            else if (this.readyState === 1) this._rawSend(data);
+          }
+          close(code, reason) {
+            if (this.readyState === 3) return;
+            this.readyState = 3;
+            if (this._handle) this._handle.close(code, reason);
+            else this._closeReq = { code, reason };
+            this._dispatch("close", { code: code || 1000, reason: reason || "", wasClean: true });
+          }
+          _fail() {
+            this.readyState = 3;
+            this._dispatch("error", {});
+            this._dispatch("close", { code: 1006, reason: "tunnel open failed", wasClean: false });
+          }
+          addEventListener(t, l) {
+            (this._listeners[t] = this._listeners[t] || new Set()).add(l);
+          }
+          removeEventListener(t, l) {
+            this._listeners[t]?.delete(l);
+          }
+          _dispatch(t, init) {
+            const ev = { type: t, target: this, ...init };
+            this["on" + t]?.call(this, ev);
+            this._listeners[t]?.forEach((l) => l.call(this, ev));
+          }
+        };
+      };
       // Every machine belonging to a room (for an ay-share room, the room itself).
       const roomSources = (name) => [...sources.values()].filter((s) => (s.room || s.id) === name);
       const roomLive = (name) =>

--- a/lab/ui/room-client.js
+++ b/lab/ui/room-client.js
@@ -1,210 +1,258 @@
-function k() {
+// src/shared/signaling.ts
+var CLIENT_WIRE_ROLE = "viewer";
+function newPeerId() {
   return crypto.randomUUID();
 }
-var g = 60000,
-  u = 1e4,
-  L = 1000,
-  b = 120000,
-  O = 25000;
-class j {
+
+// src/shared/signaling-client.ts
+var STABLE_MS = 60000;
+var CONNECT_TIMEOUT_MS = 1e4;
+var RECONNECT_MIN_MS = 1000;
+var RECONNECT_MAX_MS = 120000;
+var HEARTBEAT_MS = 25000;
+
+class SignalingClient {
   opts;
   peerId;
   ws = null;
-  closed = !1;
-  reconnectDelay = L;
+  closed = false;
+  reconnectDelay = RECONNECT_MIN_MS;
   reconnectTimer = null;
-  dormant = !1;
+  dormant = false;
   heartbeat = null;
   stableTimer = null;
   openedAt = 0;
-  constructor(z) {
-    this.opts = z;
-    this.peerId = z.peerId ?? k();
+  constructor(opts) {
+    this.opts = opts;
+    this.peerId = opts.peerId ?? newPeerId();
   }
   connect() {
-    ((this.closed = !1), this.attachWakeListeners(), this.open());
+    this.closed = false;
+    this.attachWakeListeners();
+    this.open();
   }
   onWake = () => {
-    if (this.closed) return;
-    let z = this.ws?.readyState;
-    if (z === 1) return;
-    if (z === 0) {
+    if (this.closed)
+      return;
+    const state = this.ws?.readyState;
+    if (state === 1)
+      return;
+    if (state === 0) {
       try {
         this.ws?.close();
       } catch {}
       return;
     }
-    if (this.dormant || this.reconnectTimer != null)
-      ((this.dormant = !1), this.clearReconnectTimer(), this.open());
+    if (this.dormant || this.reconnectTimer != null) {
+      this.dormant = false;
+      this.clearReconnectTimer();
+      this.open();
+    }
   };
   hidden() {
-    return globalThis.document?.visibilityState === "hidden";
+    const doc = globalThis.document;
+    return doc?.visibilityState === "hidden";
   }
   attachWakeListeners() {
-    globalThis.document?.addEventListener("visibilitychange", this.onWake);
-    let Q = globalThis.window;
-    (Q?.addEventListener("focus", this.onWake), Q?.addEventListener("online", this.onWake));
+    const doc = globalThis.document;
+    doc?.addEventListener("visibilitychange", this.onWake);
+    const win = globalThis.window;
+    win?.addEventListener("focus", this.onWake);
+    win?.addEventListener("online", this.onWake);
   }
   detachWakeListeners() {
-    globalThis.document?.removeEventListener("visibilitychange", this.onWake);
-    let Q = globalThis.window;
-    (Q?.removeEventListener("focus", this.onWake), Q?.removeEventListener("online", this.onWake));
+    const doc = globalThis.document;
+    doc?.removeEventListener("visibilitychange", this.onWake);
+    const win = globalThis.window;
+    win?.removeEventListener("focus", this.onWake);
+    win?.removeEventListener("online", this.onWake);
   }
   roomUrl() {
-    return `${this.opts.url.replace(/\/+$/, "")}/room/${encodeURIComponent(this.opts.token)}`;
+    const base = this.opts.url.replace(/\/+$/, "");
+    return `${base}/room/${encodeURIComponent(this.opts.token)}`;
   }
   open() {
-    let z = new WebSocket(this.roomUrl());
-    this.ws = z;
-    let Q = setTimeout(() => {
-      if (z.readyState === 0)
+    const ws = new WebSocket(this.roomUrl());
+    this.ws = ws;
+    const connectTimer = setTimeout(() => {
+      if (ws.readyState === 0) {
         try {
-          z.close();
+          ws.close();
         } catch {}
-    }, u);
-    ((z.onopen = () => {
-      (clearTimeout(Q),
-        (this.openedAt = Date.now()),
-        this.clearStableTimer(),
-        (this.stableTimer = setTimeout(() => {
-          this.reconnectDelay = L;
-        }, g)));
-      let Y = {
+      }
+    }, CONNECT_TIMEOUT_MS);
+    ws.onopen = () => {
+      clearTimeout(connectTimer);
+      this.openedAt = Date.now();
+      this.clearStableTimer();
+      this.stableTimer = setTimeout(() => {
+        this.reconnectDelay = RECONNECT_MIN_MS;
+      }, STABLE_MS);
+      const hello = {
         type: "hello",
         role: this.opts.role,
         peerId: this.peerId,
-        ...(this.opts.meta ? { meta: this.opts.meta } : {}),
+        ...this.opts.meta ? { meta: this.opts.meta } : {}
       };
-      (z.send(JSON.stringify(Y)), this.startHeartbeat(), this.opts.onOpen?.());
-    }),
-      (z.onmessage = (Y) => {
-        let Z;
-        try {
-          Z = JSON.parse(String(Y.data));
-        } catch {
-          return;
-        }
-        if (Z.type === "peers") this.opts.onPeers?.(Z.peers);
-        else if (Z.type === "signal") this.opts.onSignal?.(Z.from, Z.data);
-      }),
-      (z.onclose = (Y) => {
-        (clearTimeout(Q), this.clearStableTimer(), this.stopHeartbeat());
-        let Z = this.openedAt ? Date.now() - this.openedAt : 0;
-        if (
-          ((this.openedAt = 0),
-          this.opts.onClose?.({ code: Y?.code ?? 0, reason: Y?.reason ?? "", ms: Z }),
-          !this.closed)
-        )
-          this.scheduleReconnect();
-      }),
-      (z.onerror = () => {
-        try {
-          z.close();
-        } catch {}
-      }));
+      ws.send(JSON.stringify(hello));
+      this.startHeartbeat();
+      this.opts.onOpen?.();
+    };
+    ws.onmessage = (ev) => {
+      let msg;
+      try {
+        msg = JSON.parse(String(ev.data));
+      } catch {
+        return;
+      }
+      if (msg.type === "peers")
+        this.opts.onPeers?.(msg.peers, msg.now);
+      else if (msg.type === "signal")
+        this.opts.onSignal?.(msg.from, msg.data);
+    };
+    ws.onclose = (ev) => {
+      clearTimeout(connectTimer);
+      this.clearStableTimer();
+      this.stopHeartbeat();
+      const ms = this.openedAt ? Date.now() - this.openedAt : 0;
+      this.openedAt = 0;
+      this.opts.onClose?.({ code: ev?.code ?? 0, reason: ev?.reason ?? "", ms });
+      if (!this.closed)
+        this.scheduleReconnect();
+    };
+    ws.onerror = () => {
+      try {
+        ws.close();
+      } catch {}
+    };
   }
   startHeartbeat() {
-    (this.stopHeartbeat(),
-      (this.heartbeat = setInterval(() => {
-        try {
-          this.ws?.send(JSON.stringify({ type: "ping" }));
-        } catch {}
-      }, O)));
+    this.stopHeartbeat();
+    this.heartbeat = setInterval(() => {
+      try {
+        this.ws?.send(JSON.stringify({ type: "ping" }));
+      } catch {}
+    }, HEARTBEAT_MS);
   }
   stopHeartbeat() {
-    if (this.heartbeat != null) (clearInterval(this.heartbeat), (this.heartbeat = null));
+    if (this.heartbeat != null) {
+      clearInterval(this.heartbeat);
+      this.heartbeat = null;
+    }
   }
   clearStableTimer() {
-    if (this.stableTimer != null) (clearTimeout(this.stableTimer), (this.stableTimer = null));
+    if (this.stableTimer != null) {
+      clearTimeout(this.stableTimer);
+      this.stableTimer = null;
+    }
   }
   scheduleReconnect() {
     if (this.hidden()) {
-      this.dormant = !0;
+      this.dormant = true;
       return;
     }
-    let z = Math.round(this.reconnectDelay * (0.75 + Math.random() * 0.5));
-    ((this.reconnectDelay = Math.min(this.reconnectDelay * 2, b)),
-      this.clearReconnectTimer(),
-      (this.reconnectTimer = setTimeout(() => {
-        if (((this.reconnectTimer = null), this.closed)) return;
-        if (this.hidden()) {
-          this.dormant = !0;
-          return;
-        }
-        this.open();
-      }, z)));
+    const delay = Math.round(this.reconnectDelay * (0.75 + Math.random() * 0.5));
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, RECONNECT_MAX_MS);
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed)
+        return;
+      if (this.hidden()) {
+        this.dormant = true;
+        return;
+      }
+      this.open();
+    }, delay);
   }
   clearReconnectTimer() {
-    if (this.reconnectTimer != null)
-      (clearTimeout(this.reconnectTimer), (this.reconnectTimer = null));
+    if (this.reconnectTimer != null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
   }
-  sendSignal(z, Q) {
-    let Y = { type: "signal", to: z, data: Q };
-    this.ws?.send(JSON.stringify(Y));
+  sendSignal(to, data) {
+    const msg = { type: "signal", to, data };
+    this.ws?.send(JSON.stringify(msg));
   }
-  updateMeta(z) {
-    if (((this.opts.meta = z), this.ws?.readyState === 1)) {
-      let Q = { type: "meta", meta: z };
-      this.ws.send(JSON.stringify(Q));
+  updateMeta(meta) {
+    this.opts.meta = meta;
+    if (this.ws?.readyState === 1) {
+      const msg = { type: "meta", meta };
+      this.ws.send(JSON.stringify(msg));
     }
   }
   close() {
-    ((this.closed = !0),
-      (this.dormant = !1),
-      this.detachWakeListeners(),
-      this.clearReconnectTimer(),
-      this.stopHeartbeat(),
-      this.clearStableTimer());
+    this.closed = true;
+    this.dormant = false;
+    this.detachWakeListeners();
+    this.clearReconnectTimer();
+    this.stopHeartbeat();
+    this.clearStableTimer();
     try {
       this.ws?.close();
     } catch {}
   }
 }
-var A = ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
-  N = "codehost",
-  _ = "codehost-bulk";
-class B {
+
+// src/shared/rtc.ts
+var ICE_SERVERS = [
+  "stun:stun.l.google.com:19302",
+  "stun:stun1.l.google.com:19302"
+];
+var CHANNEL_LABEL = "codehost";
+var BULK_CHANNEL_LABEL = "codehost-bulk";
+
+// src/web/rtc-client.ts
+class RtcClient {
   opts;
   pc;
   channel = null;
   bulk = null;
-  constructor(z) {
-    this.opts = z;
-    ((this.pc = new RTCPeerConnection({ iceServers: A.map((Q) => ({ urls: Q })) })),
-      (this.pc.onicecandidate = (Q) => {
-        if (Q.candidate)
-          this.opts.sendSignal({
-            kind: "candidate",
-            candidate: Q.candidate.candidate,
-            mid: Q.candidate.sdpMid ?? "0",
-          });
-      }),
-      (this.pc.onconnectionstatechange = () => {
-        this.opts.onState?.(this.pc.connectionState);
-      }));
+  constructor(opts) {
+    this.opts = opts;
+    this.pc = new RTCPeerConnection({
+      iceServers: ICE_SERVERS.map((urls) => ({ urls }))
+    });
+    this.pc.onicecandidate = (ev) => {
+      if (ev.candidate) {
+        this.opts.sendSignal({
+          kind: "candidate",
+          candidate: ev.candidate.candidate,
+          mid: ev.candidate.sdpMid ?? "0"
+        });
+      }
+    };
+    this.pc.onconnectionstatechange = () => {
+      this.opts.onState?.(this.pc.connectionState);
+    };
   }
   async start() {
-    let z = this.pc.createDataChannel(N, { ordered: !0 });
-    ((z.binaryType = "arraybuffer"),
-      (this.channel = z),
-      (z.onopen = () => this.opts.onOpen?.(z)),
-      (z.onclose = () => this.opts.onClose?.()));
-    let Q = this.pc.createDataChannel(_, { ordered: !0 });
-    ((Q.binaryType = "arraybuffer"), (this.bulk = Q));
-    let Y = await this.pc.createOffer();
-    (await this.pc.setLocalDescription(Y),
-      this.opts.sendSignal({ kind: "offer", type: "offer", sdp: Y.sdp ?? "" }));
+    const channel = this.pc.createDataChannel(CHANNEL_LABEL, { ordered: true });
+    channel.binaryType = "arraybuffer";
+    this.channel = channel;
+    channel.onopen = () => this.opts.onOpen?.(channel);
+    channel.onclose = () => this.opts.onClose?.();
+    const bulk = this.pc.createDataChannel(BULK_CHANNEL_LABEL, { ordered: true });
+    bulk.binaryType = "arraybuffer";
+    this.bulk = bulk;
+    const offer = await this.pc.createOffer();
+    await this.pc.setLocalDescription(offer);
+    this.opts.sendSignal({ kind: "offer", type: "offer", sdp: offer.sdp ?? "" });
   }
-  async handleSignal(z) {
-    let Q = z;
-    if (!Q || typeof Q !== "object") return;
-    if (Q.kind === "answer") await this.pc.setRemoteDescription({ type: "answer", sdp: Q.sdp });
-    else if (Q.kind === "candidate")
+  async handleSignal(data) {
+    const sig = data;
+    if (!sig || typeof sig !== "object")
+      return;
+    if (sig.kind === "answer") {
+      await this.pc.setRemoteDescription({ type: "answer", sdp: sig.sdp });
+    } else if (sig.kind === "candidate") {
       try {
-        await this.pc.addIceCandidate({ candidate: Q.candidate, sdpMid: Q.mid });
-      } catch (Y) {
-        console.error("[rtc] addIceCandidate failed:", Y);
+        await this.pc.addIceCandidate({ candidate: sig.candidate, sdpMid: sig.mid });
+      } catch (err) {
+        console.error("[rtc] addIceCandidate failed:", err);
       }
+    }
   }
   get dataChannel() {
     return this.channel;
@@ -214,35 +262,33 @@ class B {
   }
   async selectedPath() {
     try {
-      let z = await this.pc.getStats(),
-        Q = null;
-      z.forEach((q) => {
-        if (q.type === "transport" && q.selectedCandidatePairId) Q = q.selectedCandidatePairId;
+      const stats = await this.pc.getStats();
+      let pairId = null;
+      stats.forEach((s) => {
+        if (s.type === "transport" && s.selectedCandidatePairId)
+          pairId = s.selectedCandidatePairId;
       });
-      let Y = null;
-      if (
-        (z.forEach((q) => {
-          if (
-            Q ? q.id === Q : q.type === "candidate-pair" && q.state === "succeeded" && q.nominated
-          )
-            Y = q;
-        }),
-        !Y)
-      )
+      let pair = null;
+      stats.forEach((s) => {
+        if (pairId ? s.id === pairId : s.type === "candidate-pair" && s.state === "succeeded" && s.nominated) {
+          pair = s;
+        }
+      });
+      if (!pair)
         return null;
-      let { localCandidateId: Z, remoteCandidateId: $ } = Y,
-        G = !0,
-        V = 0;
-      if (
-        (z.forEach((q) => {
-          if (q.id === Z || q.id === $) {
-            if ((V++, q.candidateType !== "host")) G = !1;
-          }
-        }),
-        V < 2)
-      )
+      const { localCandidateId, remoteCandidateId } = pair;
+      let lan = true;
+      let found = 0;
+      stats.forEach((s) => {
+        if (s.id === localCandidateId || s.id === remoteCandidateId) {
+          found++;
+          if (s.candidateType !== "host")
+            lan = false;
+        }
+      });
+      if (found < 2)
         return null;
-      return G ? "lan" : "p2p";
+      return lan ? "lan" : "p2p";
     } catch {
       return null;
     }
@@ -259,280 +305,390 @@ class B {
     } catch {}
   }
 }
-var y = new TextEncoder(),
-  S = new TextDecoder();
-function P(z, Q, Y) {
-  let Z = Y?.byteLength ?? 0,
-    $ = new Uint8Array(5 + Z);
-  if ((($[0] = z), new DataView($.buffer).setUint32(1, Q >>> 0, !1), Y && Z)) $.set(Y, 5);
-  return $;
+
+// src/tunnel/protocol.ts
+var FRAME_HEADER = 5;
+var MAX_FRAME = 64 * 1024;
+var MAX_CHUNK = MAX_FRAME - FRAME_HEADER;
+var enc = new TextEncoder;
+var dec = new TextDecoder;
+function encodeFrame(op, streamId, payload) {
+  const len = payload?.byteLength ?? 0;
+  const buf = new Uint8Array(5 + len);
+  buf[0] = op;
+  new DataView(buf.buffer).setUint32(1, streamId >>> 0, false);
+  if (payload && len)
+    buf.set(payload, 5);
+  return buf;
 }
-function J(z, Q, Y) {
-  return P(z, Q, y.encode(JSON.stringify(Y)));
+function encodeJson(op, streamId, obj) {
+  return encodeFrame(op, streamId, enc.encode(JSON.stringify(obj)));
 }
-function T(z) {
-  let Q = z instanceof Uint8Array ? z : new Uint8Array(z),
-    Y = Q[0],
-    Z = new DataView(Q.buffer, Q.byteOffset, Q.byteLength).getUint32(1, !1),
-    $ = Q.subarray(5);
-  return { op: Y, streamId: Z, payload: $ };
+function decodeFrame(data) {
+  const u8 = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const op = u8[0];
+  const streamId = new DataView(u8.buffer, u8.byteOffset, u8.byteLength).getUint32(1, false);
+  const payload = u8.subarray(5);
+  return { op, streamId, payload };
 }
-function U(z) {
-  return JSON.parse(S.decode(z));
+function payloadJson(payload) {
+  return JSON.parse(dec.decode(payload));
 }
-function E(z) {
-  return S.decode(z);
+function payloadText(payload) {
+  return dec.decode(payload);
 }
-function* C(z) {
-  for (let Q = 0; Q < z.byteLength; Q += 65531) yield z.slice(Q, Math.min(Q + 65531, z.byteLength));
-}
-function f(z) {
-  if (z.length === 1) return z[0];
-  let Q = z.reduce(($, G) => $ + G.byteLength, 0),
-    Y = new Uint8Array(Q),
-    Z = 0;
-  for (let $ of z) (Y.set($, Z), (Z += $.byteLength));
-  return Y;
-}
-function* H(z, Q, Y) {
-  let Z = 0;
-  while (Y.byteLength - Z > 65531) (yield P(13, Q, Y.subarray(Z, Z + 65531)), (Z += 65531));
-  yield P(z, Q, Y.subarray(Z));
-}
-class F {
-  pending = new Map();
-  cont(z, Q) {
-    let Y = this.pending.get(z);
-    if (Y) Y.push(Q.slice());
-    else this.pending.set(z, [Q.slice()]);
-  }
-  finish(z, Q) {
-    let Y = this.pending.get(z);
-    if (!Y) return Q;
-    return (this.pending.delete(z), Y.push(Q), f(Y));
-  }
-  drop(z) {
-    this.pending.delete(z);
+function* chunk(body) {
+  for (let off = 0;off < body.byteLength; off += MAX_CHUNK) {
+    yield body.slice(off, Math.min(off + MAX_CHUNK, body.byteLength));
   }
 }
-class R {
-  channel;
+function concatBytes(parts) {
+  if (parts.length === 1)
+    return parts[0];
+  const total = parts.reduce((n, p) => n + p.byteLength, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.byteLength;
+  }
+  return out;
+}
+function* wsMessageFrames(terminal, streamId, payload) {
+  let off = 0;
+  while (payload.byteLength - off > MAX_CHUNK) {
+    yield encodeFrame(13 /* WsCont */, streamId, payload.subarray(off, off + MAX_CHUNK));
+    off += MAX_CHUNK;
+  }
+  yield encodeFrame(terminal, streamId, payload.subarray(off));
+}
+
+class WsReassembler {
+  pending = new Map;
+  cont(streamId, payload) {
+    const buf = this.pending.get(streamId);
+    if (buf)
+      buf.push(payload.slice());
+    else
+      this.pending.set(streamId, [payload.slice()]);
+  }
+  finish(streamId, payload) {
+    const buf = this.pending.get(streamId);
+    if (!buf)
+      return payload;
+    this.pending.delete(streamId);
+    buf.push(payload);
+    return concatBytes(buf);
+  }
+  drop(streamId) {
+    this.pending.delete(streamId);
+  }
+}
+
+// src/tunnel/client.ts
+class TunnelClient {
+  transport;
   bulk;
   nextStreamId = 1;
-  https = new Map();
-  wss = new Map();
-  wsRx = new F();
-  textEncoder = new TextEncoder();
-  constructor(z, Q = null) {
-    this.channel = z;
-    this.bulk = Q;
-    if (
-      ((z.binaryType = "arraybuffer"),
-      z.addEventListener("message", (Y) => this.onFrame(Y.data)),
-      Q)
-    )
-      ((Q.binaryType = "arraybuffer"), Q.addEventListener("message", (Y) => this.onFrame(Y.data)));
+  https = new Map;
+  httpLane = new Map;
+  wss = new Map;
+  wsRx = new WsReassembler;
+  textEncoder = new TextEncoder;
+  constructor(transport, bulk = null) {
+    this.transport = transport;
+    this.bulk = bulk;
+    transport.onFrame((data) => this.onFrame(data));
+    bulk?.onFrame((data) => this.onFrame(data));
+    transport.onClose(() => this.failLane(transport, true));
+    bulk?.onClose(() => this.failLane(bulk, false));
+  }
+  failLane(lane, interactive) {
+    for (const [streamId, waiter] of [...this.https]) {
+      if ((this.httpLane.get(streamId) ?? this.transport) !== lane)
+        continue;
+      this.https.delete(streamId);
+      this.httpLane.delete(streamId);
+      waiter.onError("tunnel closed");
+    }
+    if (interactive) {
+      for (const [streamId, handlers] of [...this.wss]) {
+        this.wss.delete(streamId);
+        this.wsRx.drop(streamId);
+        handlers.onClose(1006, "tunnel closed");
+      }
+    }
   }
   allocId() {
-    let z = this.nextStreamId;
-    return ((this.nextStreamId = (this.nextStreamId + 1) >>> 0 || 1), z);
+    const id = this.nextStreamId;
+    this.nextStreamId = this.nextStreamId + 1 >>> 0 || 1;
+    return id;
   }
-  onFrame(z) {
-    if (typeof z === "string") return;
-    let { op: Q, streamId: Y, payload: Z } = T(z);
-    switch (Q) {
-      case 4:
-        this.https.get(Y)?.onHead(U(Z));
+  onFrame(data) {
+    const { op, streamId, payload } = decodeFrame(data);
+    switch (op) {
+      case 4 /* HttpResHead */:
+        this.https.get(streamId)?.onHead(payloadJson(payload));
         break;
-      case 5:
-        this.https.get(Y)?.onBody(Z.slice());
+      case 5 /* HttpResBody */:
+        this.https.get(streamId)?.onBody(payload.slice());
         break;
-      case 6:
-        (this.https.get(Y)?.onEnd(), this.https.delete(Y));
+      case 6 /* HttpResEnd */:
+        this.https.get(streamId)?.onEnd();
+        this.https.delete(streamId);
+        this.httpLane.delete(streamId);
         break;
-      case 12: {
-        let $ = this.https.get(Y);
-        if ($) ($.onError(U(Z).message), this.https.delete(Y));
+      case 12 /* Error */: {
+        const waiter = this.https.get(streamId);
+        if (waiter) {
+          waiter.onError(payloadJson(payload).message);
+          this.https.delete(streamId);
+          this.httpLane.delete(streamId);
+        }
         break;
       }
-      case 8: {
-        let $ = U(Z);
-        this.wss.get(Y)?.onOpenAck($.ok, $.protocol);
+      case 8 /* WsOpenAck */: {
+        const info = payloadJson(payload);
+        this.wss.get(streamId)?.onOpenAck(info.ok, info.protocol);
         break;
       }
-      case 13:
-        this.wsRx.cont(Y, Z);
+      case 13 /* WsCont */:
+        this.wsRx.cont(streamId, payload);
         break;
-      case 9:
-        this.wss.get(Y)?.onText(E(this.wsRx.finish(Y, Z)));
+      case 9 /* WsText */:
+        this.wss.get(streamId)?.onText(payloadText(this.wsRx.finish(streamId, payload)));
         break;
-      case 10:
-        this.wss.get(Y)?.onBin(this.wsRx.finish(Y, Z).slice());
+      case 10 /* WsBin */:
+        this.wss.get(streamId)?.onBin(this.wsRx.finish(streamId, payload).slice());
         break;
-      case 11: {
-        let $ = U(Z);
-        (this.wsRx.drop(Y),
-          this.wss.get(Y)?.onClose($.code ?? 1000, $.reason ?? ""),
-          this.wss.delete(Y));
+      case 11 /* WsClose */: {
+        const info = payloadJson(payload);
+        this.wsRx.drop(streamId);
+        this.wss.get(streamId)?.onClose(info.code ?? 1000, info.reason ?? "");
+        this.wss.delete(streamId);
         break;
       }
     }
   }
-  fetch(z, Q, Y, Z) {
-    let $ = this.allocId();
-    return new Promise((G, V) => {
-      let q = null,
-        D = null,
-        X = new ReadableStream({
-          start: (K) => {
-            D = K;
-          },
-        }),
-        v = typeof DecompressionStream < "u" ? { ...Y, "x-codehost-accept-gzip": "1" } : Y;
-      this.https.set($, {
-        onHead: (K) => {
-          q = K;
-          let x = new Headers(K.headers),
-            M = X;
-          if (x.get("content-encoding") === "gzip")
-            ((M = X.pipeThrough(new DecompressionStream("gzip"))),
-              x.delete("content-encoding"),
-              x.delete("content-length"));
-          G(
-            new Response(M, {
-              status: K.status === 204 || K.status === 304 ? K.status : K.status,
-              statusText: K.statusText,
-              headers: x,
-            }),
-          );
+  fetch(method, path, headers, body) {
+    const streamId = this.allocId();
+    return new Promise((resolve, reject) => {
+      let head = null;
+      let controller = null;
+      const stream = new ReadableStream({
+        start: (c) => {
+          controller = c;
+        }
+      });
+      const reqHeaders = typeof DecompressionStream !== "undefined" ? { ...headers, "x-codehost-accept-gzip": "1" } : headers;
+      this.https.set(streamId, {
+        onHead: (h) => {
+          head = h;
+          const resHeaders = new Headers(h.headers);
+          let bodyStream = stream;
+          if (resHeaders.get("content-encoding") === "gzip") {
+            bodyStream = stream.pipeThrough(new DecompressionStream("gzip"));
+            resHeaders.delete("content-encoding");
+            resHeaders.delete("content-length");
+          }
+          resolve(new Response(bodyStream, {
+            status: h.status === 204 || h.status === 304 ? h.status : h.status,
+            statusText: h.statusText,
+            headers: resHeaders
+          }));
         },
-        onBody: (K) => {
+        onBody: (b) => {
           try {
-            D?.enqueue(K);
+            controller?.enqueue(b);
           } catch {}
         },
         onEnd: () => {
           try {
-            D?.close();
+            controller?.close();
           } catch {}
-          if (!q) V(Error("stream ended before head"));
+          if (!head)
+            reject(new Error("stream ended before head"));
         },
-        onError: (K) => {
+        onError: (msg) => {
           try {
-            D?.error(Error(K));
+            controller?.error(new Error(msg));
           } catch {}
-          if (!q) V(Error(K));
-        },
+          if (!head)
+            reject(new Error(msg));
+        }
       });
-      let W = this.bulk?.readyState === "open" ? this.bulk : this.channel;
-      if ((this.sendOn(W, J(1, $, { method: z, path: Q, headers: v })), Z && Z.byteLength))
-        for (let K of C(Z)) this.sendOn(W, P(2, $, K));
-      this.sendOn(W, P(3, $));
+      const lane = this.bulk?.isOpen() ? this.bulk : this.transport;
+      this.httpLane.set(streamId, lane);
+      this.sendOn(lane, encodeJson(1 /* HttpReq */, streamId, { method, path, headers: reqHeaders }));
+      if (body && body.byteLength) {
+        for (const part of chunk(body))
+          this.sendOn(lane, encodeFrame(2 /* HttpReqBody */, streamId, part));
+      }
+      this.sendOn(lane, encodeFrame(3 /* HttpReqEnd */, streamId));
     });
   }
-  openWs(z, Q, Y) {
-    let Z = this.allocId();
-    return (
-      this.wss.set(Z, Y),
-      this.send(J(7, Z, { path: z, protocols: Q })),
-      {
-        sendText: ($) => {
-          for (let G of H(9, Z, this.textEncoder.encode($))) this.send(G);
-        },
-        sendBin: ($) => {
-          for (let G of H(10, Z, $)) this.send(G);
-        },
-        close: ($, G) => {
-          (this.send(J(11, Z, { code: $, reason: G })), this.wss.delete(Z));
-        },
+  openWs(path, protocols, handlers) {
+    const streamId = this.allocId();
+    this.wss.set(streamId, handlers);
+    this.send(encodeJson(7 /* WsOpen */, streamId, { path, protocols }));
+    return {
+      sendText: (text) => {
+        for (const f of wsMessageFrames(9 /* WsText */, streamId, this.textEncoder.encode(text)))
+          this.send(f);
+      },
+      sendBin: (data) => {
+        for (const f of wsMessageFrames(10 /* WsBin */, streamId, data))
+          this.send(f);
+      },
+      close: (code, reason) => {
+        this.send(encodeJson(11 /* WsClose */, streamId, { code, reason }));
+        this.wss.delete(streamId);
       }
-    );
+    };
   }
-  send(z) {
-    this.sendOn(this.channel, z);
+  send(frame) {
+    this.sendOn(this.transport, frame);
   }
-  sendOn(z, Q) {
-    if (z.readyState === "open") {
-      let Y = new Uint8Array(Q.byteLength);
-      (Y.set(Q), z.send(Y.buffer));
-    }
+  sendOn(t, frame) {
+    if (t.isOpen())
+      t.send(frame);
   }
   get ready() {
-    return this.channel.readyState === "open";
+    return this.transport.isOpen();
   }
 }
-var I = "wss://signal.codehost.dev",
-  h = 1e4;
-class w {
+
+// src/tunnel/rtc-datachannel.ts
+function rtcDataChannelTransport(channel) {
+  channel.binaryType = "arraybuffer";
+  return {
+    send(frame) {
+      const copy = new Uint8Array(frame.byteLength);
+      copy.set(frame);
+      channel.send(copy.buffer);
+    },
+    isOpen: () => channel.readyState === "open",
+    bufferedAmount: () => channel.bufferedAmount,
+    setBufferedAmountLow(bytes, cb) {
+      channel.bufferedAmountLowThreshold = bytes;
+      channel.addEventListener("bufferedamountlow", cb);
+    },
+    onFrame(cb) {
+      channel.addEventListener("message", (ev) => {
+        if (typeof ev.data === "string")
+          return;
+        cb(new Uint8Array(ev.data));
+      });
+    },
+    onClose(cb) {
+      channel.addEventListener("close", cb);
+    }
+  };
+}
+
+// src/web/tunnel-client.ts
+class TunnelClient2 extends TunnelClient {
+  constructor(channel, bulk = null) {
+    super(rtcDataChannelTransport(channel), bulk ? rtcDataChannelTransport(bulk) : null);
+  }
+}
+
+// src/web/room-client.ts
+var DEFAULT_SIGNAL_URL = "wss://signal.codehost.dev";
+var DIAL_FAIL_COOLDOWN_MS = 1e4;
+
+class CodehostRoom {
   peers = [];
   signaling;
-  rtcs = new Map();
-  tunnels = new Map();
-  dialFailedAt = new Map();
-  closed = !1;
-  constructor(z) {
-    ((this.signaling = new j({
-      url: z.signalUrl ?? I,
-      token: z.token,
-      role: "viewer",
-      onOpen: () => z.onStatus?.(!0),
-      onClose: () => z.onStatus?.(!1),
-      onPeers: (Q) => {
-        ((this.peers = Q.filter((Y) => Y.role === "server")), z.onPeers?.(this.peers));
+  rtcs = new Map;
+  tunnels = new Map;
+  dialFailedAt = new Map;
+  closed = false;
+  constructor(opts) {
+    this.signaling = new SignalingClient({
+      url: opts.signalUrl ?? DEFAULT_SIGNAL_URL,
+      token: opts.token,
+      role: CLIENT_WIRE_ROLE,
+      onOpen: () => opts.onStatus?.(true),
+      onClose: () => opts.onStatus?.(false),
+      onPeers: (peers) => {
+        this.peers = peers.filter((p) => p.role === "server");
+        opts.onPeers?.(this.peers);
       },
-      onSignal: (Q, Y) => void this.rtcs.get(Q)?.handleSignal(Y),
-    })),
-      this.signaling.connect());
+      onSignal: (from, data) => void this.rtcs.get(from)?.handleSignal(data)
+    });
+    this.signaling.connect();
   }
-  async fetch(z, Q, Y, Z = {}) {
-    let $ = await this.dial(z),
-      G = typeof Z.body === "string" ? new TextEncoder().encode(Z.body) : Z.body;
-    return $.fetch(Q, Y, Z.headers ?? {}, G);
+  async fetch(peerId, method, path, init = {}) {
+    const tunnel = await this.dial(peerId);
+    const body = typeof init.body === "string" ? new TextEncoder().encode(init.body) : init.body;
+    return tunnel.fetch(method, path, init.headers ?? {}, body);
   }
-  dial(z) {
-    let Q = this.tunnels.get(z);
-    if (Q) return Q;
-    let Y = this.dialFailedAt.get(z);
-    if (Y != null && Date.now() - Y < h)
-      return Promise.reject(Error("dial failed recently; cooling down"));
-    let Z = () => {
-        (this.tunnels.delete(z), this.rtcs.get(z)?.close(), this.rtcs.delete(z));
-      },
-      $ = new Promise((G, V) => {
-        let q = setTimeout(() => {
-            (Z(), V(Error("dial timed out")));
-          }, 15000),
-          D = new B({
-            sendSignal: (X) => this.signaling.sendSignal(z, X),
-            onOpen: (X) => {
-              (clearTimeout(q), this.dialFailedAt.delete(z), G(new R(X, D.bulkChannel)));
-            },
-            onClose: Z,
-            onState: (X) => {
-              if (X === "failed" || X === "disconnected") Z();
-            },
-          });
-        (this.rtcs.set(z, D),
-          D.start().catch((X) => {
-            (clearTimeout(q), Z(), V(X));
-          }));
+  async openWs(peerId, path, protocols, handlers) {
+    const tunnel = await this.dial(peerId);
+    return tunnel.openWs(path, protocols, handlers);
+  }
+  dial(peerId) {
+    const existing = this.tunnels.get(peerId);
+    if (existing)
+      return existing;
+    const failedAt = this.dialFailedAt.get(peerId);
+    if (failedAt != null && Date.now() - failedAt < DIAL_FAIL_COOLDOWN_MS) {
+      return Promise.reject(new Error("dial failed recently; cooling down"));
+    }
+    const drop = () => {
+      this.tunnels.delete(peerId);
+      this.rtcs.get(peerId)?.close();
+      this.rtcs.delete(peerId);
+    };
+    const dialing = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        drop();
+        reject(new Error("dial timed out"));
+      }, 15000);
+      const rtc = new RtcClient({
+        sendSignal: (data) => this.signaling.sendSignal(peerId, data),
+        onOpen: (channel) => {
+          clearTimeout(timer);
+          this.dialFailedAt.delete(peerId);
+          resolve(new TunnelClient2(channel, rtc.bulkChannel));
+        },
+        onClose: drop,
+        onState: (state) => {
+          if (state === "failed" || state === "disconnected")
+            drop();
+        }
       });
-    return (
-      this.tunnels.set(z, $),
-      $.catch(() => {
-        (this.dialFailedAt.set(z, Date.now()), this.tunnels.delete(z));
-      }),
-      $
-    );
+      this.rtcs.set(peerId, rtc);
+      rtc.start().catch((err) => {
+        clearTimeout(timer);
+        drop();
+        reject(err);
+      });
+    });
+    this.tunnels.set(peerId, dialing);
+    dialing.catch(() => {
+      this.dialFailedAt.set(peerId, Date.now());
+      this.tunnels.delete(peerId);
+    });
+    return dialing;
   }
   close() {
-    if (this.closed) return;
-    this.closed = !0;
-    for (let z of this.rtcs.values()) z.close();
-    (this.rtcs.clear(), this.tunnels.clear(), this.signaling.close());
+    if (this.closed)
+      return;
+    this.closed = true;
+    for (const rtc of this.rtcs.values())
+      rtc.close();
+    this.rtcs.clear();
+    this.tunnels.clear();
+    this.signaling.close();
   }
 }
-function zz(z) {
-  return new w(z);
+function joinRoom(opts) {
+  return new CodehostRoom(opts);
 }
-export { zz as joinRoom, I as DEFAULT_SIGNAL_URL, w as CodehostRoom };
+export {
+  joinRoom,
+  DEFAULT_SIGNAL_URL,
+  CodehostRoom
+};

--- a/lab/ui/sw.js
+++ b/lab/ui/sw.js
@@ -21,7 +21,7 @@ async function pickClient() {
   return all.find((c) => !new URL(c.url).pathname.startsWith(BASE + "p/")) || all[0] || null;
 }
 
-async function proxyPreview(request, src, port, rest) {
+async function proxyPreview(request, src, port, rest, allowInject) {
   const client = await pickClient();
   if (!client) return new Response("open the agent-yes console to preview", { status: 502 });
   const headers = {};
@@ -35,29 +35,77 @@ async function proxyPreview(request, src, port, rest) {
     let resolved = false;
     mc.port1.onmessage = (ev) => {
       const msg = ev.data;
-      if (msg.type === "head") {
-        const stream = new ReadableStream({
-          start(controller) {
-            mc.port1.onmessage = (e2) => {
-              const m2 = e2.data;
-              if (m2.type === "body") controller.enqueue(new Uint8Array(m2.chunk));
-              else if (m2.type === "end") controller.close();
-              else if (m2.type === "error") controller.error(new Error(m2.message));
-            };
-          },
-        });
-        resolved = true;
-        resolve(new Response(stream, { status: msg.status, statusText: msg.statusText, headers: msg.headers }));
-      } else if (msg.type === "error" && !resolved) {
-        resolved = true;
-        resolve(new Response("preview tunnel error: " + msg.message, { status: 502 }));
+      if (msg.type !== "head") {
+        if (msg.type === "error" && !resolved) {
+          resolved = true;
+          resolve(new Response("preview tunnel error: " + msg.message, { status: 502 }));
+        }
+        return;
       }
+      resolved = true;
+      const headers = new Headers(msg.headers);
+      const ct = headers.get("content-type") || "";
+      // HTML document navigations (the /p/ path itself, not app subresources):
+      // buffer, strip CSP, and inject a window.WebSocket shim so the app's own
+      // sockets (Vite HMR) also ride the P2P tunnel. Everything else streams.
+      if (allowInject && ct.includes("text/html")) {
+        const chunks = [];
+        mc.port1.onmessage = (e2) => {
+          const m2 = e2.data;
+          if (m2.type === "body") chunks.push(new Uint8Array(m2.chunk));
+          else if (m2.type === "end") resolve(injectBootstrap(chunks, msg, headers, src, Number(port)));
+          else if (m2.type === "error") resolve(new Response("preview error: " + m2.message, { status: 502 }));
+        };
+        return;
+      }
+      const stream = new ReadableStream({
+        start(controller) {
+          mc.port1.onmessage = (e2) => {
+            const m2 = e2.data;
+            if (m2.type === "body") controller.enqueue(new Uint8Array(m2.chunk));
+            else if (m2.type === "end") controller.close();
+            else if (m2.type === "error") controller.error(new Error(m2.message));
+          };
+        },
+      });
+      resolve(new Response(stream, { status: msg.status, statusText: msg.statusText, headers }));
     };
     client.postMessage(
       { type: "ay-preview-fetch", src, port: Number(port), method: request.method, path: rest, headers, body },
       [mc.port2, ...(body ? [body.buffer] : [])],
     );
   });
+}
+
+// Concatenate the buffered HTML chunks, strip CSP, and inject a bootstrap
+// <script> that replaces window.WebSocket with the parent console's tunneled
+// shim — so a dev server's own sockets (Vite HMR) ride the P2P tunnel too. Runs
+// first (right after <head>) so the override is in place before app scripts.
+function injectBootstrap(chunks, msg, headers, src, port) {
+  let total = 0;
+  for (const c of chunks) total += c.byteLength;
+  const all = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    all.set(c, off);
+    off += c.byteLength;
+  }
+  const raw = new TextDecoder().decode(all);
+  const boot =
+    "<script>(function(){try{var mk=window.parent&&window.parent.__ayMakeWS;" +
+    "if(mk)window.WebSocket=mk(" +
+    JSON.stringify(src) +
+    "," +
+    JSON.stringify(port) +
+    ");}catch(e){}})();</" +
+    "script>";
+  const html = /<head[^>]*>/i.test(raw)
+    ? raw.replace(/<head[^>]*>/i, (m) => m + boot)
+    : boot + raw;
+  headers.delete("content-security-policy");
+  headers.delete("content-security-policy-report-only");
+  headers.delete("content-length");
+  return new Response(html, { status: msg.status, statusText: msg.statusText, headers });
 }
 
 const SHELL = [
@@ -98,7 +146,9 @@ self.addEventListener("fetch", (e) => {
   const own = PREVIEW.exec(url.pathname);
   if (own) {
     const rest = (own[3] || "/") + url.search;
-    e.respondWith(proxyPreview(req, decodeURIComponent(own[1]), own[2], rest));
+    // Navigations to the /p/ root/route may be an HTML doc → allow WS-shim
+    // injection; app subresources (below) never inject.
+    e.respondWith(proxyPreview(req, decodeURIComponent(own[1]), own[2], rest, true));
     return;
   }
   e.respondWith(maybePreviewFromClient(e, req, url));
@@ -112,7 +162,9 @@ async function maybePreviewFromClient(e, req, url) {
     const client = await self.clients.get(clientId).catch(() => null);
     const cm = client && PREVIEW.exec(new URL(client.url).pathname);
     if (cm) {
-      return proxyPreview(req, decodeURIComponent(cm[1]), cm[2], url.pathname + url.search);
+      // Subresources (Vite's /@vite/client, module chunks, etc.) never get the
+      // WS shim injected — only the top-level /p/ navigation does.
+      return proxyPreview(req, decodeURIComponent(cm[1]), cm[2], url.pathname + url.search, false);
     }
   }
   return shellFetch(req, url);


### PR DESCRIPTION
Phase 3 of the in-console P2P preview: a proxied dev server's own WebSockets (Vite HMR) now ride the same peer-to-peer WebRTC tunnel as its HTTP — no edge relay.

## What
- **sw.js**: `proxyPreview` takes an `allowInject` flag. Only the top-level `/p/<src>/<port>/` navigation (an HTML doc) buffers the body, strips CSP, and injects a bootstrap `<script>` that overrides `window.WebSocket` with the parent console's `__ayMakeWS` shim. App subresources (e.g. `/@vite/client`) never inject.
- **index.html**: `__ayMakeWS` returns a `PreviewWebSocket` backed by `previewWs`, which dials the peer and opens a tunneled WS to `/__codehost/port/<port>/`.
- **room-client.js**: re-vendored from codehost with `CodehostRoom.openWs` (WS frames ride the tunnel data channel; codehost `TunnelHost.openWs` maps `/__codehost/port/<PORT>/` → `ws://127.0.0.1:<PORT>`).

## Verification
Verified end-to-end against a real otoji Vite dev server on :5173 over the codehost DataChannel:
- Preview iframe renders the app (title "otoji").
- Injected bootstrap present; `iframe.contentWindow.WebSocket.name === "PreviewWebSocket"`.
- A tunneled HMR socket **opens** with the `vite-hmr` subprotocol.

Depends on codehost preview WS support (already merged: codehost#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)