### PR TITLE
feat(ui): /filter slash command in both command palettes (⌘K)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -5516,20 +5516,31 @@
         },
       ];
       // Build the command rows for a "/…"-prefixed query, targeting the anchor agent.
-      // Empty when nothing is open (a command with no agent to act on is a no-op) so
-      // the omnibox falls through to its normal search/spawn behaviour.
+      // Agent-scoped commands are omitted when nothing is open (a command with no
+      // agent to act on is a no-op); global commands (/filter) are always offered,
+      // and with no rows at all the omnibox falls back to search/spawn behaviour.
       function omniCommandRows(q) {
         const target = omniAnchor();
-        if (!target) return [];
         // Match on the FIRST token so a command can carry args after it
         // (e.g. "/fork fix the auth bug" → cmd "fork", topic "fix the auth bug").
         const parts = q.slice(1).trim().split(/\s+/).filter(Boolean);
         const cmdTerm = (parts[0] || "").toLowerCase(); // command token after "/"
-        const rows = OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(cmdTerm)).map((c) => ({
-          kind: "cmd",
-          cmd: c,
-          target,
-        }));
+        const rows = target
+          ? OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(cmdTerm)).map((c) => ({
+              kind: "cmd",
+              cmd: c,
+              target,
+            }))
+          : [];
+        // "/filter [tokens…]" — global: sets the left panel's filter box (#q) to the
+        // arguments, same tokens the box itself takes (space = AND, repo:x tags).
+        // With no args it clears the filter. Needs no anchor agent — it acts on the
+        // list, not an agent — so it's offered even when nothing is open. Listed
+        // after the agent commands so bare "/" still defaults to /restart.
+        if ("filter".startsWith(cmdTerm)) {
+          rows.push({ kind: "filter", value: parts.slice(1).join(" ") });
+        }
+        if (!target) return rows;
         // "/fork [topic]" — a slash alias for the fork spawn row so fork is reachable
         // straight from the command palette (⌘K → "/fork"), not only via the row that
         // auto-appends to a search. It's a spawn (kind:"fork"), not a kind:"cmd" that
@@ -5636,6 +5647,20 @@
                 <div class="omni-main">
                   <div class="omni-title">⊕ Spawn new ${esc(anchor?.cli || "claude")} agent in a directory…</div>
                   <div class="omni-sub">⏎ to choose a working dir &nbsp;·&nbsp; prompt: ${esc(q || "(empty)")}</div>
+                </div></div>`;
+            }
+            if (r.kind === "filter") {
+              const cur = $("q").value.trim();
+              const title = r.value
+                ? `⌕ Filter list: <b>${esc(r.value)}</b> <span style="opacity:.55">/filter</span>`
+                : cur
+                  ? `⌕ Clear list filter <span style="opacity:.55">(now: ${esc(cur)})</span>`
+                  : `⌕ Filter list… <span style="opacity:.55">/filter repo:x claude</span>`;
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot idle"></span>
+                <div class="omni-main">
+                  <div class="omni-title">${title}</div>
+                  <div class="omni-sub">sets the left panel filter &nbsp;·&nbsp; space = AND, tags like repo:/wt:/cli:/host:</div>
                 </div></div>`;
             }
             if (r.kind === "cmd") {
@@ -5775,6 +5800,14 @@
         if (row && row.kind === "cmd") {
           closeOmni(false);
           await row.cmd.run(row.target);
+          return;
+        }
+        // "/filter …" sets the left panel's filter box; the input event does the
+        // rest (persists ay.filter + re-renders the list), exactly as if typed.
+        if (row && row.kind === "filter") {
+          closeOmni(false);
+          $("q").value = row.value;
+          $("q").dispatchEvent(new Event("input"));
           return;
         }
         // ⌘⏎ always = spawn-here (the fast default), regardless of the selected row.

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -620,7 +620,7 @@
           type="text"
           autocomplete="off"
           spellcheck="false"
-          placeholder="Go to agent — search title / branch / cwd / pid…"
+          placeholder="Go to agent — search title / branch / cwd / pid…  ·  /filter narrows the graph"
         />
         <div id="cmdk-list"></div>
         <div class="cmdk-foot">

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -1433,7 +1433,17 @@ function loadPanelAnchor(key: string, dflt: Panel["anchor"]): Panel["anchor"] {
   }
   return dflt;
 }
-const sysPanel: Panel = { id: "sys", title: "agents", anchor: loadPanelAnchor(SYS_PANEL_KEY, "right"), w: 200, items: [] };
+const sysPanel: Panel = {
+  id: "sys",
+  title: "agents",
+  anchor: loadPanelAnchor(SYS_PANEL_KEY, "right"),
+  w: 200,
+  items: [],
+  // Only the filter chip is clickable — clicking it clears the graph filter.
+  onItemClick: (item) => {
+    if (item.id === "filter") setRguiFilter("");
+  },
+};
 const STATUS_ROWS: [AgentStatus, string][] = [
   ["active", "active"],
   ["needs_input", "waiting"],
@@ -1457,6 +1467,8 @@ function updateSysPanel(records: AgentRecord[], live: boolean) {
   // label on the left, count right-aligned via PanelItem.value (rgui renders the
   // value column and clips the label so it never runs under the number).
   const items: PanelItem[] = [];
+  // Active graph filter chip (⌘K "/filter …") — click clears it (onItemClick).
+  if (rguiFilter) items.push({ id: "filter", label: `⌕ ${rguiFilter}`, value: "✕", color: "#d29922" });
   for (const [st, label] of STATUS_ROWS) {
     const n = counts.get(st) ?? 0;
     if (n) items.push({ id: st, label, value: String(n), color: DOT_COLOR[st] });
@@ -1675,6 +1687,42 @@ let liveKnown = false;
 let lastStruct = "";
 let lastContent = "";
 
+// ── graph filter (⌘K "/filter …" + the sys-panel chip) ───────────────────────
+// Narrows which agents the forest RENDERS — recordsByKey stays complete, so the
+// ⌘K agent list, pins, and terminals still see the whole fleet. Persisted like
+// the /w/ console's ay.filter so a reload keeps the narrowed view.
+const RGUI_FILTER_KEY = "rgui-filter";
+let rguiFilter = ((): string => {
+  try {
+    return localStorage.getItem(RGUI_FILTER_KEY) ?? "";
+  } catch {
+    return "";
+  }
+})();
+let lastRawRecords: AgentRecord[] = [];
+// Space-separated tokens AND-match (case-insensitive substrings) over the same
+// fields the ⌘K rows show: title, cwd, cli, status, branch, source.
+function matchesFilter(r: AgentRecord): boolean {
+  if (!rguiFilter) return true;
+  const hay =
+    `${nodeTitle(r)} ${r.cwd} ${r.cli} ${r.status} ${r.git?.branch ?? ""} ${r._src}`.toLowerCase();
+  return rguiFilter
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((t) => hay.includes(t));
+}
+function setRguiFilter(v: string): void {
+  rguiFilter = v.trim();
+  try {
+    localStorage.setItem(RGUI_FILTER_KEY, rguiFilter);
+  } catch {
+    /* storage unavailable — filter just won't persist */
+  }
+  lastStruct = ""; // force the graph rebuild even though the fleet didn't change
+  apply(lastRawRecords, liveKnown);
+}
+
 // Refresh title/category/fields on the existing nodes (+ terminal title bars)
 // in place. We deliberately DON'T force a redraw here: a `setGraph` per poll
 // re-renders the whole canvas AND kicks rgui's frame-animation loop, which
@@ -1831,8 +1879,12 @@ if (fedFeeds.length) {
 }
 
 function apply(records: AgentRecord[], live: boolean) {
+  lastRawRecords = records;
   recordsByKey.clear();
   for (const r of records) recordsByKey.set(r._key, r);
+  // The graph (and the sig-based change detection driving it) renders only the
+  // filtered view; recordsByKey above deliberately keeps the full fleet.
+  if (rguiFilter) records = records.filter(matchesFilter);
   const struct = structureSig(records);
   const content = contentSig(records);
   if (struct !== lastStruct) {
@@ -1857,9 +1909,10 @@ function apply(records: AgentRecord[], live: boolean) {
   statusEl.className = live ? "live" : "demo";
   const n = records.length;
   const liveW = [...wires.values()].filter(wireReady).length;
-  statusLabel.textContent = live
-    ? `live · ${n} agent${n === 1 ? "" : "s"}${liveW > 1 ? ` · ${liveW} sources` : usingRoom() ? " (room)" : ""}`
-    : "demo · no local ay serve";
+  statusLabel.textContent =
+    (live
+      ? `live · ${n} agent${n === 1 ? "" : "s"}${liveW > 1 ? ` · ${liveW} sources` : usingRoom() ? " (room)" : ""}`
+      : "demo · no local ay serve") + (rguiFilter ? ` · ⌕ ${rguiFilter}` : "");
   updateSysPanel(records, live); // refresh the screen-fixed status palette
   updatePinPanel(); // refresh the pinned-agents palette (fleet may have changed)
   updateDocTitle(); // keep the tab title's name/status/count fresh
@@ -2448,7 +2501,34 @@ const cmdkList = document.getElementById("cmdk-list")!;
 const escHtml = (s: string) =>
   s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
 let cmdkSel = 0;
-let cmdkRows: { id: string; title: string; status: string; sub: string }[] = [];
+// A row is either an agent (id = record key, Enter focuses it) or a slash
+// command (has `action`, Enter runs it — e.g. "/filter …").
+let cmdkRows: { id: string; title: string; status: string; sub: string; action?: () => void }[] =
+  [];
+
+// "/…"-prefixed queries turn the palette into a command list instead of an
+// agent search. Only /filter for now: sets the graph filter (same one the
+// sys-panel chip shows; empty args clear it).
+function cmdkCommandRows(q: string): typeof cmdkRows {
+  const parts = q.slice(1).trim().split(/\s+/).filter(Boolean);
+  const cmdTerm = (parts[0] ?? "").toLowerCase();
+  const rows: typeof cmdkRows = [];
+  if ("filter".startsWith(cmdTerm)) {
+    const args = parts.slice(1).join(" ");
+    rows.push({
+      id: "/filter",
+      status: "idle",
+      title: args
+        ? `⌕ filter: ${args}`
+        : rguiFilter
+          ? `⌕ clear filter (now: ${rguiFilter})`
+          : "⌕ filter…",
+      sub: "narrows the graph · space = AND · matches title/cwd/cli/status/branch",
+      action: () => setRguiFilter(args),
+    });
+  }
+  return rows;
+}
 
 function cmdkData() {
   const rows = [...recordsByKey.values()].map((r) => ({
@@ -2464,10 +2544,13 @@ function cmdkData() {
   return rows;
 }
 function cmdkRender() {
-  const q = cmdkInput.value.trim().toLowerCase();
-  cmdkRows = cmdkData().filter(
-    (r) => !q || `${r.title} ${r.id} ${r.sub} ${r.status}`.toLowerCase().includes(q),
-  );
+  const raw = cmdkInput.value.trim();
+  const q = raw.toLowerCase();
+  cmdkRows = raw.startsWith("/")
+    ? cmdkCommandRows(raw)
+    : cmdkData().filter(
+        (r) => !q || `${r.title} ${r.id} ${r.sub} ${r.status}`.toLowerCase().includes(q),
+      );
   if (cmdkSel >= cmdkRows.length) cmdkSel = Math.max(0, cmdkRows.length - 1);
   cmdkList.innerHTML = cmdkRows
     .map(
@@ -2479,7 +2562,8 @@ function cmdkRender() {
         `<span class="cmdk-dim">${escHtml(r.sub)}</span></div>`,
     )
     .join("");
-  cmdkRows[cmdkSel] && viewer.setSelection([cmdkRows[cmdkSel]!.id]); // preview highlight
+  const cur = cmdkRows[cmdkSel];
+  if (cur && !cur.action) viewer.setSelection([cur.id]); // preview highlight (agents only)
   cmdkList.querySelector(".cmdk-row.sel")?.scrollIntoView({ block: "nearest" });
 }
 function cmdkOpen() {
@@ -2494,7 +2578,8 @@ function cmdkClose() {
 }
 function cmdkGo(overlay: boolean) {
   const r = cmdkRows[cmdkSel];
-  if (r) focusNode(r.id, overlay);
+  if (r?.action) r.action();
+  else if (r) focusNode(r.id, overlay);
   cmdkClose();
 }
 addEventListener("keydown", (e) => {

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -280,12 +280,13 @@ describe("console DOM behaviour", () => {
       await page.keyboard.press("Control+k");
       await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
 
-      // "/" lists the commands; both /restart and /kill are offered.
+      // "/" lists the commands; /restart, /kill and the global /filter are offered.
       await page.fill("#omni-input", "/");
-      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(2);
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(3);
       const menu = (await page.locator("#omni-results").innerText()).toLowerCase();
       expect(menu).toContain("restart");
       expect(menu).toContain("kill");
+      expect(menu).toContain("filter");
 
       // "/restart" narrows to one row; ⏎ fires POST /api/restart for pid 101.
       await page.fill("#omni-input", "/restart");
@@ -305,6 +306,37 @@ describe("console DOM behaviour", () => {
       await expect.poll(() => posts.filter((x) => x.path === "/api/kill").length).toBe(1);
       const kill = posts.find((x) => x.path === "/api/kill")!;
       expect(kill.body.keyword).toBe("101");
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("Cmd+K /filter sets and clears the left panel filter box", async () => {
+    const { ctx, page } = await openConsole(browser, url);
+    try {
+      // "/filter claude" applies the tokens to #q (persisted via its input path).
+      await page.keyboard.press("Control+k");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
+      await page.fill("#omni-input", "/filter claude");
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(1);
+      await page.keyboard.press("Enter");
+      await expect.poll(() => page.locator("#q").inputValue()).toBe("claude");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(false);
+      expect(await page.evaluate(() => localStorage.getItem("ay.filter"))).toBe("claude");
+
+      // Bare "/filter" clears it again.
+      await page.keyboard.press("Control+k");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
+      await page.fill("#omni-input", "/filter");
+      await expect.poll(() =>
+        page
+          .locator("#omni-results")
+          .innerText()
+          .then((t) => t.toLowerCase().includes("clear list filter")),
+      ).toBe(true);
+      await page.keyboard.press("Enter");
+      await expect.poll(() => page.locator("#q").inputValue()).toBe("");
+      expect(await page.evaluate(() => localStorage.getItem("ay.filter"))).toBe("");
     } finally {
       await ctx.close();
     }


### PR DESCRIPTION
## What

**/w/ console** — the ⌘K omnibox gains `/filter [tokens…]`:
- sets the left panel's filter box to the arguments and re-renders the list through the exact input path the box itself uses (so `ay.filter` persistence and token semantics — space = AND, `repo:`/`wt:`/`cli:`/`host:` tags — are identical to typing);
- works with or without an open agent (it acts on the list, not an agent);
- `/filter` with no args clears the filter (the row shows the current value being cleared);
- listed after the agent commands so a bare `/` still defaults to `/restart`.

**/r/ rgui** — the ⌘K palette gains a `/…` command mode with the same `/filter [tokens…]`:
- narrows which agents the forest renders — AND substring match over title / cwd / cli / status / branch / source;
- persisted as `rgui-filter` so a reload keeps the narrowed view;
- active filter surfaces as a `⌕ <filter>` chip in the status bar and as a row in the screen-fixed sys panel — clicking the panel row clears it;
- `recordsByKey` deliberately stays complete, so the ⌘K agent search, pins, and per-node terminals still see the whole fleet.

## Verified (real browser via rech, against a local `ay serve`)

- /w/: `⌘K → /filter claude ⏎` → `#q` = "claude", `ay.filter` persisted, list filtered, omnibox closed; `/filter ⏎` clears (row reads "Clear list filter (now: claude)").
- /r/: `⌘K → /filter claude ⏎` → status `live · 89 agents · ⌕ claude` (from 97), `rgui-filter` persisted; `/filter ⏎` restores all 97.
- Non-slash ⌘K agent search unchanged in both views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)