### PR TITLE
Warn about stray ay serve processes

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -46,6 +46,7 @@ import { findSpawnHiddenLauncher } from "./rustBinary.ts";
 import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
+import { listStrayServeProcesses } from "./strayServe.ts";
 import {
   getProvisionHook,
   getProvisionRoot,
@@ -707,6 +708,17 @@ function portFromArgs(args: string[]): number {
   return m ? Number(m[1]) : DEFAULT_PORT;
 }
 
+async function warnStrayServeProcesses(): Promise<void> {
+  const stray = await listStrayServeProcesses();
+  if (stray.length === 0) return;
+  const pids = stray.map((p) => p.pid);
+  process.stderr.write(
+    `warning: ${stray.length} unmanaged ay serve process(es) running (pid ${pids.join(
+      ", ",
+    )}) — they will fight the daemon for the WebRTC room; stop them: kill ${pids.join(" ")}\n`,
+  );
+}
+
 // An explicit webrtc:// URL passed to --webrtc/--share in the daemon's serve args,
 // or undefined for a bare flag (which mints a persisted room instead). Mirrors how
 // cmdServe resolves argv.webrtc/argv.share, but over the raw arg list install holds
@@ -785,6 +797,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
     }
     if (removed === 0 && failed === 0)
       process.stdout.write(`no '${DAEMON_NAME}' daemon registered with any manager\n`);
+    await warnStrayServeProcesses();
     return failed ? 1 : 0;
   }
 
@@ -893,6 +906,7 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
       await spawnExit([mgr.bin, "stop", DAEMON_NAME]);
       await spawnExit([mgr.bin, "delete", DAEMON_NAME]);
     }
+    await warnStrayServeProcesses();
 
     // oxmgr takes the command as one string; pm2 takes the binary plus its
     // args after `--`. Both auto-restart on crash by default (pm2) / via the

--- a/ts/strayServe.spec.ts
+++ b/ts/strayServe.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseStrayServeProcesses } from "./strayServe.ts";
+
+describe("parseStrayServeProcesses", () => {
+  it("finds foreground ay serve processes", () => {
+    const rows = parseStrayServeProcesses(
+      [
+        "  101 /Users/me/.bun/bin/bun /Users/me/.bun/bin/ay serve --webrtc",
+        "  102 bun /repo/dist/agent-yes.js serve --share",
+      ].join("\n"),
+      { selfPid: 999, parentPid: 998 },
+    );
+
+    expect(rows).toEqual([
+      { pid: 101, command: "/Users/me/.bun/bin/bun /Users/me/.bun/bin/ay serve --webrtc" },
+      { pid: 102, command: "bun /repo/dist/agent-yes.js serve --share" },
+    ]);
+  });
+
+  it("excludes management commands and this process family", () => {
+    const rows = parseStrayServeProcesses(
+      [
+        "  200 ay serve install --webrtc",
+        "  201 ay serve uninstall",
+        "  202 ay serve status",
+        "  203 ay serve logs",
+        "  204 ay serve restart",
+        "  300 ay serve --webrtc",
+        "  301 ay serve --webrtc",
+        "  302 ay serve --webrtc",
+      ].join("\n"),
+      { selfPid: 300, parentPid: 301 },
+    );
+
+    expect(rows).toEqual([{ pid: 302, command: "ay serve --webrtc" }]);
+  });
+
+  it("ignores unrelated commands", () => {
+    const rows = parseStrayServeProcesses(
+      [
+        "  401 ay send serve --webrtc",
+        "  402 agent-yes status",
+        "  403 node ./dist/cli.js share",
+      ].join("\n"),
+      { selfPid: 999, parentPid: 998 },
+    );
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/ts/strayServe.ts
+++ b/ts/strayServe.ts
@@ -1,0 +1,56 @@
+import { liveEnv } from "./nodeRuntime.ts";
+
+export type StrayServeProcess = { pid: number; command: string };
+
+const MANAGEMENT_COMMAND_RE = /\b(?:install|uninstall|status|logs|restart)\b/;
+
+function isServeCommand(command: string): boolean {
+  return (
+    /\bay(?:\.js)?\s+serve\b/.test(command) ||
+    /\bagent-yes(?:\.js)?\s+serve\b/.test(command) ||
+    /\bagent-yes\.js\s+serve\b/.test(command)
+  );
+}
+
+export function parseStrayServeProcesses(
+  psOutput: string,
+  opts: { selfPid: number; parentPid: number },
+): StrayServeProcess[] {
+  const ignoredPids = new Set([opts.selfPid, opts.parentPid]);
+  const processes: StrayServeProcess[] = [];
+
+  for (const line of psOutput.split(/\r?\n/)) {
+    const match = /^\s*(\d+)\s+(.+?)\s*$/.exec(line);
+    if (!match) continue;
+
+    const pid = Number(match[1]);
+    const command = match[2]!;
+    if (!Number.isFinite(pid) || ignoredPids.has(pid)) continue;
+    if (!isServeCommand(command)) continue;
+    if (MANAGEMENT_COMMAND_RE.test(command)) continue;
+
+    processes.push({ pid, command });
+  }
+
+  return processes;
+}
+
+export async function listStrayServeProcesses(): Promise<StrayServeProcess[]> {
+  if (process.platform === "win32") return [];
+
+  try {
+    const ps = Bun.spawn(["ps", "-axo", "pid=,command="], {
+      stdout: "pipe",
+      stderr: "ignore",
+      env: liveEnv(),
+    });
+    const output = await new Response(ps.stdout).text();
+    if ((await ps.exited) !== 0) return [];
+    return parseStrayServeProcesses(output, {
+      selfPid: process.pid,
+      parentPid: process.ppid,
+    });
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add stray ay serve process detection via ps on POSIX
- warn during ay serve install before manager start, after any stop/delete
- warn during ay serve uninstall after sweeping managers
- add parser unit coverage for serve matches and exclusions

## Verification
- bunx vitest run --coverage.enabled=false ts/strayServe.spec.ts ts/serve.spec.ts
- bun run build

Note: the requested command without coverage override (bunx vitest run ts/strayServe.spec.ts ts/serve.spec.ts) had all 17 tests pass, but exited 1 because the repo enables global coverage thresholds for partial test runs.