### PR TITLE
fix(notify): treat Windows mkdir-vs-rm lock races as contention, not errors

### DIFF
--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import {
+  isTransientLockMkdirError,
   acquireLock,
   appendEvent,
   clearWatcher,
@@ -307,5 +308,29 @@ describe("notifyStore — seq self-heal + cursor defaults", () => {
     // so an inbox nobody reads is never trimmed.
     await appendEvent(999, baseEvent("idle"));
     expect(await minConsumerCursor(host, 999)).toBe(0);
+  });
+});
+
+// Windows mkdir-vs-rm race: a lock-dir mkdir colliding with a concurrent rm
+// (steal/release mid-delete) surfaces as EPERM/EBUSY/ENOTEMPTY/EACCES on
+// win32 — contention, not a real permission problem. POSIX keeps throwing.
+describe("isTransientLockMkdirError", () => {
+  it("treats EEXIST as contention on every platform", () => {
+    expect(isTransientLockMkdirError("EEXIST", "linux")).toBe(true);
+    expect(isTransientLockMkdirError("EEXIST", "win32")).toBe(true);
+    expect(isTransientLockMkdirError("EEXIST", "darwin")).toBe(true);
+  });
+
+  it("treats the rm-race codes as contention only on win32", () => {
+    for (const code of ["EPERM", "EBUSY", "ENOTEMPTY", "EACCES"]) {
+      expect(isTransientLockMkdirError(code, "win32")).toBe(true);
+      expect(isTransientLockMkdirError(code, "linux")).toBe(false);
+      expect(isTransientLockMkdirError(code, "darwin")).toBe(false);
+    }
+  });
+
+  it("never masks unrelated errors", () => {
+    expect(isTransientLockMkdirError("ENOSPC", "win32")).toBe(false);
+    expect(isTransientLockMkdirError(undefined, "win32")).toBe(false);
   });
 });

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -138,6 +138,24 @@ async function atomicWrite(file: string, data: string): Promise<boolean> {
  * deliberately NO wall-clock backstop: elapsed wait time alone never steals, so a
  * live holder is inviolable.
  */
+// Is this mkdir failure just lock contention in disguise? EEXIST always is.
+// On Windows, mkdir racing a concurrent rm of the SAME dir (another contender
+// stealing a stale lock, or a holder releasing) can surface as a transient
+// EPERM/EBUSY/ENOTEMPTY/EACCES instead — a real Windows-ism, seen as a flaky
+// EPERM in the concurrent-GC spec on windows-latest. Only win32 gets that
+// leniency: on POSIX those codes mean a genuine permission problem and must
+// throw immediately.
+export function isTransientLockMkdirError(
+  code: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (code === "EEXIST") return true;
+  return (
+    platform === "win32" &&
+    (code === "EPERM" || code === "EBUSY" || code === "ENOTEMPTY" || code === "EACCES")
+  );
+}
+
 export async function acquireLock(lockDir: string, staleMs = 30_000): Promise<() => Promise<void>> {
   const ownerFile = path.join(lockDir, "owner");
   // A fencing token unique to THIS acquisition. Everything we do to the lock is
@@ -173,6 +191,7 @@ export async function acquireLock(lockDir: string, staleMs = 30_000): Promise<()
       .catch(() => Date.now());
     return Date.now() - m;
   };
+  let transientErrors = 0;
   for (;;) {
     try {
       await mkdir(lockDir, { recursive: false });
@@ -212,7 +231,17 @@ export async function acquireLock(lockDir: string, staleMs = 30_000): Promise<()
           await rm(lockDir, { recursive: true, force: true }).catch(() => {});
       };
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      const code = (e as NodeJS.ErrnoException).code;
+      if (!isTransientLockMkdirError(code)) throw e;
+      if (code !== "EEXIST") {
+        // Windows race-with-rm: the dir is mid-delete, not held — the steal
+        // logic below would misread it. Just retry; bounded so a PERSISTENT
+        // EPERM (a genuine permission problem) still surfaces instead of
+        // spinning forever.
+        if (++transientErrors > 200) throw e;
+        await new Promise((r) => setTimeout(r, 15));
+        continue;
+      }
       const raw = await readFile(ownerFile, "utf8").catch(() => "");
       if (
         shouldStealLock(raw, Date.now(), {


### PR DESCRIPTION
Fixes the windows-latest (bun) flake that blocked #253 once: `ts/notifyStore.spec.ts > concurrent GC and appends never lose an event` failing with `EPERM: operation not permitted, mkdir <lockdir>`.

On Windows, `mkdir` of a lock dir that a concurrent contender is **mid-`rm`** (stale-lock steal or holder release) can return `EPERM`/`EBUSY`/`ENOTEMPTY`/`EACCES` instead of `EEXIST`. `acquireLock` threw on anything non-EEXIST, so a benign race failed the whole append.

- `isTransientLockMkdirError(code, platform)`: EEXIST is contention everywhere; the rm-race codes are contention **on win32 only** — on POSIX they indicate a genuine permission problem and still throw.
- The retry is bounded (200 × 15ms ≈ 3s) so a persistent real EPERM surfaces instead of spinning forever, and it skips the steal logic (the dir is mid-delete, not held — the owner file would misread).
- Unit tests for the classifier (all-platform EEXIST, win32-only race codes, unrelated codes never masked). 27/27 notifyStore specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)