### PR TITLE
feat(console): ⌘K /ws workspace browser — GET /api/ws + lazy git status

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2086,7 +2086,7 @@
       <div class="omnibox">
         <input
           id="omni-input"
-          placeholder="Search agents by title, then output…"
+          placeholder="Search agents by title, then output…  ·  &quot;/&quot; commands  ·  /ws workspaces"
           spellcheck="false"
           autocapitalize="off"
           autocomplete="off"
@@ -5520,16 +5520,19 @@
       // the omnibox falls through to its normal search/spawn behaviour.
       function omniCommandRows(q) {
         const target = omniAnchor();
-        if (!target) return [];
         // Match on the FIRST token so a command can carry args after it
         // (e.g. "/fork fix the auth bug" → cmd "fork", topic "fix the auth bug").
         const parts = q.slice(1).trim().split(/\s+/).filter(Boolean);
         const cmdTerm = (parts[0] || "").toLowerCase(); // command token after "/"
-        const rows = OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(cmdTerm)).map((c) => ({
-          kind: "cmd",
-          cmd: c,
-          target,
-        }));
+        // Agent-targeted commands need an open agent to act on; /ws (below)
+        // doesn't, so the target check gates only these rows, not the builder.
+        const rows = !target
+          ? []
+          : OMNI_COMMANDS.filter((c) => c.cmd.slice(1).startsWith(cmdTerm)).map((c) => ({
+              kind: "cmd",
+              cmd: c,
+              target,
+            }));
         // "/fork [topic]" — a slash alias for the fork spawn row so fork is reachable
         // straight from the command palette (⌘K → "/fork"), not only via the row that
         // auto-appends to a search. It's a spawn (kind:"fork"), not a kind:"cmd" that
@@ -5549,7 +5552,122 @@
               src: src._src,
             });
         }
+        // "/ws" discoverability — typing "/" (or "/w") lists the workspace
+        // browser next to the agent commands; a full "/ws…" query is intercepted
+        // in runOmni before this builder runs. Needs no anchor: workspaces exist
+        // independently of any open agent.
+        if ("ws".startsWith(cmdTerm)) rows.push({ kind: "wshint" });
         return rows;
+      }
+
+      // ---- "/ws" — workspace browser (⌘K → /ws) ------------------------------
+      // Lists every workspace under each connected host's codehost layout
+      // (<wsRoot>/<owner>/<repo>/tree/<branch>) via GET /api/ws — including ones
+      // with NO live agents, which the agent list can never show. Enter spawns a
+      // new agent in the highlighted workspace; a "/ws owner/repo[@branch]" query
+      // that parses as a source adds a provision row (POST /api/spawn {from},
+      // gated server-side by the provision hook/allowlist). Fetched at most once
+      // per TTL from every writable host; hosts without the endpoint (older
+      // daemon) or without codehost (501) just drop out of the merge.
+      const OMNI_WS_TTL = 30_000;
+      let omniWsCache = null; // { at, items: [{ ws, srcId, host }] }
+      let omniWsFetchSeq = 0;
+      let omniWsFetching = false;
+      function omniWsFetch() {
+        const seq = ++omniWsFetchSeq;
+        omniWsFetching = true;
+        const srcs = [...sources.values()].filter((s) => s.tx?.fetchJSON && s.live && !s.readonly);
+        Promise.all(
+          srcs.map(async (s) => {
+            try {
+              const r = await s.tx.fetchJSON("/api/ws");
+              const host = s.deviceLabel || (s.id === LOCAL ? "local" : s.room || s.id);
+              return (r?.workspaces || []).map((ws) => ({ ws, srcId: s.id, host }));
+            } catch {
+              return []; // 404 (older daemon) / 501 (no codehost) / transport error
+            }
+          }),
+        ).then((all) => {
+          if (seq !== omniWsFetchSeq) return; // superseded by a newer fetch
+          omniWsFetching = false;
+          omniWsCache = { at: Date.now(), items: all.flat() };
+          // Repaint only if the user is still looking at a /ws view.
+          if (omniOpen() && /^\/ws(\s|$)/i.test($("omni-input").value.trim())) runOmni();
+        });
+      }
+      const wsSpecOf = (w) => `${w.owner}/${w.repo}@${w.branch}`;
+      // JS twin of ts/ws.ts gitSummary — keep the vocabulary identical.
+      function wsGitSummary(ws) {
+        if (ws.gitError) return "error: " + ws.gitError;
+        const g = ws.git;
+        if (!g) return "";
+        const parts = [];
+        if (g.dirty) parts.push("dirty");
+        if (g.ahead > 0) parts.push("ahead " + g.ahead);
+        if (g.behind > 0) parts.push("behind " + g.behind);
+        if (!g.hasUpstream) parts.push("no-upstream");
+        return parts.length ? parts.join(", ") : "clean";
+      }
+      function omniWsRows(q) {
+        const arg = q.replace(/^\/ws\s*/i, "").trim();
+        if (!omniWsCache) {
+          if (!omniWsFetching) omniWsFetch();
+          return [{ kind: "wsinfo", text: "loading workspaces…" }];
+        }
+        // Stale cache: refresh behind the (still rendered) cached view.
+        if (Date.now() - omniWsCache.at > OMNI_WS_TTL && !omniWsFetching) omniWsFetch();
+        const toks = arg.toLowerCase().split(/\s+/).filter(Boolean);
+        const rows = omniWsCache.items
+          .filter((it) =>
+            toks.every((t) =>
+              (wsSpecOf(it.ws) + " " + it.ws.path + " " + it.host).toLowerCase().includes(t),
+            ),
+          )
+          .sort(
+            (a, b) =>
+              (b.ws.agents?.live || 0) - (a.ws.agents?.live || 0) ||
+              wsSpecOf(a.ws).localeCompare(wsSpecOf(b.ws)),
+          )
+          .slice(0, 30)
+          .map((it) => ({ kind: "ws", ws: it.ws, srcId: it.srcId, host: it.host }));
+        // A single owner/repo[@branch] token that parses as a source gets a
+        // provision row even when similar workspaces exist (the user may want a
+        // branch that isn't checked out yet).
+        if (/^[\w.-]+\/[\w.-]+(@[\w./-]+)?$/.test(arg)) rows.push({ kind: "wsnew", spec: arg });
+        if (!rows.length)
+          rows.push({
+            kind: "wsinfo",
+            text: omniWsCache.items.length
+              ? "no workspaces match — /ws owner/repo@branch provisions a new one"
+              : "no workspaces on any connected host (layout <wsRoot>/<owner>/<repo>/tree/<branch>)",
+          });
+        return rows;
+      }
+      // Lazy git status for the HIGHLIGHTED workspace only — a full-status join
+      // is O(workspaces × git status) and measured in seconds, so state loads
+      // per-row on selection, debounced like the terminal preview. Results land
+      // on the CACHED ws object, so they survive re-filtering keystrokes.
+      let omniWsStatusTimer = null;
+      function omniWsStatusPeek() {
+        const row = omniRows[omniIdx];
+        if (!row || row.kind !== "ws" || row.ws.git !== undefined || row.ws._st) return;
+        if (omniWsStatusTimer) clearTimeout(omniWsStatusTimer);
+        omniWsStatusTimer = setTimeout(async () => {
+          if (!omniOpen()) return;
+          row.ws._st = 1;
+          const s = sources.get(row.srcId);
+          if (!s?.tx?.fetchJSON) return;
+          try {
+            const r = await s.tx.fetchJSON(
+              "/api/ws/status?path=" + encodeURIComponent(row.ws.path),
+            );
+            if (r?.workspace) Object.assign(row.ws, r.workspace);
+            else row.ws.git = null;
+          } catch {
+            row.ws.git = null; // no status chip — the row stays useful without it
+          }
+          if (omniOpen() && omniRows.includes(row)) renderOmni();
+        }, 150);
       }
 
       // Which agent the highlighted candidate should preview in the background: an
@@ -5638,6 +5756,39 @@
                   <div class="omni-sub">⏎ to choose a working dir &nbsp;·&nbsp; prompt: ${esc(q || "(empty)")}</div>
                 </div></div>`;
             }
+            if (r.kind === "wshint") {
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot active"></span>
+                <div class="omni-main">
+                  <div class="omni-title">▤ Workspaces <span style="opacity:.55">/ws</span></div>
+                  <div class="omni-sub">browse every workspace on the fleet — spawn into idle checkouts &nbsp;·&nbsp; ⏎ to open</div>
+                </div></div>`;
+            }
+            if (r.kind === "wsinfo") {
+              return `<div class="omni-row${sc}" data-i="${i}">
+                <div class="omni-main"><div class="omni-sub">${esc(r.text)}</div></div></div>`;
+            }
+            if (r.kind === "ws") {
+              const live = r.ws.agents?.live || 0;
+              const st = wsGitSummary(r.ws);
+              const multi = sources.size > 1;
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot ${live ? "active" : "exited"}"></span>
+                <div class="omni-main">
+                  <div class="omni-title">▤ ${esc(wsSpecOf(r.ws))}${
+                    live ? ` <span style="opacity:.7">· ${live} agent${live > 1 ? "s" : ""}</span>` : ""
+                  }${multi ? ` <span style="opacity:.55">@ ${esc(r.host)}</span>` : ""}</div>
+                  <div class="omni-sub">${esc(r.ws.path)}${st ? " &nbsp;·&nbsp; <b>" + esc(st) + "</b>" : ""} &nbsp;·&nbsp; ⏎ spawn agent here</div>
+                </div></div>`;
+            }
+            if (r.kind === "wsnew") {
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot active"></span>
+                <div class="omni-main">
+                  <div class="omni-title">⊕ Provision workspace <b>${esc(r.spec)}</b> &amp; spawn ${esc(anchor?.cli || "claude")}</div>
+                  <div class="omni-sub">clone/refresh via codehost — gated by the host's provision hook/allowlist</div>
+                </div></div>`;
+            }
             if (r.kind === "cmd") {
               const t = r.target;
               const dz = r.cmd.danger ? " danger" : "";
@@ -5662,6 +5813,7 @@
         $("omni-results").innerHTML = html || `<div class="omni-empty">no matches</div>`;
         const selrow = $("omni-results").querySelector(".omni-row.sel");
         if (selrow) selrow.scrollIntoView({ block: "nearest" });
+        omniWsStatusPeek(); // lazy git state for a highlighted /ws row (no-op otherwise)
       }
 
       function runOmni() {
@@ -5669,6 +5821,16 @@
         // A "/…" query is a slash command against the open agent, not a search —
         // show the matching command rows and skip the agent/spawn/tail machinery.
         if (q.startsWith("/")) {
+          // "/ws …" opens the workspace browser — its rows come from /api/ws,
+          // not the agent list, and it must never fall through to agent search
+          // (the query is a workspace filter, not a spawn prompt).
+          if (/^\/ws(\s|$)/i.test(q)) {
+            if (omniTailTimer) clearTimeout(omniTailTimer);
+            omniRows = omniWsRows(q);
+            omniIdx = 0;
+            renderOmni();
+            return;
+          }
           const cmds = omniCommandRows(q);
           if (cmds.length) {
             if (omniTailTimer) clearTimeout(omniTailTimer);
@@ -5775,6 +5937,25 @@
         if (row && row.kind === "cmd") {
           closeOmni(false);
           await row.cmd.run(row.target);
+          return;
+        }
+        // /ws rows — handled BEFORE the ⌘⏎ spawn-here fallthrough: in the
+        // workspace browser the typed text is a filter, not a prompt, so
+        // "spawn here with this prompt" is never the right reading of it.
+        if (row && row.kind === "wshint") {
+          $("omni-input").value = "/ws ";
+          runOmni();
+          return; // stays open — the browser replaces the command list
+        }
+        if (row && row.kind === "wsinfo") return; // informational, not activatable
+        if (row && row.kind === "ws") {
+          closeOmni(false);
+          await spawnAndSelect({ cli: anchor?.cli || "claude", cwd: row.ws.path }, row.srcId);
+          return;
+        }
+        if (row && row.kind === "wsnew") {
+          closeOmni(false);
+          await spawnAndSelect({ cli: anchor?.cli || "claude", from: row.spec }, anchor?._src);
           return;
         }
         // ⌘⏎ always = spawn-here (the fast default), regardless of the selected row.

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -280,12 +280,13 @@ describe("console DOM behaviour", () => {
       await page.keyboard.press("Control+k");
       await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
 
-      // "/" lists the commands; both /restart and /kill are offered.
+      // "/" lists the commands; /restart, /kill and the /ws browser are offered.
       await page.fill("#omni-input", "/");
-      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(2);
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(3);
       const menu = (await page.locator("#omni-results").innerText()).toLowerCase();
       expect(menu).toContain("restart");
       expect(menu).toContain("kill");
+      expect(menu).toContain("workspaces");
 
       // "/restart" narrows to one row; ⏎ fires POST /api/restart for pid 101.
       await page.fill("#omni-input", "/restart");
@@ -305,6 +306,63 @@ describe("console DOM behaviour", () => {
       await expect.poll(() => posts.filter((x) => x.path === "/api/kill").length).toBe(1);
       const kill = posts.find((x) => x.path === "/api/kill")!;
       expect(kill.body.keyword).toBe("101");
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("Cmd+K /ws browses workspaces, lazy-loads git state, and spawns into one", async () => {
+    // The /ws browser lists GET /api/ws results (including the idle acme/widgets
+    // checkout no agent row could surface), fetches the highlighted row's git
+    // state lazily via /api/ws/status, and Enter fires POST /api/spawn with the
+    // workspace path as cwd. A source-looking query offers a provision row that
+    // spawns with {from} instead.
+    const { ctx, page } = await openConsole(browser, url);
+    const spawns: any[] = [];
+    page.on("request", (r) => {
+      if (r.method() === "POST" && new URL(r.url()).pathname === "/api/spawn") {
+        try {
+          spawns.push(r.postDataJSON());
+        } catch {}
+      }
+    });
+    try {
+      await page.keyboard.press("Control+k");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
+
+      // "/ws" lists both fixture workspaces, live-agent one first.
+      await page.fill("#omni-input", "/ws");
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(2);
+      const rows = await page.locator("#omni-results").innerText();
+      expect(rows).toContain("snomiao/agent-yes@main");
+      expect(rows).toContain("acme/widgets@dev");
+      expect(rows.indexOf("agent-yes")).toBeLessThan(rows.indexOf("widgets"));
+
+      // The highlighted (first) row lazily pulls /api/ws/status → "dirty, ahead 2".
+      await expect
+        .poll(() => page.locator("#omni-results").innerText())
+        .toContain("dirty, ahead 2");
+
+      // Filter to the idle workspace and Enter → spawn with its path as cwd.
+      await page.fill("#omni-input", "/ws widgets");
+      await expect.poll(() => page.locator("#omni-results .omni-row").count()).toBe(1);
+      await page.keyboard.press("Enter");
+      await expect.poll(() => spawns.length).toBe(1);
+      expect(spawns[0].cwd).toBe("/home/u/ws/acme/widgets/tree/dev");
+      expect(spawns[0].from).toBeUndefined();
+
+      // A source-looking query that matches nothing offers the provision row;
+      // Enter spawns with {from} so the host clones it behind its gate.
+      await page.keyboard.press("Control+k");
+      await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
+      await page.fill("#omni-input", "/ws acme/newrepo@dev");
+      await expect
+        .poll(() => page.locator("#omni-results").innerText())
+        .toContain("Provision workspace");
+      await page.keyboard.press("Enter");
+      await expect.poll(() => spawns.length).toBe(2);
+      expect(spawns[1].from).toBe("acme/newrepo@dev");
+      expect(spawns[1].cwd).toBeUndefined();
     } finally {
       await ctx.close();
     }

--- a/tests/ui-dom/server.ts
+++ b/tests/ui-dom/server.ts
@@ -16,6 +16,9 @@
  *   POST /api/send              → ok
  *   POST /api/kill              → { ok: true }  (Cmd+K /kill, ⋯ Force-kill)
  *   POST /api/restart           → { ok: true }  (Cmd+K /restart, ⋯ Restart)
+ *   GET  /api/ws                → WORKSPACES fixture  (Cmd+K /ws browser)
+ *   GET  /api/ws/status?path=   → one workspace + a fixed dirty git state
+ *   POST /api/spawn             → { ok: true }  (Enter on a /ws row)
  */
 import http from "http";
 import { readFileSync } from "fs";
@@ -58,6 +61,25 @@ export const AGENTS = [
     prompt: "",
     status: "active",
     started_at: T0,
+  },
+];
+
+// Workspace fixture for the Cmd+K /ws browser (GET /api/ws): one workspace with
+// a live agent in it and one idle checkout no agent list could ever surface.
+export const WORKSPACES = [
+  {
+    owner: "snomiao",
+    repo: "agent-yes",
+    branch: "main",
+    path: "/home/u/ws/snomiao/agent-yes/tree/main",
+    agents: { live: 1 },
+  },
+  {
+    owner: "acme",
+    repo: "widgets",
+    branch: "dev",
+    path: "/home/u/ws/acme/widgets/tree/dev",
+    agents: { live: 0 },
   },
 ];
 
@@ -123,6 +145,42 @@ export async function startServer(
     if (req.method === "POST" && (p === "/api/kill" || p === "/api/restart")) {
       res.writeHead(200, { "Content-Type": "application/json" });
       return res.end(JSON.stringify({ ok: true }));
+    }
+    // Cmd+K /ws browser: the workspace walk, one workspace's lazy git status,
+    // and the spawn the Enter action fires (the test asserts the request body).
+    if (req.method === "GET" && p === "/api/ws") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(
+        JSON.stringify({ schema: "ay-ws/v1", wsRoot: "/home/u/ws", workspaces: WORKSPACES }),
+      );
+    }
+    if (req.method === "GET" && p === "/api/ws/status") {
+      const target = WORKSPACES.find((w) => w.path === url.searchParams.get("path"));
+      if (!target) {
+        res.writeHead(404);
+        return res.end("not a workspace checkout");
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(
+        JSON.stringify({
+          schema: "ay-ws/v1",
+          workspace: {
+            ...target,
+            git: {
+              branch: target.branch,
+              head: "abc1234",
+              ahead: 2,
+              behind: 0,
+              dirty: true,
+              hasUpstream: true,
+            },
+          },
+        }),
+      );
+    }
+    if (req.method === "POST" && p === "/api/spawn") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({ ok: true, pid: 999 }));
     }
 
     res.writeHead(404);

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,5 +1,5 @@
 import { mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
-import { renameSync, watch, writeFileSync } from "node:fs";
+import { existsSync, renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
@@ -2024,6 +2024,57 @@ export async function cmdServe(rest: string[]): Promise<number> {
           provision: hasProvisionHook(),
         },
       });
+    }
+
+    // GET /api/ws — every workspace under the codehost layout
+    // (<wsRoot>/<owner>/<repo>/tree/<branch>) with live-agent counts. This is
+    // what the console's ⌘K "/ws" browser renders: unlike /api/ls it also shows
+    // workspaces with NO agents in them, so you can spawn into an idle checkout.
+    // Read-only and cheap (a directory walk, no git); per-workspace git state is
+    // fetched lazily via /api/ws/status below. 501 mirrors the fork path when
+    // codehost/provision isn't installed on this host.
+    if (req.method === "GET" && p === "/api/ws") {
+      const ws = await import("./ws.ts");
+      try {
+        await ws.loadProvision();
+      } catch (e) {
+        return new Response((e as Error).message, { status: 501 });
+      }
+      try {
+        const { wsRoot, workspaces } = await ws.collectWorkspaces();
+        return Response.json({ schema: ws.WS_JSON_SCHEMA, wsRoot, workspaces });
+      } catch (e) {
+        return new Response(`workspace walk failed: ${(e as Error).message}`, { status: 500 });
+      }
+    }
+
+    // GET /api/ws/status?path=<dir> — one workspace's git state (dirty / ahead /
+    // behind / no-upstream) + live-agent count. The path must sit inside the
+    // workspace root: this endpoint runs `git status` on the directory, and a
+    // console client with the share token is not necessarily a host admin, so it
+    // must not be able to probe arbitrary host paths.
+    if (req.method === "GET" && p === "/api/ws/status") {
+      const dirRaw = url.searchParams.get("path");
+      if (!dirRaw) return new Response("missing ?path=<workspace dir>", { status: 400 });
+      const ws = await import("./ws.ts");
+      let prov: Awaited<ReturnType<typeof ws.loadProvision>>;
+      try {
+        prov = await ws.loadProvision();
+      } catch (e) {
+        return new Response((e as Error).message, { status: 501 });
+      }
+      const wsRoot = prov.resolveWsRoot(getProvisionRoot());
+      const dir = path.resolve(dirRaw);
+      if (!ws.isPathInside(wsRoot, dir))
+        return new Response(`path is outside the workspace root ${wsRoot}`, { status: 400 });
+      if (!existsSync(path.join(dir, ".git")))
+        return new Response(`not a workspace checkout (no .git): ${dir}`, { status: 404 });
+      try {
+        const workspace = await ws.workspaceStatus(dir);
+        return Response.json({ schema: ws.WS_JSON_SCHEMA, workspace });
+      } catch (e) {
+        return new Response(`git status failed: ${(e as Error).message}`, { status: 502 });
+      }
     }
 
     // GET /api/notes

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -2,7 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, symlinkSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
-import { cmdWs, isPathInside, resolveOperand, walkWorkspaces, WS_JSON_SCHEMA } from "./ws.ts";
+import {
+  cmdWs,
+  collectWorkspaces,
+  isPathInside,
+  resolveOperand,
+  walkWorkspaces,
+  workspaceStatus,
+  WS_JSON_SCHEMA,
+} from "./ws.ts";
 
 // Mutable fake for codehost/provision — each test overrides what it needs.
 // ws.ts imports the module lazily; vitest's registry mock intercepts that too.
@@ -431,5 +439,68 @@ describe("cmdWs (mocked provision)", () => {
     } finally {
       if (envBackup !== undefined) process.env.AGENT_YES_PID = envBackup;
     }
+  });
+});
+
+// Data API consumed by serve's GET /api/ws and /api/ws/status (the console's
+// ⌘K /ws browser) — same mocked provision, no stdout involved.
+describe("collectWorkspaces / workspaceStatus (mocked provision)", () => {
+  let root: string;
+  let homeBackup: string | undefined;
+
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(path.join(os.tmpdir(), "ay-ws-api-")));
+    prov.wsRoot = root;
+    prov.readStatus
+      .mockReset()
+      .mockResolvedValue({ branch: "main", head: "abc123", ahead: 1, behind: 0, dirty: true, hasUpstream: true });
+    homeBackup = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = path.join(root, ".ay-home");
+  });
+  afterEach(() => {
+    if (homeBackup === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = homeBackup;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const mkCheckout = (rel: string) => {
+    const dir = path.join(root, rel);
+    mkdirSync(path.join(dir, ".git"), { recursive: true });
+    return dir;
+  };
+
+  it("collectWorkspaces: entries without git by default, joined when status:true", async () => {
+    const dir = mkCheckout("o/r/tree/main");
+    const bare = await collectWorkspaces();
+    expect(bare.wsRoot).toBe(root);
+    expect(bare.workspaces).toEqual([
+      { owner: "o", repo: "r", branch: "main", path: dir, agents: { live: 0 } },
+    ]);
+    expect(prov.readStatus).not.toHaveBeenCalled();
+
+    const withStatus = await collectWorkspaces({ status: true });
+    expect(withStatus.workspaces[0]!.git).toMatchObject({ dirty: true, ahead: 1 });
+  });
+
+  it("workspaceStatus: back-derives the layout spec (slash branch) and counts agents", async () => {
+    const dir = mkCheckout("o/r/tree/feat/x");
+    const entry = await workspaceStatus(dir);
+    expect(entry).toMatchObject({
+      owner: "o",
+      repo: "r",
+      branch: "feat/x",
+      path: dir,
+      agents: { live: 0 },
+    });
+    expect(entry.git).toMatchObject({ dirty: true });
+  });
+
+  it("workspaceStatus: a dir outside the layout keeps git's branch, no spec", async () => {
+    const dir = path.join(root, "elsewhere");
+    mkdirSync(path.join(dir, ".git"), { recursive: true });
+    prov.wsRoot = path.join(root, "not-here");
+    const entry = await workspaceStatus(dir);
+    expect(entry.owner).toBe("");
+    expect(entry.branch).toBe("main"); // from readStatus, not the layout
   });
 });

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -69,7 +69,7 @@ interface Provision {
   }): Promise<ProvisionResult>;
 }
 
-async function loadProvision(): Promise<Provision> {
+export async function loadProvision(): Promise<Provision> {
   try {
     return (await import("codehost/provision")) as unknown as Provision;
   } catch (e) {
@@ -298,9 +298,14 @@ function parseFlags(
 // subcommands
 // ---------------------------------------------------------------------------
 
-async function cmdWsLs(args: string[]): Promise<number> {
-  const { flags, positional } = parseFlags(args, { status: "bool", json: "bool" });
-  if (positional.length > 0) throw new Error(`ws ls takes no positional args`);
+/**
+ * Data API shared by `ay ws ls` and serve's `GET /api/ws`: every workspace
+ * under the standard layout with its live-agent count, optionally joined with
+ * git status (bounded concurrency — readStatus can block on git's timeout).
+ */
+export async function collectWorkspaces(opts?: {
+  status?: boolean;
+}): Promise<{ wsRoot: string; workspaces: WsEntry[] }> {
   const prov = await loadProvision();
   const wsRoot = prov.resolveWsRoot(getProvisionRoot());
 
@@ -314,7 +319,7 @@ async function cmdWsLs(args: string[]): Promise<number> {
     agents: { live: liveAgentsIn(records, w.path).length },
   }));
 
-  if (flags.status) {
+  if (opts?.status) {
     entries = await mapBounded(entries, STATUS_CONCURRENCY, async (e) => {
       try {
         return { ...e, git: await prov.readStatus(e.path) };
@@ -323,6 +328,13 @@ async function cmdWsLs(args: string[]): Promise<number> {
       }
     });
   }
+  return { wsRoot, workspaces: entries };
+}
+
+async function cmdWsLs(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { status: "bool", json: "bool" });
+  if (positional.length > 0) throw new Error(`ws ls takes no positional args`);
+  const { wsRoot, workspaces: entries } = await collectWorkspaces({ status: !!flags.status });
 
   if (flags.json) {
     process.stdout.write(
@@ -366,22 +378,20 @@ function gitSummary(e: WsEntry): string {
   return parts.length ? parts.join(", ") : "clean";
 }
 
-async function cmdWsStatus(args: string[]): Promise<number> {
-  const { flags, positional } = parseFlags(args, { json: "bool", path: "bool", spec: "bool" });
-  if (flags.path && flags.spec) throw new Error("--path and --spec are mutually exclusive");
-  if (positional.length > 1) throw new Error("ws status takes at most one target");
+/**
+ * One workspace's WsEntry by checkout dir — git status + live-agent count, the
+ * owner/repo/branch back-derived from the layout when `spec` isn't provided.
+ * Shared by `ay ws status` and serve's `GET /api/ws/status`.
+ */
+export async function workspaceStatus(dir: string, spec?: RepoSpec | null): Promise<WsEntry> {
   const prov = await loadProvision();
-  const wsRoot = getProvisionRoot();
-  const operand = positional[0] ?? ".";
-  const mode = flags.path ? "path" : flags.spec ? "spec" : "auto";
-  const { dir, spec } = await resolveOperand(prov, operand, mode, wsRoot);
   const git = await prov.readStatus(dir);
 
   // Fill owner/repo/branch from the layout when addressed by path, best-effort.
   const layoutSpec =
     spec ??
     (() => {
-      const root = prov.resolveWsRoot(wsRoot);
+      const root = prov.resolveWsRoot(getProvisionRoot());
       if (!isPathInside(root, dir)) return null;
       const segs = path.relative(root, dir).split(path.sep);
       return segs.length >= 4 && segs[2] === "tree"
@@ -389,7 +399,7 @@ async function cmdWsStatus(args: string[]): Promise<number> {
         : null;
     })();
 
-  const entry: WsEntry = {
+  return {
     owner: layoutSpec?.owner ?? "",
     repo: layoutSpec?.repo ?? "",
     branch: layoutSpec?.branch ?? git.branch,
@@ -408,14 +418,27 @@ async function cmdWsStatus(args: string[]): Promise<number> {
     },
     git,
   };
+}
+
+async function cmdWsStatus(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { json: "bool", path: "bool", spec: "bool" });
+  if (flags.path && flags.spec) throw new Error("--path and --spec are mutually exclusive");
+  if (positional.length > 1) throw new Error("ws status takes at most one target");
+  const prov = await loadProvision();
+  const wsRoot = getProvisionRoot();
+  const operand = positional[0] ?? ".";
+  const mode = flags.path ? "path" : flags.spec ? "spec" : "auto";
+  const { dir, spec } = await resolveOperand(prov, operand, mode, wsRoot);
+  const entry = await workspaceStatus(dir, spec);
 
   if (flags.json) {
     process.stdout.write(JSON.stringify({ schema: WS_JSON_SCHEMA, workspace: entry }, null, 2) + "\n");
     return 0;
   }
+  const git = entry.git!;
   process.stdout.write(
     `${dir}\n` +
-      (layoutSpec ? `  spec:     ${layoutSpec.owner}/${layoutSpec.repo}@${layoutSpec.branch}\n` : "") +
+      (entry.owner ? `  spec:     ${entry.owner}/${entry.repo}@${entry.branch}\n` : "") +
       `  branch:   ${git.branch} @ ${git.head}\n` +
       `  state:    ${gitSummary(entry)}\n` +
       `  agents:   ${entry.agents.live} live\n`,


### PR DESCRIPTION
## What

The web console's Cmd+K omnibox gains a **/ws** command: a flat, fuzzy-filtered browser over every workspace in the codehost layout (`<wsRoot>/<owner>/<repo>/tree/<branch>`) across all connected hosts — including idle checkouts with **no** live agents, which the agent list can never surface. Follow-up to #254 (`ay ws` CLI).

### Server (ts/serve.ts)
- `GET /api/ws` — workspace walk + live-agent counts (cheap, no git). 501s like the fork path when `codehost/provision` is missing.
- `GET /api/ws/status?path=` — one workspace's git state, **containment-checked against the workspace root** so a share-token holder can't probe arbitrary host paths (400 outside, 404 non-checkout, 502 on git failure).
- Both reuse new data exports from `ts/ws.ts` (`collectWorkspaces()` / `workspaceStatus()` — pure refactor, `ay ws` behavior unchanged).

### UI (lab/ui/index.html)
- `/ws [filter]` lists workspaces sorted by live-agent count, host badge when multi-host; merged from all writable connected hosts with a 30s TTL cache (older daemons / codehost-less hosts silently drop out).
- **Enter = spawn an agent in that workspace's cwd** (the common "get an agent running in workspace X" path is 1 hop).
- Git state (`dirty / ahead / behind / no-upstream`) loads **lazily for the highlighted row only** — a full-status join measures in seconds, so it's never done eagerly.
- `/ws owner/repo[@branch]` that parses as a source offers a **Provision** row → `POST /api/spawn {from}`, so cloning stays behind the host's existing provision hook/allowlist gate (no new mutating endpoint).
- `/` command list gains a Workspaces entry; the anchor gate now applies only to agent-targeted commands (`/restart`, `/kill`), so `/ws` works with nothing open.

## Tests
- `ts/ws.spec.ts`: +3 for the new data exports (36 total).
- `tests/ui-dom`: stub `/api/ws`, `/api/ws/status`, `/api/spawn`; new Playwright DOM test covers browse → lazy `dirty, ahead 2` chip → filter → Enter-spawns-with-cwd → provision row spawns-with-from. 23/23 green.
- Full vitest suite green locally with the coverage gate (ws.ts 93% branches; serve.ts is coverage-excluded).

## E2E (real machine)
- `curl /api/ws` → 25 real workspaces with correct live counts; `/api/ws/status` → real `behind 19, dirty` state.
- Real Chrome against a fresh `ay serve --http`: ⌘K → `/ws` renders the fleet (17-agent workspace first), filter narrows, highlighted row lazily shows `dirty`, unknown spec shows the Provision row.

## Not in scope (by design, see #254)
- `rm`/`gc` UI — deletion waits for the two-phase `removeWorkspace()` upstream design.
- Eager all-workspace git status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)