### PR TITLE
feat(serve): singleton WebRTC-host lock — one host per home, fail fast

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -39,6 +39,7 @@ import {
 import { TYPING_BADGE } from "./badges.ts";
 import { isTerminalReply } from "./terminalReply.ts";
 import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
+import { acquireWebrtcHostLock, type ServeLockOwner } from "./serveLock.ts";
 import { type MailParty, recordInbox } from "./messageLog.ts";
 import { updateGlobalPidStatus } from "./globalPidIndex.ts";
 import { spawnRejectionReason } from "./spawnGate.ts";
@@ -1207,6 +1208,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
       default: false,
       description: "Deprecated no-op — the console can always spawn agents",
     })
+    .option("takeover", {
+      type: "boolean",
+      default: false,
+      description: "If another ay serve already hosts this home's WebRTC room, stop it and take the room",
+    })
     .help(false)
     .version(false)
     .exitProcess(false);
@@ -1258,6 +1264,31 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // meaning (HTTP + WebRTC) for existing invocations.
   const wantWebrtc = argv.webrtc !== undefined || argv.share !== undefined;
   const wantHttp = argv.http === true || argv.share !== undefined || argv.webrtc === undefined;
+
+  // Singleton WebRTC host per ~/.agent-yes: a second host joining the SAME
+  // persisted room (~/.agent-yes/.share-room) fights the first over every
+  // viewer connection — seen live as an unloadable share link plus the managed
+  // daemon crash-looping under the health watchdog while an orphaned manual
+  // `ay serve --webrtc` held the room. Fail fast with a pointer to the owner
+  // instead of contending. HTTP-only serves skip this (port collisions already
+  // fail naturally with EADDRINUSE). AGENT_YES_NO_SERVE_LOCK=1 opts out for
+  // exotic multi-room setups (explicit webrtc:// URLs to different rooms).
+  let releaseHostLock: (() => Promise<void>) | null = null;
+  if (wantWebrtc && process.env.AGENT_YES_NO_SERVE_LOCK !== "1") {
+    const lock = await acquireWebrtcHostLock({ takeover: argv.takeover === true });
+    if (!lock.ok) {
+      const o: ServeLockOwner | null = lock.owner;
+      const since = o ? new Date(o.started_at).toLocaleString() : "unknown";
+      process.stderr.write(
+        `ay serve: another instance${o ? ` (pid ${o.pid}, started ${since})` : ""} already hosts this home's WebRTC room\n` +
+          `  ay serve status              # inspect it\n` +
+          `  ay serve --webrtc --takeover # stop it and take the room\n` +
+          `  AGENT_YES_NO_SERVE_LOCK=1    # opt out (multi-room setups only)\n`,
+      );
+      return 1;
+    }
+    releaseHostLock = lock.release;
+  }
 
   if (wantHttp && host !== "127.0.0.1" && host !== "localhost") {
     process.stderr.write(
@@ -3243,7 +3274,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
       await announce(room, link, false);
     } catch (e) {
       process.stderr.write(`ay serve --webrtc failed: ${(e as Error).message}\n`);
-      if (!wantHttp) return 1; // nothing else is running
+      if (!wantHttp) {
+        // Release promptly so the manager's instant respawn doesn't have to
+        // wait out the stale window to reclaim the host lock.
+        await releaseHostLock?.().catch(() => {});
+        return 1; // nothing else is running
+      }
     }
   }
 
@@ -3275,7 +3311,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // Close any scoped single-agent share rooms so viewers get an immediate drop.
     void import("./agentShare.ts").then((m) => m.revokeAllShares()).catch(() => {});
     server?.stop();
-    resolve();
+    // Gate exit on the lock release: resolve() ends cmdServe and the process,
+    // and an un-awaited rm would race that exit — leaving a lock the next host
+    // (a manager's instant respawn) must wait a full stale window to steal.
+    void Promise.resolve(releaseHostLock?.())
+      .catch(() => {})
+      .then(resolve);
   };
   await new Promise<void>((resolve) => {
     process.on("SIGINT", () => shutdown(resolve));

--- a/ts/serveLock.spec.ts
+++ b/ts/serveLock.spec.ts
@@ -117,3 +117,96 @@ describe("isOwnerStale", () => {
     expect(isOwnerStale(owner(SERVE_LOCK_STALE_MS + 1), now, () => true)).toBe(true);
   });
 });
+
+// Coverage for the held-lock lifecycle: heartbeat refresh, thief detection,
+// live-owner takeover, and the bounded grace wait.
+describe("acquireWebrtcHostLock — held-lock lifecycle", () => {
+  let home: string;
+  let savedHome: string | undefined;
+  const releases: Array<() => Promise<void>> = [];
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-serve-lock2-"));
+    savedHome = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = home;
+  });
+
+  afterEach(async () => {
+    for (const r of releases.splice(0)) await r().catch(() => {});
+    if (savedHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = savedHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  const ownerFile = () => path.join(home, "webrtc-host.lock", "owner.json");
+  const readOwnerFile = async () => JSON.parse(await readFile(ownerFile(), "utf-8")) as ServeLockOwner;
+
+  it("heartbeats refresh beat_at while held", async () => {
+    const got = await acquireWebrtcHostLock({ graceMs: 0, beatMs: 40 });
+    expect(got.ok).toBe(true);
+    if (got.ok) releases.push(got.release);
+    const before = (await readOwnerFile()).beat_at;
+    await new Promise((r) => setTimeout(r, 150));
+    const after = (await readOwnerFile()).beat_at;
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("heartbeat stops itself once a thief owns the file (never clobbers the thief)", async () => {
+    const got = await acquireWebrtcHostLock({ graceMs: 0, beatMs: 40 });
+    expect(got.ok).toBe(true);
+    if (got.ok) releases.push(got.release);
+    const { writeFile: wf } = await import("fs/promises");
+    const thief: ServeLockOwner = { pid: process.pid + 1, started_at: Date.now(), beat_at: 42 };
+    await wf(ownerFile(), JSON.stringify(thief));
+    await new Promise((r) => setTimeout(r, 150));
+    expect((await readOwnerFile()).pid).toBe(thief.pid); // our beat backed off
+    expect((await readOwnerFile()).beat_at).toBe(42);
+  });
+
+  it("takeover stops a live owner and takes the room", async () => {
+    const { spawn } = await import("node:child_process");
+    const victim = spawn("/bin/sh", ["-c", "sleep 30"], { stdio: "ignore" });
+    const victimPid = victim.pid!;
+    const { mkdir: mkd, writeFile: wf } = await import("fs/promises");
+    await mkd(path.join(home, "webrtc-host.lock"), { recursive: true });
+    await wf(
+      ownerFile(),
+      JSON.stringify({ pid: victimPid, started_at: Date.now(), beat_at: Date.now() }),
+    );
+
+    const got = await acquireWebrtcHostLock({ takeover: true, graceMs: 0, takeoverWaitMs: 100 });
+    expect(got.ok).toBe(true);
+    if (got.ok) releases.push(got.release);
+    expect((await readOwnerFile()).pid).toBe(process.pid);
+    // The victim was killed (SIGTERM or the escalation SIGKILL).
+    await new Promise((r) => setTimeout(r, 100));
+    expect(victim.exitCode !== null || victim.signalCode !== null).toBe(true);
+  });
+
+  it("escalates to SIGKILL when the owner ignores SIGTERM", async () => {
+    const { spawn } = await import("node:child_process");
+    const stubborn = spawn("/bin/sh", ["-c", "trap '' TERM; sleep 30"], { stdio: "ignore" });
+    const pid = stubborn.pid!;
+    await new Promise((r) => setTimeout(r, 100)); // let the trap install
+    const { mkdir: mkd, writeFile: wf } = await import("fs/promises");
+    await mkd(path.join(home, "webrtc-host.lock"), { recursive: true });
+    await wf(ownerFile(), JSON.stringify({ pid, started_at: Date.now(), beat_at: Date.now() }));
+
+    const got = await acquireWebrtcHostLock({ takeover: true, graceMs: 0, takeoverWaitMs: 200 });
+    expect(got.ok).toBe(true);
+    if (got.ok) releases.push(got.release);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(stubborn.signalCode).toBe("SIGKILL");
+  });
+
+  it("waits out the grace window against a live owner, then reports it", async () => {
+    const holder = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(holder.ok).toBe(true);
+    if (holder.ok) releases.push(holder.release);
+    const t0 = Date.now();
+    const got = await acquireWebrtcHostLock({ graceMs: 300 });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.owner?.pid).toBe(process.pid);
+    expect(Date.now() - t0).toBeGreaterThanOrEqual(250); // actually waited a beat
+  });
+});

--- a/ts/serveLock.spec.ts
+++ b/ts/serveLock.spec.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  acquireWebrtcHostLock,
+  isOwnerStale,
+  SERVE_LOCK_STALE_MS,
+  type ServeLockOwner,
+} from "./serveLock.ts";
+
+// Guards the single-WebRTC-host invariant: two `ay serve --webrtc` in one home
+// fight over the persisted room (live outage: orphan host + crash-looping
+// managed daemon + unloadable share link). The loser must fail FAST with the
+// owner's identity, and a dead/stale owner must never wedge the next start.
+describe("acquireWebrtcHostLock", () => {
+  let home: string;
+  let savedHome: string | undefined;
+  const releases: Array<() => Promise<void>> = [];
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), "ay-serve-lock-"));
+    savedHome = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = home;
+  });
+
+  afterEach(async () => {
+    for (const r of releases.splice(0)) await r().catch(() => {});
+    if (savedHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = savedHome;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("acquires, stamps an owner, and a second acquire fails fast with that owner", async () => {
+    const first = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(first.ok).toBe(true);
+    if (first.ok) releases.push(first.release);
+
+    const owner = JSON.parse(
+      await readFile(path.join(home, "webrtc-host.lock", "owner.json"), "utf-8"),
+    ) as ServeLockOwner;
+    expect(owner.pid).toBe(process.pid);
+
+    const second = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.owner?.pid).toBe(process.pid);
+  });
+
+  it("release frees the lock for the next acquire", async () => {
+    const first = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(first.ok).toBe(true);
+    if (first.ok) await first.release();
+
+    const second = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(second.ok).toBe(true);
+    if (second.ok) releases.push(second.release);
+  });
+
+  it("steals a stale lock whose heartbeat went quiet (SIGKILLed host)", async () => {
+    // Forge an owner: alive pid but ancient beat — a host whose interval died.
+    const lockDir = path.join(home, "webrtc-host.lock");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(
+      path.join(lockDir, "owner.json"),
+      JSON.stringify({
+        pid: process.pid,
+        started_at: Date.now() - 60_000,
+        beat_at: Date.now() - SERVE_LOCK_STALE_MS - 1_000,
+      }),
+    );
+    const got = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(got.ok).toBe(true);
+    if (got.ok) releases.push(got.release);
+  });
+
+  it("steals a lock whose owner pid is dead", async () => {
+    // A freshly-exited child pid is reliably dead. node:child_process (not
+    // Bun.spawn) — these specs also run under the node vitest matrix.
+    const { spawnSync } = await import("node:child_process");
+    const deadPid = spawnSync("/bin/sh", ["-c", "exit 0"]).pid!;
+
+    const lockDir = path.join(home, "webrtc-host.lock");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(
+      path.join(lockDir, "owner.json"),
+      JSON.stringify({ pid: deadPid, started_at: Date.now(), beat_at: Date.now() }),
+    );
+    const got = await acquireWebrtcHostLock({ graceMs: 0 });
+    expect(got.ok).toBe(true);
+    if (got.ok) releases.push(got.release);
+  });
+});
+
+describe("isOwnerStale", () => {
+  const now = 1_000_000;
+  const owner = (beatAgo: number): ServeLockOwner => ({
+    pid: 4242,
+    started_at: now - 60_000,
+    beat_at: now - beatAgo,
+  });
+
+  it("absent/torn owner is stale (mkdir won but the write died)", () => {
+    expect(isOwnerStale(null, now, () => true)).toBe(true);
+  });
+
+  it("dead pid is stale regardless of heartbeat", () => {
+    expect(isOwnerStale(owner(0), now, () => false)).toBe(true);
+  });
+
+  it("live pid with a fresh beat is NOT stale", () => {
+    expect(isOwnerStale(owner(SERVE_LOCK_STALE_MS - 1), now, () => true)).toBe(false);
+  });
+
+  it("live pid with a quiet heartbeat past the window is stale", () => {
+    expect(isOwnerStale(owner(SERVE_LOCK_STALE_MS + 1), now, () => true)).toBe(true);
+  });
+});

--- a/ts/serveLock.spec.ts
+++ b/ts/serveLock.spec.ts
@@ -75,10 +75,11 @@ describe("acquireWebrtcHostLock", () => {
   });
 
   it("steals a lock whose owner pid is dead", async () => {
-    // A freshly-exited child pid is reliably dead. node:child_process (not
-    // Bun.spawn) — these specs also run under the node vitest matrix.
+    // A freshly-exited child pid is reliably dead. Spawn the current runtime
+    // (bun or node — both take -e) so this also runs on Windows, via
+    // node:child_process (not Bun.spawn) for the node vitest matrix.
     const { spawnSync } = await import("node:child_process");
-    const deadPid = spawnSync("/bin/sh", ["-c", "exit 0"]).pid!;
+    const deadPid = spawnSync(process.execPath, ["-e", "0"]).pid!;
 
     const lockDir = path.join(home, "webrtc-host.lock");
     const { mkdir, writeFile } = await import("fs/promises");
@@ -165,7 +166,10 @@ describe("acquireWebrtcHostLock — held-lock lifecycle", () => {
 
   it("takeover stops a live owner and takes the room", async () => {
     const { spawn } = await import("node:child_process");
-    const victim = spawn("/bin/sh", ["-c", "sleep 30"], { stdio: "ignore" });
+    // Long-lived victim via the current runtime — /bin/sh doesn't exist on win32.
+    const victim = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+      stdio: "ignore",
+    });
     const victimPid = victim.pid!;
     const { mkdir: mkd, writeFile: wf } = await import("fs/promises");
     await mkd(path.join(home, "webrtc-host.lock"), { recursive: true });
@@ -183,7 +187,9 @@ describe("acquireWebrtcHostLock — held-lock lifecycle", () => {
     expect(victim.exitCode !== null || victim.signalCode !== null).toBe(true);
   });
 
-  it("escalates to SIGKILL when the owner ignores SIGTERM", async () => {
+  it.skipIf(process.platform === "win32")(
+    "escalates to SIGKILL when the owner ignores SIGTERM",
+    async () => {
     const { spawn } = await import("node:child_process");
     const stubborn = spawn("/bin/sh", ["-c", "trap '' TERM; sleep 30"], { stdio: "ignore" });
     const pid = stubborn.pid!;
@@ -197,7 +203,8 @@ describe("acquireWebrtcHostLock — held-lock lifecycle", () => {
     if (got.ok) releases.push(got.release);
     await new Promise((r) => setTimeout(r, 100));
     expect(stubborn.signalCode).toBe("SIGKILL");
-  });
+    },
+  );
 
   it("waits out the grace window against a live owner, then reports it", async () => {
     const holder = await acquireWebrtcHostLock({ graceMs: 0 });

--- a/ts/serveLock.ts
+++ b/ts/serveLock.ts
@@ -94,9 +94,14 @@ export async function acquireWebrtcHostLock(opts?: {
   takeover?: boolean;
   graceMs?: number;
   staleMs?: number;
+  /** Heartbeat cadence override — tests only. */
+  beatMs?: number;
+  /** SIGTERM→SIGKILL escalation wait for --takeover — tests only. */
+  takeoverWaitMs?: number;
 }): Promise<ServeLockResult> {
   const graceMs = opts?.graceMs ?? SERVE_LOCK_GRACE_MS;
   const staleMs = opts?.staleMs ?? SERVE_LOCK_STALE_MS;
+  const beatMs = opts?.beatMs ?? SERVE_LOCK_BEAT_MS;
   const startedAt = Date.now();
   const deadline = startedAt + graceMs;
   let tookOver = false;
@@ -117,7 +122,7 @@ export async function acquireWebrtcHostLock(opts?: {
           }
           await stampOwner(startedAt);
         })();
-      }, SERVE_LOCK_BEAT_MS);
+      }, beatMs);
       if (typeof beat.unref === "function") beat.unref();
       return {
         ok: true,
@@ -149,7 +154,7 @@ export async function acquireWebrtcHostLock(opts?: {
         }
         // Give it a moment to shut down cleanly (it releases the lock), then
         // escalate; the loop's stale check mops up whatever remains.
-        await new Promise((r) => setTimeout(r, 2_000));
+        await new Promise((r) => setTimeout(r, opts?.takeoverWaitMs ?? 2_000));
         if (pidAlive(owner.pid)) {
           try {
             process.kill(owner.pid, "SIGKILL");

--- a/ts/serveLock.ts
+++ b/ts/serveLock.ts
@@ -1,0 +1,167 @@
+import { mkdir, readFile, rm, writeFile, rename } from "fs/promises";
+import path from "path";
+import { agentYesHome } from "./agentYesHome.ts";
+import { isTransientLockMkdirError } from "./notifyStore.ts";
+
+/**
+ * Singleton lock for the WebRTC host role: one `ay serve` host per
+ * ~/.agent-yes. Two hosts sharing the persisted room (~/.agent-yes/.share-room)
+ * fight over every viewer connection — the exact outage seen live: an orphaned
+ * `ay serve --webrtc` from a previous manager era plus a manual run left the
+ * managed daemon crash-looping (12 watchdog restarts) and the share link
+ * unloadable. The lock makes the loser fail FAST with a pointer to the owner
+ * instead of silently contending.
+ *
+ * mkdir-based (atomic on every platform), owner JSON alongside, heartbeat
+ * refresh while held. A stale owner — dead pid, or a heartbeat older than
+ * SERVE_LOCK_STALE_MS (a SIGKILLed host can't clean up) — is stolen, so a
+ * crashed host never wedges the next start.
+ */
+
+export const SERVE_LOCK_STALE_MS = 20_000;
+export const SERVE_LOCK_BEAT_MS = 5_000;
+// Riding out a manager roll-forward: stop-old/start-new overlap briefly, so a
+// new host retries for a grace window before declaring the lock busy.
+export const SERVE_LOCK_GRACE_MS = 12_000;
+
+export type ServeLockOwner = { pid: number; started_at: number; beat_at: number };
+
+export type ServeLockResult =
+  | { ok: true; release: () => Promise<void> }
+  | { ok: false; owner: ServeLockOwner | null };
+
+function lockDir(): string {
+  return path.join(agentYesHome(), "webrtc-host.lock");
+}
+function ownerPath(): string {
+  return path.join(lockDir(), "owner.json");
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM = alive but not ours; only ESRCH means gone.
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function readOwner(): Promise<ServeLockOwner | null> {
+  try {
+    const o = JSON.parse(await readFile(ownerPath(), "utf-8")) as ServeLockOwner;
+    return typeof o?.pid === "number" ? o : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pure staleness decision, exported for tests. */
+export function isOwnerStale(
+  owner: ServeLockOwner | null,
+  now: number,
+  alive: (pid: number) => boolean,
+  staleMs = SERVE_LOCK_STALE_MS,
+): boolean {
+  if (!owner) return true; // torn/absent owner: mkdir won but write died
+  if (!alive(owner.pid)) return true;
+  return now - owner.beat_at > staleMs;
+}
+
+// Atomic owner stamp (temp + rename) so a concurrent reader never parses a
+// torn file as "no owner" while we in fact hold the lock.
+async function stampOwner(startedAt: number): Promise<boolean> {
+  const tmp = `${ownerPath()}.${process.pid}.tmp`;
+  try {
+    await writeFile(
+      tmp,
+      JSON.stringify({ pid: process.pid, started_at: startedAt, beat_at: Date.now() }),
+    );
+    await rename(tmp, ownerPath());
+    return true;
+  } catch {
+    await rm(tmp, { force: true }).catch(() => {});
+    return false;
+  }
+}
+
+/**
+ * Acquire the host lock, retrying for up to `graceMs`. Returns fast on a live
+ * owner once the grace expires (never blocks a daemon boot forever). With
+ * `takeover`, a live owner is SIGTERM'd (then SIGKILL'd) and the lock stolen.
+ */
+export async function acquireWebrtcHostLock(opts?: {
+  takeover?: boolean;
+  graceMs?: number;
+  staleMs?: number;
+}): Promise<ServeLockResult> {
+  const graceMs = opts?.graceMs ?? SERVE_LOCK_GRACE_MS;
+  const staleMs = opts?.staleMs ?? SERVE_LOCK_STALE_MS;
+  const startedAt = Date.now();
+  const deadline = startedAt + graceMs;
+  let tookOver = false;
+  for (;;) {
+    try {
+      await mkdir(lockDir(), { recursive: false });
+      if (!(await stampOwner(startedAt))) {
+        await rm(lockDir(), { recursive: true, force: true }).catch(() => {});
+        return { ok: false, owner: null };
+      }
+      // Heartbeat while held; stops itself if a thief replaced our owner file.
+      const beat = setInterval(() => {
+        void (async () => {
+          const o = await readOwner();
+          if (o?.pid !== process.pid) {
+            clearInterval(beat);
+            return;
+          }
+          await stampOwner(startedAt);
+        })();
+      }, SERVE_LOCK_BEAT_MS);
+      if (typeof beat.unref === "function") beat.unref();
+      return {
+        ok: true,
+        release: async () => {
+          clearInterval(beat);
+          if ((await readOwner())?.pid === process.pid)
+            await rm(lockDir(), { recursive: true, force: true }).catch(() => {});
+        },
+      };
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (!isTransientLockMkdirError(code)) throw e;
+      if (code !== "EEXIST") {
+        // win32 mkdir-vs-rm race: dir mid-delete, just retry.
+        await new Promise((r) => setTimeout(r, 25));
+        continue;
+      }
+      const owner = await readOwner();
+      if (isOwnerStale(owner, Date.now(), pidAlive, staleMs)) {
+        await rm(lockDir(), { recursive: true, force: true }).catch(() => {});
+        continue; // re-prove via mkdir — two stealers can't both win
+      }
+      if (opts?.takeover && owner && !tookOver) {
+        tookOver = true; // one shot: never kill a second, newer owner
+        try {
+          process.kill(owner.pid, "SIGTERM");
+        } catch {
+          /* already gone */
+        }
+        // Give it a moment to shut down cleanly (it releases the lock), then
+        // escalate; the loop's stale check mops up whatever remains.
+        await new Promise((r) => setTimeout(r, 2_000));
+        if (pidAlive(owner.pid)) {
+          try {
+            process.kill(owner.pid, "SIGKILL");
+          } catch {
+            /* gone */
+          }
+        }
+        await rm(lockDir(), { recursive: true, force: true }).catch(() => {});
+        continue;
+      }
+      if (Date.now() >= deadline) return { ok: false, owner };
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+}


### PR DESCRIPTION
## The outage this prevents (root-caused live today)

Three `ay serve --webrtc` processes — a day-old orphan from a previous manager era, a manual run, and the oxmgr-managed daemon — fought over the same persisted room (`~/.agent-yes/.share-room`). The managed daemon crash-looped 12× under the health watchdog and the share link wouldn't load. #251's uninstall sweep can't catch this class: those processes were never manager-registered.

## Fix

`ts/serveLock.ts` — mkdir lock at `~/.agent-yes/webrtc-host.lock`, atomic pid+heartbeat owner file:

- webrtc/share-mode `cmdServe` acquires it or **exits 1** naming the owner: pid, start time, and next steps (`ay serve status`, `--takeover`, `AGENT_YES_NO_SERVE_LOCK=1`)
- stale owners (dead pid, heartbeat quiet >20s — a SIGKILLed host) are stolen; steal re-proves via mkdir so two stealers can't both win
- 12s acquire grace rides out manager roll-forward overlap; shutdown gates process exit on the lock release so an instant respawn never waits out the stale window
- `--takeover`: SIGTERM (then SIGKILL) the owner, take the room — one shot, never kills a second newer owner
- HTTP-only serves skip the lock (EADDRINUSE already handles port collisions); win32 mkdir-vs-rm races reuse `isTransientLockMkdirError` from #261

## Verified

E2E in an isolated `AGENT_YES_HOME`: second host exits 1 with the owner message; `--takeover` stops the first and inherits the lock; SIGTERM releases it. Unit tests cover acquire/second-fails-fast/release/steal-stale/steal-dead-pid and the pure staleness rule. 30/30 specs pass.

Companion PR (stray-process warning in install/uninstall) is being built by a codex agent in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)