### PR TITLE
feat(auto-retry): informative retry nudge + anchor loose autoRetry patterns

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -71,7 +71,13 @@ clis:
     autoRetry:
       - pattern: "API Error.*Overloaded"
         flags: i
-      - Overloaded
+      # The CLI's transient status toast is a line that is ONLY "Overloaded"
+      # (optionally a leading bullet/mark). Whole-line anchored: a task title or
+      # prose merely mentioning Overloaded must not arm a spurious retry —
+      # rendered task lists / summaries sit on screen next to a ready prompt,
+      # which is exactly the arm condition.
+      - pattern: '^\s*[·•●⎿✗×]?\s*Overloaded\.?\s*$'
+        flags: m
       # "API Error: Response stalled mid-stream. The response above may be
       # incomplete." — the streamed response wedged and the client aborted
       # mid-token. Transient + server-side like Overloaded, so retry with
@@ -98,11 +104,20 @@ clis:
       # a stray "529"/"500" in normal output can't trigger a spurious retry.
       - pattern: 'API Error.{0,4}5\d\d'
         flags: i
+      # 429 / rate-limit: anchored to the "API Error" chrome. A bare
+      # `rate.?limit` here caused real spurious retries — an on-screen task
+      # list ("client ignores rate-limit drop") or an agent's own summary
+      # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
+      # perfectly healthy session.
+      - pattern: 'API Error.{0,4}429'
+        flags: i
+      - pattern: 'API Error[\s\S]{0,60}rate.?limit'
+        flags: i
       - Claude usage limit reached
       - hit your usage limit
-      - pattern: "rate.?limit"
-        flags: i
-      - pattern: "session limit"
+      # Session/5-hour limit banners keep the distinctive "… limit reached"
+      # phrase; a bare "session limit" matched ordinary prose.
+      - pattern: '(session|5-hour) limit reached'
         flags: i
     restoreArgs:
       - --continue
@@ -195,14 +210,26 @@ clis:
     autoRetry:
       - pattern: "API Error.*Overloaded"
         flags: i
-      - Overloaded
+      # Whole-line-only toast match — see the claude group for why a bare
+      # `Overloaded` substring is dangerous (task lists / prose arm retries).
+      - pattern: '^\s*[·•●⎿✗×]?\s*Overloaded\.?\s*$'
+        flags: m
       - pattern: 'API Error.{0,4}5\d\d'
+        flags: i
+      # 429 / rate-limit: anchored to the "API Error" chrome. A bare
+      # `rate.?limit` here caused real spurious retries — an on-screen task
+      # list ("client ignores rate-limit drop") or an agent's own summary
+      # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
+      # perfectly healthy session.
+      - pattern: 'API Error.{0,4}429'
+        flags: i
+      - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
       - Claude usage limit reached
       - hit your usage limit
-      - pattern: "rate.?limit"
-        flags: i
-      - pattern: "session limit"
+      # Session/5-hour limit banners keep the distinctive "… limit reached"
+      # phrase; a bare "session limit" matched ordinary prose.
+      - pattern: '(session|5-hour) limit reached'
         flags: i
     restoreArgs:
       - --continue
@@ -300,14 +327,26 @@ clis:
     autoRetry:
       - pattern: "API Error.*Overloaded"
         flags: i
-      - Overloaded
+      # Whole-line-only toast match — see the claude group for why a bare
+      # `Overloaded` substring is dangerous (task lists / prose arm retries).
+      - pattern: '^\s*[·•●⎿✗×]?\s*Overloaded\.?\s*$'
+        flags: m
       - pattern: 'API Error.{0,4}5\d\d'
+        flags: i
+      # 429 / rate-limit: anchored to the "API Error" chrome. A bare
+      # `rate.?limit` here caused real spurious retries — an on-screen task
+      # list ("client ignores rate-limit drop") or an agent's own summary
+      # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
+      # perfectly healthy session.
+      - pattern: 'API Error.{0,4}429'
+        flags: i
+      - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
       - Claude usage limit reached
       - hit your usage limit
-      - pattern: "rate.?limit"
-        flags: i
-      - pattern: "session limit"
+      # Session/5-hour limit banners keep the distinctive "… limit reached"
+      # phrase; a bare "session limit" matched ordinary prose.
+      - pattern: '(session|5-hour) limit reached'
         flags: i
     restoreArgs:
       - --continue

--- a/rs/src/config.rs
+++ b/rs/src/config.rs
@@ -298,6 +298,51 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Self-trigger guard: the informative auto-retry message is typed into the
+    /// PTY and stays visible in the transcript, so if it ever matched a CLI's
+    /// own screen-scrape patterns it would re-arm the retry loop (autoRetry),
+    /// block the streak reset, kill the session (fatal), or fake a state
+    /// (working/enter/needsInput/typingRespond). Assert every producible
+    /// message is inert against every CLI's patterns.
+    #[test]
+    fn test_auto_retry_message_is_inert_against_all_cli_patterns() {
+        use crate::context::{build_retry_message, RETRY_REASONS};
+        let configs = load_builtin_cli_configs().unwrap();
+        assert!(!configs.is_empty());
+        for (cli, config) in &configs {
+            for reason in RETRY_REASONS {
+                for (attempt, since, next) in
+                    [(1u32, 0u64, 8u64), (5, 500, 128), (12, 30_000, 256)]
+                {
+                    let msg = build_retry_message(attempt, reason, since, next);
+                    let groups: [(&str, &Vec<Regex>); 5] = [
+                        ("autoRetry", &config.auto_retry),
+                        ("fatal", &config.fatal),
+                        ("enter", &config.enter),
+                        ("working", &config.working),
+                        ("needsInput", &config.needs_input),
+                    ];
+                    for (kind, patterns) in groups {
+                        for rx in patterns {
+                            assert!(
+                                !rx.is_match(&msg),
+                                "retry message must not match {cli}.{kind} /{rx}/: {msg}"
+                            );
+                        }
+                    }
+                    for (send, patterns) in &config.typing_respond {
+                        for rx in patterns {
+                            assert!(
+                                !rx.is_match(&msg),
+                                "retry message must not match {cli}.typingRespond[{send}] /{rx}/: {msg}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_claude_patterns() {
         let config = get_cli_config("claude").unwrap();
@@ -379,6 +424,41 @@ mod tests {
             .auto_retry
             .iter()
             .any(|rx| rx.is_match("processed 529 files in 500ms")));
+        // Rate-limit is anchored to the API Error chrome: real 429 banners retry…
+        assert!(config.auto_retry.iter().any(|rx| rx.is_match(
+            r#"API Error: 429 {"type":"error","error":{"type":"rate_limit_error"}}"#
+        )));
+        // …but ordinary screen content that merely mentions rate limits must
+        // NOT — a rendered task list ("client ignores rate-limit drop") and an
+        // agent's own summary (INGEST_RATE_LIMIT_PER_MIN) both armed spurious
+        // retries on perfectly healthy sessions.
+        assert!(!config.auto_retry.iter().any(|rx| rx.is_match(
+            "P1: client ignores rate-limit drop → customer events permanently lost (#215)"
+        )));
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("set INGEST_RATE_LIMIT_PER_MIN below the batch cap")));
+        // The transient "Overloaded" toast still matches as a whole line…
+        assert!(config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("  ⎿ Overloaded\n? for shortcuts")));
+        assert!(config.auto_retry.iter().any(|rx| rx.is_match("Overloaded")));
+        // …but not embedded in prose / commit titles / task lists.
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("fix: treat Overloaded banners as recoverable")));
+        // Session/5-hour limit banners need the full "… limit reached" phrase.
+        assert!(config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("5-hour limit reached ∙ resets 3am")));
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("bump the session limit for QA runs")));
         assert!(!config.typing_respond.is_empty());
         assert!(config.typing_respond.contains_key("1\n"));
         assert_eq!(config.restore_args, vec!["--continue"]);

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -154,6 +154,89 @@ fn should_fire_retry(working: bool, ready: bool, idle_ms: u64, min_idle_ms: u64)
     !working && ready && idle_ms >= min_idle_ms
 }
 
+/// Fallback reason when no autoRetry match was captured before firing.
+pub(crate) const RETRY_REASON_FALLBACK: &str = "a transient server-side error";
+
+/// All reason strings `classify_retry_reason` can produce — used by the
+/// self-trigger guard test in config.rs to prove every possible typed message
+/// is inert against every CLI's screen-scrape patterns.
+pub(crate) const RETRY_REASONS: [&str; 6] = [
+    "the model backend reported it is temporarily busy",
+    "the response stream stalled mid-way",
+    "the connection dropped mid-response",
+    "a usage cap was reached (it may need time to reset)",
+    "requests are being throttled by the server",
+    RETRY_REASON_FALLBACK,
+];
+
+/// Paraphrase the matched recoverable-error banner into a short reason.
+///
+/// Deliberately NEVER echoes the raw banner wording ("API Error", "Overloaded",
+/// "rate limit", …): the built message is typed into the PTY and stays visible
+/// in the transcript, where raw wording would re-match the autoRetry patterns —
+/// keeping `err` true forever, which blocks the streak reset on recovery. The
+/// guard test in config.rs asserts every produced message stays pattern-inert.
+pub(crate) fn classify_retry_reason(screen: &str) -> &'static str {
+    let s = screen.to_lowercase();
+    if s.contains("overload") {
+        RETRY_REASONS[0]
+    } else if s.contains("stalled") {
+        RETRY_REASONS[1]
+    } else if s.contains("connection closed") {
+        RETRY_REASONS[2]
+    } else if s.contains("usage limit") || s.contains("session limit") {
+        RETRY_REASONS[3]
+    } else if s.contains("rate") && s.contains("limit") {
+        RETRY_REASONS[4]
+    } else {
+        RETRY_REASON_FALLBACK
+    }
+}
+
+/// Human-readable duration: "45s", "3m20s", "1h04m", "8h".
+pub(crate) fn fmt_dur_secs(total: u64) -> String {
+    if total < 60 {
+        format!("{}s", total)
+    } else if total < 3600 {
+        let (m, s) = (total / 60, total % 60);
+        if s == 0 {
+            format!("{}m", m)
+        } else {
+            format!("{}m{:02}s", m, s)
+        }
+    } else {
+        let (h, m) = (total / 3600, (total % 3600) / 60);
+        if m == 0 {
+            format!("{}h", h)
+        } else {
+            format!("{}h{:02}m", h, m)
+        }
+    }
+}
+
+/// The single line typed into the agent's prompt instead of a bare "retry":
+/// says WHO is nudging (agent-yes, automated), WHY (paraphrased reason), and
+/// the backoff state (attempt #, elapsed, next delay, give-up horizon), plus
+/// an explicit "ignore if nothing failed" clause so an agent that already
+/// recovered — or is mid-question — doesn't burn a turn asking what "retry"
+/// refers to. Must stay one line (it is submitted with a single "\r").
+pub(crate) fn build_retry_message(
+    attempt: u32,
+    reason: &str,
+    since_first_secs: u64,
+    next_backoff_secs: u64,
+) -> String {
+    format!(
+        "retry [auto-retry #{attempt} by agent-yes: {reason}; first seen {since} ago; \
+         if this attempt fails too, the next nudge comes in {next} (giving up after {give_up}). \
+         This is an automated recovery nudge - if no request actually failed, ignore it and \
+         simply continue your previous task.]",
+        since = fmt_dur_secs(since_first_secs),
+        next = fmt_dur_secs(next_backoff_secs),
+        give_up = fmt_dur_secs(RETRY_GIVE_UP_SECS),
+    )
+}
+
 /// Agent context - centralized session state
 pub struct AgentContext {
     pub cli: String,
@@ -206,6 +289,9 @@ pub struct AgentContext {
     auto_retry_streak: u32,
     auto_retry_started_at: Option<Instant>,
     auto_retry_next_at: Option<Instant>,
+    // Paraphrased reason captured when the error banner was matched — folded
+    // into the typed retry message so the agent knows why it is being nudged.
+    auto_retry_reason: Option<&'static str>,
 
     // Idle screen scanner - re-checks enter patterns after prolonged idle
     last_idle_scan_at: Option<Instant>,
@@ -318,6 +404,7 @@ impl AgentContext {
             auto_retry_streak: 0,
             auto_retry_started_at: None,
             auto_retry_next_at: None,
+            auto_retry_reason: None,
             stall_esc_sent_at: None,
             stall_force_restart: false,
             ctrl_c_times: Vec::new(),
@@ -1113,16 +1200,24 @@ impl AgentContext {
                     self.auto_retry_next_at = Some(now + Duration::from_millis(500));
                 } else {
                     self.auto_retry_streak = self.auto_retry_streak.saturating_add(1);
-                    warn!(
-                        "Auto-retry: typing 'retry' (attempt {})",
-                        self.auto_retry_streak
-                    );
-                    self.do_send_retry(msg_ctx)?;
                     // Self-schedule the next retry with escalated backoff. Leaving
                     // this None and re-arming from check_patterns would tight-loop
                     // while the error banner stays on screen. check_patterns resets
                     // the streak (cancelling this) once the agent recovers.
                     let next = retry_backoff_secs(self.auto_retry_streak);
+                    let reason = self.auto_retry_reason.unwrap_or(RETRY_REASON_FALLBACK);
+                    let since = self
+                        .auto_retry_started_at
+                        .map(|t| t.elapsed().as_secs())
+                        .unwrap_or(0);
+                    let line =
+                        build_retry_message(self.auto_retry_streak, reason, since, next);
+                    warn!(
+                        "Auto-retry: typing retry nudge (attempt {}, reason: {})",
+                        self.auto_retry_streak, reason
+                    );
+                    self.do_send_retry(msg_ctx, &line)?;
+                    self.record_auto_retry_inbox(reason, self.auto_retry_streak, next);
                     self.auto_retry_next_at = Some(now + Duration::from_secs(next));
                 }
             }
@@ -1243,19 +1338,57 @@ impl AgentContext {
     }
 
     /// Type "retry" + Enter — the auto-retry response to a recoverable API error.
-    fn do_send_retry(&mut self, msg_ctx: &MessageContext) -> Result<()> {
+    fn do_send_retry(&mut self, msg_ctx: &MessageContext, line: &str) -> Result<()> {
         {
             let mut writer = msg_ctx
                 .writer
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Lock: {}", e))?;
-            writer.write_all(b"retry")?;
+            writer.write_all(line.as_bytes())?;
             writer.write_all(b"\r")?;
             writer.flush()?;
         }
         self.idle_waiter.ping();
         self.mark_stdin_sent();
         Ok(())
+    }
+
+    /// Best-effort structured record of the nudge into this agent's own
+    /// `<cwd>/.agent-yes/inbox.jsonl` (schema mirrors ts/messageLog.ts
+    /// MessageRecord, kind "auto-retry"), so `ay msgs` / the console can show
+    /// why and how often an agent got poked. Never fails or blocks the send;
+    /// compaction is left to the TS appenders (these entries are rare —
+    /// bounded by the backoff ladder and the 8h give-up window).
+    fn record_auto_retry_inbox(&self, reason: &str, attempt: u32, next_backoff_secs: u64) {
+        let dir = std::path::Path::new(&self.cwd).join(".agent-yes");
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let record = serde_json::json!({
+            "at": at,
+            "from": serde_json::Value::Null,
+            "to": { "pid": std::process::id(), "cli": self.cli, "cwd": self.cwd },
+            "kind": "auto-retry",
+            "body": format!(
+                "{} (attempt {}, next backoff {})",
+                reason,
+                attempt,
+                fmt_dur_secs(next_backoff_secs)
+            ),
+            "wrapped": false,
+        });
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("inbox.jsonl"))
+        {
+            use std::io::Write as _;
+            let _ = writeln!(f, "{}", record);
+        }
     }
 
     /// Stamp the last-stdin time — marks a "poke" whose response (any PTY
@@ -1345,6 +1478,10 @@ impl AgentContext {
                 .any(|p| p.is_match(&buffer));
             let ready_now = self.cli_config.ready.iter().any(|p| p.is_match(&buffer));
             if err && ready_now {
+                // Remember WHY (paraphrased — see classify_retry_reason) so the
+                // typed message can explain itself. Refresh on every match: the
+                // banner may change across attempts (e.g. overload → 5xx).
+                self.auto_retry_reason = Some(classify_retry_reason(&buffer));
                 // Error banner is up AND the agent is back at its prompt: schedule
                 // the next retry unless one is already counting down.
                 if self.auto_retry_next_at.is_none() {
@@ -1541,6 +1678,54 @@ mod tests {
         // capped at RETRY_MAX_DELAY_SECS, and no shift overflow for large streaks
         assert_eq!(retry_backoff_secs(6), 256);
         assert_eq!(retry_backoff_secs(50), 256);
+    }
+
+    #[test]
+    fn test_classify_retry_reason_maps_banners_to_inert_paraphrases() {
+        assert_eq!(
+            classify_retry_reason("● API Error: 529 Overloaded"),
+            RETRY_REASONS[0]
+        );
+        assert_eq!(
+            classify_retry_reason("API Error: Response stalled mid-stream."),
+            RETRY_REASONS[1]
+        );
+        assert_eq!(
+            classify_retry_reason("API Error: Connection closed mid-response."),
+            RETRY_REASONS[2]
+        );
+        assert_eq!(
+            classify_retry_reason("Claude usage limit reached"),
+            RETRY_REASONS[3]
+        );
+        assert_eq!(classify_retry_reason("You are being rate-limited"), RETRY_REASONS[4]);
+        assert_eq!(
+            classify_retry_reason("API Error: 503 Service Unavailable"),
+            RETRY_REASON_FALLBACK
+        );
+    }
+
+    #[test]
+    fn test_fmt_dur_secs() {
+        assert_eq!(fmt_dur_secs(0), "0s");
+        assert_eq!(fmt_dur_secs(45), "45s");
+        assert_eq!(fmt_dur_secs(60), "1m");
+        assert_eq!(fmt_dur_secs(200), "3m20s");
+        assert_eq!(fmt_dur_secs(3600), "1h");
+        assert_eq!(fmt_dur_secs(3900), "1h05m");
+        assert_eq!(fmt_dur_secs(8 * 3600), "8h");
+    }
+
+    #[test]
+    fn test_build_retry_message_is_one_line_with_context() {
+        let msg = build_retry_message(3, RETRY_REASONS[0], 45, 64);
+        assert!(!msg.contains('\n'), "must be a single line: {msg}");
+        assert!(msg.starts_with("retry ["), "keeps the imperative first: {msg}");
+        assert!(msg.contains("#3"));
+        assert!(msg.contains("45s ago"));
+        assert!(msg.contains("in 1m04s"));
+        assert!(msg.contains("giving up after 8h"));
+        assert!(msg.contains("ignore it"), "needs the ignore-if-recovered clause");
     }
 
     #[test]

--- a/ts/autoRetry.spec.ts
+++ b/ts/autoRetry.spec.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { AUTO_RETRY_MAX_DELAY_SECS, autoRetryBackoffMs, shouldFireRetry } from "./autoRetry.ts";
+import {
+  AUTO_RETRY_MAX_DELAY_SECS,
+  AUTO_RETRY_REASON_FALLBACK,
+  AUTO_RETRY_REASONS,
+  autoRetryBackoffMs,
+  buildAutoRetryMessage,
+  classifyAutoRetryReason,
+  formatDurationSecs,
+  shouldFireRetry,
+} from "./autoRetry.ts";
+import { loadSharedCliDefaults } from "./configShared.ts";
 
 describe("autoRetryBackoffMs", () => {
   it("doubles 8,16,32,…,256 then caps", () => {
@@ -30,5 +40,84 @@ describe("shouldFireRetry", () => {
     // Ready, idle, and past the quiet window — fire.
     expect(shouldFireRetry(false, true, 5_000, 5_000)).toBe(true);
     expect(shouldFireRetry(false, true, 10_000, 5_000)).toBe(true);
+  });
+});
+
+describe("classifyAutoRetryReason", () => {
+  it("maps real banners to inert paraphrases", () => {
+    expect(classifyAutoRetryReason("● API Error: 529 Overloaded")).toBe(AUTO_RETRY_REASONS[0]);
+    expect(classifyAutoRetryReason("API Error: Response stalled mid-stream.")).toBe(
+      AUTO_RETRY_REASONS[1],
+    );
+    expect(classifyAutoRetryReason("API Error: Connection closed mid-response.")).toBe(
+      AUTO_RETRY_REASONS[2],
+    );
+    expect(classifyAutoRetryReason("Claude usage limit reached")).toBe(AUTO_RETRY_REASONS[3]);
+    expect(classifyAutoRetryReason("You are being rate-limited")).toBe(AUTO_RETRY_REASONS[4]);
+    expect(classifyAutoRetryReason("API Error: 503 Service Unavailable")).toBe(
+      AUTO_RETRY_REASON_FALLBACK,
+    );
+  });
+});
+
+describe("formatDurationSecs", () => {
+  it("renders s / m / h forms", () => {
+    expect(formatDurationSecs(0)).toBe("0s");
+    expect(formatDurationSecs(45)).toBe("45s");
+    expect(formatDurationSecs(60)).toBe("1m");
+    expect(formatDurationSecs(200)).toBe("3m20s");
+    expect(formatDurationSecs(3600)).toBe("1h");
+    expect(formatDurationSecs(3900)).toBe("1h05m");
+    expect(formatDurationSecs(8 * 3600)).toBe("8h");
+  });
+});
+
+describe("buildAutoRetryMessage", () => {
+  it("is one line and carries attempt/reason/backoff context + ignore clause", () => {
+    const msg = buildAutoRetryMessage(3, AUTO_RETRY_REASONS[0], 45, 64);
+    expect(msg).not.toContain("\n");
+    expect(msg.startsWith("retry [")).toBe(true);
+    expect(msg).toContain("#3");
+    expect(msg).toContain("45s ago");
+    expect(msg).toContain("in 1m04s");
+    expect(msg).toContain("giving up after 8h");
+    expect(msg).toContain("ignore it");
+  });
+
+  // Self-trigger guard: the message is typed into the PTY and stays visible in
+  // the transcript, so if it ever matched a CLI's own screen-scrape patterns
+  // it would re-arm the retry loop (autoRetry), block the streak reset, kill
+  // the session (fatal), or fake a state (working/enter/needsInput). Mirrors
+  // rs/src/config.rs test_auto_retry_message_is_inert_against_all_cli_patterns.
+  it("never matches any CLI's screen-scrape patterns", async () => {
+    const clis = await loadSharedCliDefaults();
+    expect(Object.keys(clis).length).toBeGreaterThan(0);
+    for (const [cliName, conf] of Object.entries(clis)) {
+      for (const reason of AUTO_RETRY_REASONS) {
+        const cases: [number, number, number][] = [
+          [1, 0, 8],
+          [5, 500, 128],
+          [12, 30_000, 256],
+        ];
+        for (const [attempt, since, next] of cases) {
+          const msg = buildAutoRetryMessage(attempt, reason, since, next);
+          const groups: [string, RegExp[] | undefined][] = [
+            ["autoRetry", conf.autoRetry],
+            ["fatal", conf.fatal],
+            ["enter", conf.enter],
+            ["working", conf.working],
+            ["needsInput", conf.needsInput],
+          ];
+          for (const [kind, patterns] of groups) {
+            for (const rx of patterns ?? []) {
+              expect(
+                rx.test(msg),
+                `retry message must not match ${cliName}.${kind} /${rx}/: ${msg}`,
+              ).toBe(false);
+            }
+          }
+        }
+      }
+    }
   });
 });

--- a/ts/autoRetry.ts
+++ b/ts/autoRetry.ts
@@ -37,3 +37,79 @@ export function shouldFireRetry(
 ): boolean {
   return !working && ready && idleMs >= minIdleMs;
 }
+
+/** Fallback reason when no autoRetry match was captured before firing. */
+export const AUTO_RETRY_REASON_FALLBACK = "a transient server-side error";
+
+/**
+ * All reason strings `classifyAutoRetryReason` can produce — used by the
+ * self-trigger guard spec to prove every possible typed message is inert
+ * against every CLI's screen-scrape patterns. Mirrors Rust's RETRY_REASONS.
+ */
+export const AUTO_RETRY_REASONS = [
+  "the model backend reported it is temporarily busy",
+  "the response stream stalled mid-way",
+  "the connection dropped mid-response",
+  "a usage cap was reached (it may need time to reset)",
+  "requests are being throttled by the server",
+  AUTO_RETRY_REASON_FALLBACK,
+] as const;
+
+/**
+ * Paraphrase the matched recoverable-error banner into a short reason.
+ *
+ * Deliberately NEVER echoes the raw banner wording ("API Error", "Overloaded",
+ * "rate limit", …): the built message is typed into the PTY and stays visible
+ * in the transcript, where raw wording would re-match the autoRetry patterns —
+ * keeping the error state true forever, which blocks the streak reset on
+ * recovery. Mirrors Rust's classify_retry_reason.
+ */
+export function classifyAutoRetryReason(screen: string): string {
+  const s = screen.toLowerCase();
+  if (s.includes("overload")) return AUTO_RETRY_REASONS[0];
+  if (s.includes("stalled")) return AUTO_RETRY_REASONS[1];
+  if (s.includes("connection closed")) return AUTO_RETRY_REASONS[2];
+  if (s.includes("usage limit") || s.includes("session limit")) return AUTO_RETRY_REASONS[3];
+  if (s.includes("rate") && s.includes("limit")) return AUTO_RETRY_REASONS[4];
+  return AUTO_RETRY_REASON_FALLBACK;
+}
+
+/** Human-readable duration: "45s", "3m20s", "1h04m", "8h". Mirrors Rust's fmt_dur_secs. */
+export function formatDurationSecs(total: number): string {
+  const t = Math.max(0, Math.floor(total));
+  if (t < 60) return `${t}s`;
+  if (t < 3600) {
+    const m = Math.floor(t / 60);
+    const s = t % 60;
+    return s === 0 ? `${m}m` : `${m}m${String(s).padStart(2, "0")}s`;
+  }
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}m`;
+}
+
+/**
+ * The single line typed into the agent's prompt instead of a bare "retry":
+ * says WHO is nudging (agent-yes, automated), WHY (paraphrased reason), and
+ * the backoff state (attempt #, elapsed, next delay, give-up horizon), plus an
+ * explicit "ignore if nothing failed" clause so an agent that already
+ * recovered — or is mid-question — doesn't burn a turn asking what "retry"
+ * refers to. Must stay one line (it is submitted with a single "\r").
+ * Mirrors Rust's build_retry_message in rs/src/context.rs.
+ */
+export function buildAutoRetryMessage(
+  attempt: number,
+  reason: string,
+  sinceFirstSecs: number,
+  nextBackoffSecs: number,
+): string {
+  const since = formatDurationSecs(sinceFirstSecs);
+  const next = formatDurationSecs(nextBackoffSecs);
+  const giveUp = formatDurationSecs(AUTO_RETRY_GIVE_UP_MS / 1000);
+  return (
+    `retry [auto-retry #${attempt} by agent-yes: ${reason}; first seen ${since} ago; ` +
+    `if this attempt fails too, the next nudge comes in ${next} (giving up after ${giveUp}). ` +
+    `This is an automated recovery nudge - if no request actually failed, ignore it and ` +
+    `simply continue your previous task.]`
+  );
+}

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -21,9 +21,14 @@ import { sendEnter, sendMessage } from "./core/messaging.ts";
 import {
   AUTO_RETRY_GIVE_UP_MS,
   AUTO_RETRY_MIN_IDLE_MS,
+  AUTO_RETRY_REASON_FALLBACK,
   autoRetryBackoffMs,
+  buildAutoRetryMessage,
+  classifyAutoRetryReason,
+  formatDurationSecs,
   shouldFireRetry,
 } from "./autoRetry.ts";
+import { recordInbox } from "./messageLog.ts";
 import {
   initializeLogPaths,
   setupDebugLogging,
@@ -794,6 +799,9 @@ export default async function agentYes({
   let retryStartedAt: number | null = null;
   let retryNextAt: number | null = null;
   let autoRetryScreen = "";
+  // Paraphrased reason captured when the error banner was matched — folded
+  // into the typed retry message so the agent knows why it is being nudged.
+  let retryReason: string | null = null;
   const heartbeatInterval = setInterval(async () => {
     try {
       const rendered = removeControlCharacters(xtermProxy.tail(12));
@@ -822,15 +830,36 @@ export default async function agentYes({
             retryNextAt = now + 500; // busy / not at prompt / still active — re-check shortly
           } else {
             retryStreak += 1;
-            logger.warn(`[${cli}-yes] auto-retry: typing 'retry' (attempt ${retryStreak})`);
-            // Write "retry" + Enter atomically (mirrors rs do_send_retry); using
+            const nextBackoffMs = autoRetryBackoffMs(retryStreak);
+            const reason = retryReason ?? AUTO_RETRY_REASON_FALLBACK;
+            const sinceFirstSecs = retryStartedAt === null ? 0 : (now - retryStartedAt) / 1000;
+            const line = buildAutoRetryMessage(
+              retryStreak,
+              reason,
+              sinceFirstSecs,
+              nextBackoffMs / 1000,
+            );
+            logger.warn(
+              `[${cli}-yes] auto-retry: typing retry nudge (attempt ${retryStreak}, reason: ${reason})`,
+            );
+            // Write the nudge + Enter atomically (mirrors rs do_send_retry); using
             // sendMessage would split text/Enter across the fast heartbeat ticks.
-            ctx.messageContext.shell.write("retry\r");
+            ctx.messageContext.shell.write(line + "\r");
             ctx.idleWaiter.ping();
+            // Structured trace for `ay msgs` / the console (mirrors the Rust
+            // runtime's record_auto_retry_inbox) — best-effort, never blocks.
+            void recordInbox({
+              at: now,
+              from: null,
+              to: { pid: process.pid, cli, cwd: workingDir },
+              kind: "auto-retry",
+              body: `${reason} (attempt ${retryStreak}, next backoff ${formatDurationSecs(nextBackoffMs / 1000)})`,
+              wrapped: false,
+            });
             // Self-schedule the next retry with escalated backoff. (Leaving nextAt
             // null and re-arming from the stdout pipeline would tight-loop while the
             // error banner stays on screen.) Reset on recovery cancels this.
-            retryNextAt = now + autoRetryBackoffMs(retryStreak);
+            retryNextAt = now + nextBackoffMs;
           }
         }
       }
@@ -1185,6 +1214,10 @@ export default async function agentYes({
               const errVisible = conf.autoRetry.some((rx: RegExp) => rx.test(rendered));
               const readyVisible = conf.ready?.some((rx: RegExp) => rx.test(rendered)) ?? false;
               if (errVisible && readyVisible) {
+                // Remember WHY (paraphrased — see classifyAutoRetryReason) so
+                // the typed message can explain itself. Refresh on every match:
+                // the banner may change across attempts (e.g. overload → 5xx).
+                retryReason = classifyAutoRetryReason(rendered);
                 if (retryNextAt === null) {
                   if (retryStartedAt === null) retryStartedAt = Date.now();
                   const delayMs = autoRetryBackoffMs(retryStreak);

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -39,8 +39,9 @@ export interface MessageRecord {
   to: MailParty;
   /** What kind of stdin write this was. Omitted for a normal `ay send` text
    * message; "key" for raw keystrokes (`ay key`), "select" for a menu pick
-   * (`ay select`). For key/select the `body` holds the key names / choice. */
-  kind?: "key" | "select";
+   * (`ay select`), "auto-retry" for the wrapper's own recoverable-error nudge
+   * (from is null; `body` holds the paraphrased reason + backoff state). */
+  kind?: "key" | "select" | "auto-retry";
   /** The message body (without the `[ay-msg …]` wrapper), or — for a key/select
    * record — the keystroke names / chosen option. */
   body: string;

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -211,7 +211,7 @@ export interface MessageEdge {
   by: number;
   target: number;
   at: number;
-  kind?: "key" | "select";
+  kind?: "key" | "select" | "auto-retry";
 }
 
 /**
@@ -3279,10 +3279,14 @@ async function cmdMsgs(rest: string[]): Promise<number> {
 
   for (const { dir, rec } of shown) {
     const when = new Date(rec.at).toLocaleTimeString();
-    const peer =
-      dir === "out"
-        ? `→ ${rec.to.cli} #${rec.to.pid}`
-        : `← ${rec.from ? `${rec.from.cli} #${rec.from.pid}` : "human"}`;
+    // auto-retry nudges are written by the agent's own wrapper (from is null
+    // there too) — label them as agent-yes, not a human send.
+    const fromLabel = rec.from
+      ? `${rec.from.cli} #${rec.from.pid}`
+      : rec.kind === "auto-retry"
+        ? "agent-yes"
+        : "human";
+    const peer = dir === "out" ? `→ ${rec.to.cli} #${rec.to.pid}` : `← ${fromLabel}`;
     const via = rec.remote ? ` (via ${rec.remote})` : "";
     const flag = rec.confirmed === false ? " (unconfirmed)" : "";
     const tag = rec.kind ? `[${rec.kind}] ` : "";


### PR DESCRIPTION
## Why

Two real incidents with the auto-retry loop:

1. **The bare `retry` is ambiguous.** An agent that had received a STOP instruction got a context-free `retry` typed into its prompt and burned a full turn asking "what should I retry?" — it had no way to know the nudge was automated, or why it fired.
2. **Loose patterns fire on healthy sessions.** The bare `rate.?limit` / `Overloaded` / `session limit` patterns match ordinary screen content. Observed triggers: a rendered task list (`P1: client ignores rate-limit drop …`) and an agent's own handoff summary (`INGEST_RATE_LIMIT_PER_MIN`, `429 を食らいます`). Once the agent went idle at its prompt, agent-yes typed `retry` into a perfectly healthy session — which is almost certainly what caused incident 1.

## What

**Informative nudge (both runtimes, kept in sync):** instead of `retry`, the wrapper now types a single line like:

> retry [auto-retry #3 by agent-yes: the model backend reported it is temporarily busy; first seen 45s ago; if this attempt fails too, the next nudge comes in 1m04s (giving up after 8h). This is an automated recovery nudge - if no request actually failed, ignore it and simply continue your previous task.]

The trailing clause makes the wrong-context case self-resolving: a recovered (or STOP-conflicted) agent just continues instead of asking.

**Self-trigger guard:** the reason is a paraphrase — never the raw banner wording ("API Error", "Overloaded", "rate limit") — because the typed line stays visible in the transcript where raw wording would re-match autoRetry and block the streak reset. Guard tests in both runtimes build every producible message and assert it is inert against every CLI's autoRetry/fatal/enter/working/needsInput/typingRespond patterns.

**Pattern tightening (all three autoRetry groups):**
- `rate.?limit` → anchored to the `API Error` chrome (+ explicit `API Error…429`)
- bare `Overloaded` → whole-line toast match only
- `session limit` → `(session|5-hour) limit reached`
- negative tests with the real false-positive lines from the incidents

**Observability:** each fired nudge is appended as a structured `kind:"auto-retry"` record to the agent's own `.agent-yes/inbox.jsonl` (mirrored in the Rust runtime); `ay msgs` shows it as `← agent-yes  [auto-retry] <reason> (attempt N, next backoff …)`.

## Tests

- `cargo test`: 268 passed (includes the new classify/format/build + inertness + pattern positive/negative tests)
- `vitest ts/autoRetry.spec.ts ts/messageLog.spec.ts ts/badges.spec.ts`: 33 passed
- `tsgo --noEmit`: no new errors vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)