### PR TITLE
feat(ui): filter matches host & username — bare tokens + user: tag

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -253,8 +253,10 @@ export function age(e, now = Date.now()) {
 }
 
 // Filter predicate: every space-separated token must match. A `key:value` token
-// matches against the mnemonic tags (repo/wt/cli/host); a bare token is a
-// case-insensitive substring search over title/prompt/cli/cwd/status.
+// matches against the mnemonic tags (repo/wt/cli/host) or the explicit keys
+// below; a bare token is a case-insensitive substring search over
+// title/prompt/cli/cwd/status plus the device label (user@host) and room, so
+// typing a hostname or username narrows without needing a tag.
 export function matches(e, toks) {
   const hay =
     (e.title || "") +
@@ -266,6 +268,10 @@ export function matches(e, toks) {
     (e.cwd || "") +
     " " +
     e.status +
+    " " +
+    (e._host || "") +
+    " " +
+    (e._room || "") +
     (e.git?.dirty ? " dirty" : "");
   return toks.every((tok) => {
     tok = tok.toLowerCase();
@@ -282,6 +288,9 @@ export function matches(e, toks) {
         return String(e._host || "")
           .toLowerCase()
           .includes(v);
+      // user: matches just the username half of the device label ("sno@taka"
+      // → "sno"), unlike host:/device: which match the whole label.
+      if (k === "user") return deviceParts(e._host).user.toLowerCase().includes(v);
       return tagsFor(e).some(([tk, tv]) => tk === k && tv.toLowerCase().includes(v));
     }
     return hay.toLowerCase().includes(tok);

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -5807,7 +5807,7 @@
                 <span class="dot idle"></span>
                 <div class="omni-main">
                   <div class="omni-title">${title}</div>
-                  <div class="omni-sub">sets the left panel filter &nbsp;·&nbsp; space = AND, tags like repo:/wt:/cli:/host:</div>
+                  <div class="omni-sub">sets the left panel filter &nbsp;·&nbsp; space = AND, tags like repo:/wt:/cli:/host:/user: — bare text also matches host & user</div>
                 </div></div>`;
             }
             if (r.kind === "wshint") {

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -1774,11 +1774,14 @@ let rguiFilter = ((): string => {
 })();
 let lastRawRecords: AgentRecord[] = [];
 // Space-separated tokens AND-match (case-insensitive substrings) over the same
-// fields the ⌘K rows show: title, cwd, cli, status, branch, source.
+// fields the ⌘K rows show — title, cwd, cli, status, branch, source — plus the
+// source machine's hostname (from its /api/host env info), so "taka" narrows to
+// one machine even when the wire id is a room name.
 function matchesFilter(r: AgentRecord): boolean {
   if (!rguiFilter) return true;
+  const host = wires.get(r._src)?.hostInfo?.host ?? "";
   const hay =
-    `${nodeTitle(r)} ${r.cwd} ${r.cli} ${r.status} ${r.git?.branch ?? ""} ${r._src}`.toLowerCase();
+    `${nodeTitle(r)} ${r.cwd} ${r.cli} ${r.status} ${r.git?.branch ?? ""} ${r._src} ${host}`.toLowerCase();
   return rguiFilter
     .toLowerCase()
     .split(/\s+/)

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -399,6 +399,26 @@ describe("matches", () => {
     // default claude has no cli tag, so a cli: filter must not match it
     expect(matches(agent({ cli: "claude" }), ["cli:claude"])).toBe(false);
   });
+  it("matches a bare token against the device label (user@host) and room", () => {
+    const a = agent({ _host: "sno@taka", _room: "office" });
+    expect(matches(a, ["taka"])).toBe(true);
+    expect(matches(a, ["sno"])).toBe(true);
+    expect(matches(a, ["office"])).toBe(true);
+    expect(matches(agent(), ["taka"])).toBe(false);
+  });
+  it("user: matches only the username half of the device label", () => {
+    const a = agent({ _host: "sno@taka" });
+    expect(matches(a, ["user:sno"])).toBe(true);
+    expect(matches(a, ["user:taka"])).toBe(false);
+    // host-only label ("taka", no @) has no user part
+    expect(matches(agent({ _host: "taka" }), ["user:taka"])).toBe(false);
+    expect(matches(agent(), ["user:sno"])).toBe(false);
+  });
+  it("host: still matches the whole device label", () => {
+    const a = agent({ _host: "sno@taka" });
+    expect(matches(a, ["host:taka"])).toBe(true);
+    expect(matches(a, ["host:sno"])).toBe(true);
+  });
 });
 
 describe("nextIndex", () => {


### PR DESCRIPTION
## Summary
Follow-up to #256 (⌘K /filter): host and username now work as filter input in both palettes.

**/w/ console (`console-logic.js matches()`)**
- Bare tokens now also match the device label (`user@host`) and the room name — typing `taka` or `sno` narrows the list, no tag needed.
- New explicit `user:` key matches only the username half of the device label (`user:sno` hits `sno@taka`, `user:taka` doesn't). `host:` / `device:` keep matching the whole label, so identities keep matching as before (repo/branch/owner already matched via cwd).
- `/filter` omnibox hint mentions `user:` and the bare host/user matching.

**/r/ rgui (`matchesFilter()`)**
- The haystack gains the source machine's hostname from its `/api/host` env info, so a hostname filter narrows the forest even when the wire id is a room name (previously only `_src` — the room — was searchable).

## Testing
- `tests/ui-logic/console-logic.spec.ts`: new cases for bare host/user/room tokens, `user:` precision (incl. host-only label), and `host:` whole-label behavior — 116/116 pass.
- `bun run test:ui-dom` (covers the /filter slash flow) — 24/24 pass.
- `build:rgui` bundles clean; root `tsc --noEmit` error count unchanged vs main (92 pre-existing, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)