### PR TITLE
fix(console): stop the ESC[?6n stdin-flash feedback loop

### DIFF
--- a/rs/src/vterm.rs
+++ b/rs/src/vterm.rs
@@ -39,13 +39,22 @@ impl vt100_ctt::Callbacks for ResponseCollector {
         params: &[&[u16]],
         c: char,
     ) {
-        // Only respond to plain (no private/intermediate marker) primary
-        // DA/DSR queries. CSI '?' n / CSI '>' c etc. are private or
-        // secondary forms that expect different (or no) replies.
+        let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
+        // Private/intermediate-marker forms mostly expect different (or no)
+        // replies than their plain counterparts — except DECXCPR (ESC[?6n),
+        // which some TUIs (Claude Code) poll on every render. Left unanswered
+        // the child re-asks forever, and a console viewer's xterm would answer
+        // in our place — turning protocol chatter into what looks like user
+        // input on the FIFO. Answer it here so the query dies at the source.
         if intermediates.is_some() {
+            if intermediates == Some(b'?') && c == 'n' && param == 6 {
+                let (row, col) = screen.cursor_position();
+                let response = format!("\x1b[?{};{}R", row + 1, col + 1);
+                debug!("vterm|DECXCPR cursor response: {:?}", response);
+                self.push_response(response.into_bytes());
+            }
             return;
         }
-        let param = params.first().and_then(|p| p.first()).copied().unwrap_or(0);
         match c {
             // DSR - Device Status Report
             'n' => match param {
@@ -302,10 +311,22 @@ mod tests {
     }
 
     #[test]
-    fn test_private_dsr_not_answered() {
-        // ESC[?6n → DEC private DSR, must NOT respond as plain CPR
+    fn test_private_dsr_cursor_answered_as_decxcpr() {
+        // ESC[?6n → DECXCPR: answered with the ?-prefixed CPR form, never the
+        // plain one. Claude Code polls this per render; unanswered it re-asks
+        // forever and console viewers' xterms answer instead (stdin-flash loop).
         let mut vt = VTermProxy::new(24, 80);
-        vt.process(b"\x1b[?6n");
+        vt.process(b"\x1b[5;10H\x1b[?6n");
+        let responses = vt.take_responses();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0], b"\x1b[?5;10R");
+    }
+
+    #[test]
+    fn test_other_private_dsr_not_answered() {
+        // ESC[?5n (private status) has no plain-CPR answer — stays silent
+        let mut vt = VTermProxy::new(24, 80);
+        vt.process(b"\x1b[?5n");
         assert!(vt.take_responses().is_empty());
     }
 

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -26,6 +26,7 @@ import {
   type CommonOpts,
 } from "./subcommands.ts";
 import { TYPING_BADGE } from "./badges.ts";
+import { isTerminalReply } from "./terminalReply.ts";
 import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
 import { type MailParty, recordInbox } from "./messageLog.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
@@ -1565,11 +1566,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // resolveLastStdinAt below and the /api/send handler that stamps these.
   const meaningfulStdinAt = new Map<number, number>();
   const anyDaemonWriteAt = new Map<number, number>();
-  // A payload that is PURELY a terminal auto-reply (Cursor Position Report, Device
-  // Attributes, Device Status Report) — protocol chatter a TUI emits on redraw/resize,
-  // not a keystroke. Anchored so a chunk that also carries real input never matches;
-  // real typing (incl. arrow keys like `ESC[A`) never looks like one of these.
-  const isTerminalReply = (s: string) => /^\x1b\[(\d+;\d+R|\?[\d;]*c|>[\d;]*c|\d*n)$/.test(s);
+  // isTerminalReply (ts/terminalReply.ts) spots payloads that are purely such
+  // auto-replies — incl. the DECXCPR `ESC[?r;cR` form and bursts of several
+  // replies concatenated in one chunk — so they never count as meaningful.
   // Stamp both maps after a daemon FIFO write, keyed off the FIFO's post-write mtime
   // (so `anyDaemonWriteAt` is exactly our write's mtime — an external write bumps it
   // strictly higher, which is how resolveLastStdinAt tells them apart with no clock skew).

--- a/ts/terminalReply.spec.ts
+++ b/ts/terminalReply.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isTerminalReply } from "./terminalReply.ts";
+
+describe("isTerminalReply", () => {
+  it("matches single auto-replies (CPR, DECXCPR, DA1, DA2, DSR)", () => {
+    expect(isTerminalReply("\x1b[5;10R")).toBe(true); // CPR (ESC[6n answer)
+    expect(isTerminalReply("\x1b[?1;1R")).toBe(true); // DECXCPR (ESC[?6n answer)
+    expect(isTerminalReply("\x1b[?1;1;1R")).toBe(true); // DECXCPR with page
+    expect(isTerminalReply("\x1b[?1;2c")).toBe(true); // DA1
+    expect(isTerminalReply("\x1b[>0;276;0c")).toBe(true); // DA2
+    expect(isTerminalReply("\x1b[0n")).toBe(true); // DSR status OK
+  });
+
+  it("matches a burst of replies concatenated in one chunk", () => {
+    // A viewer attach replays a tail full of queries; xterm answers them all
+    // in one onData chunk.
+    expect(isTerminalReply("\x1b[?1;1R\x1b[?1;1R\x1b[?1;1R")).toBe(true);
+    expect(isTerminalReply("\x1b[1;1R\x1b[?1;2c\x1b[0n")).toBe(true);
+  });
+
+  it("never matches real typing", () => {
+    expect(isTerminalReply("hello")).toBe(false);
+    expect(isTerminalReply("\r")).toBe(false);
+    expect(isTerminalReply("\x1b[A")).toBe(false); // arrow key
+    expect(isTerminalReply("\x1b[1;5C")).toBe(false); // ctrl+arrow (no R/c/n final)
+    expect(isTerminalReply("\x1b")).toBe(false);
+    expect(isTerminalReply("")).toBe(false);
+    expect(isTerminalReply("\x1b[R")).toBe(false); // malformed — not a reply xterm emits
+  });
+
+  it("never matches a chunk that mixes a reply with real input", () => {
+    expect(isTerminalReply("\x1b[?1;1Ry")).toBe(false);
+    expect(isTerminalReply("y\x1b[?1;1R")).toBe(false);
+    expect(isTerminalReply("\x1b[1;1R\r")).toBe(false);
+  });
+});

--- a/ts/terminalReply.ts
+++ b/ts/terminalReply.ts
@@ -1,0 +1,17 @@
+/**
+ * Is this /api/send payload PURELY terminal auto-reply chatter — the responses
+ * a viewer's xterm generates to the agent TUI's protocol queries (Cursor
+ * Position Report incl. the DECXCPR `?`-prefixed form, Device Attributes,
+ * Device Status Report) — rather than a keystroke?
+ *
+ * Used by the serve daemon to keep such writes out of `last_stdin_at`, so a
+ * redraw/resize (or a TUI polling `ESC[?6n` every render) can't pin the
+ * console's stdin-flash + stdin age at "just typed".
+ *
+ * Anchored over ONE-OR-MORE replies: a burst of queries (e.g. tail replay on
+ * viewer attach) is answered in a single onData chunk, so several replies
+ * arrive concatenated in one payload. Real typing — including arrow keys like
+ * `ESC[A` — never matches any alternative.
+ */
+export const isTerminalReply = (s: string): boolean =>
+  /^(?:\x1b\[(?:\??\d+(?:;\d+)*R|\?[\d;]*c|>[\d;]*c|\d*n))+$/.test(s);


### PR DESCRIPTION
## Problem

An agent card in the web console kept flashing forever with its stdin/active ages pinned at `0s` (observed live: room `re52667`, pid 48298, claude v2.1.204 under wrapper 1.175.1).

Verified causal chain:

1. claude polls `ESC[?6n` (DECXCPR) per render. The Rust vterm deliberately ignored all private DSR forms, so the query was never answered inside the wrapper — the raw log was saturated with `?6n`.
2. Every console viewer's xterm.js auto-replies `ESC[?1;1R` → `term.onData` → `/api/send` → daemon writes the agent's FIFO every second.
3. The `isTerminalReply` denoise regex (`^\x1b\[(\d+;\d+R|\?[\d;]*c|>[\d;]*c|\d*n)$`) misses the `?`-prefixed CPR (and concatenated reply bursts), so each write was stamped meaningful → `last_stdin_at` advanced every second → the row re-flashed on every delta and stdin age pinned at 0s.
4. The reply fed claude → re-render → another `?6n` — a self-sustaining loop while any viewer is attached.

## Fix (two independent breaks in the loop)

- **rs/src/vterm.rs**: answer `ESC[?6n` with the `?`-prefixed CPR `ESC[?<r>;<c>R`, same as plain `ESC[6n` always got — the query now dies at the source. Other private DSR forms stay silent.
- **ts/terminalReply.ts** (extracted from the `serve.ts` closure + new spec): also match the `?`-prefixed CPR and one-or-more auto-replies concatenated in a single chunk (a viewer attach replays a tail full of queries and answers them in one `onData` burst).

## Verification

- `cargo test` full suite green (255 + 10); new vterm tests `test_private_dsr_cursor_answered_as_decxcpr` / `test_other_private_dsr_not_answered`.
- `vitest ts/terminalReply.spec.ts` green (replies, bursts, real-typing negatives).
- End-to-end through a real PTY with the rebuilt binary: probe moves cursor to 12;7, emits `ESC[?6n`, receives `ESC[?12;7R` on stdin.
- TS runtime needs no change: `@xterm/headless` already answers `?6n` inside the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)