### PR TITLE
ci: fix agent-yes.com deploy + UI-test rgui build, bump rgui pin

### DIFF
--- a/.github/workflows/deploy-agent-yes.yml
+++ b/.github/workflows/deploy-agent-yes.yml
@@ -34,6 +34,28 @@ jobs:
           submodules: recursive
       # bun runs scripts/build-rgui.ts inside wrangler's build step.
       - uses: oven-sh/setup-bun@v2
+      # Cache bun's global module store so codehost@^0.32 (and the rest) don't
+      # cold-download every deploy. Keyed on the lockfile — a dep change busts it.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-deploy-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-deploy-${{ runner.os }}-
+      # The Worker bundle (worker.ts) imports npm deps like `codehost/tunnel`, so
+      # node_modules must exist before wrangler bundles — the deploy has no other
+      # install step. Without this, wrangler fails with "Could not resolve
+      # codehost/tunnel" AFTER build-rgui already ran, masking the real cause.
+      - run: bun install --frozen-lockfile
+      # Fail loudly, and at the right line, if a build input is missing: the npm
+      # deps (bun install) and the rgui source (submodule checkout). Either one
+      # absent otherwise surfaces as a cryptic bundler/`build-rgui` error further
+      # down, pointing at the wrong thing.
+      - name: Verify build inputs present
+        run: |
+          test -f node_modules/codehost/package.json \
+            || { echo "::error::node_modules/codehost missing — 'bun install' did not run or failed."; exit 1; }
+          test -f lib/rgui/src/index.ts \
+            || { echo "::error::lib/rgui/src/index.ts missing — the rgui submodule was not checked out (need submodules: recursive)."; exit 1; }
       - name: Deploy worker + synced UI to Cloudflare
         working-directory: lab/ui/cf
         env:

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -78,7 +78,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # submodules: `cf.ts deploy` runs `wrangler deploy`, whose build step
+      # (wrangler.jsonc → scripts/build-rgui.ts) bundles the /rgui page from the
+      # lib/rgui submodule. Without this the deploy fails "rgui source not found".
       - uses: actions/checkout@v5
+        with:
+          submodules: recursive
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest


### PR DESCRIPTION
## What

The **Deploy agent-yes.com** and **UI Test** checks have been red on every recent main commit — two independent, pre-existing breaks in the `/r/`+`/w/` deploy pipeline (surfaced while shipping the message-log UI, not caused by it).

## Root causes & fixes

**1. Deploy failed on the Worker bundle, not rgui.** `deploy-agent-yes.yml` ran `wrangler deploy` with **no `bun install`**, so the Worker bundle (`worker.ts`) couldn't resolve `codehost/tunnel` (npm dep `^0.32.0`) — and it failed *after* `build-rgui` already ran, masking the real cause. Fix: add `bun install --frozen-lockfile` + a bun-cache before deploy, and a **loud pre-flight guard** asserting both build inputs exist (`node_modules/codehost`, `lib/rgui/src/index.ts`) so the next missing input points at the right line.

**2. UI Test's `deploy` job lacked submodules.** It runs `cf.ts deploy` (= `wrangler deploy` → `build-rgui`) but checked out **without submodules**, so `build-rgui` threw `rgui source not found`. Fix: `submodules: recursive` on that checkout.

**3. Pin bump.** `lib/rgui` `81d5636` → `d1ca5ce` (current `origin/rgui` HEAD, released; the rgui maintainer confirmed no breaking core-export changes — today's train is lane/tree demo work + a color-util move).

## Diagnosis notes

- The submodule registration is **fine** (mode 160000 gitlink, proper `.gitmodules` https URL, valid public pin) — the deploy run's checkout log shows `Submodule path 'lib/rgui': checked out`. So the rgui failure was *only* in UI Test (which didn't check out submodules), never the deploy.
- The `/r/`+`/w/` UI was already pushed live manually via `wrangler deploy` from a checkout that has both `node_modules` and the rgui worktree (version `9c61beb8`). This PR makes CI reproduce that reliably.

## Follow-up (not in this PR)

Both workflows deploy the same Worker on a push to main — a pre-existing redundancy. Worth consolidating to the single test-gated deploy later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)