### PR TITLE
feat(pin): pin agents — right-click pin-to-top in /w/, screen-fixed palette in /r/

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1184,6 +1184,15 @@
         color: var(--peer);
         flex: none;
       }
+      .pinmark {
+        font-size: 10px;
+        line-height: 1;
+        flex: none;
+      }
+      /* Pinned rows: a subtle accent rail on the left edge (both list layouts). */
+      .row.pinned {
+        box-shadow: inset 2px 0 0 var(--accent);
+      }
       .r1 {
         display: flex;
         align-items: center;
@@ -4094,10 +4103,9 @@
           term && term.clearSelection && term.clearSelection();
         } catch {}
       }
-      function showTermMenu(ev, term) {
-        ev.preventDefault();
-        hideTermMenu();
-        const selText = term && term.hasSelection && term.hasSelection() ? term.getSelection() : "";
+      // Build an empty context-menu shell plus `addItem`/`addSep` helpers, shared
+      // by the terminal menu and the left-panel agent menu.
+      function ctxMenuShell() {
         const menu = document.createElement("div");
         menu.className = "ctxmenu";
         menu.setAttribute("role", "menu");
@@ -4127,6 +4135,28 @@
           s.className = "ctxmenu-sep";
           menu.appendChild(s);
         };
+        return { menu, addItem, addSep };
+      }
+      // Append a built menu at the pointer, clamp into the viewport, and wire the
+      // shared dismiss listeners (outside-click, Escape, blur, resize).
+      function openCtxMenu(menu, ev) {
+        document.body.appendChild(menu);
+        ctxMenuEl = menu;
+        const r = menu.getBoundingClientRect();
+        const x = Math.max(4, Math.min(ev.clientX, window.innerWidth - r.width - 4));
+        const y = Math.max(4, Math.min(ev.clientY, window.innerHeight - r.height - 4));
+        menu.style.left = x + "px";
+        menu.style.top = y + "px";
+        document.addEventListener("pointerdown", onCtxOutside, true);
+        document.addEventListener("keydown", onCtxKey, true);
+        window.addEventListener("blur", hideTermMenu);
+        window.addEventListener("resize", hideTermMenu);
+      }
+      function showTermMenu(ev, term) {
+        ev.preventDefault();
+        hideTermMenu();
+        const selText = term && term.hasSelection && term.hasSelection() ? term.getSelection() : "";
+        const { menu, addItem, addSep } = ctxMenuShell();
 
         // Copy: disabled with nothing selected (mirrors the old behavior, minus
         // the auto-copy — the user now chooses it explicitly).
@@ -4158,18 +4188,20 @@
         addSep();
         addItem("Edit quick commands…", {}, editQuickCmds);
 
-        document.body.appendChild(menu);
-        ctxMenuEl = menu;
-        // Clamp into the viewport so a right-click near an edge stays fully visible.
-        const r = menu.getBoundingClientRect();
-        const x = Math.max(4, Math.min(ev.clientX, window.innerWidth - r.width - 4));
-        const y = Math.max(4, Math.min(ev.clientY, window.innerHeight - r.height - 4));
-        menu.style.left = x + "px";
-        menu.style.top = y + "px";
-        document.addEventListener("pointerdown", onCtxOutside, true);
-        document.addEventListener("keydown", onCtxKey, true);
-        window.addEventListener("blur", hideTermMenu);
-        window.addEventListener("resize", hideTermMenu);
+        openCtxMenu(menu, ev);
+      }
+      // Right-click menu for a left-panel agent row: pin/unpin to the top of the
+      // list (a pin also surfaces the agent in /r/'s screen-fixed palette).
+      function showAgentMenu(ev, key) {
+        ev.preventDefault();
+        hideTermMenu();
+        const e = entries.find((x) => x._key === key);
+        if (!e) return;
+        const { menu, addItem } = ctxMenuShell();
+        const name = cliLabel(e) || ident(e) || "pid " + e.pid;
+        if (isPinned(key)) addItem("Unpin “" + name + "”", { hint: "📌" }, () => togglePin(key));
+        else addItem("Pin “" + name + "” to top", { hint: "📌" }, () => togglePin(key));
+        openCtxMenu(menu, ev);
       }
       // Lightweight editor: overlay + textarea of `Label | template` lines. Save
       // writes localStorage; Reset restores the built-in defaults.
@@ -4575,14 +4607,55 @@
       let sortMode = localStorage.getItem("ay.sortMode") || "state";
       if (!SORT_MODES.includes(sortMode)) sortMode = "state";
 
+      // Pinned agents: a set of agent _key values that float to the top of the
+      // list, shared (same localStorage key) with /r/, where they also surface in
+      // the screen-fixed palette. Kept in memory and re-synced on cross-tab writes.
+      const AY_PINNED_KEY = "ay.pinned";
+      function loadPinned() {
+        try {
+          const a = JSON.parse(localStorage.getItem(AY_PINNED_KEY) || "[]");
+          return new Set(Array.isArray(a) ? a : []);
+        } catch {
+          return new Set();
+        }
+      }
+      let pinned = loadPinned();
+      function isPinned(key) {
+        return pinned.has(key);
+      }
+      function togglePin(key) {
+        if (!key) return;
+        if (pinned.has(key)) pinned.delete(key);
+        else pinned.add(key);
+        try {
+          localStorage.setItem(AY_PINNED_KEY, JSON.stringify([...pinned]));
+        } catch {}
+        renderList();
+      }
+      // Cross-tab / cross-view sync: /r/ (or another /w/ tab) writing ay.pinned
+      // fires a storage event here; reload the set and re-render.
+      window.addEventListener("storage", (ev) => {
+        if (ev.key === AY_PINNED_KEY) {
+          pinned = loadPinned();
+          renderList();
+        }
+      });
+
       // The filtered + sorted entry list, in the SAME order the left panel renders
       // and the keyboard nav steps. Sorting runs before layeredRows builds the
       // room/peer/agent tree, so it reorders roots/siblings without breaking nesting.
+      // Pinned entries then float to the front of their sorted group (a pinned root
+      // rises to the top; a pinned subagent rises among its siblings).
       function orderedEntries(toks) {
-        return sortEntries(
+        const sorted = sortEntries(
           entries.filter((e) => matches(e, toks)),
           sortMode,
         );
+        if (!pinned.size) return sorted;
+        const hi = [],
+          lo = [];
+        for (const e of sorted) (pinned.has(e._key) ? hi : lo).push(e);
+        return hi.concat(lo);
       }
 
       // A small git chip (±changed ⑂pins ⊙sub-dirty ↑ahead ↓behind) for a row,
@@ -4672,8 +4745,15 @@
           (peers ? " peerfocus" : "") +
           (flash ? " stdinflash" : "") +
           (sent ? " sendflash" : "") +
-          (recv ? " recvflash" : "")
+          (recv ? " recvflash" : "") +
+          (pinned.has(e._key) ? " pinned" : "")
         );
+      }
+      // A small 📌 marker on a pinned row (right-click to unpin).
+      function pinMarkHtml(e) {
+        return pinned.has(e._key)
+          ? `<span class="pinmark" title="pinned — right-click to unpin">📌</span>`
+          : "";
       }
       // A yellow chip showing how many peers are watching this agent ("" if none).
       function peerChipHtml(e) {
@@ -4726,6 +4806,7 @@
                 const cli = cliLabel(e);
                 return `<div class="row crow ${e._key === sel ? "sel" : ""}${rowFlags(e)}" data-key="${esc(e._key)}">
         ${r.branch ? `<span class="tbranch">${esc(r.branch)}</span>` : ""}
+        ${pinMarkHtml(e)}
         <span class="dot ${esc(e.status)}"></span>
         ${hasIdent(id) ? `<span class="cident" title="${esc(fullIdent(e))}">${esc(id)}</span>` : ""}
         ${cli ? `<span class="cname">${esc(cli)}</span>` : ""}
@@ -4756,7 +4837,7 @@
                 )
                 .join("");
               return `<div class="row ${e._key === sel ? "sel" : ""}${rowFlags(e)}" data-key="${esc(e._key)}">
-        <div class="r1">${r.branch ? `<span class="tbranch">${esc(r.branch)}</span>` : ""}<span class="dot ${esc(e.status)}"></span>
+        <div class="r1">${r.branch ? `<span class="tbranch">${esc(r.branch)}</span>` : ""}${pinMarkHtml(e)}<span class="dot ${esc(e.status)}"></span>
           <span class="name">${esc(cliLabel(e) || ident(e) || "agent")}</span>
           <span class="badge">pid ${e.pid}</span>
           ${foldChipHtml(e)}
@@ -5178,6 +5259,11 @@
         }
         const row = ev.target.closest(".row");
         if (row) select(row.dataset.key);
+      });
+      // Right-click an agent row → pin/unpin menu.
+      $("list").addEventListener("contextmenu", (ev) => {
+        const row = ev.target.closest(".row");
+        if (row && row.dataset.key) showAgentMenu(ev, row.dataset.key);
       });
       // Mobile back: return to the list pane. The tail keeps streaming in the
       // background (selection unchanged), so reopening the agent is instant.

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -597,6 +597,7 @@
         <!-- environment nodes (host env / cwd / repo) double as launch targets:
              the textarea becomes the new agent's initial prompt -->
         <button id="ctx-spawn" hidden>▷ Spawn here</button>
+        <button id="ctx-pin" hidden>📌 Pin</button>
         <button id="ctx-send">Send</button>
       </div>
       <div class="ctx-share" id="ctx-share" hidden>

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -1419,9 +1419,10 @@ function updateDocTitle() {
 // per-status breakdown (items). Drag its header and rgui snaps it to the
 // viewport edges / other panels; onPanelMove persists the anchor across reloads.
 const SYS_PANEL_KEY = "rgui-syspanel-anchor";
-function loadPanelAnchor(): Panel["anchor"] {
+const PIN_PANEL_KEY = "rgui-pinpanel-anchor";
+function loadPanelAnchor(key: string, dflt: Panel["anchor"]): Panel["anchor"] {
   try {
-    const raw = localStorage.getItem(SYS_PANEL_KEY);
+    const raw = localStorage.getItem(key);
     if (raw === "left" || raw === "right") return raw;
     if (raw) {
       const p = JSON.parse(raw);
@@ -1430,9 +1431,9 @@ function loadPanelAnchor(): Panel["anchor"] {
   } catch {
     /* corrupt stored anchor — fall through to the default edge */
   }
-  return "right";
+  return dflt;
 }
-const sysPanel: Panel = { id: "sys", title: "agents", anchor: loadPanelAnchor(), w: 200, items: [] };
+const sysPanel: Panel = { id: "sys", title: "agents", anchor: loadPanelAnchor(SYS_PANEL_KEY, "right"), w: 200, items: [] };
 const STATUS_ROWS: [AgentStatus, string][] = [
   ["active", "active"],
   ["needs_input", "waiting"],
@@ -1486,7 +1487,64 @@ function updateSysPanel(records: AgentRecord[], live: boolean) {
     color: live ? "#3fb950" : "#d29922",
   });
   sysPanel.items = items;
-  viewer.setPanels([sysPanel]);
+  applyPanels();
+}
+
+// ── pinned-agents palette (screen-fixed, shared with the /w/ console) ─────────
+// Pins live in the same localStorage set the console's left-panel pin uses
+// (ay.pinned, keyed by agent _key). Each pinned agent that's present in the
+// current fleet shows as a row in a screen-fixed palette; clicking a row glides
+// the camera to that node. Pin/unpin happens via a node's right-click menu (here)
+// or the console list (there) — a storage event keeps the two views in sync.
+const AY_PINNED_KEY = "ay.pinned";
+function loadPinnedKeys(): Set<string> {
+  try {
+    const a = JSON.parse(localStorage.getItem(AY_PINNED_KEY) || "[]");
+    return new Set(Array.isArray(a) ? a : []);
+  } catch {
+    return new Set();
+  }
+}
+let pinnedKeys = loadPinnedKeys();
+function isPinned(id: string): boolean {
+  return pinnedKeys.has(id);
+}
+function togglePin(id: string): void {
+  if (pinnedKeys.has(id)) pinnedKeys.delete(id);
+  else pinnedKeys.add(id);
+  try {
+    localStorage.setItem(AY_PINNED_KEY, JSON.stringify([...pinnedKeys]));
+  } catch {
+    /* storage unavailable — pin just won't persist / sync */
+  }
+  updatePinPanel();
+}
+const pinPanel: Panel = {
+  id: "pins",
+  title: "📌 pinned",
+  // Right edge (like sysPanel) — the top-left is occupied by the page's own
+  // toolbar/legend chrome, which would hide a left-anchored panel.
+  anchor: loadPanelAnchor(PIN_PANEL_KEY, "right"),
+  w: 200,
+  items: [],
+  onItemClick: (item) => focusNode(item.id),
+};
+// The pin palette is only shown when something is pinned; sysPanel is always on.
+function applyPanels(): void {
+  viewer.setPanels(pinnedKeys.size ? [pinPanel, sysPanel] : [sysPanel]);
+}
+// Rebuild the pin palette rows from the current fleet (skip pins whose agent
+// isn't in view — another machine, or exited-and-gone).
+function updatePinPanel(): void {
+  const items: PanelItem[] = [];
+  for (const id of pinnedKeys) {
+    const r = recordsByKey.get(id);
+    if (!r) continue;
+    items.push({ id, label: nodeTitle(r), value: String(r.pid), color: DOT_COLOR[r.status] });
+  }
+  pinPanel.items = items;
+  pinPanel.title = items.length ? `📌 pinned · ${items.length}` : "📌 pinned";
+  applyPanels();
 }
 
 // ── bootstrap ────────────────────────────────────────────────────────────────
@@ -1502,10 +1560,10 @@ const viewer: Rgui = createRgui(canvas, {
   theme: initialTheme,
   debug,
   panels: [sysPanel],
-  onPanelMove: (_p, anchor) => {
-    // persist the dragged/snapped anchor so the palette stays where the user left it
+  onPanelMove: (p, anchor) => {
+    // persist the dragged/snapped anchor so each palette stays where the user left it
     try {
-      localStorage.setItem(SYS_PANEL_KEY, JSON.stringify(anchor));
+      localStorage.setItem(p.id === "pins" ? PIN_PANEL_KEY : SYS_PANEL_KEY, JSON.stringify(anchor));
     } catch {
       /* storage unavailable — position just won't persist */
     }
@@ -1803,6 +1861,7 @@ function apply(records: AgentRecord[], live: boolean) {
     ? `live · ${n} agent${n === 1 ? "" : "s"}${liveW > 1 ? ` · ${liveW} sources` : usingRoom() ? " (room)" : ""}`
     : "demo · no local ay serve";
   updateSysPanel(records, live); // refresh the screen-fixed status palette
+  updatePinPanel(); // refresh the pinned-agents palette (fleet may have changed)
   updateDocTitle(); // keep the tab title's name/status/count fresh
 }
 
@@ -2370,6 +2429,12 @@ function persistSelection() {
   }
 }
 addEventListener("storage", (e) => {
+  // pins changed in the console (or another /r/ tab) → resync the palette
+  if (e.key === AY_PINNED_KEY) {
+    pinnedKeys = loadPinnedKeys();
+    updatePinPanel();
+    return;
+  }
   // live follow: the console (another tab, same origin) opened an agent
   if (e.key !== SEL_KEY) return;
   const key = normalizeSelKey(e.newValue);
@@ -2515,6 +2580,12 @@ function openBatchMenu(sx: number, sy: number, pids: string[], spawn: typeof ctx
   document.getElementById("ctx-s")!.textContent = pids.length === 1 ? "" : "s";
   const spawnBtn = document.getElementById("ctx-spawn") as HTMLButtonElement;
   spawnBtn.hidden = !spawn;
+  // Pin toggle: single real agent only (a pin targets one agent's node).
+  const pinPid = pids.length === 1 && recordsByKey.has(pids[0]!) ? pids[0]! : null;
+  const pinBtn = document.getElementById("ctx-pin") as HTMLButtonElement;
+  pinBtn.hidden = !pinPid;
+  pinBtn.dataset.pid = pinPid ?? "";
+  pinBtn.textContent = pinPid && isPinned(pinPid) ? "📌 Unpin" : "📌 Pin";
   if (spawn)
     spawnBtn.title =
       `POST /api/spawn on ${spawn.src === LOCAL ? "this machine" : spawn.src} · ` +
@@ -2585,6 +2656,11 @@ ctxInput.addEventListener("keydown", (e) => {
 });
 document.getElementById("ctx-send")!.addEventListener("click", () => void sendBatch());
 document.getElementById("ctx-spawn")!.addEventListener("click", () => void spawnHere());
+document.getElementById("ctx-pin")!.addEventListener("click", () => {
+  const pid = (document.getElementById("ctx-pin") as HTMLButtonElement).dataset.pid;
+  if (pid) togglePin(pid);
+  closeBatchMenu();
+});
 addEventListener("mousedown", (e) => {
   if (!ctxmenu.hidden && !ctxmenu.contains(e.target as Node)) closeBatchMenu();
 });


### PR DESCRIPTION
Pin an agent so it stays reachable while the fleet churns. One shared pinned set (`localStorage['ay.pinned']`, keyed by agent `_key`) drives both views; a `storage` event keeps them in sync across tabs/views.

## /w/ console left panel
- **Right-click an agent row** → context menu with **Pin to top** / **Unpin**.
- Pinned agents float to the top of their sorted group (a pinned root rises to the very top; a pinned subagent rises among its siblings) and show a 📌 marker + a subtle accent rail.
- Refactor: extracted the terminal menu's builder into `ctxMenuShell()` / `openCtxMenu()` so the new agent menu reuses the same shell, viewport-clamping, and dismiss plumbing.

## /r/ rgui view
- A screen-fixed **"📌 pinned"** palette (rgui `Panel`, right edge, stacked above the agents panel) lists each pinned agent present in the fleet. **Click a row → the camera glides to that node.**
- **Pin/unpin from a node's right-click menu** (new "📌 Pin" button in the batch menu, single-agent only).

## Verification
Verified end-to-end against a real local fleet (via rechrome):
- `/w/`: right-click → Pin floats the row to the top with the 📌 marker + rail and writes `ay.pinned`; right-click → Unpin reverses it.
- `/r/`: a shared pin renders in the palette (`📌 pinned · 1`) and clicking it glides the camera to the node.
- All 22 `ui-dom` tests pass; merged `rgui/main.ts` builds clean.

Note: cleanly 3-way merged on top of #244 (message pulses in `rowFlags`) and #248 (preview) already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)