### PR TITLE
feat(badges): dynamic footer-counter chips — N shells, N monitors, ← N agents, PR #

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -109,7 +109,7 @@ clis:
       # list ("client ignores rate-limit drop") or an agent's own summary
       # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
       # perfectly healthy session.
-      - pattern: 'API Error.{0,4}429'
+      - pattern: "API Error.{0,4}429"
         flags: i
       - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
@@ -117,7 +117,7 @@ clis:
       - hit your usage limit
       # Session/5-hour limit banners keep the distinctive "… limit reached"
       # phrase; a bare "session limit" matched ordinary prose.
-      - pattern: '(session|5-hour) limit reached'
+      - pattern: "(session|5-hour) limit reached"
         flags: i
     restoreArgs:
       - --continue
@@ -221,7 +221,7 @@ clis:
       # list ("client ignores rate-limit drop") or an agent's own summary
       # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
       # perfectly healthy session.
-      - pattern: 'API Error.{0,4}429'
+      - pattern: "API Error.{0,4}429"
         flags: i
       - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
@@ -229,7 +229,7 @@ clis:
       - hit your usage limit
       # Session/5-hour limit banners keep the distinctive "… limit reached"
       # phrase; a bare "session limit" matched ordinary prose.
-      - pattern: '(session|5-hour) limit reached'
+      - pattern: "(session|5-hour) limit reached"
         flags: i
     restoreArgs:
       - --continue
@@ -338,7 +338,7 @@ clis:
       # list ("client ignores rate-limit drop") or an agent's own summary
       # (INGEST_RATE_LIMIT_PER_MIN) armed the loop and typed "retry" into a
       # perfectly healthy session.
-      - pattern: 'API Error.{0,4}429'
+      - pattern: "API Error.{0,4}429"
         flags: i
       - pattern: 'API Error[\s\S]{0,60}rate.?limit'
         flags: i
@@ -346,7 +346,7 @@ clis:
       - hit your usage limit
       # Session/5-hour limit banners keep the distinctive "… limit reached"
       # phrase; a bare "session limit" matched ordinary prose.
-      - pattern: '(session|5-hour) limit reached'
+      - pattern: "(session|5-hour) limit reached"
         flags: i
     restoreArgs:
       - --continue
@@ -545,7 +545,7 @@ clis:
   bash:
     promptArg: typed
     ready:
-      - pattern: '[$#] $'
+      - pattern: "[$#] $"
         flags: m
     working: []
     enter: []
@@ -570,7 +570,7 @@ clis:
   powershell:
     promptArg: typed
     ready:
-      - pattern: '^PS .*>'
+      - pattern: "^PS .*>"
         flags: m
     working: []
     enter: []

--- a/docs/launcher-exec-handoff.md
+++ b/docs/launcher-exec-handoff.md
@@ -13,11 +13,11 @@ child, 120–500 MB each) — see "Non-goals".
 
 Every agent currently runs as a 3-layer chain (measured 2026-07-01, macOS arm64):
 
-| Layer                            | Runtime | RSS         | Role                                              |
-| -------------------------------- | ------- | ----------- | ------------------------------------------------- |
-| bun launcher (`dist/agent-yes.js`) | TS/bun  | **~17 MB**  | resolves + spawns the rust binary, then **sleeps** |
-| rust wrapper (`agent-yes`)       | Rust    | ~7 MB       | PTY supervision, the real work                    |
-| `claude` child                   | node    | 120–500 MB  | the actual agent                                  |
+| Layer                              | Runtime | RSS        | Role                                               |
+| ---------------------------------- | ------- | ---------- | -------------------------------------------------- |
+| bun launcher (`dist/agent-yes.js`) | TS/bun  | **~17 MB** | resolves + spawns the rust binary, then **sleeps** |
+| rust wrapper (`agent-yes`)         | Rust    | ~7 MB      | PTY supervision, the real work                     |
+| `claude` child                     | node    | 120–500 MB | the actual agent                                   |
 
 The bun launcher does genuine **one-time** work (auto-update check, tray spawn, config
 resolution, rust-binary resolution/download, arg building) — but after that, in
@@ -26,7 +26,7 @@ resolution, rust-binary resolution/download, arg building) — but after that, i
 ```ts
 const child = spawn(rustBinary, rustArgs, { stdio: "inherit" });
 child.on("exit", (code, signal) => process.exit(/* mirror */));
-process.on("SIGINT",  () => child.kill("SIGINT"));
+process.on("SIGINT", () => child.kill("SIGINT"));
 process.on("SIGTERM", () => child.kill("SIGTERM"));
 await new Promise(() => {}); // never resolves — bun stays resident here
 ```
@@ -37,9 +37,9 @@ signals and mirror an exit code**. With N agents that is N × ~17 MB of pure ove
 ## Insight
 
 The bun/npm layer is worth keeping — it is the distribution and self-update mechanism.
-What is wasteful is that it *supervises* rather than *hands off*. On POSIX, `execvp(2)`
+What is wasteful is that it _supervises_ rather than _hands off_. On POSIX, `execvp(2)`
 **replaces the current process image**: same PID, same PPID, same open fds, same env,
-same cwd — but the bun heap is entirely freed and the process *becomes* the rust binary.
+same cwd — but the bun heap is entirely freed and the process _becomes_ the rust binary.
 `execvp` only returns on failure, which is exactly the fallback signal we want.
 
 ## Solution
@@ -64,12 +64,12 @@ export function execReplace(bin: string, args: string[]): void {
 
   // Build a NULL-terminated char *argv[]. argv[0] must be the binary path.
   const argv = [bin, ...args];
-  const cStrings = argv.map((s) => cString(s));           // keep refs alive until execv
+  const cStrings = argv.map((s) => cString(s)); // keep refs alive until execv
   const arr = new BigInt64Array(argv.length + 1);
   cStrings.forEach((c, i) => (arr[i] = BigInt(ptr(c))));
-  arr[argv.length] = 0n;                                   // NULL terminator
+  arr[argv.length] = 0n; // NULL terminator
 
-  symbols.execv(cString(bin), ptr(arr));                  // no return on success
+  symbols.execv(cString(bin), ptr(arr)); // no return on success
   // If we reach here, execv failed (errno set) — caller falls back.
 }
 ```
@@ -92,14 +92,20 @@ if (rustBinary) {
     if (existsSync(rustBinary)) {
       try {
         const { execReplace } = await import("./execReplace.ts");
-        execReplace(rustBinary, rustArgs);   // returns only on failure
-      } catch { /* fall through to spawn / TS fallback */ }
+        execReplace(rustBinary, rustArgs); // returns only on failure
+      } catch {
+        /* fall through to spawn / TS fallback */
+      }
     }
     // reaching here = exec failed → fall through to the spawn path below (or TS fallback)
   }
 
   // Existing spawn+wait path — retained for Windows and as the exec-failure fallback.
-  const child = spawn(rustBinary, rustArgs, { stdio: "inherit", env: process.env, cwd: process.cwd() });
+  const child = spawn(rustBinary, rustArgs, {
+    stdio: "inherit",
+    env: process.env,
+    cwd: process.cwd(),
+  });
   // ...unchanged exit/signal mirroring...
   await new Promise(() => {});
 }
@@ -112,15 +118,15 @@ Everything upstream (`getRustBinary()` resolution/download, update check at
 
 ## Why nothing breaks (what exec preserves)
 
-| Concern                          | Outcome after exec()                                                        |
-| -------------------------------- | --------------------------------------------------------------------------- |
-| `bun install -g` / npm packaging | **Unchanged** — the JS entry is still the installed command.                |
-| update check / tray / resolution | **Unchanged** — all run in bun *before* the handoff.                         |
-| stdio                            | Already `inherit`; fds survive exec, so the terminal stays wired.           |
-| exit code                        | rust *is* the process now → its exit code is the real one. No mirroring.     |
-| SIGINT / SIGTERM                 | Delivered natively to the (now-rust) process. No forwarding needed.          |
-| `AGENT_YES_PID` / subagent tree  | env survives exec → passes through unchanged.                                |
-| serve/other code targeting the launcher PID | PID is preserved by exec → still hits the same process.           |
+| Concern                                     | Outcome after exec()                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------ |
+| `bun install -g` / npm packaging            | **Unchanged** — the JS entry is still the installed command.             |
+| update check / tray / resolution            | **Unchanged** — all run in bun _before_ the handoff.                     |
+| stdio                                       | Already `inherit`; fds survive exec, so the terminal stays wired.        |
+| exit code                                   | rust _is_ the process now → its exit code is the real one. No mirroring. |
+| SIGINT / SIGTERM                            | Delivered natively to the (now-rust) process. No forwarding needed.      |
+| `AGENT_YES_PID` / subagent tree             | env survives exec → passes through unchanged.                            |
+| serve/other code targeting the launcher PID | PID is preserved by exec → still hits the same process.                  |
 
 ---
 
@@ -139,7 +145,7 @@ Everything upstream (`getRustBinary()` resolution/download, update check at
    which still has its ENOENT→TS fallback. Net: the fallback is preserved, just relocated.
 
 3. **Flatter pid tree may confuse `ay ls` / console rendering.** Today there are two
-   processes (bun parent + rust child); after exec there is one (bun PID *becomes* rust).
+   processes (bun parent + rust child); after exec there is one (bun PID _becomes_ rust).
    Code that assumes "launcher PID ≠ rust PID", or that walks parent/wrapper_pid for the
    subagent tree, must be re-verified. See `docs/` + the subagent-tree logic
    (`AGENT_YES_PID`, `pids.jsonl` `wrapper_pid`). **Low risk** (exec keeps PID/PPID) but

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -12,7 +12,7 @@ Three ways to produce the `cwd`, in precedence order:
 
 | Request body                | What happens                                                                                      | Backed by                                 |
 | --------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `fork: { fromCwd, branch }` | Fork an existing worktree to a **new branch (clean — committed work only)**, then spawn there      | `codehost/provision` `forkWorktree`       |
+| `fork: { fromCwd, branch }` | Fork an existing worktree to a **new branch (clean — committed work only)**, then spawn there     | `codehost/provision` `forkWorktree`       |
 | `from: "<source>"`          | Provision a GitHub source (clone / worktree / ff-pull) into `<root>/<owner>/<repo>/tree/<branch>` | `codehost/provision` `provision`          |
 | `cwd: "<dir>"` (or omitted) | Resolve against the workspace root and `mkdir -p` (a missing dir no longer ENOENTs into a 500)    | `ts/workspaceConfig.ts` `resolveSpawnCwd` |
 

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -5,7 +5,7 @@ committed their work but then **sat at an idle `❯` prompt without exiting**
 (`claude-yes` does not exit on idle by default). Claude Code's built-in
 background-task notification only fires on process **EXIT** — so the parent
 never learned the children went idle and left two of them parked **16 minutes**.
-The stop-gap was Monitor-on-HEAD polling, which catches a *commit* but is blind
+The stop-gap was Monitor-on-HEAD polling, which catches a _commit_ but is blind
 to a child that finished **without** committing (an investigation, a failure, a
 question).
 
@@ -93,7 +93,7 @@ parent addresses its own inbox with no argument.
 
 - **Singleton lock with liveness-based steal; ownership proven only by mkdir.**
   The daemon holds an mkdir lock whose `owner.json` records `{pid, started_at,
-  ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
+ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
   removes the dir; ownership is then re-proven by the next `mkdir(recursive:false)`
   (the atomic, exclusive create), so two would-be stealers can never both enter.
   A lock held by a **live** owner is respected. The parent `notify/` dir is
@@ -224,7 +224,7 @@ parent addresses its own inbox with no argument.
   daemon came up.
 
 - **pid-reuse & cross-host safety.** Inboxes are namespaced by host; events carry
-  the child pid/wrapper. (Cross-host *delivery* is out of scope — the daemon only
+  the child pid/wrapper. (Cross-host _delivery_ is out of scope — the daemon only
   sees the local registry.)
 
 - **Retention.** GC deletes an inbox (+ counter + cursors) once its parent is
@@ -259,7 +259,7 @@ with a documented mitigation, tracked in a single follow-up issue.
   goes stale within the TTL and is dropped — but carrying the watch subprocess's
   pid/token in the heartbeat for a strict check is a follow-up.
 - **No postmortem inbox inspection after the parent exits.** `ay notify
-  read/watch` fail closed when the parent isn't a live registry record (started_at
+read/watch` fail closed when the parent isn't a live registry record (started_at
   can't be resolved) — deliberately, so a recycled parent pid can't read another
   session's inbox. The trade-off is that you can't inspect a parent's inbox after
   that parent has exited. A read-only "postmortem" mode (inspect without

--- a/lab/ui/cf/exposure.ts
+++ b/lab/ui/cf/exposure.ts
@@ -83,13 +83,19 @@ export class Exposure {
       }
       const { 0: client, 1: server } = new WebSocketPair();
       this.state.acceptWebSocket(server);
-      server.serializeAttachment({ role: "daemon", authed: false, at: Date.now() } satisfies Attach);
+      server.serializeAttachment({
+        role: "daemon",
+        authed: false,
+        at: Date.now(),
+      } satisfies Attach);
       await this.ensureSweep(UNAUTH_MS);
       return new Response(null, { status: 101, webSocket: client });
     }
 
     // Visitor leg: the Worker prefixes the real path with /_visit.
-    const path = url.pathname.startsWith("/_visit") ? url.pathname.slice("/_visit".length) || "/" : url.pathname;
+    const path = url.pathname.startsWith("/_visit")
+      ? url.pathname.slice("/_visit".length) || "/"
+      : url.pathname;
 
     // Visitor claim: swap a single-use token for a session cookie.
     if (path === "/_ay/claim") {
@@ -264,7 +270,9 @@ export class Exposure {
   private async registerClaims(raw: string[] | undefined): Promise<void> {
     const claims = (raw ?? []).filter((c) => /^[a-f0-9]{64}$/.test(c)).slice(0, MAX_CLAIMS);
     if (!claims.length) return;
-    const existing = [...(await this.state.storage.list<number>({ prefix: "claim:" }))].sort((a, b) => a[1] - b[1]);
+    const existing = [...(await this.state.storage.list<number>({ prefix: "claim:" }))].sort(
+      (a, b) => a[1] - b[1],
+    );
     const excess = existing.length + claims.length - MAX_CLAIMS;
     for (const [k] of existing.slice(0, Math.max(0, excess))) await this.state.storage.delete(k);
     const expires = Date.now() + CLAIM_TTL_MS;
@@ -307,7 +315,12 @@ export class Exposure {
 
   // ---- visitor request paths ----
 
-  private async visitorHttp(tunnel: TunnelClient, hostname: string, pathAndQuery: string, req: Request): Promise<Response> {
+  private async visitorHttp(
+    tunnel: TunnelClient,
+    hostname: string,
+    pathAndQuery: string,
+    req: Request,
+  ): Promise<Response> {
     const len = Number(req.headers.get("content-length") ?? 0);
     if (len > MAX_BODY) return new Response("body too large", { status: 413 });
 
@@ -341,11 +354,19 @@ export class Exposure {
     try {
       return await tunnel.fetch(req.method, pathAndQuery, headers, body);
     } catch (err) {
-      return new Response(`upstream error: ${String(err)}\n`, { status: 502, headers: { "cache-control": "no-store" } });
+      return new Response(`upstream error: ${String(err)}\n`, {
+        status: 502,
+        headers: { "cache-control": "no-store" },
+      });
     }
   }
 
-  private visitorWebSocket(tunnel: TunnelClient, _hostname: string, pathAndQuery: string, req: Request): Response {
+  private visitorWebSocket(
+    tunnel: TunnelClient,
+    _hostname: string,
+    pathAndQuery: string,
+    req: Request,
+  ): Response {
     const protoHeader = req.headers.get("Sec-WebSocket-Protocol");
     const protocols = protoHeader ? protoHeader.split(",").map((s) => s.trim()) : undefined;
     const { 0: client, 1: server } = new WebSocketPair();
@@ -384,7 +405,10 @@ export class Exposure {
 
 /** Read a stream into one buffer, aborting (→ null) once it exceeds `max`, so a
  *  body without/with-a-lying Content-Length can't be buffered unboundedly. */
-async function readCapped(body: ReadableStream<Uint8Array>, max: number): Promise<Uint8Array | null> {
+async function readCapped(
+  body: ReadableStream<Uint8Array>,
+  max: number,
+): Promise<Uint8Array | null> {
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;

--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -199,13 +199,42 @@ export const BADGE_META = {
     label: "typing",
     title: "The user is typing at this agent's terminal — ay send backs off until they pause",
   },
+  // Dynamic footer counters: the wire id carries the captured footer text
+  // after a ":" ("shells:4 shells") and "$1" below is substituted with it,
+  // so the chip reads exactly like the CLI footer ("1 shell", "PR #310").
+  shells: {
+    label: "$1",
+    title: "Background shells running in this session ($1 in the CLI footer)",
+  },
+  monitors: {
+    label: "$1",
+    title: "Active Monitor watchers in this session ($1 in the CLI footer)",
+  },
+  "bg-agents": {
+    label: "$1",
+    title: "Background subagents running in this session ($1 in the CLI footer)",
+  },
+  pr: {
+    label: "$1",
+    title: "This session is linked to a GitHub pull request ($1 in the CLI footer)",
+  },
 };
 
 // Status-flag chips ("badges") matched against the agent's screen — e.g. an
 // active /goal loop. [] when e.badges is missing/empty. Returns
 // { id, label, title } objects ready for the caller to render as chips.
+// Dynamic ids ("shells:4 shells") resolve their meta by the part before the
+// ":" and substitute the rest into "$1" in the label/title; the returned id
+// stays the raw wire value so chips key uniquely.
 export function badgesFor(e) {
-  return (e.badges || []).map((id) => ({ id, ...(BADGE_META[id] || { label: id, title: id }) }));
+  return (e.badges || []).map((raw) => {
+    const i = raw.indexOf(":");
+    const base = i === -1 ? raw : raw.slice(0, i);
+    const arg = i === -1 ? "" : raw.slice(i + 1);
+    const meta = BADGE_META[base] || { label: raw, title: raw };
+    const sub = (s) => (s.includes("$1") ? s.replace("$1", arg) : s);
+    return { id: raw, label: sub(meta.label), title: sub(meta.title) };
+  });
 }
 
 // Time since the agent was last active ("12s" / "5m" / "3h") — measured from
@@ -402,7 +431,8 @@ export function sortEntries(entries, mode = "state") {
           ? byNewest
           : mode === "identity"
             ? (a, b) => fullIdent(a).localeCompare(fullIdent(b)) || byNewest(a, b)
-            : (a, b) => stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
+            : (a, b) =>
+                stateRank(a) - stateRank(b) || gitWeight(b) - gitWeight(a) || byNewest(a, b);
   return entries.slice().sort(cmp);
 }
 

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1835,7 +1835,11 @@
               <button id="portsbtn" class="viewbtn" title="manage exposed localhost ports">
                 ⇄ ports
               </button>
-              <button id="rguibtn" class="viewbtn" title="open the agent graph view (/r/) for this fleet">
+              <button
+                id="rguibtn"
+                class="viewbtn"
+                title="open the agent graph view (/r/) for this fleet"
+              >
                 ⌗ graph
               </button>
               <button id="newbtn" class="newbtn" title="spawn a new agent on this fleet">
@@ -2071,7 +2075,11 @@
          WebRTC tunnel (Service Worker proxies /w/p/<src>/<port>/*, no relay). -->
     <div class="preview-overlay" id="previewOverlay" hidden>
       <div class="preview-bar">
-        <span class="preview-badge" title="served over a direct P2P WebRTC tunnel — traffic does not go through agent-yes.com">⚡ P2P · no relay</span>
+        <span
+          class="preview-badge"
+          title="served over a direct P2P WebRTC tunnel — traffic does not go through agent-yes.com"
+          >⚡ P2P · no relay</span
+        >
         <span class="preview-title" id="previewTitle"></span>
         <button id="previewReload" type="button" title="reload">↻</button>
         <button id="previewPop" type="button" title="open in a new tab">↗</button>
@@ -2086,7 +2094,7 @@
       <div class="omnibox">
         <input
           id="omni-input"
-          placeholder="Search agents by title, then output…  ·  &quot;/&quot; commands  ·  /ws workspaces"
+          placeholder='Search agents by title, then output…  ·  "/" commands  ·  /ws workspaces'
           spellcheck="false"
           autocapitalize="off"
           autocomplete="off"
@@ -2317,7 +2325,12 @@
           },
           // Open a WS to the previewed port over the tunnel (Vite HMR etc.).
           previewWs(port, path, protocols, handlers) {
-            return chRoom.room.openWs(peerId, "/__codehost/port/" + port + path, protocols, handlers);
+            return chRoom.room.openWs(
+              peerId,
+              "/__codehost/port/" + port + path,
+              protocols,
+              handlers,
+            );
           },
           async fetchJSON(path) {
             let res;
@@ -2597,13 +2610,21 @@
             .then(async (res) => {
               const headers = {};
               res.headers.forEach((v, k) => (headers[k] = v));
-              port.postMessage({ type: "head", status: res.status, statusText: res.statusText, headers });
+              port.postMessage({
+                type: "head",
+                status: res.status,
+                statusText: res.statusText,
+                headers,
+              });
               if (res.body) {
                 const reader = res.body.getReader();
                 for (;;) {
                   const { done, value } = await reader.read();
                   if (done) break;
-                  const buf = value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength);
+                  const buf = value.buffer.slice(
+                    value.byteOffset,
+                    value.byteOffset + value.byteLength,
+                  );
                   port.postMessage({ type: "body", chunk: buf }, [buf]);
                 }
               }
@@ -2638,7 +2659,11 @@
             this._queue = [];
             const tx = sources.get(src)?.tx;
             const u = new URL(this.url, location.href);
-            const protoList = protocols ? (Array.isArray(protocols) ? protocols : [protocols]) : undefined;
+            const protoList = protocols
+              ? Array.isArray(protocols)
+                ? protocols
+                : [protocols]
+              : undefined;
             if (!tx || !tx.previewWs) return void this._fail();
             tx.previewWs(port, u.pathname + u.search, protoList, {
               onOpenAck: (ok, proto) => {
@@ -2658,7 +2683,8 @@
             })
               .then((h) => {
                 this._handle = h;
-                if (this.readyState === 3 && this._closeReq) h.close(this._closeReq.code, this._closeReq.reason);
+                if (this.readyState === 3 && this._closeReq)
+                  h.close(this._closeReq.code, this._closeReq.reason);
               })
               .catch(() => this._fail());
           }
@@ -2671,8 +2697,10 @@
             const h = this._handle;
             if (!h) return;
             if (typeof data === "string") h.sendText(data);
-            else if (data instanceof Blob) data.arrayBuffer().then((b) => h.sendBin(new Uint8Array(b)));
-            else if (ArrayBuffer.isView(data)) h.sendBin(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+            else if (data instanceof Blob)
+              data.arrayBuffer().then((b) => h.sendBin(new Uint8Array(b)));
+            else if (ArrayBuffer.isView(data))
+              h.sendBin(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
             else h.sendBin(new Uint8Array(data));
           }
           send(data) {
@@ -3772,7 +3800,8 @@
         } catch {}
         if (!info || !info.claim) {
           $("exposeEmpty").hidden = false;
-          $("exposeEmpty").textContent = "Couldn't expose port " + port + " (is `ay serve` reachable?).";
+          $("exposeEmpty").textContent =
+            "Couldn't expose port " + port + " (is `ay serve` reachable?).";
           return null;
         }
         return info;
@@ -3798,7 +3827,8 @@
       // the Service Worker proxies over the machine's WebRTC tunnel (no relay).
       function openPreview(src, port) {
         // Scope-relative so it works at both /w/ (agent-yes.com) and / (ay serve).
-        const url = new URL("p/" + encodeURIComponent(src) + "/" + port + "/", location.href).pathname;
+        const url = new URL("p/" + encodeURIComponent(src) + "/" + port + "/", location.href)
+          .pathname;
         const frame = $("previewFrame");
         if (!frame) return window.open(url, "_blank");
         $("previewTitle").textContent = "localhost:" + port;
@@ -3849,7 +3879,8 @@
               return;
             }
             if (Array.isArray(arr))
-              for (const ex of arr) rows.push({ ...ex, _srcName: s.name || s.id, _src: s.id, _tx: tx });
+              for (const ex of arr)
+                rows.push({ ...ex, _srcName: s.name || s.id, _src: s.id, _tx: tx });
           }),
         );
         list.textContent = "";
@@ -5335,10 +5366,10 @@
       $("rguibtn").addEventListener("click", () => {
         const [selRoom, selPid] = sel ? sel.split("#") : [null, null];
         let room = selRoom && selRoom !== LOCAL && loadRooms()[selRoom] ? selRoom : null;
-        if (!room)
-          room = [...sources.values()].find((s) => s.kind === "rtc" && s.live)?.id ?? null;
-        const frag =
-          room ? "#" + encodeURIComponent(room) + (room === selRoom && selPid ? ":" + selPid : "") : "";
+        if (!room) room = [...sources.values()].find((s) => s.kind === "rtc" && s.live)?.id ?? null;
+        const frag = room
+          ? "#" + encodeURIComponent(room) + (room === selRoom && selPid ? ":" + selPid : "")
+          : "";
         location.href = "/r/" + frag;
       });
       // Cycle the sort order: state → created → identity → state.
@@ -5799,7 +5830,9 @@
                 <span class="dot ${live ? "active" : "exited"}"></span>
                 <div class="omni-main">
                   <div class="omni-title">▤ ${esc(wsSpecOf(r.ws))}${
-                    live ? ` <span style="opacity:.7">· ${live} agent${live > 1 ? "s" : ""}</span>` : ""
+                    live
+                      ? ` <span style="opacity:.7">· ${live} agent${live > 1 ? "s" : ""}</span>`
+                      : ""
                   }${multi ? ` <span style="opacity:.55">@ ${esc(r.host)}</span>` : ""}</div>
                   <div class="omni-sub">${esc(r.ws.path)}${st ? " &nbsp;·&nbsp; <b>" + esc(st) + "</b>" : ""} &nbsp;·&nbsp; ⏎ spawn agent here</div>
                 </div></div>`;
@@ -6569,14 +6602,25 @@
       // picker (options from /api/spawn-config `clis`), preselected from the
       // chain: selected agent's cli → last used cli → explicit user pick.
       const LAST_CLI_KEY = "ay.lastSpawnCli";
-      const CLI_FALLBACK = ["claude", "codex", "gemini", "copilot", "cursor-agent", "goose", "aider"];
+      const CLI_FALLBACK = [
+        "claude",
+        "codex",
+        "gemini",
+        "copilot",
+        "cursor-agent",
+        "goose",
+        "aider",
+      ];
       function cliOptions(clis, preferred) {
         const list = clis && clis.length ? clis : CLI_FALLBACK;
         const has = preferred && list.includes(preferred);
         return (
           `<option value=""${has ? "" : " selected"} disabled>choose a CLI…</option>` +
           list
-            .map((c) => `<option value="${esc(c)}"${c === preferred && has ? " selected" : ""}>${esc(c)}</option>`)
+            .map(
+              (c) =>
+                `<option value="${esc(c)}"${c === preferred && has ? " selected" : ""}>${esc(c)}</option>`,
+            )
             .join("")
         );
       }

--- a/lab/ui/qrcode.js
+++ b/lab/ui/qrcode.js
@@ -15,8 +15,7 @@
 //
 //---------------------------------------------------------------------
 
-var qrcode = function() {
-
+var qrcode = (function () {
   //---------------------------------------------------------------------
   // qrcode
   //---------------------------------------------------------------------
@@ -26,9 +25,8 @@ var qrcode = function() {
    * @param typeNumber 1 to 40
    * @param errorCorrectionLevel 'L','M','Q','H'
    */
-  var qrcode = function(typeNumber, errorCorrectionLevel) {
-
-    var PAD0 = 0xEC;
+  var qrcode = function (typeNumber, errorCorrectionLevel) {
+    var PAD0 = 0xec;
     var PAD1 = 0x11;
 
     var _typeNumber = typeNumber;
@@ -40,10 +38,9 @@ var qrcode = function() {
 
     var _this = {};
 
-    var makeImpl = function(test, maskPattern) {
-
+    var makeImpl = function (test, maskPattern) {
       _moduleCount = _typeNumber * 4 + 17;
-      _modules = function(moduleCount) {
+      _modules = (function (moduleCount) {
         var modules = new Array(moduleCount);
         for (var row = 0; row < moduleCount; row += 1) {
           modules[row] = new Array(moduleCount);
@@ -52,7 +49,7 @@ var qrcode = function() {
           }
         }
         return modules;
-      }(_moduleCount);
+      })(_moduleCount);
 
       setupPositionProbePattern(0, 0);
       setupPositionProbePattern(_moduleCount - 7, 0);
@@ -72,19 +69,18 @@ var qrcode = function() {
       mapData(_dataCache, maskPattern);
     };
 
-    var setupPositionProbePattern = function(row, col) {
-
+    var setupPositionProbePattern = function (row, col) {
       for (var r = -1; r <= 7; r += 1) {
-
         if (row + r <= -1 || _moduleCount <= row + r) continue;
 
         for (var c = -1; c <= 7; c += 1) {
-
           if (col + c <= -1 || _moduleCount <= col + c) continue;
 
-          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
-              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
-              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+          if (
+            (0 <= r && r <= 6 && (c == 0 || c == 6)) ||
+            (0 <= c && c <= 6 && (r == 0 || r == 6)) ||
+            (2 <= r && r <= 4 && 2 <= c && c <= 4)
+          ) {
             _modules[row + r][col + c] = true;
           } else {
             _modules[row + r][col + c] = false;
@@ -93,13 +89,11 @@ var qrcode = function() {
       }
     };
 
-    var getBestMaskPattern = function() {
-
+    var getBestMaskPattern = function () {
       var minLostPoint = 0;
       var pattern = 0;
 
       for (var i = 0; i < 8; i += 1) {
-
         makeImpl(true, i);
 
         var lostPoint = QRUtil.getLostPoint(_this);
@@ -113,31 +107,27 @@ var qrcode = function() {
       return pattern;
     };
 
-    var setupTimingPattern = function() {
-
+    var setupTimingPattern = function () {
       for (var r = 8; r < _moduleCount - 8; r += 1) {
         if (_modules[r][6] != null) {
           continue;
         }
-        _modules[r][6] = (r % 2 == 0);
+        _modules[r][6] = r % 2 == 0;
       }
 
       for (var c = 8; c < _moduleCount - 8; c += 1) {
         if (_modules[6][c] != null) {
           continue;
         }
-        _modules[6][c] = (c % 2 == 0);
+        _modules[6][c] = c % 2 == 0;
       }
     };
 
-    var setupPositionAdjustPattern = function() {
-
+    var setupPositionAdjustPattern = function () {
       var pos = QRUtil.getPatternPosition(_typeNumber);
 
       for (var i = 0; i < pos.length; i += 1) {
-
         for (var j = 0; j < pos.length; j += 1) {
-
           var row = pos[i];
           var col = pos[j];
 
@@ -146,11 +136,8 @@ var qrcode = function() {
           }
 
           for (var r = -2; r <= 2; r += 1) {
-
             for (var c = -2; c <= 2; c += 1) {
-
-              if (r == -2 || r == 2 || c == -2 || c == 2
-                  || (r == 0 && c == 0) ) {
+              if (r == -2 || r == 2 || c == -2 || c == 2 || (r == 0 && c == 0)) {
                 _modules[row + r][col + c] = true;
               } else {
                 _modules[row + r][col + c] = false;
@@ -161,30 +148,27 @@ var qrcode = function() {
       }
     };
 
-    var setupTypeNumber = function(test) {
-
+    var setupTypeNumber = function (test) {
       var bits = QRUtil.getBCHTypeNumber(_typeNumber);
 
       for (var i = 0; i < 18; i += 1) {
-        var mod = (!test && ( (bits >> i) & 1) == 1);
-        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+        var mod = !test && ((bits >> i) & 1) == 1;
+        _modules[Math.floor(i / 3)][(i % 3) + _moduleCount - 8 - 3] = mod;
       }
 
       for (var i = 0; i < 18; i += 1) {
-        var mod = (!test && ( (bits >> i) & 1) == 1);
-        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+        var mod = !test && ((bits >> i) & 1) == 1;
+        _modules[(i % 3) + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
       }
     };
 
-    var setupTypeInfo = function(test, maskPattern) {
-
+    var setupTypeInfo = function (test, maskPattern) {
       var data = (_errorCorrectionLevel << 3) | maskPattern;
       var bits = QRUtil.getBCHTypeInfo(data);
 
       // vertical
       for (var i = 0; i < 15; i += 1) {
-
-        var mod = (!test && ( (bits >> i) & 1) == 1);
+        var mod = !test && ((bits >> i) & 1) == 1;
 
         if (i < 6) {
           _modules[i][8] = mod;
@@ -197,8 +181,7 @@ var qrcode = function() {
 
       // horizontal
       for (var i = 0; i < 15; i += 1) {
-
-        var mod = (!test && ( (bits >> i) & 1) == 1);
+        var mod = !test && ((bits >> i) & 1) == 1;
 
         if (i < 8) {
           _modules[8][_moduleCount - i - 1] = mod;
@@ -210,11 +193,10 @@ var qrcode = function() {
       }
 
       // fixed module
-      _modules[_moduleCount - 8][8] = (!test);
+      _modules[_moduleCount - 8][8] = !test;
     };
 
-    var mapData = function(data, maskPattern) {
-
+    var mapData = function (data, maskPattern) {
       var inc = -1;
       var row = _moduleCount - 1;
       var bitIndex = 7;
@@ -222,19 +204,15 @@ var qrcode = function() {
       var maskFunc = QRUtil.getMaskFunction(maskPattern);
 
       for (var col = _moduleCount - 1; col > 0; col -= 2) {
-
         if (col == 6) col -= 1;
 
         while (true) {
-
           for (var c = 0; c < 2; c += 1) {
-
             if (_modules[row][col - c] == null) {
-
               var dark = false;
 
               if (byteIndex < data.length) {
-                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+                dark = ((data[byteIndex] >>> bitIndex) & 1) == 1;
               }
 
               var mask = maskFunc(row, col - c);
@@ -264,8 +242,7 @@ var qrcode = function() {
       }
     };
 
-    var createBytes = function(buffer, rsBlocks) {
-
+    var createBytes = function (buffer, rsBlocks) {
       var offset = 0;
 
       var maxDcCount = 0;
@@ -275,7 +252,6 @@ var qrcode = function() {
       var ecdata = new Array(rsBlocks.length);
 
       for (var r = 0; r < rsBlocks.length; r += 1) {
-
         var dcCount = rsBlocks[r].dataCount;
         var ecCount = rsBlocks[r].totalCount - dcCount;
 
@@ -296,7 +272,7 @@ var qrcode = function() {
         ecdata[r] = new Array(rsPoly.getLength() - 1);
         for (var i = 0; i < ecdata[r].length; i += 1) {
           var modIndex = i + modPoly.getLength() - ecdata[r].length;
-          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+          ecdata[r][i] = modIndex >= 0 ? modPoly.getAt(modIndex) : 0;
         }
       }
 
@@ -329,8 +305,7 @@ var qrcode = function() {
       return data;
     };
 
-    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
-
+    var createData = function (typeNumber, errorCorrectionLevel, dataList) {
       var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
 
       var buffer = qrBitBuffer();
@@ -338,7 +313,7 @@ var qrcode = function() {
       for (var i = 0; i < dataList.length; i += 1) {
         var data = dataList[i];
         buffer.put(data.getMode(), 4);
-        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber));
         data.write(buffer);
       }
 
@@ -349,11 +324,7 @@ var qrcode = function() {
       }
 
       if (buffer.getLengthInBits() > totalDataCount * 8) {
-        throw 'code length overflow. ('
-          + buffer.getLengthInBits()
-          + '>'
-          + totalDataCount * 8
-          + ')';
+        throw "code length overflow. (" + buffer.getLengthInBits() + ">" + totalDataCount * 8 + ")";
       }
 
       // end code
@@ -368,7 +339,6 @@ var qrcode = function() {
 
       // padding
       while (true) {
-
         if (buffer.getLengthInBits() >= totalDataCount * 8) {
           break;
         }
@@ -383,45 +353,44 @@ var qrcode = function() {
       return createBytes(buffer, rsBlocks);
     };
 
-    _this.addData = function(data, mode) {
-
-      mode = mode || 'Byte';
+    _this.addData = function (data, mode) {
+      mode = mode || "Byte";
 
       var newData = null;
 
-      switch(mode) {
-      case 'Numeric' :
-        newData = qrNumber(data);
-        break;
-      case 'Alphanumeric' :
-        newData = qrAlphaNum(data);
-        break;
-      case 'Byte' :
-        newData = qr8BitByte(data);
-        break;
-      case 'Kanji' :
-        newData = qrKanji(data);
-        break;
-      default :
-        throw 'mode:' + mode;
+      switch (mode) {
+        case "Numeric":
+          newData = qrNumber(data);
+          break;
+        case "Alphanumeric":
+          newData = qrAlphaNum(data);
+          break;
+        case "Byte":
+          newData = qr8BitByte(data);
+          break;
+        case "Kanji":
+          newData = qrKanji(data);
+          break;
+        default:
+          throw "mode:" + mode;
       }
 
       _dataList.push(newData);
       _dataCache = null;
     };
 
-    _this.isDark = function(row, col) {
+    _this.isDark = function (row, col) {
       if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
-        throw row + ',' + col;
+        throw row + "," + col;
       }
       return _modules[row][col];
     };
 
-    _this.getModuleCount = function() {
+    _this.getModuleCount = function () {
       return _moduleCount;
     };
 
-    _this.make = function() {
+    _this.make = function () {
       if (_typeNumber < 1) {
         var typeNumber = 1;
 
@@ -432,7 +401,7 @@ var qrcode = function() {
           for (var i = 0; i < _dataList.length; i++) {
             var data = _dataList[i];
             buffer.put(data.getMode(), 4);
-            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber));
             data.write(buffer);
           }
 
@@ -449,53 +418,50 @@ var qrcode = function() {
         _typeNumber = typeNumber;
       }
 
-      makeImpl(false, getBestMaskPattern() );
+      makeImpl(false, getBestMaskPattern());
     };
 
-    _this.createTableTag = function(cellSize, margin) {
-
+    _this.createTableTag = function (cellSize, margin) {
       cellSize = cellSize || 2;
-      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+      margin = typeof margin == "undefined" ? cellSize * 4 : margin;
 
-      var qrHtml = '';
+      var qrHtml = "";
 
       qrHtml += '<table style="';
-      qrHtml += ' border-width: 0px; border-style: none;';
-      qrHtml += ' border-collapse: collapse;';
-      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += " border-width: 0px; border-style: none;";
+      qrHtml += " border-collapse: collapse;";
+      qrHtml += " padding: 0px; margin: " + margin + "px;";
       qrHtml += '">';
-      qrHtml += '<tbody>';
+      qrHtml += "<tbody>";
 
       for (var r = 0; r < _this.getModuleCount(); r += 1) {
-
-        qrHtml += '<tr>';
+        qrHtml += "<tr>";
 
         for (var c = 0; c < _this.getModuleCount(); c += 1) {
           qrHtml += '<td style="';
-          qrHtml += ' border-width: 0px; border-style: none;';
-          qrHtml += ' border-collapse: collapse;';
-          qrHtml += ' padding: 0px; margin: 0px;';
-          qrHtml += ' width: ' + cellSize + 'px;';
-          qrHtml += ' height: ' + cellSize + 'px;';
-          qrHtml += ' background-color: ';
-          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
-          qrHtml += ';';
+          qrHtml += " border-width: 0px; border-style: none;";
+          qrHtml += " border-collapse: collapse;";
+          qrHtml += " padding: 0px; margin: 0px;";
+          qrHtml += " width: " + cellSize + "px;";
+          qrHtml += " height: " + cellSize + "px;";
+          qrHtml += " background-color: ";
+          qrHtml += _this.isDark(r, c) ? "#000000" : "#ffffff";
+          qrHtml += ";";
           qrHtml += '"/>';
         }
 
-        qrHtml += '</tr>';
+        qrHtml += "</tr>";
       }
 
-      qrHtml += '</tbody>';
-      qrHtml += '</table>';
+      qrHtml += "</tbody>";
+      qrHtml += "</table>";
 
       return qrHtml;
     };
 
-    _this.createSvgTag = function(cellSize, margin, alt, title) {
-
+    _this.createSvgTag = function (cellSize, margin, alt, title) {
       var opts = {};
-      if (typeof arguments[0] == 'object') {
+      if (typeof arguments[0] == "object") {
         // Called by options.
         opts = arguments[0];
         // overwrite cellSize and margin.
@@ -506,83 +472,89 @@ var qrcode = function() {
       }
 
       cellSize = cellSize || 2;
-      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+      margin = typeof margin == "undefined" ? cellSize * 4 : margin;
 
       // Compose alt property surrogate
-      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt = typeof alt === "string" ? { text: alt } : alt || {};
       alt.text = alt.text || null;
-      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+      alt.id = alt.text ? alt.id || "qrcode-description" : null;
 
       // Compose title property surrogate
-      title = (typeof title === 'string') ? {text: title} : title || {};
+      title = typeof title === "string" ? { text: title } : title || {};
       title.text = title.text || null;
-      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+      title.id = title.text ? title.id || "qrcode-title" : null;
 
       var size = _this.getModuleCount() * cellSize + margin * 2;
-      var c, mc, r, mr, qrSvg='', rect;
+      var c,
+        mc,
+        r,
+        mr,
+        qrSvg = "",
+        rect;
 
-      rect = 'l' + cellSize + ',0 0,' + cellSize +
-        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+      rect = "l" + cellSize + ",0 0," + cellSize + " -" + cellSize + ",0 0,-" + cellSize + "z ";
 
       qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
-      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
-      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : "";
+      qrSvg += ' viewBox="0 0 ' + size + " " + size + '" ';
       qrSvg += ' preserveAspectRatio="xMinYMin meet"';
-      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
-          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
-      qrSvg += '>';
-      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
-          escapeXml(title.text) + '</title>' : '';
-      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
-          escapeXml(alt.text) + '</description>' : '';
+      qrSvg +=
+        title.text || alt.text
+          ? ' role="img" aria-labelledby="' + escapeXml([title.id, alt.id].join(" ").trim()) + '"'
+          : "";
+      qrSvg += ">";
+      qrSvg += title.text
+        ? '<title id="' + escapeXml(title.id) + '">' + escapeXml(title.text) + "</title>"
+        : "";
+      qrSvg += alt.text
+        ? '<description id="' + escapeXml(alt.id) + '">' + escapeXml(alt.text) + "</description>"
+        : "";
       qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
       qrSvg += '<path d="';
 
       for (r = 0; r < _this.getModuleCount(); r += 1) {
         mr = r * cellSize + margin;
         for (c = 0; c < _this.getModuleCount(); c += 1) {
-          if (_this.isDark(r, c) ) {
-            mc = c*cellSize+margin;
-            qrSvg += 'M' + mc + ',' + mr + rect;
+          if (_this.isDark(r, c)) {
+            mc = c * cellSize + margin;
+            qrSvg += "M" + mc + "," + mr + rect;
           }
         }
       }
 
       qrSvg += '" stroke="transparent" fill="black"/>';
-      qrSvg += '</svg>';
+      qrSvg += "</svg>";
 
       return qrSvg;
     };
 
-    _this.createDataURL = function(cellSize, margin) {
-
+    _this.createDataURL = function (cellSize, margin) {
       cellSize = cellSize || 2;
-      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+      margin = typeof margin == "undefined" ? cellSize * 4 : margin;
 
       var size = _this.getModuleCount() * cellSize + margin * 2;
       var min = margin;
       var max = size - margin;
 
-      return createDataURL(size, size, function(x, y) {
+      return createDataURL(size, size, function (x, y) {
         if (min <= x && x < max && min <= y && y < max) {
-          var c = Math.floor( (x - min) / cellSize);
-          var r = Math.floor( (y - min) / cellSize);
-          return _this.isDark(r, c)? 0 : 1;
+          var c = Math.floor((x - min) / cellSize);
+          var r = Math.floor((y - min) / cellSize);
+          return _this.isDark(r, c) ? 0 : 1;
         } else {
           return 1;
         }
-      } );
+      });
     };
 
-    _this.createImgTag = function(cellSize, margin, alt) {
-
+    _this.createImgTag = function (cellSize, margin, alt) {
       cellSize = cellSize || 2;
-      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+      margin = typeof margin == "undefined" ? cellSize * 4 : margin;
 
       var size = _this.getModuleCount() * cellSize + margin * 2;
 
-      var img = '';
-      img += '<img';
+      var img = "";
+      img += "<img";
       img += '\u0020src="';
       img += _this.createDataURL(cellSize, margin);
       img += '"';
@@ -597,29 +569,39 @@ var qrcode = function() {
         img += escapeXml(alt);
         img += '"';
       }
-      img += '/>';
+      img += "/>";
 
       return img;
     };
 
-    var escapeXml = function(s) {
-      var escaped = '';
+    var escapeXml = function (s) {
+      var escaped = "";
       for (var i = 0; i < s.length; i += 1) {
         var c = s.charAt(i);
-        switch(c) {
-        case '<': escaped += '&lt;'; break;
-        case '>': escaped += '&gt;'; break;
-        case '&': escaped += '&amp;'; break;
-        case '"': escaped += '&quot;'; break;
-        default : escaped += c; break;
+        switch (c) {
+          case "<":
+            escaped += "&lt;";
+            break;
+          case ">":
+            escaped += "&gt;";
+            break;
+          case "&":
+            escaped += "&amp;";
+            break;
+          case '"':
+            escaped += "&quot;";
+            break;
+          default:
+            escaped += c;
+            break;
         }
       }
       return escaped;
     };
 
-    var _createHalfASCII = function(margin) {
+    var _createHalfASCII = function (margin) {
       var cellSize = 1;
-      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+      margin = typeof margin == "undefined" ? cellSize * 2 : margin;
 
       var size = _this.getModuleCount() * cellSize + margin * 2;
       var min = margin;
@@ -628,52 +610,63 @@ var qrcode = function() {
       var y, x, r1, r2, p;
 
       var blocks = {
-        '██': '█',
-        '█ ': '▀',
-        ' █': '▄',
-        '  ': ' '
+        "██": "█",
+        "█ ": "▀",
+        " █": "▄",
+        "  ": " ",
       };
 
       var blocksLastLineNoMargin = {
-        '██': '▀',
-        '█ ': '▀',
-        ' █': ' ',
-        '  ': ' '
+        "██": "▀",
+        "█ ": "▀",
+        " █": " ",
+        "  ": " ",
       };
 
-      var ascii = '';
+      var ascii = "";
       for (y = 0; y < size; y += 2) {
         r1 = Math.floor((y - min) / cellSize);
         r2 = Math.floor((y + 1 - min) / cellSize);
         for (x = 0; x < size; x += 1) {
-          p = '█';
+          p = "█";
 
-          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
-            p = ' ';
+          if (
+            min <= x &&
+            x < max &&
+            min <= y &&
+            y < max &&
+            _this.isDark(r1, Math.floor((x - min) / cellSize))
+          ) {
+            p = " ";
           }
 
-          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
-            p += ' ';
-          }
-          else {
-            p += '█';
+          if (
+            min <= x &&
+            x < max &&
+            min <= y + 1 &&
+            y + 1 < max &&
+            _this.isDark(r2, Math.floor((x - min) / cellSize))
+          ) {
+            p += " ";
+          } else {
+            p += "█";
           }
 
           // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
-          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+          ascii += margin < 1 && y + 1 >= max ? blocksLastLineNoMargin[p] : blocks[p];
         }
 
-        ascii += '\n';
+        ascii += "\n";
       }
 
       if (size % 2 && margin > 0) {
-        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+        return ascii.substring(0, ascii.length - size - 1) + Array(size + 1).join("▀");
       }
 
-      return ascii.substring(0, ascii.length-1);
+      return ascii.substring(0, ascii.length - 1);
     };
 
-    _this.createASCII = function(cellSize, margin) {
+    _this.createASCII = function (cellSize, margin) {
       cellSize = cellSize || 1;
 
       if (cellSize < 2) {
@@ -681,7 +674,7 @@ var qrcode = function() {
       }
 
       cellSize -= 1;
-      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+      margin = typeof margin == "undefined" ? cellSize * 2 : margin;
 
       var size = _this.getModuleCount() * cellSize + margin * 2;
       var min = margin;
@@ -689,18 +682,24 @@ var qrcode = function() {
 
       var y, x, r, p;
 
-      var white = Array(cellSize+1).join('██');
-      var black = Array(cellSize+1).join('  ');
+      var white = Array(cellSize + 1).join("██");
+      var black = Array(cellSize + 1).join("  ");
 
-      var ascii = '';
-      var line = '';
+      var ascii = "";
+      var line = "";
       for (y = 0; y < size; y += 1) {
-        r = Math.floor( (y - min) / cellSize);
-        line = '';
+        r = Math.floor((y - min) / cellSize);
+        line = "";
         for (x = 0; x < size; x += 1) {
           p = 1;
 
-          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+          if (
+            min <= x &&
+            x < max &&
+            min <= y &&
+            y < max &&
+            _this.isDark(r, Math.floor((x - min) / cellSize))
+          ) {
             p = 0;
           }
 
@@ -709,23 +708,23 @@ var qrcode = function() {
         }
 
         for (r = 0; r < cellSize; r += 1) {
-          ascii += line + '\n';
+          ascii += line + "\n";
         }
       }
 
-      return ascii.substring(0, ascii.length-1);
+      return ascii.substring(0, ascii.length - 1);
     };
 
-    _this.renderTo2dContext = function(context, cellSize) {
+    _this.renderTo2dContext = function (context, cellSize) {
       cellSize = cellSize || 2;
       var length = _this.getModuleCount();
       for (var row = 0; row < length; row++) {
         for (var col = 0; col < length; col++) {
-          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillStyle = _this.isDark(row, col) ? "black" : "white";
           context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
         }
       }
-    }
+    };
 
     return _this;
   };
@@ -735,17 +734,17 @@ var qrcode = function() {
   //---------------------------------------------------------------------
 
   qrcode.stringToBytesFuncs = {
-    'default' : function(s) {
+    default: function (s) {
       var bytes = [];
       for (var i = 0; i < s.length; i += 1) {
         var c = s.charCodeAt(i);
         bytes.push(c & 0xff);
       }
       return bytes;
-    }
+    },
   };
 
-  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs["default"];
 
   //---------------------------------------------------------------------
   // qrcode.createStringToBytes
@@ -756,16 +755,14 @@ var qrcode = function() {
    * [16bit Unicode],[16bit Bytes], ...
    * @param numChars
    */
-  qrcode.createStringToBytes = function(unicodeData, numChars) {
-
+  qrcode.createStringToBytes = function (unicodeData, numChars) {
     // create conversion map.
 
-    var unicodeMap = function() {
-
+    var unicodeMap = (function () {
       var bin = base64DecodeInputStream(unicodeData);
-      var read = function() {
+      var read = function () {
         var b = bin.read();
-        if (b == -1) throw 'eof';
+        if (b == -1) throw "eof";
         return b;
       };
 
@@ -777,21 +774,21 @@ var qrcode = function() {
         var b1 = read();
         var b2 = read();
         var b3 = read();
-        var k = String.fromCharCode( (b0 << 8) | b1);
+        var k = String.fromCharCode((b0 << 8) | b1);
         var v = (b2 << 8) | b3;
         unicodeMap[k] = v;
         count += 1;
       }
       if (count != numChars) {
-        throw count + ' != ' + numChars;
+        throw count + " != " + numChars;
       }
 
       return unicodeMap;
-    }();
+    })();
 
-    var unknownChar = '?'.charCodeAt(0);
+    var unknownChar = "?".charCodeAt(0);
 
-    return function(s) {
+    return function (s) {
       var bytes = [];
       for (var i = 0; i < s.length; i += 1) {
         var c = s.charCodeAt(i);
@@ -799,8 +796,8 @@ var qrcode = function() {
           bytes.push(c);
         } else {
           var b = unicodeMap[s.charAt(i)];
-          if (typeof b == 'number') {
-            if ( (b & 0xff) == b) {
+          if (typeof b == "number") {
+            if ((b & 0xff) == b) {
               // 1byte
               bytes.push(b);
             } else {
@@ -822,10 +819,10 @@ var qrcode = function() {
   //---------------------------------------------------------------------
 
   var QRMode = {
-    MODE_NUMBER :    1 << 0,
-    MODE_ALPHA_NUM : 1 << 1,
-    MODE_8BIT_BYTE : 1 << 2,
-    MODE_KANJI :     1 << 3
+    MODE_NUMBER: 1 << 0,
+    MODE_ALPHA_NUM: 1 << 1,
+    MODE_8BIT_BYTE: 1 << 2,
+    MODE_KANJI: 1 << 3,
   };
 
   //---------------------------------------------------------------------
@@ -833,10 +830,10 @@ var qrcode = function() {
   //---------------------------------------------------------------------
 
   var QRErrorCorrectionLevel = {
-    L : 1,
-    M : 0,
-    Q : 3,
-    H : 2
+    L: 1,
+    M: 0,
+    Q: 3,
+    H: 2,
   };
 
   //---------------------------------------------------------------------
@@ -844,22 +841,21 @@ var qrcode = function() {
   //---------------------------------------------------------------------
 
   var QRMaskPattern = {
-    PATTERN000 : 0,
-    PATTERN001 : 1,
-    PATTERN010 : 2,
-    PATTERN011 : 3,
-    PATTERN100 : 4,
-    PATTERN101 : 5,
-    PATTERN110 : 6,
-    PATTERN111 : 7
+    PATTERN000: 0,
+    PATTERN001: 1,
+    PATTERN010: 2,
+    PATTERN011: 3,
+    PATTERN100: 4,
+    PATTERN101: 5,
+    PATTERN110: 6,
+    PATTERN111: 7,
   };
 
   //---------------------------------------------------------------------
   // QRUtil
   //---------------------------------------------------------------------
 
-  var QRUtil = function() {
-
+  var QRUtil = (function () {
     var PATTERN_POSITION_TABLE = [
       [],
       [6, 18],
@@ -900,15 +896,16 @@ var qrcode = function() {
       [6, 28, 54, 80, 106, 132, 158],
       [6, 32, 58, 84, 110, 136, 162],
       [6, 26, 54, 82, 110, 138, 166],
-      [6, 30, 58, 86, 114, 142, 170]
+      [6, 30, 58, 86, 114, 142, 170],
     ];
     var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
-    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G18 =
+      (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
     var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
 
     var _this = {};
 
-    var getBCHDigit = function(data) {
+    var getBCHDigit = function (data) {
       var digit = 0;
       while (data != 0) {
         digit += 1;
@@ -917,108 +914,126 @@ var qrcode = function() {
       return digit;
     };
 
-    _this.getBCHTypeInfo = function(data) {
+    _this.getBCHTypeInfo = function (data) {
       var d = data << 10;
       while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
-        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+        d ^= G15 << (getBCHDigit(d) - getBCHDigit(G15));
       }
-      return ( (data << 10) | d) ^ G15_MASK;
+      return ((data << 10) | d) ^ G15_MASK;
     };
 
-    _this.getBCHTypeNumber = function(data) {
+    _this.getBCHTypeNumber = function (data) {
       var d = data << 12;
       while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
-        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+        d ^= G18 << (getBCHDigit(d) - getBCHDigit(G18));
       }
       return (data << 12) | d;
     };
 
-    _this.getPatternPosition = function(typeNumber) {
+    _this.getPatternPosition = function (typeNumber) {
       return PATTERN_POSITION_TABLE[typeNumber - 1];
     };
 
-    _this.getMaskFunction = function(maskPattern) {
-
+    _this.getMaskFunction = function (maskPattern) {
       switch (maskPattern) {
+        case QRMaskPattern.PATTERN000:
+          return function (i, j) {
+            return (i + j) % 2 == 0;
+          };
+        case QRMaskPattern.PATTERN001:
+          return function (i, j) {
+            return i % 2 == 0;
+          };
+        case QRMaskPattern.PATTERN010:
+          return function (i, j) {
+            return j % 3 == 0;
+          };
+        case QRMaskPattern.PATTERN011:
+          return function (i, j) {
+            return (i + j) % 3 == 0;
+          };
+        case QRMaskPattern.PATTERN100:
+          return function (i, j) {
+            return (Math.floor(i / 2) + Math.floor(j / 3)) % 2 == 0;
+          };
+        case QRMaskPattern.PATTERN101:
+          return function (i, j) {
+            return ((i * j) % 2) + ((i * j) % 3) == 0;
+          };
+        case QRMaskPattern.PATTERN110:
+          return function (i, j) {
+            return (((i * j) % 2) + ((i * j) % 3)) % 2 == 0;
+          };
+        case QRMaskPattern.PATTERN111:
+          return function (i, j) {
+            return (((i * j) % 3) + ((i + j) % 2)) % 2 == 0;
+          };
 
-      case QRMaskPattern.PATTERN000 :
-        return function(i, j) { return (i + j) % 2 == 0; };
-      case QRMaskPattern.PATTERN001 :
-        return function(i, j) { return i % 2 == 0; };
-      case QRMaskPattern.PATTERN010 :
-        return function(i, j) { return j % 3 == 0; };
-      case QRMaskPattern.PATTERN011 :
-        return function(i, j) { return (i + j) % 3 == 0; };
-      case QRMaskPattern.PATTERN100 :
-        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
-      case QRMaskPattern.PATTERN101 :
-        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
-      case QRMaskPattern.PATTERN110 :
-        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
-      case QRMaskPattern.PATTERN111 :
-        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
-
-      default :
-        throw 'bad maskPattern:' + maskPattern;
+        default:
+          throw "bad maskPattern:" + maskPattern;
       }
     };
 
-    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+    _this.getErrorCorrectPolynomial = function (errorCorrectLength) {
       var a = qrPolynomial([1], 0);
       for (var i = 0; i < errorCorrectLength; i += 1) {
-        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0));
       }
       return a;
     };
 
-    _this.getLengthInBits = function(mode, type) {
-
+    _this.getLengthInBits = function (mode, type) {
       if (1 <= type && type < 10) {
-
         // 1 - 9
 
-        switch(mode) {
-        case QRMode.MODE_NUMBER    : return 10;
-        case QRMode.MODE_ALPHA_NUM : return 9;
-        case QRMode.MODE_8BIT_BYTE : return 8;
-        case QRMode.MODE_KANJI     : return 8;
-        default :
-          throw 'mode:' + mode;
+        switch (mode) {
+          case QRMode.MODE_NUMBER:
+            return 10;
+          case QRMode.MODE_ALPHA_NUM:
+            return 9;
+          case QRMode.MODE_8BIT_BYTE:
+            return 8;
+          case QRMode.MODE_KANJI:
+            return 8;
+          default:
+            throw "mode:" + mode;
         }
-
       } else if (type < 27) {
-
         // 10 - 26
 
-        switch(mode) {
-        case QRMode.MODE_NUMBER    : return 12;
-        case QRMode.MODE_ALPHA_NUM : return 11;
-        case QRMode.MODE_8BIT_BYTE : return 16;
-        case QRMode.MODE_KANJI     : return 10;
-        default :
-          throw 'mode:' + mode;
+        switch (mode) {
+          case QRMode.MODE_NUMBER:
+            return 12;
+          case QRMode.MODE_ALPHA_NUM:
+            return 11;
+          case QRMode.MODE_8BIT_BYTE:
+            return 16;
+          case QRMode.MODE_KANJI:
+            return 10;
+          default:
+            throw "mode:" + mode;
         }
-
       } else if (type < 41) {
-
         // 27 - 40
 
-        switch(mode) {
-        case QRMode.MODE_NUMBER    : return 14;
-        case QRMode.MODE_ALPHA_NUM : return 13;
-        case QRMode.MODE_8BIT_BYTE : return 16;
-        case QRMode.MODE_KANJI     : return 12;
-        default :
-          throw 'mode:' + mode;
+        switch (mode) {
+          case QRMode.MODE_NUMBER:
+            return 14;
+          case QRMode.MODE_ALPHA_NUM:
+            return 13;
+          case QRMode.MODE_8BIT_BYTE:
+            return 16;
+          case QRMode.MODE_KANJI:
+            return 12;
+          default:
+            throw "mode:" + mode;
         }
-
       } else {
-        throw 'type:' + type;
+        throw "type:" + type;
       }
     };
 
-    _this.getLostPoint = function(qrcode) {
-
+    _this.getLostPoint = function (qrcode) {
       var moduleCount = qrcode.getModuleCount();
 
       var lostPoint = 0;
@@ -1027,18 +1042,15 @@ var qrcode = function() {
 
       for (var row = 0; row < moduleCount; row += 1) {
         for (var col = 0; col < moduleCount; col += 1) {
-
           var sameCount = 0;
           var dark = qrcode.isDark(row, col);
 
           for (var r = -1; r <= 1; r += 1) {
-
             if (row + r < 0 || moduleCount <= row + r) {
               continue;
             }
 
             for (var c = -1; c <= 1; c += 1) {
-
               if (col + c < 0 || moduleCount <= col + c) {
                 continue;
               }
@@ -1047,27 +1059,27 @@ var qrcode = function() {
                 continue;
               }
 
-              if (dark == qrcode.isDark(row + r, col + c) ) {
+              if (dark == qrcode.isDark(row + r, col + c)) {
                 sameCount += 1;
               }
             }
           }
 
           if (sameCount > 5) {
-            lostPoint += (3 + sameCount - 5);
+            lostPoint += 3 + sameCount - 5;
           }
         }
-      };
+      }
 
       // LEVEL2
 
       for (var row = 0; row < moduleCount - 1; row += 1) {
         for (var col = 0; col < moduleCount - 1; col += 1) {
           var count = 0;
-          if (qrcode.isDark(row, col) ) count += 1;
-          if (qrcode.isDark(row + 1, col) ) count += 1;
-          if (qrcode.isDark(row, col + 1) ) count += 1;
-          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (qrcode.isDark(row, col)) count += 1;
+          if (qrcode.isDark(row + 1, col)) count += 1;
+          if (qrcode.isDark(row, col + 1)) count += 1;
+          if (qrcode.isDark(row + 1, col + 1)) count += 1;
           if (count == 0 || count == 4) {
             lostPoint += 3;
           }
@@ -1078,13 +1090,15 @@ var qrcode = function() {
 
       for (var row = 0; row < moduleCount; row += 1) {
         for (var col = 0; col < moduleCount - 6; col += 1) {
-          if (qrcode.isDark(row, col)
-              && !qrcode.isDark(row, col + 1)
-              &&  qrcode.isDark(row, col + 2)
-              &&  qrcode.isDark(row, col + 3)
-              &&  qrcode.isDark(row, col + 4)
-              && !qrcode.isDark(row, col + 5)
-              &&  qrcode.isDark(row, col + 6) ) {
+          if (
+            qrcode.isDark(row, col) &&
+            !qrcode.isDark(row, col + 1) &&
+            qrcode.isDark(row, col + 2) &&
+            qrcode.isDark(row, col + 3) &&
+            qrcode.isDark(row, col + 4) &&
+            !qrcode.isDark(row, col + 5) &&
+            qrcode.isDark(row, col + 6)
+          ) {
             lostPoint += 40;
           }
         }
@@ -1092,13 +1106,15 @@ var qrcode = function() {
 
       for (var col = 0; col < moduleCount; col += 1) {
         for (var row = 0; row < moduleCount - 6; row += 1) {
-          if (qrcode.isDark(row, col)
-              && !qrcode.isDark(row + 1, col)
-              &&  qrcode.isDark(row + 2, col)
-              &&  qrcode.isDark(row + 3, col)
-              &&  qrcode.isDark(row + 4, col)
-              && !qrcode.isDark(row + 5, col)
-              &&  qrcode.isDark(row + 6, col) ) {
+          if (
+            qrcode.isDark(row, col) &&
+            !qrcode.isDark(row + 1, col) &&
+            qrcode.isDark(row + 2, col) &&
+            qrcode.isDark(row + 3, col) &&
+            qrcode.isDark(row + 4, col) &&
+            !qrcode.isDark(row + 5, col) &&
+            qrcode.isDark(row + 6, col)
+          ) {
             lostPoint += 40;
           }
         }
@@ -1110,27 +1126,26 @@ var qrcode = function() {
 
       for (var col = 0; col < moduleCount; col += 1) {
         for (var row = 0; row < moduleCount; row += 1) {
-          if (qrcode.isDark(row, col) ) {
+          if (qrcode.isDark(row, col)) {
             darkCount += 1;
           }
         }
       }
 
-      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      var ratio = Math.abs((100 * darkCount) / moduleCount / moduleCount - 50) / 5;
       lostPoint += ratio * 10;
 
       return lostPoint;
     };
 
     return _this;
-  }();
+  })();
 
   //---------------------------------------------------------------------
   // QRMath
   //---------------------------------------------------------------------
 
-  var QRMath = function() {
-
+  var QRMath = (function () {
     var EXP_TABLE = new Array(256);
     var LOG_TABLE = new Array(256);
 
@@ -1139,28 +1154,23 @@ var qrcode = function() {
       EXP_TABLE[i] = 1 << i;
     }
     for (var i = 8; i < 256; i += 1) {
-      EXP_TABLE[i] = EXP_TABLE[i - 4]
-        ^ EXP_TABLE[i - 5]
-        ^ EXP_TABLE[i - 6]
-        ^ EXP_TABLE[i - 8];
+      EXP_TABLE[i] = EXP_TABLE[i - 4] ^ EXP_TABLE[i - 5] ^ EXP_TABLE[i - 6] ^ EXP_TABLE[i - 8];
     }
     for (var i = 0; i < 255; i += 1) {
-      LOG_TABLE[EXP_TABLE[i] ] = i;
+      LOG_TABLE[EXP_TABLE[i]] = i;
     }
 
     var _this = {};
 
-    _this.glog = function(n) {
-
+    _this.glog = function (n) {
       if (n < 1) {
-        throw 'glog(' + n + ')';
+        throw "glog(" + n + ")";
       }
 
       return LOG_TABLE[n];
     };
 
-    _this.gexp = function(n) {
-
+    _this.gexp = function (n) {
       while (n < 0) {
         n += 255;
       }
@@ -1173,19 +1183,18 @@ var qrcode = function() {
     };
 
     return _this;
-  }();
+  })();
 
   //---------------------------------------------------------------------
   // qrPolynomial
   //---------------------------------------------------------------------
 
   function qrPolynomial(num, shift) {
-
-    if (typeof num.length == 'undefined') {
-      throw num.length + '/' + shift;
+    if (typeof num.length == "undefined") {
+      throw num.length + "/" + shift;
     }
 
-    var _num = function() {
+    var _num = (function () {
       var offset = 0;
       while (offset < num.length && num[offset] == 0) {
         offset += 1;
@@ -1195,46 +1204,44 @@ var qrcode = function() {
         _num[i] = num[i + offset];
       }
       return _num;
-    }();
+    })();
 
     var _this = {};
 
-    _this.getAt = function(index) {
+    _this.getAt = function (index) {
       return _num[index];
     };
 
-    _this.getLength = function() {
+    _this.getLength = function () {
       return _num.length;
     };
 
-    _this.multiply = function(e) {
-
+    _this.multiply = function (e) {
       var num = new Array(_this.getLength() + e.getLength() - 1);
 
       for (var i = 0; i < _this.getLength(); i += 1) {
         for (var j = 0; j < e.getLength(); j += 1) {
-          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i)) + QRMath.glog(e.getAt(j)));
         }
       }
 
       return qrPolynomial(num, 0);
     };
 
-    _this.mod = function(e) {
-
+    _this.mod = function (e) {
       if (_this.getLength() - e.getLength() < 0) {
         return _this;
       }
 
-      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+      var ratio = QRMath.glog(_this.getAt(0)) - QRMath.glog(e.getAt(0));
 
-      var num = new Array(_this.getLength() );
+      var num = new Array(_this.getLength());
       for (var i = 0; i < _this.getLength(); i += 1) {
         num[i] = _this.getAt(i);
       }
 
       for (var i = 0; i < e.getLength(); i += 1) {
-        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i)) + ratio);
       }
 
       // recursive call
@@ -1242,16 +1249,14 @@ var qrcode = function() {
     };
 
     return _this;
-  };
+  }
 
   //---------------------------------------------------------------------
   // QRRSBlock
   //---------------------------------------------------------------------
 
-  var QRRSBlock = function() {
-
+  var QRRSBlock = (function () {
     var RS_BLOCK_TABLE = [
-
       // L
       // M
       // Q
@@ -1495,10 +1500,10 @@ var qrcode = function() {
       [19, 148, 118, 6, 149, 119],
       [18, 75, 47, 31, 76, 48],
       [34, 54, 24, 34, 55, 25],
-      [20, 45, 15, 61, 46, 16]
+      [20, 45, 15, 61, 46, 16],
     ];
 
-    var qrRSBlock = function(totalCount, dataCount) {
+    var qrRSBlock = function (totalCount, dataCount) {
       var _this = {};
       _this.totalCount = totalCount;
       _this.dataCount = dataCount;
@@ -1507,29 +1512,31 @@ var qrcode = function() {
 
     var _this = {};
 
-    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
-
-      switch(errorCorrectionLevel) {
-      case QRErrorCorrectionLevel.L :
-        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
-      case QRErrorCorrectionLevel.M :
-        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
-      case QRErrorCorrectionLevel.Q :
-        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
-      case QRErrorCorrectionLevel.H :
-        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
-      default :
-        return undefined;
+    var getRsBlockTable = function (typeNumber, errorCorrectionLevel) {
+      switch (errorCorrectionLevel) {
+        case QRErrorCorrectionLevel.L:
+          return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+        case QRErrorCorrectionLevel.M:
+          return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+        case QRErrorCorrectionLevel.Q:
+          return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+        case QRErrorCorrectionLevel.H:
+          return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+        default:
+          return undefined;
       }
     };
 
-    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
-
+    _this.getRSBlocks = function (typeNumber, errorCorrectionLevel) {
       var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
 
-      if (typeof rsBlock == 'undefined') {
-        throw 'bad rs block @ typeNumber:' + typeNumber +
-            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      if (typeof rsBlock == "undefined") {
+        throw (
+          "bad rs block @ typeNumber:" +
+          typeNumber +
+          "/errorCorrectionLevel:" +
+          errorCorrectionLevel
+        );
       }
 
       var length = rsBlock.length / 3;
@@ -1537,13 +1544,12 @@ var qrcode = function() {
       var list = [];
 
       for (var i = 0; i < length; i += 1) {
-
         var count = rsBlock[i * 3 + 0];
         var totalCount = rsBlock[i * 3 + 1];
         var dataCount = rsBlock[i * 3 + 2];
 
         for (var j = 0; j < count; j += 1) {
-          list.push(qrRSBlock(totalCount, dataCount) );
+          list.push(qrRSBlock(totalCount, dataCount));
         }
       }
 
@@ -1551,47 +1557,45 @@ var qrcode = function() {
     };
 
     return _this;
-  }();
+  })();
 
   //---------------------------------------------------------------------
   // qrBitBuffer
   //---------------------------------------------------------------------
 
-  var qrBitBuffer = function() {
-
+  var qrBitBuffer = function () {
     var _buffer = [];
     var _length = 0;
 
     var _this = {};
 
-    _this.getBuffer = function() {
+    _this.getBuffer = function () {
       return _buffer;
     };
 
-    _this.getAt = function(index) {
+    _this.getAt = function (index) {
       var bufIndex = Math.floor(index / 8);
-      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+      return ((_buffer[bufIndex] >>> (7 - (index % 8))) & 1) == 1;
     };
 
-    _this.put = function(num, length) {
+    _this.put = function (num, length) {
       for (var i = 0; i < length; i += 1) {
-        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+        _this.putBit(((num >>> (length - i - 1)) & 1) == 1);
       }
     };
 
-    _this.getLengthInBits = function() {
+    _this.getLengthInBits = function () {
       return _length;
     };
 
-    _this.putBit = function(bit) {
-
+    _this.putBit = function (bit) {
       var bufIndex = Math.floor(_length / 8);
       if (_buffer.length <= bufIndex) {
         _buffer.push(0);
       }
 
       if (bit) {
-        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+        _buffer[bufIndex] |= 0x80 >>> (_length % 8);
       }
 
       _length += 1;
@@ -1604,54 +1608,52 @@ var qrcode = function() {
   // qrNumber
   //---------------------------------------------------------------------
 
-  var qrNumber = function(data) {
-
+  var qrNumber = function (data) {
     var _mode = QRMode.MODE_NUMBER;
     var _data = data;
 
     var _this = {};
 
-    _this.getMode = function() {
+    _this.getMode = function () {
       return _mode;
     };
 
-    _this.getLength = function(buffer) {
+    _this.getLength = function (buffer) {
       return _data.length;
     };
 
-    _this.write = function(buffer) {
-
+    _this.write = function (buffer) {
       var data = _data;
 
       var i = 0;
 
       while (i + 2 < data.length) {
-        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        buffer.put(strToNum(data.substring(i, i + 3)), 10);
         i += 3;
       }
 
       if (i < data.length) {
         if (data.length - i == 1) {
-          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+          buffer.put(strToNum(data.substring(i, i + 1)), 4);
         } else if (data.length - i == 2) {
-          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+          buffer.put(strToNum(data.substring(i, i + 2)), 7);
         }
       }
     };
 
-    var strToNum = function(s) {
+    var strToNum = function (s) {
       var num = 0;
       for (var i = 0; i < s.length; i += 1) {
-        num = num * 10 + chatToNum(s.charAt(i) );
+        num = num * 10 + chatToNum(s.charAt(i));
       }
       return num;
     };
 
-    var chatToNum = function(c) {
-      if ('0' <= c && c <= '9') {
-        return c.charCodeAt(0) - '0'.charCodeAt(0);
+    var chatToNum = function (c) {
+      if ("0" <= c && c <= "9") {
+        return c.charCodeAt(0) - "0".charCodeAt(0);
       }
-      throw 'illegal char :' + c;
+      throw "illegal char :" + c;
     };
 
     return _this;
@@ -1661,58 +1663,62 @@ var qrcode = function() {
   // qrAlphaNum
   //---------------------------------------------------------------------
 
-  var qrAlphaNum = function(data) {
-
+  var qrAlphaNum = function (data) {
     var _mode = QRMode.MODE_ALPHA_NUM;
     var _data = data;
 
     var _this = {};
 
-    _this.getMode = function() {
+    _this.getMode = function () {
       return _mode;
     };
 
-    _this.getLength = function(buffer) {
+    _this.getLength = function (buffer) {
       return _data.length;
     };
 
-    _this.write = function(buffer) {
-
+    _this.write = function (buffer) {
       var s = _data;
 
       var i = 0;
 
       while (i + 1 < s.length) {
-        buffer.put(
-          getCode(s.charAt(i) ) * 45 +
-          getCode(s.charAt(i + 1) ), 11);
+        buffer.put(getCode(s.charAt(i)) * 45 + getCode(s.charAt(i + 1)), 11);
         i += 2;
       }
 
       if (i < s.length) {
-        buffer.put(getCode(s.charAt(i) ), 6);
+        buffer.put(getCode(s.charAt(i)), 6);
       }
     };
 
-    var getCode = function(c) {
-
-      if ('0' <= c && c <= '9') {
-        return c.charCodeAt(0) - '0'.charCodeAt(0);
-      } else if ('A' <= c && c <= 'Z') {
-        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+    var getCode = function (c) {
+      if ("0" <= c && c <= "9") {
+        return c.charCodeAt(0) - "0".charCodeAt(0);
+      } else if ("A" <= c && c <= "Z") {
+        return c.charCodeAt(0) - "A".charCodeAt(0) + 10;
       } else {
         switch (c) {
-        case ' ' : return 36;
-        case '$' : return 37;
-        case '%' : return 38;
-        case '*' : return 39;
-        case '+' : return 40;
-        case '-' : return 41;
-        case '.' : return 42;
-        case '/' : return 43;
-        case ':' : return 44;
-        default :
-          throw 'illegal char :' + c;
+          case " ":
+            return 36;
+          case "$":
+            return 37;
+          case "%":
+            return 38;
+          case "*":
+            return 39;
+          case "+":
+            return 40;
+          case "-":
+            return 41;
+          case ".":
+            return 42;
+          case "/":
+            return 43;
+          case ":":
+            return 44;
+          default:
+            throw "illegal char :" + c;
         }
       }
     };
@@ -1724,23 +1730,22 @@ var qrcode = function() {
   // qr8BitByte
   //---------------------------------------------------------------------
 
-  var qr8BitByte = function(data) {
-
+  var qr8BitByte = function (data) {
     var _mode = QRMode.MODE_8BIT_BYTE;
     var _data = data;
     var _bytes = qrcode.stringToBytes(data);
 
     var _this = {};
 
-    _this.getMode = function() {
+    _this.getMode = function () {
       return _mode;
     };
 
-    _this.getLength = function(buffer) {
+    _this.getLength = function (buffer) {
       return _bytes.length;
     };
 
-    _this.write = function(buffer) {
+    _this.write = function (buffer) {
       for (var i = 0; i < _bytes.length; i += 1) {
         buffer.put(_bytes[i], 8);
       }
@@ -1753,54 +1758,51 @@ var qrcode = function() {
   // qrKanji
   //---------------------------------------------------------------------
 
-  var qrKanji = function(data) {
-
+  var qrKanji = function (data) {
     var _mode = QRMode.MODE_KANJI;
     var _data = data;
 
-    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    var stringToBytes = qrcode.stringToBytesFuncs["SJIS"];
     if (!stringToBytes) {
-      throw 'sjis not supported.';
+      throw "sjis not supported.";
     }
-    !function(c, code) {
+    !(function (c, code) {
       // self test for sjis support.
       var test = stringToBytes(c);
-      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
-        throw 'sjis not supported.';
+      if (test.length != 2 || ((test[0] << 8) | test[1]) != code) {
+        throw "sjis not supported.";
       }
-    }('\u53cb', 0x9746);
+    })("\u53cb", 0x9746);
 
     var _bytes = stringToBytes(data);
 
     var _this = {};
 
-    _this.getMode = function() {
+    _this.getMode = function () {
       return _mode;
     };
 
-    _this.getLength = function(buffer) {
+    _this.getLength = function (buffer) {
       return ~~(_bytes.length / 2);
     };
 
-    _this.write = function(buffer) {
-
+    _this.write = function (buffer) {
       var data = _bytes;
 
       var i = 0;
 
       while (i + 1 < data.length) {
+        var c = ((0xff & data[i]) << 8) | (0xff & data[i + 1]);
 
-        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
-
-        if (0x8140 <= c && c <= 0x9FFC) {
+        if (0x8140 <= c && c <= 0x9ffc) {
           c -= 0x8140;
-        } else if (0xE040 <= c && c <= 0xEBBF) {
-          c -= 0xC140;
+        } else if (0xe040 <= c && c <= 0xebbf) {
+          c -= 0xc140;
         } else {
-          throw 'illegal char at ' + (i + 1) + '/' + c;
+          throw "illegal char at " + (i + 1) + "/" + c;
         }
 
-        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+        c = ((c >>> 8) & 0xff) * 0xc0 + (c & 0xff);
 
         buffer.put(c, 13);
 
@@ -1808,7 +1810,7 @@ var qrcode = function() {
       }
 
       if (i < data.length) {
-        throw 'illegal char at ' + (i + 1);
+        throw "illegal char at " + (i + 1);
       }
     };
 
@@ -1823,22 +1825,21 @@ var qrcode = function() {
   // byteArrayOutputStream
   //---------------------------------------------------------------------
 
-  var byteArrayOutputStream = function() {
-
+  var byteArrayOutputStream = function () {
     var _bytes = [];
 
     var _this = {};
 
-    _this.writeByte = function(b) {
+    _this.writeByte = function (b) {
       _bytes.push(b & 0xff);
     };
 
-    _this.writeShort = function(i) {
+    _this.writeShort = function (i) {
       _this.writeByte(i);
       _this.writeByte(i >>> 8);
     };
 
-    _this.writeBytes = function(b, off, len) {
+    _this.writeBytes = function (b, off, len) {
       off = off || 0;
       len = len || b.length;
       for (var i = 0; i < len; i += 1) {
@@ -1846,26 +1847,26 @@ var qrcode = function() {
       }
     };
 
-    _this.writeString = function(s) {
+    _this.writeString = function (s) {
       for (var i = 0; i < s.length; i += 1) {
-        _this.writeByte(s.charCodeAt(i) );
+        _this.writeByte(s.charCodeAt(i));
       }
     };
 
-    _this.toByteArray = function() {
+    _this.toByteArray = function () {
       return _bytes;
     };
 
-    _this.toString = function() {
-      var s = '';
-      s += '[';
+    _this.toString = function () {
+      var s = "";
+      s += "[";
       for (var i = 0; i < _bytes.length; i += 1) {
         if (i > 0) {
-          s += ',';
+          s += ",";
         }
         s += _bytes[i];
       }
-      s += ']';
+      s += "]";
       return s;
     };
 
@@ -1876,20 +1877,19 @@ var qrcode = function() {
   // base64EncodeOutputStream
   //---------------------------------------------------------------------
 
-  var base64EncodeOutputStream = function() {
-
+  var base64EncodeOutputStream = function () {
     var _buffer = 0;
     var _buflen = 0;
     var _length = 0;
-    var _base64 = '';
+    var _base64 = "";
 
     var _this = {};
 
-    var writeEncoded = function(b) {
-      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    var writeEncoded = function (b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f));
     };
 
-    var encode = function(n) {
+    var encode = function (n) {
       if (n < 0) {
         // error.
       } else if (n < 26) {
@@ -1903,39 +1903,37 @@ var qrcode = function() {
       } else if (n == 63) {
         return 0x2f;
       }
-      throw 'n:' + n;
+      throw "n:" + n;
     };
 
-    _this.writeByte = function(n) {
-
+    _this.writeByte = function (n) {
       _buffer = (_buffer << 8) | (n & 0xff);
       _buflen += 8;
       _length += 1;
 
       while (_buflen >= 6) {
-        writeEncoded(_buffer >>> (_buflen - 6) );
+        writeEncoded(_buffer >>> (_buflen - 6));
         _buflen -= 6;
       }
     };
 
-    _this.flush = function() {
-
+    _this.flush = function () {
       if (_buflen > 0) {
-        writeEncoded(_buffer << (6 - _buflen) );
+        writeEncoded(_buffer << (6 - _buflen));
         _buffer = 0;
         _buflen = 0;
       }
 
       if (_length % 3 != 0) {
         // padding
-        var padlen = 3 - _length % 3;
+        var padlen = 3 - (_length % 3);
         for (var i = 0; i < padlen; i += 1) {
-          _base64 += '=';
+          _base64 += "=";
         }
       }
     };
 
-    _this.toString = function() {
+    _this.toString = function () {
       return _base64;
     };
 
@@ -1946,8 +1944,7 @@ var qrcode = function() {
   // base64DecodeInputStream
   //---------------------------------------------------------------------
 
-  var base64DecodeInputStream = function(str) {
-
+  var base64DecodeInputStream = function (str) {
     var _str = str;
     var _pos = 0;
     var _buffer = 0;
@@ -1955,38 +1952,36 @@ var qrcode = function() {
 
     var _this = {};
 
-    _this.read = function() {
-
+    _this.read = function () {
       while (_buflen < 8) {
-
         if (_pos >= _str.length) {
           if (_buflen == 0) {
             return -1;
           }
-          throw 'unexpected end of file./' + _buflen;
+          throw "unexpected end of file./" + _buflen;
         }
 
         var c = _str.charAt(_pos);
         _pos += 1;
 
-        if (c == '=') {
+        if (c == "=") {
           _buflen = 0;
           return -1;
-        } else if (c.match(/^\s$/) ) {
+        } else if (c.match(/^\s$/)) {
           // ignore if whitespace.
           continue;
         }
 
-        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0));
         _buflen += 6;
       }
 
-      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      var n = (_buffer >>> (_buflen - 8)) & 0xff;
       _buflen -= 8;
       return n;
     };
 
-    var decode = function(c) {
+    var decode = function (c) {
       if (0x41 <= c && c <= 0x5a) {
         return c - 0x41;
       } else if (0x61 <= c && c <= 0x7a) {
@@ -1998,7 +1993,7 @@ var qrcode = function() {
       } else if (c == 0x2f) {
         return 63;
       } else {
-        throw 'c:' + c;
+        throw "c:" + c;
       }
     };
 
@@ -2009,24 +2004,22 @@ var qrcode = function() {
   // gifImage (B/W)
   //---------------------------------------------------------------------
 
-  var gifImage = function(width, height) {
-
+  var gifImage = function (width, height) {
     var _width = width;
     var _height = height;
     var _data = new Array(width * height);
 
     var _this = {};
 
-    _this.setPixel = function(x, y, pixel) {
+    _this.setPixel = function (x, y, pixel) {
       _data[y * _width + x] = pixel;
     };
 
-    _this.write = function(out) {
-
+    _this.write = function (out) {
       //---------------------------------
       // GIF Signature
 
-      out.writeString('GIF87a');
+      out.writeString("GIF87a");
 
       //---------------------------------
       // Screen Descriptor
@@ -2054,7 +2047,7 @@ var qrcode = function() {
       //---------------------------------
       // Image Descriptor
 
-      out.writeString(',');
+      out.writeString(",");
       out.writeShort(0);
       out.writeShort(0);
       out.writeShort(_width);
@@ -2086,27 +2079,25 @@ var qrcode = function() {
 
       //---------------------------------
       // GIF Terminator
-      out.writeString(';');
+      out.writeString(";");
     };
 
-    var bitOutputStream = function(out) {
-
+    var bitOutputStream = function (out) {
       var _out = out;
       var _bitLength = 0;
       var _bitBuffer = 0;
 
       var _this = {};
 
-      _this.write = function(data, length) {
-
-        if ( (data >>> length) != 0) {
-          throw 'length over';
+      _this.write = function (data, length) {
+        if (data >>> length != 0) {
+          throw "length over";
         }
 
         while (_bitLength + length >= 8) {
-          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
-          length -= (8 - _bitLength);
-          data >>>= (8 - _bitLength);
+          _out.writeByte(0xff & ((data << _bitLength) | _bitBuffer));
+          length -= 8 - _bitLength;
+          data >>>= 8 - _bitLength;
           _bitBuffer = 0;
           _bitLength = 0;
         }
@@ -2115,7 +2106,7 @@ var qrcode = function() {
         _bitLength = _bitLength + length;
       };
 
-      _this.flush = function() {
+      _this.flush = function () {
         if (_bitLength > 0) {
           _out.writeByte(_bitBuffer);
         }
@@ -2124,8 +2115,7 @@ var qrcode = function() {
       return _this;
     };
 
-    var getLZWRaster = function(lzwMinCodeSize) {
-
+    var getLZWRaster = function (lzwMinCodeSize) {
       var clearCode = 1 << lzwMinCodeSize;
       var endCode = (1 << lzwMinCodeSize) + 1;
       var bitLength = lzwMinCodeSize + 1;
@@ -2134,10 +2124,10 @@ var qrcode = function() {
       var table = lzwTable();
 
       for (var i = 0; i < clearCode; i += 1) {
-        table.add(String.fromCharCode(i) );
+        table.add(String.fromCharCode(i));
       }
-      table.add(String.fromCharCode(clearCode) );
-      table.add(String.fromCharCode(endCode) );
+      table.add(String.fromCharCode(clearCode));
+      table.add(String.fromCharCode(endCode));
 
       var byteOut = byteArrayOutputStream();
       var bitOut = bitOutputStream(byteOut);
@@ -2151,21 +2141,16 @@ var qrcode = function() {
       dataIndex += 1;
 
       while (dataIndex < _data.length) {
-
         var c = String.fromCharCode(_data[dataIndex]);
         dataIndex += 1;
 
-        if (table.contains(s + c) ) {
-
+        if (table.contains(s + c)) {
           s = s + c;
-
         } else {
-
           bitOut.write(table.indexOf(s), bitLength);
 
           if (table.size() < 0xfff) {
-
-            if (table.size() == (1 << bitLength) ) {
+            if (table.size() == 1 << bitLength) {
               bitLength += 1;
             }
 
@@ -2186,31 +2171,30 @@ var qrcode = function() {
       return byteOut.toByteArray();
     };
 
-    var lzwTable = function() {
-
+    var lzwTable = function () {
       var _map = {};
       var _size = 0;
 
       var _this = {};
 
-      _this.add = function(key) {
-        if (_this.contains(key) ) {
-          throw 'dup key:' + key;
+      _this.add = function (key) {
+        if (_this.contains(key)) {
+          throw "dup key:" + key;
         }
         _map[key] = _size;
         _size += 1;
       };
 
-      _this.size = function() {
+      _this.size = function () {
         return _size;
       };
 
-      _this.indexOf = function(key) {
+      _this.indexOf = function (key) {
         return _map[key];
       };
 
-      _this.contains = function(key) {
-        return typeof _map[key] != 'undefined';
+      _this.contains = function (key) {
+        return typeof _map[key] != "undefined";
       };
 
       return _this;
@@ -2219,11 +2203,11 @@ var qrcode = function() {
     return _this;
   };
 
-  var createDataURL = function(width, height, getPixel) {
+  var createDataURL = function (width, height, getPixel) {
     var gif = gifImage(width, height);
     for (var y = 0; y < height; y += 1) {
       for (var x = 0; x < width; x += 1) {
-        gif.setPixel(x, y, getPixel(x, y) );
+        gif.setPixel(x, y, getPixel(x, y));
       }
     }
 
@@ -2237,33 +2221,32 @@ var qrcode = function() {
     }
     base64.flush();
 
-    return 'data:image/gif;base64,' + base64;
+    return "data:image/gif;base64," + base64;
   };
 
   //---------------------------------------------------------------------
   // returns qrcode function.
 
   return qrcode;
-}();
+})();
 
 // multibyte support
-!function() {
-
-  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+!(function () {
+  qrcode.stringToBytesFuncs["UTF-8"] = function (s) {
     // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
     function toUTF8Array(str) {
       var utf8 = [];
-      for (var i=0; i < str.length; i++) {
+      for (var i = 0; i < str.length; i++) {
         var charcode = str.charCodeAt(i);
         if (charcode < 0x80) utf8.push(charcode);
         else if (charcode < 0x800) {
-          utf8.push(0xc0 | (charcode >> 6),
-              0x80 | (charcode & 0x3f));
-        }
-        else if (charcode < 0xd800 || charcode >= 0xe000) {
-          utf8.push(0xe0 | (charcode >> 12),
-              0x80 | ((charcode>>6) & 0x3f),
-              0x80 | (charcode & 0x3f));
+          utf8.push(0xc0 | (charcode >> 6), 0x80 | (charcode & 0x3f));
+        } else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(
+            0xe0 | (charcode >> 12),
+            0x80 | ((charcode >> 6) & 0x3f),
+            0x80 | (charcode & 0x3f),
+          );
         }
         // surrogate pair
         else {
@@ -2271,27 +2254,27 @@ var qrcode = function() {
           // UTF-16 encodes 0x10000-0x10FFFF by
           // subtracting 0x10000 and splitting the
           // 20 bits of 0x0-0xFFFFF into two halves
-          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
-            | (str.charCodeAt(i) & 0x3ff));
-          utf8.push(0xf0 | (charcode >>18),
-              0x80 | ((charcode>>12) & 0x3f),
-              0x80 | ((charcode>>6) & 0x3f),
-              0x80 | (charcode & 0x3f));
+          charcode = 0x10000 + (((charcode & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(
+            0xf0 | (charcode >> 18),
+            0x80 | ((charcode >> 12) & 0x3f),
+            0x80 | ((charcode >> 6) & 0x3f),
+            0x80 | (charcode & 0x3f),
+          );
         }
       }
       return utf8;
     }
     return toUTF8Array(s);
   };
-
-}();
+})();
 
 (function (factory) {
-  if (typeof define === 'function' && define.amd) {
-      define([], factory);
-  } else if (typeof exports === 'object') {
-      module.exports = factory();
+  if (typeof define === "function" && define.amd) {
+    define([], factory);
+  } else if (typeof exports === "object") {
+    module.exports = factory();
   }
-}(function () {
-    return qrcode;
-}));
+})(function () {
+  return qrcode;
+});

--- a/lab/ui/rgui/dev.ts
+++ b/lab/ui/rgui/dev.ts
@@ -52,4 +52,8 @@ Bun.serve({
 });
 
 console.log(`rgui dev  →  http://localhost:${PORT}   (proxying ${AY_API})`);
-console.log(watch ? "  --watch: rebuilding bundle on every request" : "  restart to rebuild (or pass --watch)");
+console.log(
+  watch
+    ? "  --watch: rebuilding bundle on every request"
+    : "  restart to rebuild (or pass --watch)",
+);

--- a/lab/ui/rgui/index.html
+++ b/lab/ui/rgui/index.html
@@ -121,7 +121,11 @@
         border: 1px solid var(--border);
         border-radius: 4px;
         color: var(--text);
-        font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        font:
+          11px/1.5 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
         white-space: pre;
         pointer-events: none;
         user-select: none;
@@ -145,7 +149,11 @@
         border: 1px solid var(--border);
         border-radius: 4px;
         color: var(--text);
-        font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        font:
+          11px/1.5 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
         white-space: pre;
         pointer-events: none;
         user-select: none;
@@ -374,7 +382,11 @@
         padding: 14px 16px;
         background: transparent;
         color: var(--text);
-        font: 15px ui-monospace, SFMono-Regular, Menlo, monospace;
+        font:
+          15px ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
         border-bottom: 1px solid var(--border);
       }
       #cmdk-input::placeholder {
@@ -491,7 +503,11 @@
         min-height: 44px;
         background: transparent;
         color: var(--text);
-        font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        font:
+          13px/1.4 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          monospace;
       }
       #ctxmenu textarea::placeholder {
         color: var(--text-muted);
@@ -576,7 +592,9 @@
       <span id="status"><span class="dot"></span><span class="label">connecting…</span></span>
       <button id="fit" title="Fit all agents to view">fit</button>
       <button id="wires" title="Toggle read/tail relationship wires">⇢ wires</button>
-      <button id="console" title="Open the terminal console view (/w/) for this fleet">☰ console</button>
+      <button id="console" title="Open the terminal console view (/w/) for this fleet">
+        ☰ console
+      </button>
       <button id="theme" title="Toggle light/dark">◐</button>
     </div>
 
@@ -631,7 +649,10 @@
         </div>
       </div>
     </div>
-    <div id="hint">⌘K = go to agent · drag = select · right-click = batch send · scroll = zoom · shift+drag corner = magnify</div>
+    <div id="hint">
+      ⌘K = go to agent · drag = select · right-click = batch send · scroll = zoom · shift+drag
+      corner = magnify
+    </div>
 
     <!-- xterm.js — SAME versions the console (agent-yes.com/w) uses, so each
          node's live terminal renders the raw PTY stream identically. -->

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -107,12 +107,20 @@ function hostEnvFields(src: string): [string, string][] {
   }
   fields.push(["agents", `${live.length} live${stuck ? ` · ⚠ ${stuck} stuck` : ""}`]);
   if (h.caps) {
-    const on = Object.entries(h.caps).filter(([, v]) => v).map(([k]) => k);
+    const on = Object.entries(h.caps)
+      .filter(([, v]) => v)
+      .map(([k]) => k);
     if (on.length) fields.push(["caps", on.join(" · ")]);
   }
   const exposed = exposedBySrc.get(src) ?? [];
   if (exposed.length) {
-    fields.push(["⇄ exposed", exposed.map((e) => e.port).sort((a, b) => a - b).join(" · ")]);
+    fields.push([
+      "⇄ exposed",
+      exposed
+        .map((e) => e.port)
+        .sort((a, b) => a - b)
+        .join(" · "),
+    ]);
   }
   return fields;
 }
@@ -158,11 +166,7 @@ function resolveRoom(hash: string): { room: string; token: string; host: string 
   const p = parseRoomHash(hash) as { room: string; token: string; host: string } | null;
   if (p) {
     saveRoom(p.room, p.token, p.host);
-    history.replaceState(
-      null,
-      document.title,
-      location.pathname + location.search + "#" + p.room,
-    );
+    history.replaceState(null, document.title, location.pathname + location.search + "#" + p.room);
     return p;
   }
   // #<room> or #<room>:<pid> — token-less forms; reconnect from the cache.
@@ -206,7 +210,9 @@ const embedPid =
   null;
 const embedMode = !!embedPid && hashParts.some((s) => s === "embed" || s.startsWith("embed="));
 const withTok = (path: string) =>
-  httpToken ? `${path}${path.includes("?") ? "&" : "?"}token=${encodeURIComponent(httpToken)}` : path;
+  httpToken
+    ? `${path}${path.includes("?") ? "&" : "?"}token=${encodeURIComponent(httpToken)}`
+    : path;
 
 // ── wires: one transport per source, console-compatible ids ─────────────────
 // "local" (same-origin HTTP) + one RTC client per known room. Mirrors the
@@ -280,7 +286,11 @@ function localhostPort(uri: string): number | null {
 // Ask, then publish 127.0.0.1:<port> on the clicked node's machine through
 // agent-yes.com and open the one-time claim link (sets the 8h cookie).
 async function exposeFromRgui(port: number, src: string): Promise<void> {
-  if (!confirm(`Expose localhost:${port} on agent-yes.com?\n\nA private link tunnels to this port on the agent's machine. Only someone with the one-time claim link (opens now) can reach it. Revoke from the /w/ console's ports manager.`))
+  if (
+    !confirm(
+      `Expose localhost:${port} on agent-yes.com?\n\nA private link tunnels to this port on the agent's machine. Only someone with the one-time claim link (opens now) can reach it. Revoke from the /w/ console's ports manager.`,
+    )
+  )
     return;
   const r = await apiPost("/api/expose", { port }, src);
   let info: ExposureInfo & { claim?: string };
@@ -435,7 +445,8 @@ function portsOf(r: AgentRecord): { inputs: Port[]; outputs: Port[] } {
   // state (stable hashed color); the label (shown zoomed in) is the state text.
   const outputs: Port[] = [{ id: "status", label: r.status, kind: r.status }];
   if (r.question) outputs.push({ id: "ask", label: "needs input", kind: "ctl" });
-  if (branch) outputs.push({ id: "result", label: (r.git?.dirty ? "±" : "") + branch, kind: "text" });
+  if (branch)
+    outputs.push({ id: "result", label: (r.git?.dirty ? "±" : "") + branch, kind: "text" });
   return { inputs, outputs };
 }
 
@@ -750,14 +761,53 @@ function sampleRecords(): AgentRecord[] {
     ...extra,
   });
   return [
-    mk(1001, "claude", "active", "~/ws/acme/agent-yes/tree/rgui", "rgui", "impl /rgui + ship to pages", { wrapper_pid: 1001 }),
-    mk(1002, "claude", "idle", "~/ws/acme/rgui/tree/main", "main", "rgui heavy dev — org-chart containers", { wrapper_pid: 1002 }),
+    mk(
+      1001,
+      "claude",
+      "active",
+      "~/ws/acme/agent-yes/tree/rgui",
+      "rgui",
+      "impl /rgui + ship to pages",
+      { wrapper_pid: 1001 },
+    ),
+    mk(
+      1002,
+      "claude",
+      "idle",
+      "~/ws/acme/rgui/tree/main",
+      "main",
+      "rgui heavy dev — org-chart containers",
+      { wrapper_pid: 1002 },
+    ),
     // a parent agent (wrapper 1003) with two subagents nested inside it
-    mk(1003, "claude", "active", "~/ws/acme/api/tree/main", "chore/pin-bump", "goal: pin bump wave", { wrapper_pid: 1003 }),
-    mk(1004, "claude", "idle", "~/ws/acme/api/tree/proxy", "proxy", "proxy work", { wrapper_pid: 1004, parent_pid: 1003 }),
-    mk(1005, "claude", "needs_input", "~/ws/acme/api/tree/main/lib/edge", "feat/force-h1", "force h1 land — awaiting review", { wrapper_pid: 1005, parent_pid: 1003, question: "Proceed with merge?" }),
-    mk(1006, "claude", "idle", "~/ws/acme/tools/tree/main", "main", "tooling", { wrapper_pid: 1006 }),
-    mk(1007, "claude", "stuck", "~/ws/acme/web/tree/main", "main", "resume web build", { wrapper_pid: 1007 }),
+    mk(
+      1003,
+      "claude",
+      "active",
+      "~/ws/acme/api/tree/main",
+      "chore/pin-bump",
+      "goal: pin bump wave",
+      { wrapper_pid: 1003 },
+    ),
+    mk(1004, "claude", "idle", "~/ws/acme/api/tree/proxy", "proxy", "proxy work", {
+      wrapper_pid: 1004,
+      parent_pid: 1003,
+    }),
+    mk(
+      1005,
+      "claude",
+      "needs_input",
+      "~/ws/acme/api/tree/main/lib/edge",
+      "feat/force-h1",
+      "force h1 land — awaiting review",
+      { wrapper_pid: 1005, parent_pid: 1003, question: "Proceed with merge?" },
+    ),
+    mk(1006, "claude", "idle", "~/ws/acme/tools/tree/main", "main", "tooling", {
+      wrapper_pid: 1006,
+    }),
+    mk(1007, "claude", "stuck", "~/ws/acme/web/tree/main", "main", "resume web build", {
+      wrapper_pid: 1007,
+    }),
   ];
 }
 
@@ -868,16 +918,34 @@ const XTermCtor = (window as unknown as { Terminal?: new (o: unknown) => Xterm }
 // console's GitHub dark/light terminal palettes (kept legible on a white bg)
 const prefersLight = matchMedia("(prefers-color-scheme: light)");
 function isLight() {
-  return (document.documentElement.dataset.theme ?? (prefersLight.matches ? "light" : "dark")) === "light";
+  return (
+    (document.documentElement.dataset.theme ?? (prefersLight.matches ? "light" : "dark")) ===
+    "light"
+  );
 }
 function termTheme() {
   return isLight()
     ? {
-        background: "#ffffff", foreground: "#1f2328", cursor: "#1f2328",
-        selectionBackground: "#b6d6ff", black: "#24292e", red: "#cf222e", green: "#116329",
-        yellow: "#4d2d00", blue: "#0969da", magenta: "#8250df", cyan: "#1b7c83", white: "#6e7781",
-        brightBlack: "#57606a", brightRed: "#a40e26", brightGreen: "#1a7f37", brightYellow: "#633c01",
-        brightBlue: "#218bff", brightMagenta: "#a475f9", brightCyan: "#3192aa", brightWhite: "#1f2328",
+        background: "#ffffff",
+        foreground: "#1f2328",
+        cursor: "#1f2328",
+        selectionBackground: "#b6d6ff",
+        black: "#24292e",
+        red: "#cf222e",
+        green: "#116329",
+        yellow: "#4d2d00",
+        blue: "#0969da",
+        magenta: "#8250df",
+        cyan: "#1b7c83",
+        white: "#6e7781",
+        brightBlack: "#57606a",
+        brightRed: "#a40e26",
+        brightGreen: "#1a7f37",
+        brightYellow: "#633c01",
+        brightBlue: "#218bff",
+        brightMagenta: "#a475f9",
+        brightCyan: "#3192aa",
+        brightWhite: "#1f2328",
       }
     : { background: "#0d1117", foreground: "#c9d1d9", cursor: "#0d1117" };
 }
@@ -996,8 +1064,11 @@ function makeTerm(pid: string): TermEntry | null {
   }
   // Clickable URLs. A localhost link offers to publish through agent-yes.com on
   // THIS node's machine (src); any other URL just opens in a new tab.
-  const WebLinks = (window as unknown as { WebLinksAddon?: { WebLinksAddon: new (h: (e: MouseEvent, uri: string) => void) => unknown } })
-    .WebLinksAddon?.WebLinksAddon;
+  const WebLinks = (
+    window as unknown as {
+      WebLinksAddon?: { WebLinksAddon: new (h: (e: MouseEvent, uri: string) => void) => unknown };
+    }
+  ).WebLinksAddon?.WebLinksAddon;
   if (WebLinks) {
     try {
       (term as unknown as { loadAddon(a: unknown): void }).loadAddon(
@@ -1348,10 +1419,11 @@ function syncTerminals(view: { x: number; y: number; k: number }) {
   cand.sort((a, b) => b.area - a.area);
   const wanted = new Set(cand.slice(0, MAX_TERMS).map((c) => c.id));
 
-  for (const id of wanted) if (!terms.has(id)) {
-    const e = makeTerm(id);
-    if (e) terms.set(id, e);
-  }
+  for (const id of wanted)
+    if (!terms.has(id)) {
+      const e = makeTerm(id);
+      if (e) terms.set(id, e);
+    }
   for (const [id, e] of terms) {
     if (wanted.has(id)) e.miss = 0;
     else if (++e.miss >= TERM_DROP_TICKS) dropTerm(id);
@@ -1468,7 +1540,8 @@ function updateSysPanel(records: AgentRecord[], live: boolean) {
   // value column and clips the label so it never runs under the number).
   const items: PanelItem[] = [];
   // Active graph filter chip (⌘K "/filter …") — click clears it (onItemClick).
-  if (rguiFilter) items.push({ id: "filter", label: `⌕ ${rguiFilter}`, value: "✕", color: "#d29922" });
+  if (rguiFilter)
+    items.push({ id: "filter", label: `⌕ ${rguiFilter}`, value: "✕", color: "#d29922" });
   for (const [st, label] of STATUS_ROWS) {
     const n = counts.get(st) ?? 0;
     if (n) items.push({ id: st, label, value: String(n), color: DOT_COLOR[st] });
@@ -1811,7 +1884,9 @@ function mergeFederated(local: Graph): Graph {
     // land when the authoritative feed provides the real node — so a hostile
     // feed can't paint content as somebody else's agent.
     const ns = entry.ns;
-    const g = ns ? { ...entry.g, nodes: entry.g.nodes.filter((n) => n.id.startsWith(ns)) } : entry.g;
+    const g = ns
+      ? { ...entry.g, nodes: entry.g.nodes.filter((n) => n.id.startsWith(ns)) }
+      : entry.g;
     if (!g.nodes.length) continue;
     const minX = Math.min(...g.nodes.map((n) => n.x));
     const minY = Math.min(...g.nodes.map((n) => n.y));
@@ -1871,7 +1946,10 @@ if (fedDemo) {
   // diff → filter → translate → tts) from rgui itself, no feed server needed
   // the baked demo chain intentionally spans all three namespaces — it ships in
   // the bundle (rgui source), not from a network feed, so it merges unenforced
-  fedGraphs.set("demo", { g: federatedGraphToRgui(federatedDemoChain(), { container: true }), ns: null });
+  fedGraphs.set("demo", {
+    g: federatedGraphToRgui(federatedDemoChain(), { container: true }),
+    ns: null,
+  });
 }
 if (fedFeeds.length) {
   void pollFeeds();
@@ -2299,7 +2377,9 @@ addEventListener("hashchange", () => location.reload());
 if (location.hash.startsWith("#qa")) {
   setTimeout(() => {
     const parents = new Set(viewer.graph.nodes.map((n) => n.parent).filter(Boolean));
-    const leaf = viewer.graph.nodes.filter((n) => !parents.has(n.id) && !n.id.startsWith("repo:"))[6];
+    const leaf = viewer.graph.nodes.filter(
+      (n) => !parents.has(n.id) && !n.id.startsWith("repo:"),
+    )[6];
     if (!leaf) return;
     const cx = leaf.x + leaf.w / 2;
     const cy = leaf.y + (leaf.h ?? CARD_H) / 2;
@@ -2321,11 +2401,15 @@ if (location.hash.startsWith("#qa")) {
             xtermMutWhileMoving++;
             const el = (t.nodeType === 3 ? t.parentElement : t) as Element;
             if (mutSample.size < 8)
-              mutSample.add(`${m.type}:${el?.tagName?.toLowerCase()}.${(el?.className || "").toString().slice(0, 24)}`);
+              mutSample.add(
+                `${m.type}:${el?.tagName?.toLowerCase()}.${(el?.className || "").toString().slice(0, 24)}`,
+              );
           }
         } else if (m.type === "childList") {
-          for (const n of m.addedNodes) if ((n as Element).classList?.contains("ay-term")) termChurn++;
-          for (const n of m.removedNodes) if ((n as Element).classList?.contains("ay-term")) termChurn++;
+          for (const n of m.addedNodes)
+            if ((n as Element).classList?.contains("ay-term")) termChurn++;
+          for (const n of m.removedNodes)
+            if ((n as Element).classList?.contains("ay-term")) termChurn++;
         } else if (m.type === "attributes" && m.attributeName === "style") {
           const el = m.target as HTMLElement;
           const d = el.style.display;
@@ -2590,8 +2674,10 @@ addEventListener("keydown", (e) => {
   }
   if (cmdk.hidden) return;
   if (e.key === "Escape") (e.preventDefault(), cmdkClose());
-  else if (e.key === "ArrowDown") (e.preventDefault(), (cmdkSel = Math.min(cmdkRows.length - 1, cmdkSel + 1)), cmdkRender());
-  else if (e.key === "ArrowUp") (e.preventDefault(), (cmdkSel = Math.max(0, cmdkSel - 1)), cmdkRender());
+  else if (e.key === "ArrowDown")
+    (e.preventDefault(), (cmdkSel = Math.min(cmdkRows.length - 1, cmdkSel + 1)), cmdkRender());
+  else if (e.key === "ArrowUp")
+    (e.preventDefault(), (cmdkSel = Math.max(0, cmdkSel - 1)), cmdkRender());
   else if (e.key === "Enter") (e.preventDefault(), cmdkGo(e.metaKey || e.ctrlKey));
 });
 cmdkInput.addEventListener("input", () => ((cmdkSel = 0), cmdkRender()));
@@ -2639,7 +2725,11 @@ function spawnSpecOf(id: string): { src: string; cwd: string | null; cli: string
   const cliOf = (keys: string[]) => recordsByKey.get(keys[0] ?? "")?.cli ?? "claude";
   if (id.startsWith("env:")) {
     const src = id.slice(4);
-    return { src, cwd: null, cli: cliOf([...recordsByKey.values()].filter((r) => r._src === src).map((r) => r._key)) };
+    return {
+      src,
+      cwd: null,
+      cli: cliOf([...recordsByKey.values()].filter((r) => r._src === src).map((r) => r._key)),
+    };
   }
   if (id.startsWith("cwd:") || id.startsWith("repo:")) {
     const rest = id.slice(id.indexOf(":") + 1);
@@ -2781,9 +2871,13 @@ async function fetchShares() {
   // shares are minted per daemon — collect active ones from every live wire so
   // the outbound halo shows no matter which machine the shared agent runs on
   const results = await Promise.allSettled(
-    [...wires.values()].filter(wireReady).map((w) => apiJSON<{ agentId: string }[]>("/api/shares", w.id)),
+    [...wires.values()]
+      .filter(wireReady)
+      .map((w) => apiJSON<{ agentId: string }[]>("/api/shares", w.id)),
   );
-  const ids = results.flatMap((p) => (p.status === "fulfilled" ? p.value.map((x) => x.agentId) : []));
+  const ids = results.flatMap((p) =>
+    p.status === "fulfilled" ? p.value.map((x) => x.agentId) : [],
+  );
   if (ids.length || sharedIds.size) {
     sharedIds = new Set(ids);
     markShared();

--- a/lab/ui/room-client.js
+++ b/lab/ui/room-client.js
@@ -32,11 +32,9 @@ class SignalingClient {
     this.open();
   }
   onWake = () => {
-    if (this.closed)
-      return;
+    if (this.closed) return;
     const state = this.ws?.readyState;
-    if (state === 1)
-      return;
+    if (state === 1) return;
     if (state === 0) {
       try {
         this.ws?.close();
@@ -92,7 +90,7 @@ class SignalingClient {
         type: "hello",
         role: this.opts.role,
         peerId: this.peerId,
-        ...this.opts.meta ? { meta: this.opts.meta } : {}
+        ...(this.opts.meta ? { meta: this.opts.meta } : {}),
       };
       ws.send(JSON.stringify(hello));
       this.startHeartbeat();
@@ -105,10 +103,8 @@ class SignalingClient {
       } catch {
         return;
       }
-      if (msg.type === "peers")
-        this.opts.onPeers?.(msg.peers, msg.now);
-      else if (msg.type === "signal")
-        this.opts.onSignal?.(msg.from, msg.data);
+      if (msg.type === "peers") this.opts.onPeers?.(msg.peers, msg.now);
+      else if (msg.type === "signal") this.opts.onSignal?.(msg.from, msg.data);
     };
     ws.onclose = (ev) => {
       clearTimeout(connectTimer);
@@ -117,8 +113,7 @@ class SignalingClient {
       const ms = this.openedAt ? Date.now() - this.openedAt : 0;
       this.openedAt = 0;
       this.opts.onClose?.({ code: ev?.code ?? 0, reason: ev?.reason ?? "", ms });
-      if (!this.closed)
-        this.scheduleReconnect();
+      if (!this.closed) this.scheduleReconnect();
     };
     ws.onerror = () => {
       try {
@@ -156,8 +151,7 @@ class SignalingClient {
     this.clearReconnectTimer();
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
-      if (this.closed)
-        return;
+      if (this.closed) return;
       if (this.hidden()) {
         this.dormant = true;
         return;
@@ -196,10 +190,7 @@ class SignalingClient {
 }
 
 // src/shared/rtc.ts
-var ICE_SERVERS = [
-  "stun:stun.l.google.com:19302",
-  "stun:stun1.l.google.com:19302"
-];
+var ICE_SERVERS = ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"];
 var CHANNEL_LABEL = "codehost";
 var BULK_CHANNEL_LABEL = "codehost-bulk";
 
@@ -212,14 +203,14 @@ class RtcClient {
   constructor(opts) {
     this.opts = opts;
     this.pc = new RTCPeerConnection({
-      iceServers: ICE_SERVERS.map((urls) => ({ urls }))
+      iceServers: ICE_SERVERS.map((urls) => ({ urls })),
     });
     this.pc.onicecandidate = (ev) => {
       if (ev.candidate) {
         this.opts.sendSignal({
           kind: "candidate",
           candidate: ev.candidate.candidate,
-          mid: ev.candidate.sdpMid ?? "0"
+          mid: ev.candidate.sdpMid ?? "0",
         });
       }
     };
@@ -242,8 +233,7 @@ class RtcClient {
   }
   async handleSignal(data) {
     const sig = data;
-    if (!sig || typeof sig !== "object")
-      return;
+    if (!sig || typeof sig !== "object") return;
     if (sig.kind === "answer") {
       await this.pc.setRemoteDescription({ type: "answer", sdp: sig.sdp });
     } else if (sig.kind === "candidate") {
@@ -265,29 +255,29 @@ class RtcClient {
       const stats = await this.pc.getStats();
       let pairId = null;
       stats.forEach((s) => {
-        if (s.type === "transport" && s.selectedCandidatePairId)
-          pairId = s.selectedCandidatePairId;
+        if (s.type === "transport" && s.selectedCandidatePairId) pairId = s.selectedCandidatePairId;
       });
       let pair = null;
       stats.forEach((s) => {
-        if (pairId ? s.id === pairId : s.type === "candidate-pair" && s.state === "succeeded" && s.nominated) {
+        if (
+          pairId
+            ? s.id === pairId
+            : s.type === "candidate-pair" && s.state === "succeeded" && s.nominated
+        ) {
           pair = s;
         }
       });
-      if (!pair)
-        return null;
+      if (!pair) return null;
       const { localCandidateId, remoteCandidateId } = pair;
       let lan = true;
       let found = 0;
       stats.forEach((s) => {
         if (s.id === localCandidateId || s.id === remoteCandidateId) {
           found++;
-          if (s.candidateType !== "host")
-            lan = false;
+          if (s.candidateType !== "host") lan = false;
         }
       });
-      if (found < 2)
-        return null;
+      if (found < 2) return null;
       return lan ? "lan" : "p2p";
     } catch {
       return null;
@@ -310,15 +300,14 @@ class RtcClient {
 var FRAME_HEADER = 5;
 var MAX_FRAME = 64 * 1024;
 var MAX_CHUNK = MAX_FRAME - FRAME_HEADER;
-var enc = new TextEncoder;
-var dec = new TextDecoder;
+var enc = new TextEncoder();
+var dec = new TextDecoder();
 function encodeFrame(op, streamId, payload) {
   const len = payload?.byteLength ?? 0;
   const buf = new Uint8Array(5 + len);
   buf[0] = op;
   new DataView(buf.buffer).setUint32(1, streamId >>> 0, false);
-  if (payload && len)
-    buf.set(payload, 5);
+  if (payload && len) buf.set(payload, 5);
   return buf;
 }
 function encodeJson(op, streamId, obj) {
@@ -338,13 +327,12 @@ function payloadText(payload) {
   return dec.decode(payload);
 }
 function* chunk(body) {
-  for (let off = 0;off < body.byteLength; off += MAX_CHUNK) {
+  for (let off = 0; off < body.byteLength; off += MAX_CHUNK) {
     yield body.slice(off, Math.min(off + MAX_CHUNK, body.byteLength));
   }
 }
 function concatBytes(parts) {
-  if (parts.length === 1)
-    return parts[0];
+  if (parts.length === 1) return parts[0];
   const total = parts.reduce((n, p) => n + p.byteLength, 0);
   const out = new Uint8Array(total);
   let off = 0;
@@ -364,18 +352,15 @@ function* wsMessageFrames(terminal, streamId, payload) {
 }
 
 class WsReassembler {
-  pending = new Map;
+  pending = new Map();
   cont(streamId, payload) {
     const buf = this.pending.get(streamId);
-    if (buf)
-      buf.push(payload.slice());
-    else
-      this.pending.set(streamId, [payload.slice()]);
+    if (buf) buf.push(payload.slice());
+    else this.pending.set(streamId, [payload.slice()]);
   }
   finish(streamId, payload) {
     const buf = this.pending.get(streamId);
-    if (!buf)
-      return payload;
+    if (!buf) return payload;
     this.pending.delete(streamId);
     buf.push(payload);
     return concatBytes(buf);
@@ -390,11 +375,11 @@ class TunnelClient {
   transport;
   bulk;
   nextStreamId = 1;
-  https = new Map;
-  httpLane = new Map;
-  wss = new Map;
-  wsRx = new WsReassembler;
-  textEncoder = new TextEncoder;
+  https = new Map();
+  httpLane = new Map();
+  wss = new Map();
+  wsRx = new WsReassembler();
+  textEncoder = new TextEncoder();
   constructor(transport, bulk = null) {
     this.transport = transport;
     this.bulk = bulk;
@@ -405,8 +390,7 @@ class TunnelClient {
   }
   failLane(lane, interactive) {
     for (const [streamId, waiter] of [...this.https]) {
-      if ((this.httpLane.get(streamId) ?? this.transport) !== lane)
-        continue;
+      if ((this.httpLane.get(streamId) ?? this.transport) !== lane) continue;
       this.https.delete(streamId);
       this.httpLane.delete(streamId);
       waiter.onError("tunnel closed");
@@ -421,7 +405,7 @@ class TunnelClient {
   }
   allocId() {
     const id = this.nextStreamId;
-    this.nextStreamId = this.nextStreamId + 1 >>> 0 || 1;
+    this.nextStreamId = (this.nextStreamId + 1) >>> 0 || 1;
     return id;
   }
   onFrame(data) {
@@ -478,9 +462,12 @@ class TunnelClient {
       const stream = new ReadableStream({
         start: (c) => {
           controller = c;
-        }
+        },
       });
-      const reqHeaders = typeof DecompressionStream !== "undefined" ? { ...headers, "x-codehost-accept-gzip": "1" } : headers;
+      const reqHeaders =
+        typeof DecompressionStream !== "undefined"
+          ? { ...headers, "x-codehost-accept-gzip": "1" }
+          : headers;
       this.https.set(streamId, {
         onHead: (h) => {
           head = h;
@@ -491,11 +478,13 @@ class TunnelClient {
             resHeaders.delete("content-encoding");
             resHeaders.delete("content-length");
           }
-          resolve(new Response(bodyStream, {
-            status: h.status === 204 || h.status === 304 ? h.status : h.status,
-            statusText: h.statusText,
-            headers: resHeaders
-          }));
+          resolve(
+            new Response(bodyStream, {
+              status: h.status === 204 || h.status === 304 ? h.status : h.status,
+              statusText: h.statusText,
+              headers: resHeaders,
+            }),
+          );
         },
         onBody: (b) => {
           try {
@@ -506,20 +495,21 @@ class TunnelClient {
           try {
             controller?.close();
           } catch {}
-          if (!head)
-            reject(new Error("stream ended before head"));
+          if (!head) reject(new Error("stream ended before head"));
         },
         onError: (msg) => {
           try {
             controller?.error(new Error(msg));
           } catch {}
-          if (!head)
-            reject(new Error(msg));
-        }
+          if (!head) reject(new Error(msg));
+        },
       });
       const lane = this.bulk?.isOpen() ? this.bulk : this.transport;
       this.httpLane.set(streamId, lane);
-      this.sendOn(lane, encodeJson(1 /* HttpReq */, streamId, { method, path, headers: reqHeaders }));
+      this.sendOn(
+        lane,
+        encodeJson(1 /* HttpReq */, streamId, { method, path, headers: reqHeaders }),
+      );
       if (body && body.byteLength) {
         for (const part of chunk(body))
           this.sendOn(lane, encodeFrame(2 /* HttpReqBody */, streamId, part));
@@ -537,21 +527,19 @@ class TunnelClient {
           this.send(f);
       },
       sendBin: (data) => {
-        for (const f of wsMessageFrames(10 /* WsBin */, streamId, data))
-          this.send(f);
+        for (const f of wsMessageFrames(10 /* WsBin */, streamId, data)) this.send(f);
       },
       close: (code, reason) => {
         this.send(encodeJson(11 /* WsClose */, streamId, { code, reason }));
         this.wss.delete(streamId);
-      }
+      },
     };
   }
   send(frame) {
     this.sendOn(this.transport, frame);
   }
   sendOn(t, frame) {
-    if (t.isOpen())
-      t.send(frame);
+    if (t.isOpen()) t.send(frame);
   }
   get ready() {
     return this.transport.isOpen();
@@ -575,14 +563,13 @@ function rtcDataChannelTransport(channel) {
     },
     onFrame(cb) {
       channel.addEventListener("message", (ev) => {
-        if (typeof ev.data === "string")
-          return;
+        if (typeof ev.data === "string") return;
         cb(new Uint8Array(ev.data));
       });
     },
     onClose(cb) {
       channel.addEventListener("close", cb);
-    }
+    },
   };
 }
 
@@ -600,9 +587,9 @@ var DIAL_FAIL_COOLDOWN_MS = 1e4;
 class CodehostRoom {
   peers = [];
   signaling;
-  rtcs = new Map;
-  tunnels = new Map;
-  dialFailedAt = new Map;
+  rtcs = new Map();
+  tunnels = new Map();
+  dialFailedAt = new Map();
   closed = false;
   constructor(opts) {
     this.signaling = new SignalingClient({
@@ -615,7 +602,7 @@ class CodehostRoom {
         this.peers = peers.filter((p) => p.role === "server");
         opts.onPeers?.(this.peers);
       },
-      onSignal: (from, data) => void this.rtcs.get(from)?.handleSignal(data)
+      onSignal: (from, data) => void this.rtcs.get(from)?.handleSignal(data),
     });
     this.signaling.connect();
   }
@@ -630,8 +617,7 @@ class CodehostRoom {
   }
   dial(peerId) {
     const existing = this.tunnels.get(peerId);
-    if (existing)
-      return existing;
+    if (existing) return existing;
     const failedAt = this.dialFailedAt.get(peerId);
     if (failedAt != null && Date.now() - failedAt < DIAL_FAIL_COOLDOWN_MS) {
       return Promise.reject(new Error("dial failed recently; cooling down"));
@@ -655,9 +641,8 @@ class CodehostRoom {
         },
         onClose: drop,
         onState: (state) => {
-          if (state === "failed" || state === "disconnected")
-            drop();
-        }
+          if (state === "failed" || state === "disconnected") drop();
+        },
       });
       this.rtcs.set(peerId, rtc);
       rtc.start().catch((err) => {
@@ -674,11 +659,9 @@ class CodehostRoom {
     return dialing;
   }
   close() {
-    if (this.closed)
-      return;
+    if (this.closed) return;
     this.closed = true;
-    for (const rtc of this.rtcs.values())
-      rtc.close();
+    for (const rtc of this.rtcs.values()) rtc.close();
     this.rtcs.clear();
     this.tunnels.clear();
     this.signaling.close();
@@ -687,8 +670,4 @@ class CodehostRoom {
 function joinRoom(opts) {
   return new CodehostRoom(opts);
 }
-export {
-  joinRoom,
-  DEFAULT_SIGNAL_URL,
-  CodehostRoom
-};
+export { joinRoom, DEFAULT_SIGNAL_URL, CodehostRoom };

--- a/lab/ui/rtc.js
+++ b/lab/ui/rtc.js
@@ -70,9 +70,7 @@ export class RTCClient {
     this._s = s;
     this._v2 = v2;
     if (!v2 && !ALLOW_LEGACY_PLAINTEXT)
-      throw new Error(
-        "this link uses the old unencrypted protocol — ask the host to upgrade",
-      );
+      throw new Error("this link uses the old unencrypted protocol — ask the host to upgrade");
     const authToken = v2 ? await deriveAuthToken(s, this.room, this.host) : this.token;
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(`wss://${this.host}/${this.room}`, [SUB]);
@@ -172,13 +170,7 @@ export class RTCClient {
       if (!this.dc || this.dc.readyState !== "open" || !this._keyC2H || !this._tHash) return;
       let frame;
       try {
-        frame = await e2eSeal(
-          this._keyC2H,
-          this._send,
-          flags,
-          this._tHash,
-          packEnvelope(obj),
-        );
+        frame = await e2eSeal(this._keyC2H, this._send, flags, this._tHash, packEnvelope(obj));
       } catch {
         this.close();
         return;

--- a/lab/ui/sw.js
+++ b/lab/ui/sw.js
@@ -13,7 +13,9 @@ const CACHE = "agent-yes-w-v3";
 // request to the controlling page (which does), streaming the response back.
 // Scope-relative so it works at both /w/ (agent-yes.com) and / (ay serve --http).
 const BASE = new URL("./", self.location.href).pathname; // "/w/" or "/"
-const PREVIEW = new RegExp("^" + BASE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "p/([^/]+)/(\\d{1,5})(/.*)?$");
+const PREVIEW = new RegExp(
+  "^" + BASE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "p/([^/]+)/(\\d{1,5})(/.*)?$",
+);
 
 async function pickClient() {
   const all = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
@@ -53,8 +55,10 @@ async function proxyPreview(request, src, port, rest, allowInject) {
         mc.port1.onmessage = (e2) => {
           const m2 = e2.data;
           if (m2.type === "body") chunks.push(new Uint8Array(m2.chunk));
-          else if (m2.type === "end") resolve(injectBootstrap(chunks, msg, headers, src, Number(port)));
-          else if (m2.type === "error") resolve(new Response("preview error: " + m2.message, { status: 502 }));
+          else if (m2.type === "end")
+            resolve(injectBootstrap(chunks, msg, headers, src, Number(port)));
+          else if (m2.type === "error")
+            resolve(new Response("preview error: " + m2.message, { status: 502 }));
         };
         return;
       }
@@ -71,7 +75,15 @@ async function proxyPreview(request, src, port, rest, allowInject) {
       resolve(new Response(stream, { status: msg.status, statusText: msg.statusText, headers }));
     };
     client.postMessage(
-      { type: "ay-preview-fetch", src, port: Number(port), method: request.method, path: rest, headers, body },
+      {
+        type: "ay-preview-fetch",
+        src,
+        port: Number(port),
+        method: request.method,
+        path: rest,
+        headers,
+        body,
+      },
       [mc.port2, ...(body ? [body.buffer] : [])],
     );
   });
@@ -99,9 +111,7 @@ function injectBootstrap(chunks, msg, headers, src, port) {
     JSON.stringify(port) +
     ");}catch(e){}})();</" +
     "script>";
-  const html = /<head[^>]*>/i.test(raw)
-    ? raw.replace(/<head[^>]*>/i, (m) => m + boot)
-    : boot + raw;
+  const html = /<head[^>]*>/i.test(raw) ? raw.replace(/<head[^>]*>/i, (m) => m + boot) : boot + raw;
   headers.delete("content-security-policy");
   headers.delete("content-security-policy-report-only");
   headers.delete("content-length");

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "amp-yes": "./dist/amp-yes.js",
     "auggie-yes": "./dist/auggie-yes.js",
     "ay": "./dist/agent-yes.js",
+    "bash-yes": "./dist/bash-yes.js",
     "claude-yes": "./dist/claude-yes.js",
+    "cmd-yes": "./dist/cmd-yes.js",
     "codex-yes": "./dist/codex-yes.js",
     "copilot-yes": "./dist/copilot-yes.js",
     "cursor-yes": "./dist/cursor-yes.js",
@@ -45,10 +47,8 @@
     "openrouter-yes": "./dist/openrouter-yes.js",
     "orcy": "./dist/orcy.js",
     "pi-yes": "./dist/pi-yes.js",
-    "qwen-yes": "./dist/qwen-yes.js",
-    "bash-yes": "./dist/bash-yes.js",
-    "cmd-yes": "./dist/cmd-yes.js",
-    "powershell-yes": "./dist/powershell-yes.js"
+    "powershell-yes": "./dist/powershell-yes.js",
+    "qwen-yes": "./dist/qwen-yes.js"
   },
   "directories": {
     "doc": "docs"
@@ -137,6 +137,7 @@
     "@types/yargs": "^17.0.35",
     "@typescript/native-preview": "^7.0.0-dev.20260124.1",
     "@vitest/coverage-v8": "4.1.0",
+    "codehost": "^0.32.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "node-pty": "^1.1.0",
@@ -150,8 +151,7 @@
     "tsdown": "^0.20.3",
     "vitest": "4.1.0",
     "ws": "^8.20.0",
-    "zod": "^3.23.0",
-    "codehost": "^0.32.0"
+    "zod": "^3.23.0"
   },
   "peerDependencies": {
     "node-pty": "latest",

--- a/scripts/build-rgui.ts
+++ b/scripts/build-rgui.ts
@@ -45,7 +45,9 @@ if (!existsSync(path.join(RGUI_DIR, "node_modules/d3-selection"))) {
   await $`bun install --cwd ${RGUI_DIR}`;
 }
 
-const outdir = process.argv[2] ? path.resolve(process.argv[2]) : path.join(root, "lab/ui/rgui/dist");
+const outdir = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(root, "lab/ui/rgui/dist");
 await mkdir(outdir, { recursive: true });
 
 const result = await Bun.build({

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -330,12 +330,14 @@ describe("console DOM behaviour", () => {
       await page.keyboard.press("Control+k");
       await expect.poll(() => page.locator("#omni").isVisible()).toBe(true);
       await page.fill("#omni-input", "/filter");
-      await expect.poll(() =>
-        page
-          .locator("#omni-results")
-          .innerText()
-          .then((t) => t.toLowerCase().includes("clear list filter")),
-      ).toBe(true);
+      await expect
+        .poll(() =>
+          page
+            .locator("#omni-results")
+            .innerText()
+            .then((t) => t.toLowerCase().includes("clear list filter")),
+        )
+        .toBe(true);
       await page.keyboard.press("Enter");
       await expect.poll(() => page.locator("#q").inputValue()).toBe("");
       expect(await page.evaluate(() => localStorage.getItem("ay.filter"))).toBe("");
@@ -630,10 +632,48 @@ describe("fold subagent trees", () => {
   let url: string;
   let close: () => void;
   const NESTED = [
-    { pid: 201, wrapper_pid: 201, cli: "claude", cwd: "/home/u/ws/o/r/tree/w", title: "root", status: "active", started_at: 1_700_000_000_000 },
-    { pid: 202, wrapper_pid: 202, parent_pid: 201, cli: "claude", cwd: "/home/u/ws/o/r/tree/w/a", title: "sub-a", status: "active", started_at: 1_700_000_000_000, last_active_at: 1_700_000_005_000 },
-    { pid: 203, wrapper_pid: 203, parent_pid: 201, cli: "claude", cwd: "/home/u/ws/o/r/tree/w/b", title: "sub-b", status: "idle", started_at: 1_700_000_000_000, last_active_at: 1_700_000_001_000 },
-    { pid: 204, wrapper_pid: 204, parent_pid: 202, cli: "claude", cwd: "/home/u/ws/o/r/tree/w/a/c", title: "grandchild", status: "active", started_at: 1_700_000_000_000, last_active_at: 1_700_000_003_000 },
+    {
+      pid: 201,
+      wrapper_pid: 201,
+      cli: "claude",
+      cwd: "/home/u/ws/o/r/tree/w",
+      title: "root",
+      status: "active",
+      started_at: 1_700_000_000_000,
+    },
+    {
+      pid: 202,
+      wrapper_pid: 202,
+      parent_pid: 201,
+      cli: "claude",
+      cwd: "/home/u/ws/o/r/tree/w/a",
+      title: "sub-a",
+      status: "active",
+      started_at: 1_700_000_000_000,
+      last_active_at: 1_700_000_005_000,
+    },
+    {
+      pid: 203,
+      wrapper_pid: 203,
+      parent_pid: 201,
+      cli: "claude",
+      cwd: "/home/u/ws/o/r/tree/w/b",
+      title: "sub-b",
+      status: "idle",
+      started_at: 1_700_000_000_000,
+      last_active_at: 1_700_000_001_000,
+    },
+    {
+      pid: 204,
+      wrapper_pid: 204,
+      parent_pid: 202,
+      cli: "claude",
+      cwd: "/home/u/ws/o/r/tree/w/a/c",
+      title: "grandchild",
+      status: "active",
+      started_at: 1_700_000_000_000,
+      last_active_at: 1_700_000_003_000,
+    },
   ];
 
   beforeAll(async () => {
@@ -655,9 +695,9 @@ describe("fold subagent trees", () => {
         .poll(() => page.locator(".row[data-key='local#201'] .subs").innerText())
         .toBe("⊞ 2/3");
       // The recency the badge face omits lives in the tooltip.
-      expect(await page.locator(".row[data-key='local#201'] .subs").getAttribute("title")).toContain(
-        "last active",
-      );
+      expect(
+        await page.locator(".row[data-key='local#201'] .subs").getAttribute("title"),
+      ).toContain("last active");
     } finally {
       await ctx.close();
     }

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -371,9 +371,9 @@ describe("age", () => {
     expect(age(agent({ started_at: now + 10_000 }), now)).toBe("0s");
   });
   it("prefers last_active_at (last stdout) over started_at when present", () => {
-    expect(
-      age(agent({ started_at: now - 3 * 3_600_000, last_active_at: now - 5_000 }), now),
-    ).toBe("5s");
+    expect(age(agent({ started_at: now - 3 * 3_600_000, last_active_at: now - 5_000 }), now)).toBe(
+      "5s",
+    );
   });
   it("falls back to started_at when last_active_at is absent", () => {
     expect(age(agent({ started_at: now - 5 * 60_000, last_active_at: undefined }), now)).toBe("5m");
@@ -561,6 +561,31 @@ describe("badgesFor (status flag chips)", () => {
       "goal-active",
       "some-future-flag",
     ]);
+  });
+
+  it("renders a dynamic footer counter with the captured text as the label", () => {
+    const [chip] = badgesFor({ badges: ["shells:4 shells"] });
+    expect(chip.id).toBe("shells:4 shells");
+    expect(chip.label).toBe("4 shells");
+    expect(chip.title).toContain("4 shells");
+  });
+
+  it("keeps the CLI footer's singular wording", () => {
+    expect(badgesFor({ badges: ["shells:1 shell"] })[0].label).toBe("1 shell");
+    expect(badgesFor({ badges: ["monitors:1 monitor"] })[0].label).toBe("1 monitor");
+  });
+
+  it("renders the PR chip and the background-agents counter", () => {
+    expect(badgesFor({ badges: ["pr:PR #310"] })[0].label).toBe("PR #310");
+    expect(badgesFor({ badges: ["bg-agents:3 agents"] })[0].label).toBe("3 agents");
+  });
+
+  it("falls back to the raw value for an unknown dynamic id", () => {
+    expect(badgesFor({ badges: ["future:stuff"] })[0]).toEqual({
+      id: "future:stuff",
+      label: "future:stuff",
+      title: "future:stuff",
+    });
   });
 });
 
@@ -916,10 +941,7 @@ describe("sortEntries", () => {
   });
 
   it("active mode: falls back to started_at when last_active_at is absent", () => {
-    const list = [
-      a({ _k: "old", started_at: 100 }),
-      a({ _k: "new", started_at: 900 }),
-    ];
+    const list = [a({ _k: "old", started_at: 100 }), a({ _k: "new", started_at: 900 })];
     expect(keys(sortEntries(list, "active"))).toEqual(["new", "old"]);
   });
 

--- a/ts/agentShare.spec.ts
+++ b/ts/agentShare.spec.ts
@@ -147,9 +147,11 @@ describe("scopedFetch — /api/ls/subscribe remove + teardown", () => {
   }
 
   it("forwards removes only for pids it forwarded (sibling removals stay hidden)", async () => {
-    const res = await scopedFetch(SHARED, removalInner(), "r")(
-      new Request("http://ay.local/api/ls/subscribe"),
-    );
+    const res = await scopedFetch(
+      SHARED,
+      removalInner(),
+      "r",
+    )(new Request("http://ay.local/api/ls/subscribe"));
     const events = (await sse(res))
       .split("\n\n")
       .filter((e) => e.startsWith("data:"))

--- a/ts/badges.spec.ts
+++ b/ts/badges.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { badgeDef, BADGE_DEFS, matchBadges, TYPING_BADGE, type BadgeDef } from "./badges.ts";
+import {
+  badgeDef,
+  badgeLabel,
+  BADGE_DEFS,
+  matchBadges,
+  TYPING_BADGE,
+  type BadgeDef,
+} from "./badges.ts";
 
 describe("matchBadges", () => {
   it("matches goal-active when the /goal status line is on screen", () => {
@@ -78,6 +85,61 @@ describe("matchBadges", () => {
   });
 });
 
+describe("dynamic footer counters", () => {
+  // Real footer lines captured from live agents (`ay tail`), singular and plural.
+  it("matches the shell counter and carries the footer text on the wire", () => {
+    expect(
+      matchBadges([
+        "  ⏸ manual mode on · 1 shell · ctrl+t to hide tasks · ← for agents · ↓ to manage",
+      ]),
+    ).toEqual(["shells:1 shell"]);
+    expect(matchBadges(["  ⏸ manual mode on · 4 shells · ↓ to manage"])).toEqual([
+      "shells:4 shells",
+    ]);
+  });
+
+  it("matches the monitor counter", () => {
+    expect(
+      matchBadges(["  ⏸ manual mode on · 3 monitors · esc to interrupt · ↓ to manage"]),
+    ).toEqual(["monitors:3 monitors"]);
+    expect(matchBadges(["  ⏸ manual mode on · 1 monitor · ↓ to manage"])).toEqual([
+      "monitors:1 monitor",
+    ]);
+  });
+
+  it("matches the background-agents counter (← N agents) at end of line", () => {
+    expect(matchBadges(["  ⏸ manual mode on · ? for shortcuts · ← 3 agents"])).toEqual([
+      "bg-agents:3 agents",
+    ]);
+  });
+
+  it("does not light bg-agents on the plain '← for agents' hint (no count)", () => {
+    expect(matchBadges(["  ⏸ manual mode on · ctrl+t to hide tasks · ← for agents"])).toEqual([]);
+  });
+
+  it("matches the PR chip", () => {
+    expect(matchBadges(["  ⏸ manual mode on · PR #310"])).toEqual(["pr:PR #310"]);
+    expect(matchBadges(["  ⏸ manual mode on · PR #229 · esc to interrupt"])).toEqual([
+      "pr:PR #229",
+    ]);
+  });
+
+  it("is anchored to footer chrome — prose mentions don't match", () => {
+    expect(
+      matchBadges([
+        "I opened 4 shells and 2 monitors while checking PR #310 today",
+        "there are 3 agents running",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("can light several counters on one footer line", () => {
+    expect(
+      matchBadges(["  ⏸ manual mode on · 2 shells · 3 monitors · PR #12 · ← 5 agents"]),
+    ).toEqual(["shells:2 shells", "monitors:3 monitors", "bg-agents:5 agents", "pr:PR #12"]);
+  });
+});
+
 describe("badgeDef", () => {
   it("looks up a built-in definition by id", () => {
     expect(badgeDef("goal-active")).toBe(BADGE_DEFS[0]);
@@ -87,9 +149,30 @@ describe("badgeDef", () => {
     expect(badgeDef("does-not-exist")).toBeUndefined();
   });
 
+  it("resolves a dynamic id by the part before the ':'", () => {
+    expect(badgeDef("shells:4 shells")?.id).toBe("shells");
+  });
+
   it("resolves the time-derived typing badge even though it isn't in BADGE_DEFS", () => {
     expect(badgeDef("typing")).toBe(TYPING_BADGE);
     expect(BADGE_DEFS).not.toContain(TYPING_BADGE);
+  });
+});
+
+describe("badgeLabel", () => {
+  it("returns the static label for a plain id", () => {
+    expect(badgeLabel("goal-active")).toBe("goal");
+    expect(badgeLabel("typing")).toBe("typing");
+  });
+
+  it("substitutes the captured footer text into a dynamic label", () => {
+    expect(badgeLabel("shells:1 shell")).toBe("1 shell");
+    expect(badgeLabel("shells:4 shells")).toBe("4 shells");
+    expect(badgeLabel("pr:PR #310")).toBe("PR #310");
+  });
+
+  it("falls back to the raw id for an unknown badge", () => {
+    expect(badgeLabel("some-future-flag")).toBe("some-future-flag");
   });
 });
 

--- a/ts/badges.ts
+++ b/ts/badges.ts
@@ -11,11 +11,20 @@
 export interface BadgeDef {
   /** Stable id, used as the wire value and as the key when re-deriving the label. */
   id: string;
-  /** Short chip text, e.g. "goal". Keep it a couple of characters — the chip is tiny. */
+  /**
+   * Short chip text, e.g. "goal". Keep it a couple of characters — the chip is
+   * tiny. May contain `$1`, replaced with the pattern's first capture group
+   * (see the dynamic footer-counter defs below).
+   */
   label: string;
   /** Tooltip shown on hover, explaining what the badge means. */
   title: string;
-  /** Matched against the tail-rendered screen text (lines joined with \n). */
+  /**
+   * Matched against the tail-rendered screen text (lines joined with \n).
+   * A pattern with a capture group makes the badge DYNAMIC: the wire id
+   * becomes `id:capture` (e.g. "shells:4 shells") and `$1` in label/title is
+   * substituted with the captured text when the chip is rendered.
+   */
   pattern: RegExp;
 }
 
@@ -46,15 +55,55 @@ export const BADGE_DEFS: BadgeDef[] = [
     title: "Waiting for the API — the CLI is auto-retrying on its own backoff (no action needed)",
     pattern: /Waiting for API response[\s\S]{0,40}will retry in \d/i,
   },
+  // ---- Dynamic footer counters -------------------------------------------
+  // claude's status footer lists live counters between "·" separators, e.g.
+  //   ⏸ manual mode on · 1 shell · ctrl+t to hide tasks · ← for agents · ↓ to manage
+  //   ⏸ manual mode on · 3 monitors · esc to interrupt · ↓ to manage
+  //   ⏸ manual mode on · ? for shortcuts · ← 3 agents
+  //   ⏸ manual mode on · PR #310
+  // Each pattern anchors on that chrome (the "· " separator / the "←" arrow),
+  // not the bare phrase, so ordinary conversation text about "4 shells" can't
+  // light the chip. The capture keeps the CLI's own singular/plural wording,
+  // so the chip reads exactly like the footer ("1 shell", "4 shells").
+  {
+    id: "shells",
+    label: "$1",
+    title: "Background shells running in this session ($1 in the CLI footer)",
+    pattern: /· (\d+ shells?)(?= ·|\s*$)/m,
+  },
+  {
+    id: "monitors",
+    label: "$1",
+    title: "Active Monitor watchers in this session ($1 in the CLI footer)",
+    pattern: /· (\d+ monitors?)(?= ·|\s*$)/m,
+  },
+  {
+    id: "bg-agents",
+    label: "$1",
+    title: "Background subagents running in this session ($1 in the CLI footer)",
+    pattern: /← (\d+ agents?)(?= ·|\s*$)/m,
+  },
+  {
+    id: "pr",
+    label: "$1",
+    title: "This session is linked to a GitHub pull request ($1 in the CLI footer)",
+    pattern: /· (PR #\d+)(?= ·|\s*$)/m,
+  },
 ];
 
 /**
  * Which badge ids match the given rendered screen lines. Pure so it's
- * unit-tested without a live PTY/log file.
+ * unit-tested without a live PTY/log file. A def whose pattern captured a
+ * group yields `id:capture` (e.g. "shells:4 shells") so the count travels
+ * with the id over the wire; static defs yield the bare id as before.
  */
 export function matchBadges(lines: string[], defs: BadgeDef[] = BADGE_DEFS): string[] {
   const text = lines.join("\n");
-  return defs.filter((d) => d.pattern.test(text)).map((d) => d.id);
+  return defs.flatMap((d) => {
+    const m = d.pattern.exec(text);
+    if (!m) return [];
+    return [m[1] !== undefined ? `${d.id}:${m[1]}` : d.id];
+  });
 }
 
 /**
@@ -72,5 +121,20 @@ export const TYPING_BADGE: BadgeDef = {
 };
 
 export function badgeDef(id: string, defs: BadgeDef[] = BADGE_DEFS): BadgeDef | undefined {
-  return defs.find((d) => d.id === id) ?? (id === TYPING_BADGE.id ? TYPING_BADGE : undefined);
+  // Dynamic ids carry their captured text after a ":" ("shells:4 shells") —
+  // strip it so the base def resolves.
+  const base = id.includes(":") ? id.slice(0, id.indexOf(":")) : id;
+  return defs.find((d) => d.id === base) ?? (base === TYPING_BADGE.id ? TYPING_BADGE : undefined);
+}
+
+/**
+ * Rendered chip text for a (possibly dynamic) badge id: resolves the def and
+ * substitutes `$1` in its label with the id's captured text. Unknown ids fall
+ * back to the raw id so a newer server's badge never renders blank.
+ */
+export function badgeLabel(id: string, defs: BadgeDef[] = BADGE_DEFS): string {
+  const def = badgeDef(id, defs);
+  if (!def) return id;
+  const arg = id.includes(":") ? id.slice(id.indexOf(":") + 1) : "";
+  return def.label.includes("$1") ? def.label.replace("$1", arg) : def.label;
 }

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -91,10 +91,7 @@ describe("notifyd singleton lock", () => {
     expect(await acquireDaemonLock(() => true)).toBe(true);
     const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
     // Rewrite the owner to a DIFFERENT, "alive" pid to simulate another daemon.
-    await writeFile(
-      daemonLockOwnerPath(),
-      JSON.stringify({ ...owner, pid: owner.pid + 1 }),
-    );
+    await writeFile(daemonLockOwnerPath(), JSON.stringify({ ...owner, pid: owner.pid + 1 }));
     expect(await acquireDaemonLock((pid) => pid === owner.pid + 1)).toBe(false);
   });
 });
@@ -139,10 +136,7 @@ describe("notifyd identity (status/stop safety)", () => {
   it("returns null for an INCOMPLETE owner missing started_at (I1)", async () => {
     await mkdir(daemonLockDir(), { recursive: true });
     // pid alive + fresh ts, but no started_at → identity incomplete, not trusted.
-    await writeFile(
-      daemonLockOwnerPath(),
-      JSON.stringify({ pid: process.pid, ts: Date.now() }),
-    );
+    await writeFile(daemonLockOwnerPath(), JSON.stringify({ pid: process.pid, ts: Date.now() }));
     expect(await daemonStatus()).toBeNull();
   });
 

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -18,17 +18,8 @@
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, rm, stat, writeFile } from "fs/promises";
-import {
-  type ChildObservation,
-  type RouterState,
-  stepRouter,
-} from "./notifyRouter.ts";
-import {
-  type NotifyEvent,
-  daemonLockDir,
-  daemonLockOwnerPath,
-  notifyDir,
-} from "./notifyInbox.ts";
+import { type ChildObservation, type RouterState, stepRouter } from "./notifyRouter.ts";
+import { type NotifyEvent, daemonLockDir, daemonLockOwnerPath, notifyDir } from "./notifyInbox.ts";
 import {
   appendEvent,
   gcInboxes,
@@ -303,7 +294,12 @@ async function writeOwner(): Promise<boolean> {
   try {
     await writeFile(
       tmp,
-      JSON.stringify({ pid: process.pid, started_at: daemonStartedAt, ts: Date.now(), token: daemonToken }),
+      JSON.stringify({
+        pid: process.pid,
+        started_at: daemonStartedAt,
+        ts: Date.now(),
+        token: daemonToken,
+      }),
     );
     await rename(tmp, daemonLockOwnerPath());
     return true;
@@ -321,7 +317,9 @@ async function writeOwner(): Promise<boolean> {
  * mkdir→writeOwner window of another daemon coming up), so two concurrent starts
  * can't both "win". The liveness predicate is injectable for tests.
  */
-export async function acquireDaemonLock(isAlive: (pid: number) => boolean = isPidAlive): Promise<boolean> {
+export async function acquireDaemonLock(
+  isAlive: (pid: number) => boolean = isPidAlive,
+): Promise<boolean> {
   // The lock dir lives under notify/ — ensure that exists first, else mkdir of
   // the lock throws ENOENT which must NOT be mistaken for "someone holds it".
   await mkdir(notifyDir(), { recursive: true }).catch(() => {});
@@ -414,20 +412,23 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   // tick — many watched children, slow log I/O — can't let the heartbeat cross
   // OWNER_TTL and have another `watch` steal the lock as "stale" → double daemon.
   // Refresh well inside the TTL; cleared on shutdown.
-  const ownerBeat = setInterval(() => {
-    void (async () => {
-      // Refresh ONLY while the owner still carries OUR token. Any other value — a
-      // different token (superseded) OR null/absent (a new daemon's mkdir→write
-      // window) — means we no longer own it, so stop rather than clobber an
-      // unknown/absent owner. Atomic writeOwner means a null read is never our own
-      // write in flight.
-      if ((await readDaemonOwnerToken()) !== daemonToken) {
-        clearInterval(ownerBeat);
-        return;
-      }
-      await writeOwner();
-    })();
-  }, Math.max(1000, Math.floor(OWNER_TTL_MS / 3)));
+  const ownerBeat = setInterval(
+    () => {
+      void (async () => {
+        // Refresh ONLY while the owner still carries OUR token. Any other value — a
+        // different token (superseded) OR null/absent (a new daemon's mkdir→write
+        // window) — means we no longer own it, so stop rather than clobber an
+        // unknown/absent owner. Atomic writeOwner means a null read is never our own
+        // write in flight.
+        if ((await readDaemonOwnerToken()) !== daemonToken) {
+          clearInterval(ownerBeat);
+          return;
+        }
+        await writeOwner();
+      })();
+    },
+    Math.max(1000, Math.floor(OWNER_TTL_MS / 3)),
+  );
   if (typeof ownerBeat.unref === "function") ownerBeat.unref();
   const cleanup = async () => {
     running = false;
@@ -443,11 +444,7 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   // Seed the router from prior inbox state — scoped to currently-watched parents
   // and guarded against pid reuse by the current registry snapshot.
   const watchedAtStart = new Set((await liveWatchers()).keys());
-  let prev = await reconcileFromInboxes(
-    host,
-    await liveChildrenSnapshot(),
-    watchedAtStart,
-  );
+  let prev = await reconcileFromInboxes(host, await liveChildrenSnapshot(), watchedAtStart);
   let ticks = 0;
   let emptySince: number | null = null;
   // Durable across ticks: edges whose append failed, retried until they land.
@@ -556,7 +553,9 @@ async function tickState(
       pendingRetry.set(retryKey(stored), stored);
       logger.warn(`[notifyd] append failed for parent ${stored.parent_pid} — queued for retry`);
     } else {
-      logger.warn(`[notifyd] retry queue full (${RETRY_CAP}) — dropping edge for parent ${stored.parent_pid}`);
+      logger.warn(
+        `[notifyd] retry queue full (${RETRY_CAP}) — dropping edge for parent ${stored.parent_pid}`,
+      );
     }
   }
   return { next, watcherCount };

--- a/ts/notifyInbox.spec.ts
+++ b/ts/notifyInbox.spec.ts
@@ -58,7 +58,8 @@ describe("notifyInbox — NDJSON round-trip + torn-line tolerance", () => {
   });
 
   it("skips a torn final line from a mid-append writer", () => {
-    const text = serializeEvent(ev({ seq: 1 })) + "\n" + serializeEvent(ev({ seq: 2 })) + "\n{ \"seq\": 3, \"ed";
+    const text =
+      serializeEvent(ev({ seq: 1 })) + "\n" + serializeEvent(ev({ seq: 2 })) + '\n{ "seq": 3, "ed';
     const got = parseInboxText(text);
     expect(got.map((e) => e.seq)).toEqual([1, 2]);
   });

--- a/ts/notifyRouter.spec.ts
+++ b/ts/notifyRouter.spec.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { classifyNeedsInput } from "./needsInput.ts";
-import {
-  type ChildObservation,
-  type RouterState,
-  stepRouter,
-} from "./notifyRouter.ts";
+import { type ChildObservation, type RouterState, stepRouter } from "./notifyRouter.ts";
 
 // Mirror the claude `needsInput`/`working` config (rs/default.config.yaml): the
 // menu cursor sits on a NUMBERED option, and a spinner marker means "working".
@@ -75,7 +71,11 @@ describe("notifyRouter — idle hysteresis (P1)", () => {
 
 describe("notifyRouter — needs_input", () => {
   it("emits immediately on entering needs_input, with the question", () => {
-    const r = step(new Map(), [child({ state: "needs_input", question: "Approve? 1.Yes 2.No" })], 0);
+    const r = step(
+      new Map(),
+      [child({ state: "needs_input", question: "Approve? 1.Yes 2.No" })],
+      0,
+    );
     expect(r.events).toHaveLength(1);
     expect(r.events[0]!.edge).toBe("needs_input");
     expect(r.events[0]!.question).toBe("Approve? 1.Yes 2.No");
@@ -167,11 +167,7 @@ describe("notifyRouter — idle-prompt fixture (P1 regression)", () => {
   });
 
   it("an ACTIVE menu (cursor on a number) still classifies as needs_input", () => {
-    const activeMenu = [
-      "  Do you want to proceed?",
-      "❯ 1. Yes",
-      "  2. No, keep planning",
-    ];
+    const activeMenu = ["  Do you want to proceed?", "❯ 1. Yes", "  2. No, keep planning"];
     expect(classifyNeedsInput(activeMenu, CFG)).not.toBeNull();
   });
 

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -176,7 +176,10 @@ describe("notifyStore (fs)", () => {
     await mkdir(inboxDir(host), { recursive: true });
     // Simulate a crash between "reserve seq 5" and "append line": the counter
     // says 5, but the inbox only has 1..3 (4 and 5 are reserved gaps).
-    await writeFile(inboxPath(host, 700), [1, 2, 3].map((s) => JSON.stringify(baseEvent("idle", { seq: s }))).join("\n") + "\n");
+    await writeFile(
+      inboxPath(host, 700),
+      [1, 2, 3].map((s) => JSON.stringify(baseEvent("idle", { seq: s }))).join("\n") + "\n",
+    );
     await writeFile(seqPath(host, 700), "5");
     const next = await appendEvent(700, baseEvent("idle"));
     expect(next).toBe(6); // continues past the reserved gap, never reuses 4 or 5

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -138,10 +138,7 @@ async function atomicWrite(file: string, data: string): Promise<boolean> {
  * deliberately NO wall-clock backstop: elapsed wait time alone never steals, so a
  * live holder is inviolable.
  */
-export async function acquireLock(
-  lockDir: string,
-  staleMs = 30_000,
-): Promise<() => Promise<void>> {
+export async function acquireLock(lockDir: string, staleMs = 30_000): Promise<() => Promise<void>> {
   const ownerFile = path.join(lockDir, "owner");
   // A fencing token unique to THIS acquisition. Everything we do to the lock is
   // gated on the owner file still carrying our token — so if we were stale-stolen
@@ -194,15 +191,18 @@ export async function acquireLock(
       // window) — means we no longer own it, so we stop rather than clobber an
       // unknown/absent owner. Atomic writes above mean a null read is never just
       // our own write in flight. Refresh well inside staleMs; cleared on release.
-      const beat = setInterval(() => {
-        void (async () => {
-          if ((await readOwnerToken()) !== token) {
-            clearInterval(beat);
-            return;
-          }
-          await stampOwner();
-        })();
-      }, Math.max(500, Math.floor(staleMs / 3)));
+      const beat = setInterval(
+        () => {
+          void (async () => {
+            if ((await readOwnerToken()) !== token) {
+              clearInterval(beat);
+              return;
+            }
+            await stampOwner();
+          })();
+        },
+        Math.max(500, Math.floor(staleMs / 3)),
+      );
       if (typeof beat.unref === "function") beat.unref();
       return async () => {
         clearInterval(beat);
@@ -296,7 +296,11 @@ export async function listInboxParents(host: string): Promise<number[]> {
   return pids;
 }
 
-export async function getCursor(host: string, parentPid: number, consumer = "parent"): Promise<number> {
+export async function getCursor(
+  host: string,
+  parentPid: number,
+  consumer = "parent",
+): Promise<number> {
   const text = await readFile(cursorPath(host, parentPid, consumer), "utf8").catch(() => null);
   return parseCursor(text).seq;
 }

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -45,9 +45,9 @@ describe("isNoNodeExecError", () => {
   });
 
   it("matches Windows cmd output", () => {
-    expect(
-      isNoNodeExecError("'node' is not recognized as an internal or external command"),
-    ).toBe(true);
+    expect(isNoNodeExecError("'node' is not recognized as an internal or external command")).toBe(
+      true,
+    );
   });
 
   it("matches localized-then-normalized output (probe pins LC_ALL=C)", () => {
@@ -58,9 +58,7 @@ describe("isNoNodeExecError", () => {
 
   it("does not match a real native/glibc failure", () => {
     expect(
-      isNoNodeExecError(
-        "oxmgr: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found",
-      ),
+      isNoNodeExecError("oxmgr: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found"),
     ).toBe(false);
     expect(isNoNodeExecError("")).toBe(false);
   });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -3,7 +3,18 @@ import { existsSync, renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createHash, randomBytes, timingSafeEqual } from "crypto";
-import { arch, cpus, freemem, homedir, hostname, loadavg, platform, totalmem, uptime, userInfo } from "os";
+import {
+  arch,
+  cpus,
+  freemem,
+  homedir,
+  hostname,
+  loadavg,
+  platform,
+  totalmem,
+  uptime,
+  userInfo,
+} from "os";
 import path from "path";
 import yargs from "yargs";
 import {
@@ -400,9 +411,7 @@ function resolveDaemonManager(): DaemonManager | null {
 //   - npm: `npm prefix -g` prints the prefix; the bin lives at <prefix>/bin.
 async function globalBinDir(installer: string[]): Promise<string | null> {
   const isBun = installer[1] === "add";
-  const query = isBun
-    ? [installer[0]!, "pm", "bin", "-g"]
-    : [installer[0]!, "prefix", "-g"];
+  const query = isBun ? [installer[0]!, "pm", "bin", "-g"] : [installer[0]!, "prefix", "-g"];
   const p = Bun.spawn(query, { stdout: "pipe", stderr: "ignore" });
   if ((await p.exited) !== 0) return null;
   const out = (await new Response(p.stdout).text()).trim();
@@ -1292,7 +1301,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
         // by the console's HTML escaper.
         if (title) {
           // eslint-disable-next-line no-control-regex
-          title = title.replace(/[\x00-\x1f\x7f-\x9f]/g, "").slice(0, 256).trim() || null;
+          title =
+            title
+              .replace(/[\x00-\x1f\x7f-\x9f]/g, "")
+              .slice(0, 256)
+              .trim() || null;
         }
         titleCache.set(logFile, { size, mtimeMs, title });
         return title;
@@ -1311,7 +1324,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // the SOURCE: secret-shaped lines are dropped to "···" and long credential-ish
   // blobs masked — the feed is token-gated, but tails travel to other rgui hosts.
   const previewCache = new Map<string, { size: number; mtimeMs: number; lines: string[] | null }>();
-  const SECRETISH = /(api[-_]?key|secret|token|password|passwd|bearer|authorization|private[-_]?key)\s*[=:]/i;
+  const SECRETISH =
+    /(api[-_]?key|secret|token|password|passwd|bearer|authorization|private[-_]?key)\s*[=:]/i;
   const logPreviewLines = async (logFile: string | null | undefined): Promise<string[] | null> => {
     if (!logFile) return null;
     try {
@@ -1860,7 +1874,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
             category: "agent-yes",
             owner: `agent-yes:${hostname()}`,
             status: r.status,
-            parent: r.parent_pid && byWrapper.has(r.parent_pid) ? nid(byWrapper.get(r.parent_pid)!) : undefined,
+            parent:
+              r.parent_pid && byWrapper.has(r.parent_pid)
+                ? nid(byWrapper.get(r.parent_pid)!)
+                : undefined,
             pos: { x: (i % 8) * (NODE_W + 64), y: Math.floor(i / 8) * 480 },
             size: await sizeOf(r.pid),
             inputs: [textIn, envIn],
@@ -1887,7 +1904,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
           configPublic: {
             scope: "native-device",
             runtime: "native",
-            caps: { send: true, kill: true, spawn: true, spawnHook: hasSpawnHook(), provision: hasProvisionHook() },
+            caps: {
+              send: true,
+              kill: true,
+              spawn: true,
+              spawnHook: hasSpawnHook(),
+              provision: hasProvisionHook(),
+            },
           },
         } as unknown as (typeof nodes)[number]); // configPublic is envelope-legal but absent from the agent-node literal type
         const codex = records
@@ -1936,11 +1959,19 @@ export async function cmdServe(rest: string[]): Promise<number> {
           {
             kind: "rgui-federated-graph",
             schema: "org.rgui.graph.v1",
-            producer: { app: "ay", origin, deviceId: hostname(), label: `agent-yes fleet @ ${hostname()}` },
+            producer: {
+              app: "ay",
+              origin,
+              deviceId: hostname(),
+              label: `agent-yes fleet @ ${hostname()}`,
+            },
             revision: Date.now(),
             ts: Date.now(),
             graph: { nodes, edges },
-            capabilities: { nodeTypes: [...new Set(nodes.map((n) => n.type))], portTypes: ["text", "environment"] },
+            capabilities: {
+              nodeTypes: [...new Set(nodes.map((n) => n.type))],
+              portTypes: ["text", "environment"],
+            },
           },
           { headers: { "Access-Control-Allow-Origin": "*" } },
         );
@@ -2205,7 +2236,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
                   // verify before demoting: give it 100ms to fire, and only
                   // then demote this stream to the fast poll it would have used
                   // had watch() failed outright.
-                  if (viaPoll && watcher && !demoteCheck && Date.now() - lastWatcherFireAt > POLL_WATCHED - 50) {
+                  if (
+                    viaPoll &&
+                    watcher &&
+                    !demoteCheck &&
+                    Date.now() - lastWatcherFireAt > POLL_WATCHED - 50
+                  ) {
                     const suspectAt = Date.now();
                     demoteCheck = setTimeout(() => {
                       demoteCheck = null;
@@ -2673,7 +2709,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
         // Allowlist gate — only when a provision hook did NOT already gate this
         // (a configured hook overrides the allowlist). The fork runs setup-repo.sh
         // (code exec), the same risk surface as `from`.
-        if (!forkHook.ran && result.spec && !isProvisionAllowed(result.spec.owner, result.spec.repo))
+        if (
+          !forkHook.ran &&
+          result.spec &&
+          !isProvisionAllowed(result.spec.owner, result.spec.repo)
+        )
           return new Response(
             `forking '${result.spec.owner}/${result.spec.repo}' is not allowed — add the owner ` +
               `to provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all), ` +
@@ -2912,7 +2952,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
         return Response.json(share);
       } catch (e) {
         const msg = (e as Error).message;
-        const status = /too many active shares/.test(msg) ? 409 : /no agent matched|no stable/.test(msg) ? 404 : 500;
+        const status = /too many active shares/.test(msg)
+          ? 409
+          : /no agent matched|no stable/.test(msg)
+            ? 404
+            : 500;
         return new Response(msg, { status });
       }
     }
@@ -2947,7 +2991,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
       try {
         const { ensureExposure } = await import("./expose.ts");
         const h = await ensureExposure(port, body.relay);
-        return Response.json({ id: h.id, port: h.port, url: h.url, claim: h.mintClaim(), createdAt: h.createdAt });
+        return Response.json({
+          id: h.id,
+          port: h.port,
+          url: h.url,
+          claim: h.mintClaim(),
+          createdAt: h.createdAt,
+        });
       } catch (e) {
         return new Response(`expose failed: ${(e as Error).message}`, { status: 502 });
       }
@@ -3000,7 +3050,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
   const RGUI_CSP = CONSOLE_CSP.replace("frame-ancestors 'none'", "frame-ancestors *")
     // #feed= mirrors fetch OTHER rgui hosts' envelopes (federation consumers):
     // otoji.org in prod, localhost/loopback for wrangler-dev feeds
-    .replace("connect-src 'self'", "connect-src 'self' https://otoji.org http://127.0.0.1:* http://localhost:*");
+    .replace(
+      "connect-src 'self'",
+      "connect-src 'self' https://otoji.org http://127.0.0.1:* http://localhost:*",
+    );
   const serveUiFile = async (name: string, type: string, csp = CONSOLE_CSP): Promise<Response> => {
     try {
       const buf = await readFile(path.join(uiDir, name));
@@ -3046,8 +3099,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return serveUiFile("sw.js", "text/javascript; charset=utf-8");
     if (req.method === "GET" && p === "/manifest.webmanifest")
       return serveUiFile("manifest.webmanifest", "application/manifest+json");
-    if (req.method === "GET" && p === "/icon.svg")
-      return serveUiFile("icon.svg", "image/svg+xml");
+    if (req.method === "GET" && p === "/icon.svg") return serveUiFile("icon.svg", "image/svg+xml");
     if (req.method === "GET" && p === "/favicon.ico") return new Response(null, { status: 204 });
     return apiFetch(req);
   };

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -28,7 +28,7 @@ import {
   recordMessage,
   recordOutbox,
 } from "./messageLog.ts";
-import { badgeDef, matchBadges, TYPING_BADGE } from "./badges.ts";
+import { badgeLabel, matchBadges, TYPING_BADGE } from "./badges.ts";
 import {
   classifyNeedsInput,
   isWorkingScreen,
@@ -37,7 +37,13 @@ import {
   type NeedsInput,
 } from "./needsInput.ts";
 import { diffLsStates, type LiveState, type LsAgentState } from "./lsWatch.ts";
-import { filterSinceSeq, filterSinceTs, filterUnread, maxSeq, type NotifyEvent } from "./notifyInbox.ts";
+import {
+  filterSinceSeq,
+  filterSinceTs,
+  filterUnread,
+  maxSeq,
+  type NotifyEvent,
+} from "./notifyInbox.ts";
 import {
   clearWatcher,
   getCursor,
@@ -1283,7 +1289,8 @@ async function runAllRemotesLs(opts: {
     byHost.push({ host: "local", records: enriched });
   }
   for (const res of remoteResults) {
-    if (res.status === "fulfilled") byHost.push({ host: res.value.host, records: res.value.records });
+    if (res.status === "fulfilled")
+      byHost.push({ host: res.value.host, records: res.value.records });
   }
 
   // Flatten each host's records into its agent>subagent forest (parent_pid links),
@@ -1471,7 +1478,7 @@ function branchLabel(g: GitInfo | null | undefined): string {
  */
 function badgeLabels(ids: string[] | null | undefined): string {
   if (!ids || ids.length === 0) return "";
-  return ids.map((id) => badgeDef(id)?.label ?? id).join(" ");
+  return ids.map((id) => badgeLabel(id)).join(" ");
 }
 
 // porcelain=v2 --branch parser — mirrors parseGitStatus in serve.ts (that copy
@@ -2887,7 +2894,8 @@ export async function backoffWhileTyping(
   const deadline = start + maxWaitMs;
   let waited = false;
   while (Date.now() < deadline) {
-    if (!(await isUserTyping(pid))) return { clear: true, waitedMs: waited ? Date.now() - start : 0 };
+    if (!(await isUserTyping(pid)))
+      return { clear: true, waitedMs: waited ? Date.now() - start : 0 };
     waited = true;
     await new Promise((r) => setTimeout(r, SEND_TYPING_POLL_MS));
   }
@@ -4237,9 +4245,7 @@ async function cmdRestart(rest: string[]): Promise<number> {
     cwd: record.cwd,
     detached: true,
     stdio: ["ignore", "ignore", "ignore"],
-    env: record.agent_id
-      ? { ...process.env, AGENT_YES_AGENT_ID: record.agent_id }
-      : process.env,
+    env: record.agent_id ? { ...process.env, AGENT_YES_AGENT_ID: record.agent_id } : process.env,
   });
 
   const { out, err } = restartHintLines(record.cli, record.cwd, strategy);
@@ -4765,15 +4771,38 @@ async function cmdNotify(rest: string[]): Promise<number> {
   }
 
   const y = yargs(args)
-    .option("parent", { type: "number", description: "Parent pid whose inbox to drain (default: $AGENT_YES_PID)" })
+    .option("parent", {
+      type: "number",
+      description: "Parent pid whose inbox to drain (default: $AGENT_YES_PID)",
+    })
     .option("since", { type: "number", description: "Only edges with seq greater than this" })
     .option("since-ts", { type: "number", description: "Only edges at/after this epoch-ms" })
-    .option("unread", { type: "boolean", default: false, description: "Only edges past the saved cursor" })
-    .option("ack", { type: "boolean", default: false, description: "Advance the cursor past what's shown (at-least-once: off by default)" })
+    .option("unread", {
+      type: "boolean",
+      default: false,
+      description: "Only edges past the saved cursor",
+    })
+    .option("ack", {
+      type: "boolean",
+      default: false,
+      description: "Advance the cursor past what's shown (at-least-once: off by default)",
+    })
     .option("json", { type: "boolean", default: false, description: "Emit raw NDJSON events" })
-    .option("consumer", { type: "string", default: "parent", description: "Cursor identity (for multiple readers)" })
-    .option("interval", { type: "number", default: 2, description: "Poll interval in seconds (watch)" })
-    .option("ensure-daemon", { type: "boolean", default: true, description: "Start the notifyd singleton if not running (watch)" })
+    .option("consumer", {
+      type: "string",
+      default: "parent",
+      description: "Cursor identity (for multiple readers)",
+    })
+    .option("interval", {
+      type: "number",
+      default: 2,
+      description: "Poll interval in seconds (watch)",
+    })
+    .option("ensure-daemon", {
+      type: "boolean",
+      default: true,
+      description: "Start the notifyd singleton if not running (watch)",
+    })
     .help(false)
     .version(false)
     .exitProcess(false);
@@ -4810,7 +4839,8 @@ async function cmdNotify(rest: string[]): Promise<number> {
     } else {
       if (sinceSeqOverride !== undefined) events = filterSinceSeq(events, sinceSeqOverride);
       else if (Number.isFinite(argv.since)) events = filterSinceSeq(events, argv.since as number);
-      if (Number.isFinite(argv["since-ts"])) events = filterSinceTs(events, argv["since-ts"] as number);
+      if (Number.isFinite(argv["since-ts"]))
+        events = filterSinceTs(events, argv["since-ts"] as number);
     }
     printNotifyEvents(events, argv.json);
     return maxSeq(events);
@@ -4902,9 +4932,7 @@ async function resolveParentStartedAt(parent: number): Promise<number> {
   }).catch(() => [] as GlobalPidRecord[]);
   const live = records.filter(
     (r) =>
-      (r.wrapper_pid === parent || r.pid === parent) &&
-      r.status !== "exited" &&
-      isPidAlive(r.pid),
+      (r.wrapper_pid === parent || r.pid === parent) && r.status !== "exited" && isPidAlive(r.pid),
   );
   // Exactly one live match, or fail closed.
   if (live.length !== 1) return 0;

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -170,9 +170,9 @@ describe("resolveOperand", () => {
   });
 
   it("reports a precise parse error for garbage", async () => {
-    await expect(resolveOperand(fakeProv("/unused"), "not a spec", "spec", undefined)).rejects.toThrow(
-      /cannot parse "not a spec"/,
-    );
+    await expect(
+      resolveOperand(fakeProv("/unused"), "not a spec", "spec", undefined),
+    ).rejects.toThrow(/cannot parse "not a spec"/);
   });
 });
 
@@ -188,7 +188,14 @@ describe("cmdWs (mocked provision)", () => {
   let err: string[];
   let homeBackup: string | undefined;
 
-  const CLEAN = { branch: "main", head: "abc123", ahead: 0, behind: 0, dirty: false, hasUpstream: true };
+  const CLEAN = {
+    branch: "main",
+    head: "abc123",
+    ahead: 0,
+    behind: 0,
+    dirty: false,
+    hasUpstream: true,
+  };
 
   beforeEach(() => {
     // realpath: os.tmpdir() is a symlink on macOS (/var → /private/var), and
@@ -312,7 +319,12 @@ describe("cmdWs (mocked provision)", () => {
   });
 
   it("new: branch-not-found hints at --create, and --create falls back to createBranch", async () => {
-    prov.provision.mockResolvedValue({ ok: false, action: "error", reason: "branch-not-found", error: "nope" });
+    prov.provision.mockResolvedValue({
+      ok: false,
+      action: "error",
+      reason: "branch-not-found",
+      error: "nope",
+    });
     expect(await cmdWs(["new", "o/r@dev"])).toBe(1);
     expect(err.join("")).toContain("--create");
     expect(prov.createBranch).not.toHaveBeenCalled();
@@ -397,7 +409,12 @@ describe("cmdWs (mocked provision)", () => {
   });
 
   it("new: a non-branch failure reports without the --create hint", async () => {
-    prov.provision.mockResolvedValue({ ok: false, action: "error", reason: "repo-not-found", error: "gone" });
+    prov.provision.mockResolvedValue({
+      ok: false,
+      action: "error",
+      reason: "repo-not-found",
+      error: "gone",
+    });
     expect(await cmdWs(["new", "o/r"])).toBe(1);
     const msg = err.join("");
     expect(msg).toContain("repo-not-found");
@@ -453,7 +470,14 @@ describe("collectWorkspaces / workspaceStatus (mocked provision)", () => {
     prov.wsRoot = root;
     prov.readStatus
       .mockReset()
-      .mockResolvedValue({ branch: "main", head: "abc123", ahead: 1, behind: 0, dirty: true, hasUpstream: true });
+      .mockResolvedValue({
+        branch: "main",
+        head: "abc123",
+        ahead: 1,
+        behind: 0,
+        dirty: true,
+        hasUpstream: true,
+      });
     homeBackup = process.env.AGENT_YES_HOME;
     process.env.AGENT_YES_HOME = path.join(root, ".ay-home");
   });

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -231,7 +231,8 @@ export async function resolveOperand(
       );
     }
     const dir = prov.folderFor(spec, wsRoot);
-    if (!existsSync(dir)) throw new Error(`workspace not provisioned: ${dir}  (ay ws new ${operand})`);
+    if (!existsSync(dir))
+      throw new Error(`workspace not provisioned: ${dir}  (ay ws new ${operand})`);
     return { dir, spec };
   };
   if (mode === "path") return asPath();
@@ -311,7 +312,13 @@ export async function collectWorkspaces(opts?: {
 
   const [bare, records] = await Promise.all([
     walkWorkspaces(wsRoot),
-    listRecords(undefined, { all: false, active: false, json: false, latest: false, cwdScope: null }),
+    listRecords(undefined, {
+      all: false,
+      active: false,
+      json: false,
+      latest: false,
+      cwdScope: null,
+    }),
   ]);
 
   let entries: WsEntry[] = bare.map((w) => ({
@@ -432,7 +439,9 @@ async function cmdWsStatus(args: string[]): Promise<number> {
   const entry = await workspaceStatus(dir, spec);
 
   if (flags.json) {
-    process.stdout.write(JSON.stringify({ schema: WS_JSON_SCHEMA, workspace: entry }, null, 2) + "\n");
+    process.stdout.write(
+      JSON.stringify({ schema: WS_JSON_SCHEMA, workspace: entry }, null, 2) + "\n",
+    );
     return 0;
   }
   const git = entry.git!;
@@ -487,7 +496,9 @@ async function cmdWsFork(args: string[]): Promise<number> {
     typeof flags.from === "string" ? flags.from : await defaultForkFrom(),
   );
 
-  process.stderr.write(`forking ${fromCwd} → branch ${branch}${flags.wip ? " (with WIP)" : ""} …\n`);
+  process.stderr.write(
+    `forking ${fromCwd} → branch ${branch}${flags.wip ? " (with WIP)" : ""} …\n`,
+  );
   const res = await prov.forkWorktree({
     fromCwd,
     branch,


### PR DESCRIPTION
## What

The console's badge system (ts/badges.ts) only matched static flags (goal/limit/retry/typing). Claude's status footer also lists live counters between "·" separators:

```
⏸ manual mode on · 1 shell · ctrl+t to hide tasks · ← for agents · ↓ to manage
⏸ manual mode on · 3 monitors · esc to interrupt · ↓ to manage
⏸ manual mode on · ? for shortcuts · ← 3 agents
⏸ manual mode on · PR #310
```

(all captured from live agents via `ay tail`.)

This PR matches them as **dynamic badges**: a `BadgeDef` pattern with a capture group now emits `id:capture` on the wire (e.g. `shells:4 shells`), and `$1` in the label/title is substituted at render time — on `ay ls` (`badgeLabel`) and in the web console (`badgesFor` / `BADGE_META`). The chip reads exactly like the footer, keeping the CLI's own singular/plural wording (`1 shell`, `4 shells`).

New badges: `shells`, `monitors`, `bg-agents` (`← N agents`), `pr` (`PR #123`).

## Anchoring

Patterns anchor on the footer chrome (the `· ` separator / the `←` arrow, plus a `·`-or-EOL lookahead), so prose merely *mentioning* "4 shells" or "PR #310" can't light a chip — same convention as the existing `retrying` badge. The bare `← for agents` hint (no count) does not match.

## Compat

- Static ids are wire-identical; unknown/dynamic ids still fall back to the raw value in an older console, so nothing renders blank.
- Server-side matching only (TS), no Rust change.

## Verified

- 142 tests pass (`ts/badges.spec.ts` + `tests/ui-logic/console-logic.spec.ts`), incl. real-footer fixtures and negative prose cases.
- Live: after `bun run build && bun link`, `ay ls` shows `1 shell`, `3 agents`, `PR #310` chips on the actual running fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)