### PR TITLE
feat(ws): ay ws subcommand — list/status/new/fork over the codehost workspace layout

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -71,7 +71,13 @@ clis:
     autoRetry:
       - pattern: "API Error.*Overloaded"
         flags: i
-      - Overloaded
+      # The CLI's transient status toast is a line that is ONLY "Overloaded"
+      # (optionally a leading bullet/mark). Whole-line anchored: a task title or
+      # prose merely mentioning Overloaded must not arm a spurious retry —
+      # rendered task lists / summaries sit on screen next to a ready prompt,
+      # which is exactly the arm condition.
+      - pattern: '^\s*[·•●⎿✗×]?\s*Overloaded\.?\s*$'
+        flags: m
       # "API Error: Response stalled mid-stream. The response above may be
       # incomplete." — the streamed response wedged and the client aborted
       # mid-token. Transient + server-side like Overloaded, so retry with
@@ -98,11 +104,20 @@ clis:
       # a stray "529"/"500" in normal output can't trigger a spurious retry.
       - pattern: 'API Error.{0,4}5\d\d'
         flags: i
+      # 429 / rate-limit: anchored to the "API Error" chrome. A bare
+      # `rate.?limit` here caused real spurious retries — an on-screen task
+      # list ("client ignores rate-limit drop") or an agent's own summary
+      # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
+      # perfectly healthy session.
+      - pattern: 'API Error.{0,4}429'
+        flags: i
+      - pattern: 'API Error[\s\S]{0,60}rate.?limit'
+        flags: i
       - Claude usage limit reached
       - hit your usage limit
-      - pattern: "rate.?limit"
-        flags: i
-      - pattern: "session limit"
+      # Session/5-hour limit banners keep the distinctive "… limit reached"
+      # phrase; a bare "session limit" matched ordinary prose.
+      - pattern: '(session|5-hour) limit reached'
         flags: i
     restoreArgs:
       - --continue
@@ -195,14 +210,26 @@ clis:
     autoRetry:
       - pattern: "API Error.*Overloaded"
         flags: i
-      - Overloaded
+      # Whole-line-only toast match — see the claude group for why a bare
+      # `Overloaded` substring is dangerous (task lists / prose arm retries).
+      - pattern: '^\s*[·•●⎿✗×]?\s*Overloaded\.?\s*$'
+        flags: m
       - pattern: 'API Error.{0,4}5\d\d'
+        flags: i
+      # 429 / rate-limit: anchored to the "API Error" chrome. A bare
+      # `rate.?limit` here caused real spurious retries — an on-screen task
+      # list ("client ignores rate-limit drop") or an agent's own summary
+      # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
+      # perfectly healthy session.
+      - pattern: 'API Error.{0,4}429'
+        flags: i
+      - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
       - Claude usage limit reached
       - hit your usage limit
-      - pattern: "rate.?limit"
-        flags: i
-      - pattern: "session limit"
+      # Session/5-hour limit banners keep the distinctive "… limit reached"
+      # phrase; a bare "session limit" matched ordinary prose.
+      - pattern: '(session|5-hour) limit reached'
         flags: i
     restoreArgs:
       - --continue
@@ -300,14 +327,26 @@ clis:
     autoRetry:
       - pattern: "API Error.*Overloaded"
         flags: i
-      - Overloaded
+      # Whole-line-only toast match — see the claude group for why a bare
+      # `Overloaded` substring is dangerous (task lists / prose arm retries).
+      - pattern: '^\s*[·•●⎿✗×]?\s*Overloaded\.?\s*$'
+        flags: m
       - pattern: 'API Error.{0,4}5\d\d'
+        flags: i
+      # 429 / rate-limit: anchored to the "API Error" chrome. A bare
+      # `rate.?limit` here caused real spurious retries — an on-screen task
+      # list ("client ignores rate-limit drop") or an agent's own summary
+      # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
+      # perfectly healthy session.
+      - pattern: 'API Error.{0,4}429'
+        flags: i
+      - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
       - Claude usage limit reached
       - hit your usage limit
-      - pattern: "rate.?limit"
-        flags: i
-      - pattern: "session limit"
+      # Session/5-hour limit banners keep the distinctive "… limit reached"
+      # phrase; a bare "session limit" matched ordinary prose.
+      - pattern: '(session|5-hour) limit reached'
         flags: i
     restoreArgs:
       - --continue

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -27,7 +27,7 @@ pub const SUBCOMMANDS: &[&str] = &[
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a
 /// cli-bound alias like `cy`. Mirrors `MANAGER_SUBCOMMANDS` in ts/subcommands.ts.
-pub const MANAGER_SUBCOMMANDS: &[&str] = &["setup"];
+pub const MANAGER_SUBCOMMANDS: &[&str] = &["setup", "ws"];
 
 /// Whether `name` is a management subcommand. `manager_commands` (true for the
 /// generic `ay`/`agent-yes` entry) additionally admits manager-only commands

--- a/rs/src/config.rs
+++ b/rs/src/config.rs
@@ -298,6 +298,51 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Self-trigger guard: the informative auto-retry message is typed into the
+    /// PTY and stays visible in the transcript, so if it ever matched a CLI's
+    /// own screen-scrape patterns it would re-arm the retry loop (autoRetry),
+    /// block the streak reset, kill the session (fatal), or fake a state
+    /// (working/enter/needsInput/typingRespond). Assert every producible
+    /// message is inert against every CLI's patterns.
+    #[test]
+    fn test_auto_retry_message_is_inert_against_all_cli_patterns() {
+        use crate::context::{build_retry_message, RETRY_REASONS};
+        let configs = load_builtin_cli_configs().unwrap();
+        assert!(!configs.is_empty());
+        for (cli, config) in &configs {
+            for reason in RETRY_REASONS {
+                for (attempt, since, next) in
+                    [(1u32, 0u64, 8u64), (5, 500, 128), (12, 30_000, 256)]
+                {
+                    let msg = build_retry_message(attempt, reason, since, next);
+                    let groups: [(&str, &Vec<Regex>); 5] = [
+                        ("autoRetry", &config.auto_retry),
+                        ("fatal", &config.fatal),
+                        ("enter", &config.enter),
+                        ("working", &config.working),
+                        ("needsInput", &config.needs_input),
+                    ];
+                    for (kind, patterns) in groups {
+                        for rx in patterns {
+                            assert!(
+                                !rx.is_match(&msg),
+                                "retry message must not match {cli}.{kind} /{rx}/: {msg}"
+                            );
+                        }
+                    }
+                    for (send, patterns) in &config.typing_respond {
+                        for rx in patterns {
+                            assert!(
+                                !rx.is_match(&msg),
+                                "retry message must not match {cli}.typingRespond[{send}] /{rx}/: {msg}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_claude_patterns() {
         let config = get_cli_config("claude").unwrap();
@@ -379,6 +424,41 @@ mod tests {
             .auto_retry
             .iter()
             .any(|rx| rx.is_match("processed 529 files in 500ms")));
+        // Rate-limit is anchored to the API Error chrome: real 429 banners retry…
+        assert!(config.auto_retry.iter().any(|rx| rx.is_match(
+            r#"API Error: 429 {"type":"error","error":{"type":"rate_limit_error"}}"#
+        )));
+        // …but ordinary screen content that merely mentions rate limits must
+        // NOT — a rendered task list ("client ignores rate-limit drop") and an
+        // agent's own summary (INGEST_RATE_LIMIT_PER_MIN) both armed spurious
+        // retries on perfectly healthy sessions.
+        assert!(!config.auto_retry.iter().any(|rx| rx.is_match(
+            "P1: client ignores rate-limit drop → customer events permanently lost (#215)"
+        )));
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("set INGEST_RATE_LIMIT_PER_MIN below the batch cap")));
+        // The transient "Overloaded" toast still matches as a whole line…
+        assert!(config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("  ⎿ Overloaded\n? for shortcuts")));
+        assert!(config.auto_retry.iter().any(|rx| rx.is_match("Overloaded")));
+        // …but not embedded in prose / commit titles / task lists.
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("fix: treat Overloaded banners as recoverable")));
+        // Session/5-hour limit banners need the full "… limit reached" phrase.
+        assert!(config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("5-hour limit reached ∙ resets 3am")));
+        assert!(!config
+            .auto_retry
+            .iter()
+            .any(|rx| rx.is_match("bump the session limit for QA runs")));
         assert!(!config.typing_respond.is_empty());
         assert!(config.typing_respond.contains_key("1\n"));
         assert_eq!(config.restore_args, vec!["--continue"]);

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -154,6 +154,89 @@ fn should_fire_retry(working: bool, ready: bool, idle_ms: u64, min_idle_ms: u64)
     !working && ready && idle_ms >= min_idle_ms
 }
 
+/// Fallback reason when no autoRetry match was captured before firing.
+pub(crate) const RETRY_REASON_FALLBACK: &str = "a transient server-side error";
+
+/// All reason strings `classify_retry_reason` can produce — used by the
+/// self-trigger guard test in config.rs to prove every possible typed message
+/// is inert against every CLI's screen-scrape patterns.
+pub(crate) const RETRY_REASONS: [&str; 6] = [
+    "the model backend reported it is temporarily busy",
+    "the response stream stalled mid-way",
+    "the connection dropped mid-response",
+    "a usage cap was reached (it may need time to reset)",
+    "requests are being throttled by the server",
+    RETRY_REASON_FALLBACK,
+];
+
+/// Paraphrase the matched recoverable-error banner into a short reason.
+///
+/// Deliberately NEVER echoes the raw banner wording ("API Error", "Overloaded",
+/// "rate limit", …): the built message is typed into the PTY and stays visible
+/// in the transcript, where raw wording would re-match the autoRetry patterns —
+/// keeping `err` true forever, which blocks the streak reset on recovery. The
+/// guard test in config.rs asserts every produced message stays pattern-inert.
+pub(crate) fn classify_retry_reason(screen: &str) -> &'static str {
+    let s = screen.to_lowercase();
+    if s.contains("overload") {
+        RETRY_REASONS[0]
+    } else if s.contains("stalled") {
+        RETRY_REASONS[1]
+    } else if s.contains("connection closed") {
+        RETRY_REASONS[2]
+    } else if s.contains("usage limit") || s.contains("session limit") {
+        RETRY_REASONS[3]
+    } else if s.contains("rate") && s.contains("limit") {
+        RETRY_REASONS[4]
+    } else {
+        RETRY_REASON_FALLBACK
+    }
+}
+
+/// Human-readable duration: "45s", "3m20s", "1h04m", "8h".
+pub(crate) fn fmt_dur_secs(total: u64) -> String {
+    if total < 60 {
+        format!("{}s", total)
+    } else if total < 3600 {
+        let (m, s) = (total / 60, total % 60);
+        if s == 0 {
+            format!("{}m", m)
+        } else {
+            format!("{}m{:02}s", m, s)
+        }
+    } else {
+        let (h, m) = (total / 3600, (total % 3600) / 60);
+        if m == 0 {
+            format!("{}h", h)
+        } else {
+            format!("{}h{:02}m", h, m)
+        }
+    }
+}
+
+/// The single line typed into the agent's prompt instead of a bare "retry":
+/// says WHO is nudging (agent-yes, automated), WHY (paraphrased reason), and
+/// the backoff state (attempt #, elapsed, next delay, give-up horizon), plus
+/// an explicit "ignore if nothing failed" clause so an agent that already
+/// recovered — or is mid-question — doesn't burn a turn asking what "retry"
+/// refers to. Must stay one line (it is submitted with a single "\r").
+pub(crate) fn build_retry_message(
+    attempt: u32,
+    reason: &str,
+    since_first_secs: u64,
+    next_backoff_secs: u64,
+) -> String {
+    format!(
+        "retry [auto-retry #{attempt} by agent-yes: {reason}; first seen {since} ago; \
+         if this attempt fails too, the next nudge comes in {next} (giving up after {give_up}). \
+         This is an automated recovery nudge - if no request actually failed, ignore it and \
+         simply continue your previous task.]",
+        since = fmt_dur_secs(since_first_secs),
+        next = fmt_dur_secs(next_backoff_secs),
+        give_up = fmt_dur_secs(RETRY_GIVE_UP_SECS),
+    )
+}
+
 /// Agent context - centralized session state
 pub struct AgentContext {
     pub cli: String,
@@ -206,6 +289,9 @@ pub struct AgentContext {
     auto_retry_streak: u32,
     auto_retry_started_at: Option<Instant>,
     auto_retry_next_at: Option<Instant>,
+    // Paraphrased reason captured when the error banner was matched — folded
+    // into the typed retry message so the agent knows why it is being nudged.
+    auto_retry_reason: Option<&'static str>,
 
     // Idle screen scanner - re-checks enter patterns after prolonged idle
     last_idle_scan_at: Option<Instant>,
@@ -318,6 +404,7 @@ impl AgentContext {
             auto_retry_streak: 0,
             auto_retry_started_at: None,
             auto_retry_next_at: None,
+            auto_retry_reason: None,
             stall_esc_sent_at: None,
             stall_force_restart: false,
             ctrl_c_times: Vec::new(),
@@ -1113,16 +1200,24 @@ impl AgentContext {
                     self.auto_retry_next_at = Some(now + Duration::from_millis(500));
                 } else {
                     self.auto_retry_streak = self.auto_retry_streak.saturating_add(1);
-                    warn!(
-                        "Auto-retry: typing 'retry' (attempt {})",
-                        self.auto_retry_streak
-                    );
-                    self.do_send_retry(msg_ctx)?;
                     // Self-schedule the next retry with escalated backoff. Leaving
                     // this None and re-arming from check_patterns would tight-loop
                     // while the error banner stays on screen. check_patterns resets
                     // the streak (cancelling this) once the agent recovers.
                     let next = retry_backoff_secs(self.auto_retry_streak);
+                    let reason = self.auto_retry_reason.unwrap_or(RETRY_REASON_FALLBACK);
+                    let since = self
+                        .auto_retry_started_at
+                        .map(|t| t.elapsed().as_secs())
+                        .unwrap_or(0);
+                    let line =
+                        build_retry_message(self.auto_retry_streak, reason, since, next);
+                    warn!(
+                        "Auto-retry: typing retry nudge (attempt {}, reason: {})",
+                        self.auto_retry_streak, reason
+                    );
+                    self.do_send_retry(msg_ctx, &line)?;
+                    self.record_auto_retry_inbox(reason, self.auto_retry_streak, next);
                     self.auto_retry_next_at = Some(now + Duration::from_secs(next));
                 }
             }
@@ -1243,19 +1338,57 @@ impl AgentContext {
     }
 
     /// Type "retry" + Enter — the auto-retry response to a recoverable API error.
-    fn do_send_retry(&mut self, msg_ctx: &MessageContext) -> Result<()> {
+    fn do_send_retry(&mut self, msg_ctx: &MessageContext, line: &str) -> Result<()> {
         {
             let mut writer = msg_ctx
                 .writer
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Lock: {}", e))?;
-            writer.write_all(b"retry")?;
+            writer.write_all(line.as_bytes())?;
             writer.write_all(b"\r")?;
             writer.flush()?;
         }
         self.idle_waiter.ping();
         self.mark_stdin_sent();
         Ok(())
+    }
+
+    /// Best-effort structured record of the nudge into this agent's own
+    /// `<cwd>/.agent-yes/inbox.jsonl` (schema mirrors ts/messageLog.ts
+    /// MessageRecord, kind "auto-retry"), so `ay msgs` / the console can show
+    /// why and how often an agent got poked. Never fails or blocks the send;
+    /// compaction is left to the TS appenders (these entries are rare —
+    /// bounded by the backoff ladder and the 8h give-up window).
+    fn record_auto_retry_inbox(&self, reason: &str, attempt: u32, next_backoff_secs: u64) {
+        let dir = std::path::Path::new(&self.cwd).join(".agent-yes");
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let record = serde_json::json!({
+            "at": at,
+            "from": serde_json::Value::Null,
+            "to": { "pid": std::process::id(), "cli": self.cli, "cwd": self.cwd },
+            "kind": "auto-retry",
+            "body": format!(
+                "{} (attempt {}, next backoff {})",
+                reason,
+                attempt,
+                fmt_dur_secs(next_backoff_secs)
+            ),
+            "wrapped": false,
+        });
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("inbox.jsonl"))
+        {
+            use std::io::Write as _;
+            let _ = writeln!(f, "{}", record);
+        }
     }
 
     /// Stamp the last-stdin time — marks a "poke" whose response (any PTY
@@ -1345,6 +1478,10 @@ impl AgentContext {
                 .any(|p| p.is_match(&buffer));
             let ready_now = self.cli_config.ready.iter().any(|p| p.is_match(&buffer));
             if err && ready_now {
+                // Remember WHY (paraphrased — see classify_retry_reason) so the
+                // typed message can explain itself. Refresh on every match: the
+                // banner may change across attempts (e.g. overload → 5xx).
+                self.auto_retry_reason = Some(classify_retry_reason(&buffer));
                 // Error banner is up AND the agent is back at its prompt: schedule
                 // the next retry unless one is already counting down.
                 if self.auto_retry_next_at.is_none() {
@@ -1541,6 +1678,54 @@ mod tests {
         // capped at RETRY_MAX_DELAY_SECS, and no shift overflow for large streaks
         assert_eq!(retry_backoff_secs(6), 256);
         assert_eq!(retry_backoff_secs(50), 256);
+    }
+
+    #[test]
+    fn test_classify_retry_reason_maps_banners_to_inert_paraphrases() {
+        assert_eq!(
+            classify_retry_reason("● API Error: 529 Overloaded"),
+            RETRY_REASONS[0]
+        );
+        assert_eq!(
+            classify_retry_reason("API Error: Response stalled mid-stream."),
+            RETRY_REASONS[1]
+        );
+        assert_eq!(
+            classify_retry_reason("API Error: Connection closed mid-response."),
+            RETRY_REASONS[2]
+        );
+        assert_eq!(
+            classify_retry_reason("Claude usage limit reached"),
+            RETRY_REASONS[3]
+        );
+        assert_eq!(classify_retry_reason("You are being rate-limited"), RETRY_REASONS[4]);
+        assert_eq!(
+            classify_retry_reason("API Error: 503 Service Unavailable"),
+            RETRY_REASON_FALLBACK
+        );
+    }
+
+    #[test]
+    fn test_fmt_dur_secs() {
+        assert_eq!(fmt_dur_secs(0), "0s");
+        assert_eq!(fmt_dur_secs(45), "45s");
+        assert_eq!(fmt_dur_secs(60), "1m");
+        assert_eq!(fmt_dur_secs(200), "3m20s");
+        assert_eq!(fmt_dur_secs(3600), "1h");
+        assert_eq!(fmt_dur_secs(3900), "1h05m");
+        assert_eq!(fmt_dur_secs(8 * 3600), "8h");
+    }
+
+    #[test]
+    fn test_build_retry_message_is_one_line_with_context() {
+        let msg = build_retry_message(3, RETRY_REASONS[0], 45, 64);
+        assert!(!msg.contains('\n'), "must be a single line: {msg}");
+        assert!(msg.starts_with("retry ["), "keeps the imperative first: {msg}");
+        assert!(msg.contains("#3"));
+        assert!(msg.contains("45s ago"));
+        assert!(msg.contains("in 1m04s"));
+        assert!(msg.contains("giving up after 8h"));
+        assert!(msg.contains("ignore it"), "needs the ignore-if-recovered clause");
     }
 
     #[test]

--- a/ts/autoRetry.spec.ts
+++ b/ts/autoRetry.spec.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { AUTO_RETRY_MAX_DELAY_SECS, autoRetryBackoffMs, shouldFireRetry } from "./autoRetry.ts";
+import {
+  AUTO_RETRY_MAX_DELAY_SECS,
+  AUTO_RETRY_REASON_FALLBACK,
+  AUTO_RETRY_REASONS,
+  autoRetryBackoffMs,
+  buildAutoRetryMessage,
+  classifyAutoRetryReason,
+  formatDurationSecs,
+  shouldFireRetry,
+} from "./autoRetry.ts";
+import { loadSharedCliDefaults } from "./configShared.ts";
 
 describe("autoRetryBackoffMs", () => {
   it("doubles 8,16,32,…,256 then caps", () => {
@@ -30,5 +40,84 @@ describe("shouldFireRetry", () => {
     // Ready, idle, and past the quiet window — fire.
     expect(shouldFireRetry(false, true, 5_000, 5_000)).toBe(true);
     expect(shouldFireRetry(false, true, 10_000, 5_000)).toBe(true);
+  });
+});
+
+describe("classifyAutoRetryReason", () => {
+  it("maps real banners to inert paraphrases", () => {
+    expect(classifyAutoRetryReason("● API Error: 529 Overloaded")).toBe(AUTO_RETRY_REASONS[0]);
+    expect(classifyAutoRetryReason("API Error: Response stalled mid-stream.")).toBe(
+      AUTO_RETRY_REASONS[1],
+    );
+    expect(classifyAutoRetryReason("API Error: Connection closed mid-response.")).toBe(
+      AUTO_RETRY_REASONS[2],
+    );
+    expect(classifyAutoRetryReason("Claude usage limit reached")).toBe(AUTO_RETRY_REASONS[3]);
+    expect(classifyAutoRetryReason("You are being rate-limited")).toBe(AUTO_RETRY_REASONS[4]);
+    expect(classifyAutoRetryReason("API Error: 503 Service Unavailable")).toBe(
+      AUTO_RETRY_REASON_FALLBACK,
+    );
+  });
+});
+
+describe("formatDurationSecs", () => {
+  it("renders s / m / h forms", () => {
+    expect(formatDurationSecs(0)).toBe("0s");
+    expect(formatDurationSecs(45)).toBe("45s");
+    expect(formatDurationSecs(60)).toBe("1m");
+    expect(formatDurationSecs(200)).toBe("3m20s");
+    expect(formatDurationSecs(3600)).toBe("1h");
+    expect(formatDurationSecs(3900)).toBe("1h05m");
+    expect(formatDurationSecs(8 * 3600)).toBe("8h");
+  });
+});
+
+describe("buildAutoRetryMessage", () => {
+  it("is one line and carries attempt/reason/backoff context + ignore clause", () => {
+    const msg = buildAutoRetryMessage(3, AUTO_RETRY_REASONS[0], 45, 64);
+    expect(msg).not.toContain("\n");
+    expect(msg.startsWith("retry [")).toBe(true);
+    expect(msg).toContain("#3");
+    expect(msg).toContain("45s ago");
+    expect(msg).toContain("in 1m04s");
+    expect(msg).toContain("giving up after 8h");
+    expect(msg).toContain("ignore it");
+  });
+
+  // Self-trigger guard: the message is typed into the PTY and stays visible in
+  // the transcript, so if it ever matched a CLI's own screen-scrape patterns
+  // it would re-arm the retry loop (autoRetry), block the streak reset, kill
+  // the session (fatal), or fake a state (working/enter/needsInput). Mirrors
+  // rs/src/config.rs test_auto_retry_message_is_inert_against_all_cli_patterns.
+  it("never matches any CLI's screen-scrape patterns", async () => {
+    const clis = await loadSharedCliDefaults();
+    expect(Object.keys(clis).length).toBeGreaterThan(0);
+    for (const [cliName, conf] of Object.entries(clis)) {
+      for (const reason of AUTO_RETRY_REASONS) {
+        const cases: [number, number, number][] = [
+          [1, 0, 8],
+          [5, 500, 128],
+          [12, 30_000, 256],
+        ];
+        for (const [attempt, since, next] of cases) {
+          const msg = buildAutoRetryMessage(attempt, reason, since, next);
+          const groups: [string, RegExp[] | undefined][] = [
+            ["autoRetry", conf.autoRetry],
+            ["fatal", conf.fatal],
+            ["enter", conf.enter],
+            ["working", conf.working],
+            ["needsInput", conf.needsInput],
+          ];
+          for (const [kind, patterns] of groups) {
+            for (const rx of patterns ?? []) {
+              expect(
+                rx.test(msg),
+                `retry message must not match ${cliName}.${kind} /${rx}/: ${msg}`,
+              ).toBe(false);
+            }
+          }
+        }
+      }
+    }
   });
 });

--- a/ts/autoRetry.ts
+++ b/ts/autoRetry.ts
@@ -37,3 +37,79 @@ export function shouldFireRetry(
 ): boolean {
   return !working && ready && idleMs >= minIdleMs;
 }
+
+/** Fallback reason when no autoRetry match was captured before firing. */
+export const AUTO_RETRY_REASON_FALLBACK = "a transient server-side error";
+
+/**
+ * All reason strings `classifyAutoRetryReason` can produce — used by the
+ * self-trigger guard spec to prove every possible typed message is inert
+ * against every CLI's screen-scrape patterns. Mirrors Rust's RETRY_REASONS.
+ */
+export const AUTO_RETRY_REASONS = [
+  "the model backend reported it is temporarily busy",
+  "the response stream stalled mid-way",
+  "the connection dropped mid-response",
+  "a usage cap was reached (it may need time to reset)",
+  "requests are being throttled by the server",
+  AUTO_RETRY_REASON_FALLBACK,
+] as const;
+
+/**
+ * Paraphrase the matched recoverable-error banner into a short reason.
+ *
+ * Deliberately NEVER echoes the raw banner wording ("API Error", "Overloaded",
+ * "rate limit", …): the built message is typed into the PTY and stays visible
+ * in the transcript, where raw wording would re-match the autoRetry patterns —
+ * keeping the error state true forever, which blocks the streak reset on
+ * recovery. Mirrors Rust's classify_retry_reason.
+ */
+export function classifyAutoRetryReason(screen: string): string {
+  const s = screen.toLowerCase();
+  if (s.includes("overload")) return AUTO_RETRY_REASONS[0];
+  if (s.includes("stalled")) return AUTO_RETRY_REASONS[1];
+  if (s.includes("connection closed")) return AUTO_RETRY_REASONS[2];
+  if (s.includes("usage limit") || s.includes("session limit")) return AUTO_RETRY_REASONS[3];
+  if (s.includes("rate") && s.includes("limit")) return AUTO_RETRY_REASONS[4];
+  return AUTO_RETRY_REASON_FALLBACK;
+}
+
+/** Human-readable duration: "45s", "3m20s", "1h04m", "8h". Mirrors Rust's fmt_dur_secs. */
+export function formatDurationSecs(total: number): string {
+  const t = Math.max(0, Math.floor(total));
+  if (t < 60) return `${t}s`;
+  if (t < 3600) {
+    const m = Math.floor(t / 60);
+    const s = t % 60;
+    return s === 0 ? `${m}m` : `${m}m${String(s).padStart(2, "0")}s`;
+  }
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}m`;
+}
+
+/**
+ * The single line typed into the agent's prompt instead of a bare "retry":
+ * says WHO is nudging (agent-yes, automated), WHY (paraphrased reason), and
+ * the backoff state (attempt #, elapsed, next delay, give-up horizon), plus an
+ * explicit "ignore if nothing failed" clause so an agent that already
+ * recovered — or is mid-question — doesn't burn a turn asking what "retry"
+ * refers to. Must stay one line (it is submitted with a single "\r").
+ * Mirrors Rust's build_retry_message in rs/src/context.rs.
+ */
+export function buildAutoRetryMessage(
+  attempt: number,
+  reason: string,
+  sinceFirstSecs: number,
+  nextBackoffSecs: number,
+): string {
+  const since = formatDurationSecs(sinceFirstSecs);
+  const next = formatDurationSecs(nextBackoffSecs);
+  const giveUp = formatDurationSecs(AUTO_RETRY_GIVE_UP_MS / 1000);
+  return (
+    `retry [auto-retry #${attempt} by agent-yes: ${reason}; first seen ${since} ago; ` +
+    `if this attempt fails too, the next nudge comes in ${next} (giving up after ${giveUp}). ` +
+    `This is an automated recovery nudge - if no request actually failed, ignore it and ` +
+    `simply continue your previous task.]`
+  );
+}

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -21,9 +21,14 @@ import { sendEnter, sendMessage } from "./core/messaging.ts";
 import {
   AUTO_RETRY_GIVE_UP_MS,
   AUTO_RETRY_MIN_IDLE_MS,
+  AUTO_RETRY_REASON_FALLBACK,
   autoRetryBackoffMs,
+  buildAutoRetryMessage,
+  classifyAutoRetryReason,
+  formatDurationSecs,
   shouldFireRetry,
 } from "./autoRetry.ts";
+import { recordInbox } from "./messageLog.ts";
 import {
   initializeLogPaths,
   setupDebugLogging,
@@ -794,6 +799,9 @@ export default async function agentYes({
   let retryStartedAt: number | null = null;
   let retryNextAt: number | null = null;
   let autoRetryScreen = "";
+  // Paraphrased reason captured when the error banner was matched — folded
+  // into the typed retry message so the agent knows why it is being nudged.
+  let retryReason: string | null = null;
   const heartbeatInterval = setInterval(async () => {
     try {
       const rendered = removeControlCharacters(xtermProxy.tail(12));
@@ -822,15 +830,36 @@ export default async function agentYes({
             retryNextAt = now + 500; // busy / not at prompt / still active — re-check shortly
           } else {
             retryStreak += 1;
-            logger.warn(`[${cli}-yes] auto-retry: typing 'retry' (attempt ${retryStreak})`);
-            // Write "retry" + Enter atomically (mirrors rs do_send_retry); using
+            const nextBackoffMs = autoRetryBackoffMs(retryStreak);
+            const reason = retryReason ?? AUTO_RETRY_REASON_FALLBACK;
+            const sinceFirstSecs = retryStartedAt === null ? 0 : (now - retryStartedAt) / 1000;
+            const line = buildAutoRetryMessage(
+              retryStreak,
+              reason,
+              sinceFirstSecs,
+              nextBackoffMs / 1000,
+            );
+            logger.warn(
+              `[${cli}-yes] auto-retry: typing retry nudge (attempt ${retryStreak}, reason: ${reason})`,
+            );
+            // Write the nudge + Enter atomically (mirrors rs do_send_retry); using
             // sendMessage would split text/Enter across the fast heartbeat ticks.
-            ctx.messageContext.shell.write("retry\r");
+            ctx.messageContext.shell.write(line + "\r");
             ctx.idleWaiter.ping();
+            // Structured trace for `ay msgs` / the console (mirrors the Rust
+            // runtime's record_auto_retry_inbox) — best-effort, never blocks.
+            void recordInbox({
+              at: now,
+              from: null,
+              to: { pid: process.pid, cli, cwd: workingDir },
+              kind: "auto-retry",
+              body: `${reason} (attempt ${retryStreak}, next backoff ${formatDurationSecs(nextBackoffMs / 1000)})`,
+              wrapped: false,
+            });
             // Self-schedule the next retry with escalated backoff. (Leaving nextAt
             // null and re-arming from the stdout pipeline would tight-loop while the
             // error banner stays on screen.) Reset on recovery cancels this.
-            retryNextAt = now + autoRetryBackoffMs(retryStreak);
+            retryNextAt = now + nextBackoffMs;
           }
         }
       }
@@ -1185,6 +1214,10 @@ export default async function agentYes({
               const errVisible = conf.autoRetry.some((rx: RegExp) => rx.test(rendered));
               const readyVisible = conf.ready?.some((rx: RegExp) => rx.test(rendered)) ?? false;
               if (errVisible && readyVisible) {
+                // Remember WHY (paraphrased — see classifyAutoRetryReason) so
+                // the typed message can explain itself. Refresh on every match:
+                // the banner may change across attempts (e.g. overload → 5xx).
+                retryReason = classifyAutoRetryReason(rendered);
                 if (retryNextAt === null) {
                   if (retryStartedAt === null) retryStartedAt = Date.now();
                   const delayMs = autoRetryBackoffMs(retryStreak);

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -39,8 +39,9 @@ export interface MessageRecord {
   to: MailParty;
   /** What kind of stdin write this was. Omitted for a normal `ay send` text
    * message; "key" for raw keystrokes (`ay key`), "select" for a menu pick
-   * (`ay select`). For key/select the `body` holds the key names / choice. */
-  kind?: "key" | "select";
+   * (`ay select`), "auto-retry" for the wrapper's own recoverable-error nudge
+   * (from is null; `body` holds the paraphrased reason + backoff state). */
+  kind?: "key" | "select" | "auto-retry";
   /** The message body (without the `[ay-msg …]` wrapper), or — for a key/select
    * record — the keystroke names / chosen option. */
   body: string;

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -211,7 +211,7 @@ export interface MessageEdge {
   by: number;
   target: number;
   at: number;
-  kind?: "key" | "select";
+  kind?: "key" | "select" | "auto-retry";
 }
 
 /**
@@ -3279,10 +3279,14 @@ async function cmdMsgs(rest: string[]): Promise<number> {
 
   for (const { dir, rec } of shown) {
     const when = new Date(rec.at).toLocaleTimeString();
-    const peer =
-      dir === "out"
-        ? `→ ${rec.to.cli} #${rec.to.pid}`
-        : `← ${rec.from ? `${rec.from.cli} #${rec.from.pid}` : "human"}`;
+    // auto-retry nudges are written by the agent's own wrapper (from is null
+    // there too) — label them as agent-yes, not a human send.
+    const fromLabel = rec.from
+      ? `${rec.from.cli} #${rec.from.pid}`
+      : rec.kind === "auto-retry"
+        ? "agent-yes"
+        : "human";
+    const peer = dir === "out" ? `→ ${rec.to.cli} #${rec.to.pid}` : `← ${fromLabel}`;
     const via = rec.remote ? ` (via ${rec.remote})` : "";
     const flag = rec.confirmed === false ? " (unconfirmed)" : "";
     const tag = rec.kind ? `[${rec.kind}] ` : "";

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -368,7 +368,7 @@ const SUBCOMMANDS = new Set([
 // alias like `cy` (= claude-yes = "agent-yes claude") must NOT treat these as
 // subcommands — `cy setup …` should run claude with that text, not manage the
 // host. Kept separate from SUBCOMMANDS so a runner alias falls straight through.
-const MANAGER_SUBCOMMANDS = new Set(["setup"]);
+const MANAGER_SUBCOMMANDS = new Set(["setup", "ws"]);
 
 const IDLE_THRESHOLD_MS = 60 * 1000;
 
@@ -475,6 +475,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         const { cmdSetup } = await import("./setup.ts");
         return cmdSetup(rest);
       }
+      case "ws": {
+        const { cmdWs } = await import("./ws.ts");
+        return cmdWs(rest);
+      }
       case "schedule": {
         const { cmdSchedule } = await import("./schedule.ts");
         return cmdSchedule(rest);
@@ -572,6 +576,11 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
   const setupLine = managerCommands
     ? `  ay setup                            guided setup: pick a workspace, share to agent-yes.com\n`
     : ``;
+  // `ws` is manager-only for the same reason as `setup`.
+  const wsLines = managerCommands
+    ? `  ay ws ls [--status]                 list <owner>/<repo>/tree/<branch> workspaces\n` +
+      `  ay ws new <owner>/<repo>[@branch]   clone/refresh a workspace (ay ws help for more)\n`
+    : ``;
   // Only agents carry AGENT_YES_PID — a human shell never sets it — so this
   // section is skipped entirely (no async work at all) for interactive use.
   const self = process.env.AGENT_YES_PID ? await resolveSender() : null;
@@ -599,6 +608,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay result <keyword> [--wait]        pull an agent's structured result envelope\n` +
       `  ay result set '<json>'              (inside an agent) deposit your result envelope\n` +
       `  ay reap                             kill process groups leaked by dead agents\n` +
+      wsLines +
       `\n` +
       `Remote:\n` +
       setupLine +

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -1,8 +1,33 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
-import { isPathInside, resolveOperand, walkWorkspaces, WS_JSON_SCHEMA } from "./ws.ts";
+import { cmdWs, isPathInside, resolveOperand, walkWorkspaces, WS_JSON_SCHEMA } from "./ws.ts";
+
+// Mutable fake for codehost/provision — each test overrides what it needs.
+// ws.ts imports the module lazily; vitest's registry mock intercepts that too.
+const prov = vi.hoisted(() => ({
+  wsRoot: "",
+  parseSource: (input: string): { owner: string; repo: string; branch: string } | null => {
+    const m = input.match(/^([^/]+)\/([^/@]+)(?:@(.+))?$/);
+    return m ? { owner: m[1]!, repo: m[2]!, branch: m[3] ?? "main" } : null;
+  },
+  readStatus: vi.fn(),
+  provision: vi.fn(),
+  createBranch: vi.fn(),
+  forkWorktree: vi.fn(),
+}));
+
+vi.mock("codehost/provision", () => ({
+  resolveWsRoot: (w?: string) => w ?? prov.wsRoot,
+  folderFor: (spec: { owner: string; repo: string; branch: string }, wsRoot?: string) =>
+    path.join(wsRoot ?? prov.wsRoot, spec.owner, spec.repo, "tree", spec.branch),
+  parseSource: (input: string) => prov.parseSource(input),
+  readStatus: (dir: string) => prov.readStatus(dir),
+  provision: (spec: unknown, opts?: unknown) => prov.provision(spec, opts),
+  createBranch: (spec: unknown, opts?: unknown) => prov.createBranch(spec, opts),
+  forkWorktree: (opts: unknown) => prov.forkWorktree(opts),
+}));
 
 describe("isPathInside", () => {
   it("contains itself and descendants", () => {
@@ -146,5 +171,178 @@ describe("resolveOperand", () => {
 describe("json schema tag", () => {
   it("is versioned", () => {
     expect(WS_JSON_SCHEMA).toBe("ay-ws/v1");
+  });
+});
+
+describe("cmdWs (mocked provision)", () => {
+  let root: string;
+  let out: string[];
+  let err: string[];
+  let homeBackup: string | undefined;
+
+  const CLEAN = { branch: "main", head: "abc123", ahead: 0, behind: 0, dirty: false, hasUpstream: true };
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "ay-ws-cmd-"));
+    prov.wsRoot = root;
+    prov.readStatus.mockReset().mockResolvedValue(CLEAN);
+    prov.provision.mockReset();
+    prov.createBranch.mockReset();
+    prov.forkWorktree.mockReset();
+    out = [];
+    err = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((s: any) => (out.push(String(s)), true));
+    vi.spyOn(process.stderr, "write").mockImplementation((s: any) => (err.push(String(s)), true));
+    // Isolate the agent registry so live-agent counts are deterministic (0).
+    homeBackup = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = path.join(root, ".ay-home");
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (homeBackup === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = homeBackup;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const mkCheckout = (rel: string) => {
+    const dir = path.join(root, rel);
+    mkdirSync(path.join(dir, ".git"), { recursive: true });
+    return dir;
+  };
+
+  it("no args / unknown sub → help (0) and error (1)", async () => {
+    expect(await cmdWs([])).toBe(0);
+    expect(out.join("")).toContain("ay ws ls");
+    expect(await cmdWs(["nope"])).toBe(1);
+    expect(err.join("")).toContain('unknown subcommand "nope"');
+  });
+
+  it("ls: empty root note, then table with agent hint column", async () => {
+    expect(await cmdWs(["ls"])).toBe(0);
+    expect(err.join("")).toContain("no workspaces under");
+    mkCheckout("o/r/tree/main");
+    expect(await cmdWs(["ls"])).toBe(0);
+    const table = out.join("");
+    expect(table).toContain("WORKSPACE");
+    expect(table).toContain("o/r@main");
+  });
+
+  it("ls --json: versioned schema envelope", async () => {
+    const dir = mkCheckout("o/r/tree/feat/x");
+    expect(await cmdWs(["ls", "--json"])).toBe(0);
+    const doc = JSON.parse(out.join(""));
+    expect(doc.schema).toBe(WS_JSON_SCHEMA);
+    expect(doc.wsRoot).toBe(root);
+    expect(doc.workspaces).toEqual([
+      { owner: "o", repo: "r", branch: "feat/x", path: dir, agents: { live: 0 } },
+    ]);
+  });
+
+  it("ls --status: git summaries and the per-entry error fallback", async () => {
+    mkCheckout("o/r/tree/clean");
+    mkCheckout("o/r/tree/messy");
+    mkCheckout("o/r/tree/broken");
+    prov.readStatus.mockImplementation(async (dir: string) => {
+      if (dir.endsWith("broken")) throw new Error("boom");
+      if (dir.endsWith("messy"))
+        return { branch: "messy", head: "h", ahead: 2, behind: 1, dirty: true, hasUpstream: false };
+      return CLEAN;
+    });
+    expect(await cmdWs(["ls", "--status"])).toBe(0);
+    const table = out.join("");
+    expect(table).toContain("clean");
+    expect(table).toContain("dirty, ahead 2, behind 1, no-upstream");
+    expect(table).toContain("error: boom");
+  });
+
+  it("ls rejects positional args and unknown flags", async () => {
+    await expect(cmdWs(["ls", "stray"])).rejects.toThrow(/no positional/);
+    await expect(cmdWs(["ls", "--nope"])).rejects.toThrow(/unknown flag --nope/);
+    await expect(cmdWs(["ls", "--json=1"])).rejects.toThrow(/takes no value/);
+  });
+
+  it("status: layout spec + state text for a path target, --json shape", async () => {
+    const dir = mkCheckout("o/r/tree/feat/y");
+    expect(await cmdWs(["status", dir])).toBe(0);
+    const text = out.join("");
+    expect(text).toContain("spec:     o/r@feat/y");
+    expect(text).toContain("state:    clean");
+    out.length = 0;
+    expect(await cmdWs(["status", dir, "--json"])).toBe(0);
+    const doc = JSON.parse(out.join(""));
+    expect(doc.schema).toBe(WS_JSON_SCHEMA);
+    expect(doc.workspace.branch).toBe("feat/y");
+    expect(doc.workspace.git).toEqual(CLEAN);
+  });
+
+  it("status: a checkout outside the layout omits the spec line", async () => {
+    const outside = mkdtempSync(path.join(os.tmpdir(), "ay-ws-out-"));
+    try {
+      mkdirSync(path.join(outside, ".git"));
+      expect(await cmdWs(["status", outside])).toBe(0);
+      expect(out.join("")).not.toContain("spec:");
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("status: --path and --spec are mutually exclusive; one target max", async () => {
+    await expect(cmdWs(["status", "--path", "--spec"])).rejects.toThrow(/mutually exclusive/);
+    await expect(cmdWs(["status", "a", "b"])).rejects.toThrow(/at most one/);
+  });
+
+  it("new: provisions and prints the action + folder", async () => {
+    prov.provision.mockResolvedValue({ ok: true, action: "cloned", folder: "/x" });
+    expect(await cmdWs(["new", "o/r@dev"])).toBe(0);
+    expect(prov.provision).toHaveBeenCalledWith(
+      { owner: "o", repo: "r", branch: "dev" },
+      { wsRoot: undefined },
+    );
+    expect(out.join("")).toContain("cloned  /x");
+  });
+
+  it("new: branch-not-found hints at --create, and --create falls back to createBranch", async () => {
+    prov.provision.mockResolvedValue({ ok: false, action: "error", reason: "branch-not-found", error: "nope" });
+    expect(await cmdWs(["new", "o/r@dev"])).toBe(1);
+    expect(err.join("")).toContain("--create");
+    expect(prov.createBranch).not.toHaveBeenCalled();
+
+    prov.createBranch.mockResolvedValue({ ok: true, action: "created", folder: "/y" });
+    expect(await cmdWs(["new", "o/r@dev", "--create"])).toBe(0);
+    expect(out.join("")).toContain("created  /y");
+  });
+
+  it("new: usage and parse errors", async () => {
+    await expect(cmdWs(["new"])).rejects.toThrow(/usage: ay ws new/);
+    await expect(cmdWs(["new", "///"])).rejects.toThrow(/cannot parse/);
+  });
+
+  it("fork: --from is resolved and passed through with --wip", async () => {
+    prov.forkWorktree.mockResolvedValue({ ok: true, action: "forked", folder: "/f" });
+    expect(await cmdWs(["fork", "nb", "--from", root, "--wip"])).toBe(0);
+    expect(prov.forkWorktree).toHaveBeenCalledWith({
+      fromCwd: path.resolve(root),
+      branch: "nb",
+      wsRoot: undefined,
+      wip: true,
+    });
+    expect(out.join("")).toContain("forked  /f");
+  });
+
+  it("fork: defaults --from to cwd (no agent env), surfaces failure", async () => {
+    const envBackup = process.env.AGENT_YES_PID;
+    delete process.env.AGENT_YES_PID;
+    try {
+      prov.forkWorktree.mockResolvedValue({ ok: false, error: "no origin" });
+      expect(await cmdWs(["fork", "nb"])).toBe(1);
+      expect(prov.forkWorktree).toHaveBeenCalledWith(
+        expect.objectContaining({ fromCwd: path.resolve(process.cwd()), wip: false }),
+      );
+      expect(err.join("")).toContain("fork failed: no origin");
+      await expect(cmdWs(["fork"])).rejects.toThrow(/usage: ay ws fork/);
+      await expect(cmdWs(["fork", "nb", "--from"])).rejects.toThrow(/requires a value/);
+    } finally {
+      if (envBackup !== undefined) process.env.AGENT_YES_PID = envBackup;
+    }
   });
 });

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { isPathInside, resolveOperand, walkWorkspaces, WS_JSON_SCHEMA } from "./ws.ts";
+
+describe("isPathInside", () => {
+  it("contains itself and descendants", () => {
+    expect(isPathInside("/a/b", "/a/b")).toBe(true);
+    expect(isPathInside("/a/b", "/a/b/c/d")).toBe(true);
+  });
+
+  it("rejects siblings sharing a name prefix (segment boundary, not startsWith)", () => {
+    expect(isPathInside("/a/repo", "/a/repo-two/x")).toBe(false);
+  });
+
+  it("rejects parents and unrelated paths", () => {
+    expect(isPathInside("/a/b/c", "/a/b")).toBe(false);
+    expect(isPathInside("/a/b", "/z")).toBe(false);
+  });
+
+  it("resolves relative segments before comparing", () => {
+    expect(isPathInside("/a/b", "/a/b/../b/c")).toBe(true);
+    expect(isPathInside("/a/b", "/a/b/../c")).toBe(false);
+  });
+});
+
+describe("walkWorkspaces", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "ay-ws-test-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const mkCheckout = (rel: string, gitAs: "dir" | "file") => {
+    const dir = path.join(root, rel);
+    mkdirSync(dir, { recursive: true });
+    if (gitAs === "dir") mkdirSync(path.join(dir, ".git"));
+    else writeFileSync(path.join(dir, ".git"), "gitdir: /elsewhere\n");
+    return dir;
+  };
+
+  it("finds clones and linked worktrees, including branches containing '/'", async () => {
+    const a = mkCheckout("owner/repo/tree/main", "dir");
+    const b = mkCheckout("owner/repo/tree/feat/deep/branch", "file");
+    const found = await walkWorkspaces(root);
+    expect(found).toEqual([
+      { owner: "owner", repo: "repo", branch: "feat/deep/branch", path: b },
+      { owner: "owner", repo: "repo", branch: "main", path: a },
+    ]);
+  });
+
+  it("does not descend into a checkout root looking for nested checkouts", async () => {
+    const a = mkCheckout("o/r/tree/main", "dir");
+    // a stray nested checkout below an existing root must not double-report
+    mkdirSync(path.join(a, "vendor", ".git"), { recursive: true });
+    const found = await walkWorkspaces(root);
+    expect(found.map((w) => w.branch)).toEqual(["main"]);
+  });
+
+  it("skips non-layout dirs, dotdirs, and symlinks", async () => {
+    mkCheckout("o/r/tree/main", "dir");
+    mkdirSync(path.join(root, "o/r/notes"), { recursive: true }); // no tree/ marker
+    mkdirSync(path.join(root, ".hidden/x/tree/y"), { recursive: true });
+    mkdirSync(path.join(root, "loop/r/tree"), { recursive: true });
+    // symlink cycle under tree/ must not hang or be reported
+    symlinkSync(path.join(root, "loop"), path.join(root, "loop/r/tree/self"));
+    const found = await walkWorkspaces(root);
+    expect(found.map((w) => `${w.owner}/${w.repo}@${w.branch}`)).toEqual(["o/r@main"]);
+  });
+
+  it("bounds the branch-depth walk", async () => {
+    const deep = "o/r/tree/" + Array.from({ length: 12 }, (_, i) => `d${i}`).join("/");
+    mkCheckout(deep, "dir");
+    const found = await walkWorkspaces(root);
+    expect(found).toEqual([]); // beyond MAX_BRANCH_DEPTH → ignored, not crashed
+  });
+
+  it("returns [] for an empty or missing root", async () => {
+    expect(await walkWorkspaces(root)).toEqual([]);
+    expect(await walkWorkspaces(path.join(root, "nope"))).toEqual([]);
+  });
+});
+
+describe("resolveOperand", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "ay-ws-op-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const fakeProv = (specDir: string) =>
+    ({
+      parseSource: (input: string) => {
+        const m = input.match(/^([^/]+)\/([^/@]+)@(.+)$/);
+        return m ? { owner: m[1]!, repo: m[2]!, branch: m[3]! } : null;
+      },
+      folderFor: () => specDir,
+      resolveWsRoot: (w?: string) => w ?? root,
+    }) as any;
+
+  const mkCheckout = (rel: string) => {
+    const dir = path.join(root, rel);
+    mkdirSync(path.join(dir, ".git"), { recursive: true });
+    return dir;
+  };
+
+  it("an existing local path wins over spec parsing in auto mode", async () => {
+    const dir = mkCheckout("o/r/tree/main");
+    const res = await resolveOperand(fakeProv("/unused"), dir, "auto", undefined);
+    expect(res).toEqual({ dir, spec: null });
+  });
+
+  it("falls back to spec parsing when the operand is not a path", async () => {
+    const dir = mkCheckout("o/r/tree/main");
+    const res = await resolveOperand(fakeProv(dir), "o/r@main", "auto", undefined);
+    expect(res.dir).toBe(dir);
+    expect(res.spec).toEqual({ owner: "o", repo: "r", branch: "main" });
+  });
+
+  it("--path mode rejects a directory that is not a checkout root", async () => {
+    const dir = path.join(root, "plain");
+    mkdirSync(dir);
+    await expect(resolveOperand(fakeProv("/unused"), dir, "path", undefined)).rejects.toThrow(
+      /not a git checkout root/,
+    );
+  });
+
+  it("--spec mode reports an unprovisioned workspace with the fix-it hint", async () => {
+    await expect(
+      resolveOperand(fakeProv(path.join(root, "missing")), "o/r@main", "spec", undefined),
+    ).rejects.toThrow(/not provisioned.*ay ws new/s);
+  });
+
+  it("reports a precise parse error for garbage", async () => {
+    await expect(resolveOperand(fakeProv("/unused"), "not a spec", "spec", undefined)).rejects.toThrow(
+      /cannot parse "not a spec"/,
+    );
+  });
+});
+
+describe("json schema tag", () => {
+  it("is versioned", () => {
+    expect(WS_JSON_SCHEMA).toBe("ay-ws/v1");
+  });
+});

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, symlinkSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
 import { cmdWs, isPathInside, resolveOperand, walkWorkspaces, WS_JSON_SCHEMA } from "./ws.ts";
@@ -183,7 +183,9 @@ describe("cmdWs (mocked provision)", () => {
   const CLEAN = { branch: "main", head: "abc123", ahead: 0, behind: 0, dirty: false, hasUpstream: true };
 
   beforeEach(() => {
-    root = mkdtempSync(path.join(os.tmpdir(), "ay-ws-cmd-"));
+    // realpath: os.tmpdir() is a symlink on macOS (/var → /private/var), and
+    // process.chdir + cwd-derived paths come back resolved.
+    root = realpathSync(mkdtempSync(path.join(os.tmpdir(), "ay-ws-cmd-")));
     prov.wsRoot = root;
     prov.readStatus.mockReset().mockResolvedValue(CLEAN);
     prov.provision.mockReset();
@@ -327,6 +329,91 @@ describe("cmdWs (mocked provision)", () => {
       wip: true,
     });
     expect(out.join("")).toContain("forked  /f");
+  });
+
+  it("help aliases and the list alias dispatch", async () => {
+    for (const h of ["help", "--help", "-h"]) {
+      out.length = 0;
+      expect(await cmdWs([h])).toBe(0);
+      expect(out.join("")).toContain("ay ws ls");
+    }
+    mkCheckout("o/r/tree/main");
+    out.length = 0;
+    expect(await cmdWs(["list"])).toBe(0);
+    expect(out.join("")).toContain("o/r@main");
+  });
+
+  it("ls/status: live agents from the registry produce counts and the ay-ls hint", async () => {
+    const dir = mkCheckout("o/r/tree/main");
+    const home = process.env.AGENT_YES_HOME!;
+    mkdirSync(home, { recursive: true });
+    writeFileSync(
+      path.join(home, "pids.jsonl"),
+      JSON.stringify({
+        pid: process.pid,
+        cli: "claude",
+        prompt: null,
+        cwd: path.join(dir, "sub"),
+        log_file: null,
+        status: "active",
+        exit_code: null,
+        exit_reason: null,
+        started_at: 1,
+      }) + "\n",
+    );
+    expect(await cmdWs(["ls"])).toBe(0);
+    expect(err.join("")).toContain("ay ls --cwd");
+    out.length = 0;
+    err.length = 0;
+    expect(await cmdWs(["status", dir])).toBe(0);
+    expect(out.join("")).toContain("agents:   1 live");
+    expect(err.join("")).toContain(`ay ls --cwd ${dir}`);
+  });
+
+  it("status: defaults to cwd, and honors --path / --spec modes", async () => {
+    const dir = mkCheckout("o/r/tree/main");
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      expect(await cmdWs(["status"])).toBe(0);
+      expect(out.join("")).toContain("spec:     o/r@main");
+    } finally {
+      process.chdir(prevCwd);
+    }
+    out.length = 0;
+    expect(await cmdWs(["status", dir, "--path"])).toBe(0);
+    expect(out.join("")).toContain("branch:   main");
+    out.length = 0;
+    expect(await cmdWs(["status", "o/r@main", "--spec", "--json"])).toBe(0);
+    expect(JSON.parse(out.join("")).workspace.path).toBe(dir);
+  });
+
+  it("new: a non-branch failure reports without the --create hint", async () => {
+    prov.provision.mockResolvedValue({ ok: false, action: "error", reason: "repo-not-found", error: "gone" });
+    expect(await cmdWs(["new", "o/r"])).toBe(1);
+    const msg = err.join("");
+    expect(msg).toContain("repo-not-found");
+    expect(msg).not.toContain("--create");
+  });
+
+  it("fork: --from=<eq-form> and a stale AGENT_YES_PID both resolve", async () => {
+    prov.forkWorktree.mockResolvedValue({ ok: true, action: "forked", folder: "/f" });
+    expect(await cmdWs(["fork", "nb", `--from=${root}`])).toBe(0);
+    expect(prov.forkWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ fromCwd: path.resolve(root) }),
+    );
+    // An AGENT_YES_PID with no matching registry record falls back to cwd.
+    const envBackup = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = "999999999";
+    try {
+      expect(await cmdWs(["fork", "nb2"])).toBe(0);
+      expect(prov.forkWorktree).toHaveBeenLastCalledWith(
+        expect.objectContaining({ fromCwd: path.resolve(process.cwd()) }),
+      );
+    } finally {
+      if (envBackup === undefined) delete process.env.AGENT_YES_PID;
+      else process.env.AGENT_YES_PID = envBackup;
+    }
   });
 
   it("fork: defaults --from to cwd (no agent env), surfaces failure", async () => {

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -1,0 +1,522 @@
+/**
+ * `ay ws` — workspace management over the codehost/provision standard layout
+ * (`<wsRoot>/<owner>/<repo>/tree/<branch>`, independent clones except forked
+ * linked worktrees).
+ *
+ * v1 surface (read/list/new/fork only — deletion/gc/doctor are deliberately
+ * deferred until workspace lifecycle data exists to design them around):
+ *
+ *   ay ws ls [--status] [--json]
+ *   ay ws status [<spec-or-path>] [--path|--spec] [--json]
+ *   ay ws new <source> [--create]
+ *   ay ws fork <branch> [--from <path>] [--wip]
+ *
+ * `--json` schema (stable, versioned via `schema`):
+ *   ls:     { schema:"ay-ws/v1", wsRoot, workspaces: WsEntry[] }
+ *   status: { schema:"ay-ws/v1", workspace: WsEntry }
+ *   WsEntry = { owner, repo, branch, path, agents: { live: number },
+ *               git?: GitStatus | null, gitError?: string }
+ *
+ * codehost/provision is a peer package (bun-linked in dev). Like serve.ts's
+ * fork path, it is imported lazily so `ay ls` etc. never pay for it and a
+ * missing install produces a clear actionable error instead of a module crash.
+ */
+
+import path from "path";
+import { opendir, lstat } from "fs/promises";
+import { existsSync } from "fs";
+import { getProvisionRoot } from "./workspaceConfig.ts";
+import { listRecords } from "./subcommands.ts";
+import type { GlobalPidRecord } from "./globalPidIndex.ts";
+
+// Everything we consume from codehost/provision, typed locally so this module
+// compiles without the package present (it is resolved at runtime).
+interface RepoSpec {
+  owner: string;
+  repo: string;
+  branch: string;
+}
+interface GitStatus {
+  branch: string;
+  head: string;
+  ahead: number;
+  behind: number;
+  dirty: boolean;
+  hasUpstream: boolean;
+}
+interface ProvisionResult {
+  ok: boolean;
+  spec: RepoSpec;
+  folder: string;
+  existed: boolean;
+  action: string;
+  git?: GitStatus;
+  error?: string;
+  reason?: "branch-not-found" | "repo-not-found" | "other";
+}
+interface Provision {
+  resolveWsRoot(wsRoot?: string): string;
+  parseSource(input: string): RepoSpec | null;
+  folderFor(spec: RepoSpec, wsRoot?: string): string;
+  readStatus(dir: string): Promise<GitStatus>;
+  provision(spec: RepoSpec, opts?: { wsRoot?: string }): Promise<ProvisionResult>;
+  createBranch(spec: RepoSpec, opts?: { wsRoot?: string }): Promise<ProvisionResult>;
+  forkWorktree(opts: {
+    fromCwd: string;
+    branch: string;
+    wsRoot?: string;
+    wip?: boolean;
+  }): Promise<ProvisionResult>;
+}
+
+async function loadProvision(): Promise<Provision> {
+  try {
+    return (await import("codehost/provision")) as unknown as Provision;
+  } catch (e) {
+    throw new Error(
+      `'ay ws' needs the 'codehost' package (codehost/provision) — install it ` +
+        `(npm i -g codehost) or 'bun link' it for local dev: ${(e as Error).message}`,
+    );
+  }
+}
+
+export const WS_JSON_SCHEMA = "ay-ws/v1";
+
+// A workspace found under the standard layout.
+export interface WsEntry {
+  owner: string;
+  repo: string;
+  branch: string;
+  path: string;
+  agents: { live: number };
+  git?: GitStatus | null;
+  gitError?: string;
+}
+
+// readStatus can block up to git's 120s timeout per workspace, so status joins
+// run through a small worker pool instead of one unbounded Promise.all.
+const STATUS_CONCURRENCY = 8;
+// Branch names may contain `/`, so the walk below `tree/` is recursive; this
+// bounds a pathological/looping layout, not a legitimate branch depth.
+const MAX_BRANCH_DEPTH = 8;
+
+/**
+ * Path containment that matches how the OS actually compares paths: segment
+ * boundaries via path.relative (never a raw startsWith), case-insensitive on
+ * Windows (and macOS's default case-insensitive FS is fine with this too —
+ * false positives there require two dirs differing only by case).
+ */
+export function isPathInside(parent: string, child: string): boolean {
+  let p = path.resolve(parent);
+  let c = path.resolve(child);
+  if (process.platform === "win32") {
+    p = p.toLowerCase();
+    c = c.toLowerCase();
+  }
+  const rel = path.relative(p, c);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/** True when `dir` is a git checkout root (`.git` file = linked worktree, dir = clone). */
+function isCheckoutRoot(dir: string): boolean {
+  return existsSync(path.join(dir, ".git"));
+}
+
+// List real subdirectories (no symlinks, no dotdirs), tolerating vanished dirs.
+async function subdirs(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  let d: Awaited<ReturnType<typeof opendir>>;
+  try {
+    d = await opendir(dir);
+  } catch {
+    return out;
+  }
+  for await (const ent of d) {
+    if (ent.name.startsWith(".")) continue;
+    if (ent.isDirectory()) {
+      out.push(ent.name);
+    } else if (ent.isSymbolicLink()) {
+      // never follow symlinks — a link cycle under tree/ must not loop the walk
+      continue;
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Walk `<wsRoot>/<owner>/<repo>/tree/**` collecting checkout roots. The branch
+ * may contain `/`, so below `tree/` we descend until a `.git` marker is found
+ * (a checkout root is never nested inside another checkout in this layout),
+ * bounded by MAX_BRANCH_DEPTH.
+ */
+export async function walkWorkspaces(wsRoot: string): Promise<Omit<WsEntry, "agents">[]> {
+  const found: Omit<WsEntry, "agents">[] = [];
+
+  async function walkBranches(dir: string, owner: string, repo: string, segs: string[]) {
+    if (segs.length > MAX_BRANCH_DEPTH) return;
+    for (const name of await subdirs(dir)) {
+      const p = path.join(dir, name);
+      const branchSegs = [...segs, name];
+      if (isCheckoutRoot(p)) {
+        found.push({ owner, repo, branch: branchSegs.join("/"), path: p });
+      } else {
+        await walkBranches(p, owner, repo, branchSegs);
+      }
+    }
+  }
+
+  for (const owner of await subdirs(wsRoot)) {
+    for (const repo of await subdirs(path.join(wsRoot, owner))) {
+      const tree = path.join(wsRoot, owner, repo, "tree");
+      try {
+        if (!(await lstat(tree)).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      await walkBranches(tree, owner, repo, []);
+    }
+  }
+  return found;
+}
+
+/** Live (non-exited) agents whose cwd sits inside `wsPath`. */
+function liveAgentsIn(records: GlobalPidRecord[], wsPath: string): GlobalPidRecord[] {
+  return records.filter((r) => r.cwd && isPathInside(wsPath, r.cwd));
+}
+
+// Run `fn` over items with at most `limit` in flight (order preserved).
+async function mapBounded<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const i = next++;
+      out[i] = await fn(items[i]!);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+/**
+ * Resolve a status/inspect operand deterministically:
+ *   1. `--path` forces path, `--spec` forces source-spec parsing
+ *   2. an operand that exists on disk is a path
+ *   3. otherwise it must parse as a source (owner/repo[@branch|/tree/branch] or URL)
+ * Prints the normalized resolution so the user always sees what was addressed.
+ */
+export async function resolveOperand(
+  prov: Provision,
+  operand: string,
+  mode: "auto" | "path" | "spec",
+  wsRoot: string | undefined,
+): Promise<{ dir: string; spec: RepoSpec | null }> {
+  const asPath = () => {
+    const dir = path.resolve(operand);
+    if (!existsSync(dir)) throw new Error(`path does not exist: ${dir}`);
+    if (!isCheckoutRoot(dir)) throw new Error(`not a git checkout root (no .git): ${dir}`);
+    return { dir, spec: null };
+  };
+  const asSpec = () => {
+    const spec = prov.parseSource(operand);
+    if (!spec) {
+      throw new Error(
+        `cannot parse "${operand}" as a source — expected <owner>/<repo>, ` +
+          `<owner>/<repo>@<branch>, <owner>/<repo>/tree/<branch>, or a github URL` +
+          (existsSync(operand) ? "" : " (and it is not an existing path)"),
+      );
+    }
+    const dir = prov.folderFor(spec, wsRoot);
+    if (!existsSync(dir)) throw new Error(`workspace not provisioned: ${dir}  (ay ws new ${operand})`);
+    return { dir, spec };
+  };
+  if (mode === "path") return asPath();
+  if (mode === "spec") return asSpec();
+  // auto: an existing local path wins; only then try the spec grammar.
+  if (existsSync(path.resolve(operand))) return asPath();
+  return asSpec();
+}
+
+/**
+ * Default source for `ws fork`: the calling agent's registered cwd when run
+ * inside an agent (AGENT_YES_PID is the wrapper pid of the enclosing agent),
+ * else the current directory.
+ */
+async function defaultForkFrom(): Promise<string> {
+  const envPid = Number(process.env.AGENT_YES_PID);
+  if (envPid > 0) {
+    const recs = await listRecords(undefined, {
+      all: true,
+      active: false,
+      json: false,
+      latest: false,
+      cwdScope: null,
+    });
+    const self = recs.find((r) => r.wrapper_pid === envPid) ?? recs.find((r) => r.pid === envPid);
+    if (self?.cwd) return self.cwd;
+  }
+  return process.cwd();
+}
+
+// ---------------------------------------------------------------------------
+// arg parsing (tiny, flag-only — no positional grammar beyond one operand)
+// ---------------------------------------------------------------------------
+
+function parseFlags(
+  args: string[],
+  known: Record<string, "bool" | "value">,
+): { flags: Record<string, string | boolean>; positional: string[] } {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (!a.startsWith("--")) {
+      positional.push(a);
+      continue;
+    }
+    const eq = a.indexOf("=");
+    const name = eq === -1 ? a.slice(2) : a.slice(2, eq);
+    const kind = known[name];
+    if (!kind) throw new Error(`unknown flag --${name}`);
+    if (kind === "bool") {
+      if (eq !== -1) throw new Error(`--${name} takes no value`);
+      flags[name] = true;
+    } else {
+      const v = eq !== -1 ? a.slice(eq + 1) : args[++i];
+      if (v === undefined) throw new Error(`--${name} requires a value`);
+      flags[name] = v;
+    }
+  }
+  return { flags, positional };
+}
+
+// ---------------------------------------------------------------------------
+// subcommands
+// ---------------------------------------------------------------------------
+
+async function cmdWsLs(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { status: "bool", json: "bool" });
+  if (positional.length > 0) throw new Error(`ws ls takes no positional args`);
+  const prov = await loadProvision();
+  const wsRoot = prov.resolveWsRoot(getProvisionRoot());
+
+  const [bare, records] = await Promise.all([
+    walkWorkspaces(wsRoot),
+    listRecords(undefined, { all: false, active: false, json: false, latest: false, cwdScope: null }),
+  ]);
+
+  let entries: WsEntry[] = bare.map((w) => ({
+    ...w,
+    agents: { live: liveAgentsIn(records, w.path).length },
+  }));
+
+  if (flags.status) {
+    entries = await mapBounded(entries, STATUS_CONCURRENCY, async (e) => {
+      try {
+        return { ...e, git: await prov.readStatus(e.path) };
+      } catch (err) {
+        return { ...e, git: null, gitError: (err as Error).message.slice(0, 200) };
+      }
+    });
+  }
+
+  if (flags.json) {
+    process.stdout.write(
+      JSON.stringify({ schema: WS_JSON_SCHEMA, wsRoot, workspaces: entries }, null, 2) + "\n",
+    );
+    return 0;
+  }
+
+  if (entries.length === 0) {
+    process.stderr.write(`no workspaces under ${wsRoot} (layout <owner>/<repo>/tree/<branch>)\n`);
+    return 0;
+  }
+
+  const specOf = (e: WsEntry) => `${e.owner}/${e.repo}@${e.branch}`;
+  const specW = Math.max(9, ...entries.map((e) => specOf(e).length));
+  const agentsW = 6;
+  const header = flags.status
+    ? `${"WORKSPACE".padEnd(specW)}  ${"AGENTS".padEnd(agentsW)}  GIT\n`
+    : `${"WORKSPACE".padEnd(specW)}  ${"AGENTS".padEnd(agentsW)}  PATH\n`;
+  process.stdout.write(header);
+  for (const e of entries) {
+    const agents = e.agents.live > 0 ? String(e.agents.live) : "-";
+    const tail = flags.status ? gitSummary(e) : e.path;
+    process.stdout.write(`${specOf(e).padEnd(specW)}  ${agents.padEnd(agentsW)}  ${tail}\n`);
+  }
+  if (entries.some((e) => e.agents.live > 0)) {
+    process.stderr.write(`\n  ay ls --cwd <path>    # the agents inside a workspace\n`);
+  }
+  return 0;
+}
+
+function gitSummary(e: WsEntry): string {
+  if (e.gitError) return `error: ${e.gitError}`;
+  const g = e.git;
+  if (!g) return "?";
+  const parts: string[] = [];
+  if (g.dirty) parts.push("dirty");
+  if (g.ahead > 0) parts.push(`ahead ${g.ahead}`);
+  if (g.behind > 0) parts.push(`behind ${g.behind}`);
+  if (!g.hasUpstream) parts.push("no-upstream");
+  return parts.length ? parts.join(", ") : "clean";
+}
+
+async function cmdWsStatus(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { json: "bool", path: "bool", spec: "bool" });
+  if (flags.path && flags.spec) throw new Error("--path and --spec are mutually exclusive");
+  if (positional.length > 1) throw new Error("ws status takes at most one target");
+  const prov = await loadProvision();
+  const wsRoot = getProvisionRoot();
+  const operand = positional[0] ?? ".";
+  const mode = flags.path ? "path" : flags.spec ? "spec" : "auto";
+  const { dir, spec } = await resolveOperand(prov, operand, mode, wsRoot);
+  const git = await prov.readStatus(dir);
+
+  // Fill owner/repo/branch from the layout when addressed by path, best-effort.
+  const layoutSpec =
+    spec ??
+    (() => {
+      const root = prov.resolveWsRoot(wsRoot);
+      if (!isPathInside(root, dir)) return null;
+      const segs = path.relative(root, dir).split(path.sep);
+      return segs.length >= 4 && segs[2] === "tree"
+        ? { owner: segs[0]!, repo: segs[1]!, branch: segs.slice(3).join("/") }
+        : null;
+    })();
+
+  const entry: WsEntry = {
+    owner: layoutSpec?.owner ?? "",
+    repo: layoutSpec?.repo ?? "",
+    branch: layoutSpec?.branch ?? git.branch,
+    path: dir,
+    agents: {
+      live: liveAgentsIn(
+        await listRecords(undefined, {
+          all: false,
+          active: false,
+          json: false,
+          latest: false,
+          cwdScope: null,
+        }),
+        dir,
+      ).length,
+    },
+    git,
+  };
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify({ schema: WS_JSON_SCHEMA, workspace: entry }, null, 2) + "\n");
+    return 0;
+  }
+  process.stdout.write(
+    `${dir}\n` +
+      (layoutSpec ? `  spec:     ${layoutSpec.owner}/${layoutSpec.repo}@${layoutSpec.branch}\n` : "") +
+      `  branch:   ${git.branch} @ ${git.head}\n` +
+      `  state:    ${gitSummary(entry)}\n` +
+      `  agents:   ${entry.agents.live} live\n`,
+  );
+  if (entry.agents.live > 0) process.stderr.write(`\n  ay ls --cwd ${dir}\n`);
+  return 0;
+}
+
+async function cmdWsNew(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { create: "bool" });
+  const source = positional[0];
+  if (!source || positional.length > 1)
+    throw new Error("usage: ay ws new <owner>/<repo>[@branch] [--create]");
+  const prov = await loadProvision();
+  const wsRoot = getProvisionRoot();
+  const spec = prov.parseSource(source);
+  if (!spec) throw new Error(`cannot parse "${source}" as a source (owner/repo[@branch] or URL)`);
+
+  // Echo the normalized target before mutating anything.
+  process.stderr.write(`provisioning ${spec.owner}/${spec.repo}@${spec.branch} …\n`);
+  let res = await prov.provision(spec, { wsRoot });
+  if (!res.ok && res.reason === "branch-not-found" && flags.create) {
+    process.stderr.write(`branch not found on remote — creating it locally (--create)\n`);
+    res = await prov.createBranch(spec, { wsRoot });
+  }
+  if (!res.ok) {
+    process.stderr.write(
+      `provision failed (${res.reason ?? "error"}): ${res.error ?? "unknown"}\n` +
+        (res.reason === "branch-not-found" && !flags.create
+          ? `  (branch missing on the remote — re-run with --create to branch off the default)\n`
+          : ""),
+    );
+    return 1;
+  }
+  process.stdout.write(`${res.action}  ${res.folder}\n`);
+  return 0;
+}
+
+async function cmdWsFork(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { from: "value", wip: "bool" });
+  const branch = positional[0];
+  if (!branch || positional.length > 1)
+    throw new Error("usage: ay ws fork <new-branch> [--from <path>] [--wip]");
+  const prov = await loadProvision();
+  const fromCwd = path.resolve(
+    typeof flags.from === "string" ? flags.from : await defaultForkFrom(),
+  );
+
+  process.stderr.write(`forking ${fromCwd} → branch ${branch}${flags.wip ? " (with WIP)" : ""} …\n`);
+  const res = await prov.forkWorktree({
+    fromCwd,
+    branch,
+    wsRoot: getProvisionRoot(),
+    wip: !!flags.wip,
+  });
+  if (!res.ok) {
+    process.stderr.write(`fork failed: ${res.error ?? "unknown"}\n`);
+    return 1;
+  }
+  process.stdout.write(`${res.action}  ${res.folder}\n`);
+  process.stderr.write(`\n  ay claude --cwd ${res.folder} -- "<prompt>"   # work there\n`);
+  return 0;
+}
+
+function wsHelp(): number {
+  process.stdout.write(
+    `ay ws - workspaces under <wsRoot>/<owner>/<repo>/tree/<branch>\n` +
+      `\n` +
+      `  ay ws ls [--status] [--json]           list workspaces (+git state, +live agent count)\n` +
+      `  ay ws status [<spec|path>] [--json]    one workspace's git state (default: cwd)\n` +
+      `  ay ws new <owner>/<repo>[@branch]      clone/refresh a workspace  (--create: new branch)\n` +
+      `  ay ws fork <branch> [--from <path>]    sibling worktree off HEAD  (--wip: carry changes)\n` +
+      `\n` +
+      `  targets: owner/repo, owner/repo@branch, owner/repo/tree/branch, github URL, or a path\n` +
+      `  wsRoot:  CODEHOST_WS_ROOT > config provisionRoot > ~/ws\n`,
+  );
+  return 0;
+}
+
+/** `ay ws <sub> …` dispatcher (called from runSubcommand). */
+export async function cmdWs(args: string[]): Promise<number> {
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case "ls":
+    case "list":
+      return cmdWsLs(rest);
+    case "status":
+      return cmdWsStatus(rest);
+    case "new":
+      return cmdWsNew(rest);
+    case "fork":
+      return cmdWsFork(rest);
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      return wsHelp();
+    default:
+      process.stderr.write(`ay ws: unknown subcommand "${sub}"\n\n`);
+      wsHelp();
+      return 1;
+  }
+}


### PR DESCRIPTION
## What

New manager-only `ay ws` subcommand (hidden from cli-bound aliases like `cy`, same as `setup`) for workspaces under the codehost/provision standard layout `<wsRoot>/<owner>/<repo>/tree/<branch>`:

```
ay ws ls [--status] [--json]           list workspaces (+git state, +live agent count)
ay ws status [<spec|path>] [--json]    one workspace's git state (default: cwd)
ay ws new <owner>/<repo>[@branch]      clone/refresh a workspace  (--create: new branch)
ay ws fork <branch> [--from <path>]    sibling worktree off HEAD  (--wip: carry changes)
```

## Design notes (v1 scope after external critique)

- **ls walk**: branch names may contain `/`, so the walk below `tree/` descends until a `.git` marker (file = linked worktree, dir = clone), bounded depth, symlinks never followed. `readStatus` joins run through a bounded pool (8) since each call can block up to git's 120s timeout.
- **Agent counts stay compact**: `ay ws ls` is workspace-centric; it shows a live-agent count from the global pid index and points at `ay ls --cwd <path>` for details, instead of reproducing the agent table.
- **Deterministic operand resolution** for `status`: an existing local path wins, else source-spec parsing (`owner/repo`, `owner/repo@branch`, `owner/repo/tree/branch`, github URL), with `--path`/`--spec` escape hatches and precise parse errors.
- **`--json` is versioned** (`ay-ws/v1`) so the console picker and a future gc can build on the CLI schema without an HTTP API becoming the source of truth.
- **No implicit branch creation**: `new` falls back to `createBranch` only with explicit `--create`.
- **`fork --from` default**: the calling agent's registered cwd (via `AGENT_YES_PID`) when run inside an agent, else `process.cwd()`; resolved to a canonical path before `forkWorktree()`.
- **Deletion deferred**: `rm`/`gc`/`doctor` are deliberately NOT in v1 — safe deletion can't be reduced to `dirty || ahead>0` (unpublished commits without upstream, stale ahead/behind without fetch, clones owning linked worktrees, agent-check races). They'll be designed against observed lifecycle data, with the git op upstreamed into codehost as a two-phase `removeWorkspace()`.
- Path containment uses `path.relative` + win32 case normalization, never raw `startsWith`.
- The pre-existing Rust `SUBCOMMANDS` drift (`key`/`select` missing) is left for a separate PR — this one only adds `"ws"` to `MANAGER_SUBCOMMANDS` in both runtimes.

## Verified

- 15 new unit tests (`ts/ws.spec.ts`): walk (nested-branch, no-descend-into-checkout, symlink cycle, depth bound), operand resolution, containment boundaries. Full suite: 863 TS + Rust `cargo test` green.
- End-to-end on this machine: `ay ws ls` (25 workspaces), `ay ws ls --status` (4.6s bounded join), `--json`, `ay ws status .` / by spec, real `ay ws fork` off `qqdocs@main` then status by spec (worktree cleaned up after).
- `cy ws` correctly falls through to the agent (manager-only check in both runtimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)