### PR TITLE
fix(serve): pm2 save --force after uninstall so the dump actually empties

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -763,8 +763,12 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
       removed++;
       process.stdout.write(`removed '${DAEMON_NAME}' from ${m.id}\n`);
       if (m.id === "pm2") {
-        // Drop it from the persisted pm2 list too, so `pm2 resurrect` won't revive it.
-        await spawnExit([m.bin, "save"]);
+        // Drop it from the persisted pm2 list too, so `pm2 resurrect` won't
+        // revive it. --force is required: with the process list now empty, a
+        // plain `pm2 save` REFUSES to overwrite the dump ("Nothing to save!
+        // Please use --force") and the deleted daemon stays in dump.pm2 —
+        // resurrect/startup would then boot it alongside the new manager's.
+        await spawnExit([m.bin, "save", "--force"]);
         // Remove the Windows login auto-start entry we added at install time.
         if (process.platform === "win32")
           await spawnExit(["reg", "delete", WIN_RUN_KEY, "/v", WIN_RUN_VALUE, "/f"]);


### PR DESCRIPTION
Follow-up to #251, from qamac's live re-verification on sym003: the uninstall sweep deletes the pm2 daemon, but the subsequent plain `pm2 save` runs against a now-empty process list and pm2 **refuses to overwrite the dump** ("Nothing to save! Please use --force"). The deleted daemon therefore survives in `~/.pm2/dump.pm2`, and any user who ever ran `pm2 startup` gets the old daemon resurrected **alongside** the new manager's on reboot — the double-daemon reborn via the resurrect path.

One-liner: `pm2 save --force` after the delete. `ensureBootAutostart`'s save is deliberately untouched — the list is non-empty there, so plain save works and --force would be gratuitous.

qamac will re-verify the full pm2-baseline → oxmgr migration on sym003 (dump auto-empties, no manual --force, zero double-start) once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)