### PR TITLE
fix(serve): restore oxmgr as the working default — trust its postinstall

### DIFF
--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -1,6 +1,6 @@
 import { readFile } from "fs/promises";
 import { describe, expect, it } from "vitest";
-import { isNoNodeExecError, oxmgrVersionHasWindowsFix } from "./serve.ts";
+import { installerArgv, isNoNodeExecError, oxmgrVersionHasWindowsFix } from "./serve.ts";
 
 // Guards the Windows daemon-manager selection: on Windows we only PREFER oxmgr
 // when the installed build carries the daemon-socket-inheritance fix. Stock
@@ -88,5 +88,33 @@ describe("manager spawns pass a live env snapshot", () => {
         /env: (?:\{\s*(?:\.\.\.)?)?liveEnv\(\)/,
       );
     }
+  });
+});
+
+// Guards the oxmgr bootstrap: bun blocks untrusted postinstalls, and oxmgr's
+// native binary only arrives via its postinstall — without --trust the install
+// "succeeds" but leaves a launcher that dies with "oxmgr binary is missing"
+// (the real reason bootstrap used to fall back to pm2 on fresh boxes).
+describe("installerArgv", () => {
+  it("trusts oxmgr's postinstall under bun", () => {
+    expect(installerArgv("oxmgr", "/x/bun", null)).toEqual([
+      "/x/bun",
+      "add",
+      "-g",
+      "--trust",
+      "oxmgr",
+    ]);
+  });
+
+  it("keeps pm2 untrusted under bun (pure JS, no required scripts)", () => {
+    expect(installerArgv("pm2", "/x/bun", "/x/npm")).toEqual(["/x/bun", "add", "-g", "pm2"]);
+  });
+
+  it("falls back to npm without a trust flag (npm runs scripts by default)", () => {
+    expect(installerArgv("oxmgr", null, "/x/npm")).toEqual(["/x/npm", "install", "-g", "oxmgr"]);
+  });
+
+  it("returns null with neither installer", () => {
+    expect(installerArgv("pm2", null, null)).toBeNull();
   });
 });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -471,16 +471,37 @@ async function resolveActiveManager(): Promise<DaemonManager | null> {
   return firstRunnable ?? resolveDaemonManager();
 }
 
+// The install command for one PM package. oxmgr gets `--trust` under bun: its
+// native binary arrives via the package's postinstall (scripts/install.js
+// downloads the platform build), and bun BLOCKS lifecycle scripts of untrusted
+// packages by default — which leaves a JS launcher that dies with "oxmgr binary
+// is missing" and was the real reason bootstrap kept falling back to pm2 on
+// fresh boxes. Re-adding with --trust also heals such a blocked install. pm2 is
+// pure JS with no required scripts, so it stays untrusted. npm runs lifecycle
+// scripts by default — no flag needed.
+export function installerArgv(
+  pkg: "oxmgr" | "pm2",
+  bun: string | null,
+  npm: string | null,
+): string[] | null {
+  if (bun) return [bun, "add", "-g", ...(pkg === "oxmgr" ? ["--trust"] : []), pkg];
+  if (npm) return [npm, "install", "-g", pkg];
+  return null;
+}
+
 // Install one PM package globally via the SAME JS package manager that installed
 // `ay` (bun preferred, npm fallback — no Rust toolchain required, so a fresh
 // Linux box with only bun from setup.sh works), then confirm the resulting
 // binary actually execs. Returns a runnable manager, or null if the install
 // failed or the binary can't run here (caller then tries the next candidate).
 async function installAndVerify(pkg: "oxmgr" | "pm2"): Promise<DaemonManager | null> {
-  const bun = Bun.which("bun");
-  const npm = Bun.which("npm");
-  const installer = bun ? [bun, "add", "-g", pkg] : npm ? [npm, "install", "-g", pkg] : null;
+  const installer = installerArgv(pkg, Bun.which("bun"), Bun.which("npm"));
   if (!installer) return null;
+  // The node→bun shim must exist BEFORE the install, not just before the probe:
+  // oxmgr's postinstall itself runs `node scripts/install.js` to fetch the
+  // native binary, so on a bun-only box a missing shim silently skips the
+  // download even when the script is trusted.
+  await ensureNodeRuntime();
   process.stderr.write(`ay serve install: installing ${pkg}…\n`);
   const code =
     (await Bun.spawn(installer, {


### PR DESCRIPTION
## Why sym003 (and every fresh bun box) ended up on pm2

oxmgr is still the preferred manager in `bootstrapDaemonManager` — it just kept losing: `bun add -g oxmgr` **blocks the untrusted postinstall** that downloads oxmgr's native binary (`scripts/install.js`; darwin-arm64 builds exist), leaving a JS launcher that dies with `oxmgr binary is missing`, so `installAndVerify` fell through to pm2 every time.

Verified live (darwin-arm64, node-less PATH):
- without `--trust`: launcher installs, binary missing → exact sym003 failure reproduced
- with `--trust` + node→bun shim: `oxmgr 0.5.0` runs
- re-adding with `--trust` heals a previously blocked install (relevant for sym003's current state)

## Fix

- `installerArgv()`: bun installs oxmgr with `--trust`; pm2 stays untrusted (pure JS, no required scripts); npm fallback unchanged (runs scripts by default). Unit-tested.
- `ensureNodeRuntime()` now runs **before** the install spawn — the postinstall itself is `node scripts/install.js`, so the shim must already be on PATH on a bun-only box.

22/22 serve+nodeRuntime specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)