### PR TITLE
feat(serve,ui): PTY size negotiation across viewers + pinch-zoom reflows the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ bun add -g agent-yes      # or: npm install -g agent-yes
 
 Then: `ay claude` (run an agent with auto-yes) · `ay serve --share` (web console + shareable link) · live console at https://agent-yes.com
 
+For the local web console, install [Portless](https://portless.sh/) once with `npm install -g portless`, then run `ay serve`. It assigns a free internal port and serves the console at `https://agent-yes.localhost/`. `ay serve --port N` remains available for a fixed-port API listener.
+
 ## Features
 
 - **Multi-CLI Support**: Works with Claude, Gemini, Codex, Copilot, and Cursor CLI tools

--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -7,7 +7,7 @@
 // `now` so age() is deterministic under test.
 
 // An agent entry as surfaced by /api/ls (the fields this module reads):
-//   { cli, cwd, title, prompt, status, started_at, pid, _host }
+//   { cli, cwd, title, status_text, prompt, status, started_at, pid, _host }
 
 // claude is the default CLI — show the cli name only when it differs, so the
 // common case stays uncluttered and the identity (repo/branch) leads instead.
@@ -260,6 +260,8 @@ export function age(e, now = Date.now()) {
 export function matches(e, toks) {
   const hay =
     (e.title || "") +
+    " " +
+    (e.status_text || "") +
     " " +
     (e.prompt || "") +
     " " +

--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -701,6 +701,26 @@ export function fitTransform(gridW, gridH, paneW, paneH) {
   return s > 0.985 && s < 1.04 ? "none" : "scale(" + s.toFixed(4) + ")";
 }
 
+// Centered variant: same scale selection as fitTransform, plus a translate that
+// centers the scaled grid in the pane (fit-width → vertically centered,
+// fit-height → horizontally centered). transform-origin stays top-left, so the
+// translate is in pane px and consumers mapping grid→screen coords (peer
+// overlays) can read the offset back off this same object. "none" (the crisp
+// driver path) never gets a translate — grid ≈ pane, nothing to center.
+export function fitTransformCentered(gridW, gridH, paneW, paneH) {
+  const t = fitTransform(gridW, gridH, paneW, paneH);
+  if (t === "none") return { transform: "none", scale: 1, dx: 0, dy: 0 };
+  const s = Math.min(paneW / gridW, paneH / gridH);
+  const dx = Math.max(0, (paneW - gridW * s) / 2);
+  const dy = Math.max(0, (paneH - gridH * s) / 2);
+  return {
+    transform: `translate(${dx.toFixed(1)}px, ${dy.toFixed(1)}px) ` + t,
+    scale: s,
+    dx,
+    dy,
+  };
+}
+
 // Browser-tab title: "<glyph> <selected agent title> - agent-yes", or the bare
 // console title when nothing is selected (blank/whitespace name). The leading
 // glyph mirrors the agent's status dot — ⌨ needs_input ("your turn"), ⚠ stuck,

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2148,7 +2148,7 @@
         selFromBottom,
         parseSel,
         selSegments,
-        fitTransform,
+        fitTransformCentered,
         docTitle,
         omniScore,
       } from "./console-logic.js";
@@ -2205,7 +2205,15 @@
         } catch {}
         if (term) {
           term.options.fontSize = termFontSize;
-          if (fit)
+          // Negotiating host: the grid is canonical (host-owned) — a font change
+          // here only alters our glyph px, so re-letterbox and report the new
+          // capacity; the host reflows the PTY if our readable cols/rows moved.
+          // This is what makes font size a ZOOM control on mobile: bigger font →
+          // fewer readable cells → the PTY itself shrinks → bigger crisp text.
+          if (negoActive) {
+            applyCanvasScale();
+            sendPresence();
+          } else if (fit)
             try {
               fit.fit();
             } catch {}
@@ -3107,6 +3115,13 @@
       // short lease after that, the heartbeat won't follow/override — so our own
       // push isn't fought while the agent's /api/size is still catching up.
       let lastDroveAt = 0;
+      // The selected agent's host negotiates the PTY size from viewer
+      // capacities (its /api/size responses carry nego:true). On such hosts we
+      // never push /api/resize — we report our readable capacity in presence
+      // (sendPresence cap) and follow the negotiated canonical grid, so a phone
+      // and a desktop watching the same agent converge on the smallest
+      // viewer's readable size instead of fighting last-writer-wins.
+      let negoActive = false;
 
       function isDarkColor(c) {
         try {
@@ -3252,6 +3267,18 @@
           const s = term.getSelectionPosition && term.getSelectionPosition();
           selR = selFromBottom(s, term.buffer.active.length);
         } catch {}
+        // Our readable capacity: the grid our pane fits at the current font —
+        // measured from the container (transform-independent), NOT term.cols
+        // (which may be a foreign canonical grid we're letterboxing). The host
+        // negotiates the PTY to the min cap across viewers; read-only viewers
+        // report none (they can't influence the PTY). Older hosts ignore it.
+        let cap = null;
+        try {
+          if (!isReadonlyEnt(cur.e) && fit) {
+            const d = fit.proposeDimensions();
+            if (d && d.cols > 0 && d.rows > 0) cap = { cols: d.cols, rows: d.rows };
+          }
+        } catch {}
         cur.tx
           .post("/api/presence", {
             viewer: myViewerId,
@@ -3259,6 +3286,7 @@
             cols: term.cols,
             rows: term.rows,
             sel: selR,
+            cap,
           })
           .catch(() => {});
       }
@@ -3575,14 +3603,36 @@
           const cs = getComputedStyle(logEl);
           const pw = logEl.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
           const ph = logEl.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
-          // fitTransform (console-logic.js) decides none-vs-scale (unit-tested).
-          xt.style.transform = fitTransform(gw, gh, pw, ph);
+          // fitTransformCentered (console-logic.js, unit-tested) decides
+          // none-vs-scale and centers the letterboxed grid in the pane (fit
+          // width → vertically centered, fit height → horizontally). The peer
+          // overlay reads the transformed screen rect back via
+          // getBoundingClientRect, so the translate needs no extra bookkeeping.
+          xt.style.transform = fitTransformCentered(gw, gh, pw, ph).transform;
         } catch {}
+      }
+      // Pane geometry changed (window resize, splitter drag, soft keyboard, tab
+      // refocus): on legacy hosts re-fit the grid to the pane (the size push
+      // rides term.onResize → pushSize); on negotiating hosts the grid is
+      // canonical — never reflow it locally, just re-letterbox and report the
+      // new capacity so the host can move the min if needed.
+      function refitPane() {
+        if (!term) return;
+        if (negoActive) {
+          applyCanvasScale();
+          sendPresence();
+          return;
+        }
+        if (fit)
+          try {
+            fit.fit();
+          } catch {}
       }
       // Follow the canonical grid: resize our xterm to the agent's size (set by the
       // active driver / local owner) WITHOUT reflowing to our pane, then scale to
       // fit. No-op when we already match (we're the driver, or sizes agree).
       function followAgentSize(sz) {
+        if (sz && sz.nego != null) negoActive = !!sz.nego;
         if (!term || !sz || !sz.cols || !sz.rows) return;
         // While our own recent push is still settling, don't fight it.
         if (Date.now() - lastDroveAt < 6000) {
@@ -5162,6 +5212,14 @@
               applyCanvasScale();
               return;
             }
+            // Negotiating host: the PTY size is the host's min over viewer
+            // capacities, not ours to push. Re-letterbox and refresh our cap
+            // (the pane may have changed) — the host resizes if the min moved.
+            if (negoActive) {
+              applyCanvasScale();
+              sendPresence();
+              return;
+            }
             lastDroveAt = Date.now(); // we're driving the size now (lease the grid)
             tx.post("/api/resize/" + encodeURIComponent(pid), {
               cols: term.cols,
@@ -5202,6 +5260,7 @@
         const selKey = e._key;
         const fitAndSync = (sz) => {
           if (sel !== selKey || !term) return;
+          negoActive = !!(sz && sz.nego);
           if (sz && sz.cols && sz.rows) agentSize = sz; // remember for the badge tooltip
           // Read-only viewer: don't reflow the agent to our pane (we can't resize
           // it, and shouldn't). Adopt the AGENT's own grid and CSS-scale it to fit,
@@ -5211,6 +5270,22 @@
             if (sz && sz.cols && sz.rows) followAgentSize(sz);
             else applyCanvasScale();
             suppressPush = false;
+            return;
+          }
+          // Negotiating host: adopt the canonical (negotiated) grid like a
+          // watcher and report our capacity via presence — the host takes the
+          // min over all viewers and resizes the PTY itself. No direct push, so
+          // two viewers can't fight over the size.
+          if (negoActive) {
+            if (sz.cols && sz.rows) followAgentSize(sz);
+            else {
+              // agent has no size on record yet — seed from our own fit
+              try {
+                fit.fit();
+              } catch {}
+            }
+            suppressPush = false;
+            sendPresence(); // cap → host negotiates → size event brings the grid
             return;
           }
           try {
@@ -5388,13 +5463,9 @@
         renderList();
       });
       window.addEventListener("resize", () => {
-        // Resizing our window is strong intent → re-fit to our pane (we become the
-        // size driver; the push rides term.onResize). applyCanvasScale then clears
-        // the transform since our grid now matches our pane.
-        if (fit)
-          try {
-            fit.fit();
-          } catch {}
+        // Resizing our window is strong intent → re-fit / re-report capacity
+        // (refitPane picks the legacy-push vs negotiate path).
+        refitPane();
         applyCanvasScale();
         renderPeerSelections(); // cell size changed → reposition peer-selection overlays
       });
@@ -5409,15 +5480,76 @@
         const onVV = () => {
           const kb = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop));
           document.documentElement.style.setProperty("--kb", kb + "px");
-          if (fit)
-            try {
-              fit.fit();
-            } catch {}
+          refitPane();
         };
         vv.addEventListener("resize", onVV);
         vv.addEventListener("scroll", onVV);
         onVV();
       }
+      // ── mobile pinch on the terminal = terminal zoom, not page zoom ─────────
+      // Two fingers over the log pane adjust the terminal FONT SIZE. On a
+      // negotiating host that reflows the PTY itself (bigger font → fewer
+      // readable cells → the host shrinks the grid → bigger crisp text; smaller
+      // font → more rows/cols), which is what a phone user actually means by
+      // pinch: "show me more / make it readable", with the surrounding UI
+      // staying put. Only 2-touch gestures over .log are intercepted — 1-finger
+      // scroll/selection passes to xterm, and the page keeps its native
+      // pinch-zoom everywhere else (an a11y requirement, WCAG 1.4.4).
+      (function () {
+        const logEl = $("log");
+        if (!logEl) return;
+        let startDist = 0; // 0 = no pinch in flight
+        let startFont = 0;
+        let lastRatio = 1;
+        let baseTransform = "";
+        const dist = (t) => Math.hypot(t[0].clientX - t[1].clientX, t[0].clientY - t[1].clientY);
+        logEl.addEventListener(
+          "touchstart",
+          (ev) => {
+            if (ev.touches.length !== 2) return;
+            ev.preventDefault(); // this gesture is ours — no page zoom
+            startDist = dist(ev.touches);
+            startFont = termFontSize;
+            lastRatio = 1;
+            const xt = logEl.querySelector(".xterm");
+            baseTransform = xt ? xt.style.transform || "none" : "none";
+          },
+          { passive: false },
+        );
+        logEl.addEventListener(
+          "touchmove",
+          (ev) => {
+            if (ev.touches.length !== 2 || !startDist) return;
+            ev.preventDefault();
+            lastRatio = dist(ev.touches) / startDist;
+            // Live preview: compose the pinch onto the fitted transform. The
+            // grid truly reflows only when the negotiated size lands after the
+            // gesture commits — a brief settle, traded for zero SIGWINCH storm
+            // while the fingers are still moving.
+            const xt = logEl.querySelector(".xterm");
+            if (xt)
+              xt.style.transform =
+                `scale(${lastRatio.toFixed(3)})` +
+                (baseTransform === "none" ? "" : " " + baseTransform);
+          },
+          { passive: false },
+        );
+        const endPinch = () => {
+          if (!startDist) return;
+          const target = Math.round(startFont * lastRatio);
+          startDist = 0;
+          if (target !== termFontSize) setTermFontSize(target); // nego: cap → host reflows
+          applyCanvasScale(); // clear the preview; re-letterbox at the real grid
+        };
+        logEl.addEventListener("touchend", (ev) => {
+          if (ev.touches.length < 2) endPinch();
+        });
+        logEl.addEventListener("touchcancel", () => endPinch());
+        // Safari's proprietary gesture events fire for pinch regardless of
+        // touch-action; swallow them over the terminal so the page never zooms.
+        for (const t of ["gesturestart", "gesturechange", "gestureend"])
+          logEl.addEventListener(t, (ev) => ev.preventDefault());
+      })();
 
       // Step the selection up/down the (filtered) list — same order the left panel
       // renders. Clamps at the ends, scrolls the row into view.
@@ -6958,11 +7090,7 @@
             // terminal of a different size) that re-push fights the local terminal
             // and reflows the stream on every tab switch — the glitch the eager
             // per-focus resync introduced. The one-shot adopt still runs on select.
-            if (term && fit) {
-              try {
-                fit.fit();
-              } catch {}
-            }
+            refitPane();
           }
         });
         watchVersion();
@@ -7014,10 +7142,7 @@
           if (!dragging) return;
           const w = Math.min(Math.max(e.clientX, 280), window.innerWidth - 360);
           app.style.setProperty("--leftw", w + "px");
-          if (fit)
-            try {
-              fit.fit();
-            } catch {}
+          refitPane();
         });
         const end = (e) => {
           if (!dragging) return;

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1325,6 +1325,14 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .statusline {
+        color: var(--muted);
+        font-size: 12.5px;
+        margin-top: 4px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
       /* compact view: one line per agent — dot + cli + live title (or prompt), age */
       .row.crow {
         display: flex;
@@ -4832,7 +4840,7 @@
               .map((r) => {
                 if (r.kind !== "agent") return headerHtml(r);
                 const e = r.entry;
-                const t = e.title || e.prompt || "";
+                const t = e.title || e.status_text || e.prompt || "";
                 const id = compactIdent(e, ctx, 3, r.parentEntry);
                 const cli = cliLabel(e);
                 return `<div class="row crow ${e._key === sel ? "sel" : ""}${rowFlags(e)}" data-key="${esc(e._key)}">
@@ -4875,9 +4883,10 @@
           ${taskChipHtml(e)}
           ${badgeChipsHtml(e)}
           ${gitChipHtml(e)}
-          ${peerChipHtml(e)}
-          <span class="age">${age(e)}</span></div>
+        ${peerChipHtml(e)}
+        <span class="age">${age(e)}</span></div>
         ${e.title ? `<div class="rowtitle" title="${esc(e.title)}">${esc(e.title)}</div>` : ""}
+        ${e.status_text ? `<div class="statusline" title="${esc(e.status_text)}">${esc(e.status_text)}</div>` : ""}
         ${
           e.status === "needs_input" && e.question
             ? `<div class="detail ask" title="${esc(e.question)}">⌨ ${esc(e.question)}</div>`

--- a/lab/ui/rtc.js
+++ b/lab/ui/rtc.js
@@ -30,6 +30,46 @@ const SIG_DEFAULT = "s.agent-yes.com"; // signaling host (override in the hash w
 const SUB = "ay-signal-1";
 export { SIG_DEFAULT };
 
+const PERF_KEY = "ay.perf";
+const PERF_SLOW_MS = 750;
+const perfNow = () => Math.round(performance.now());
+function perfEnabled() {
+  try {
+    return localStorage.getItem(PERF_KEY) === "1" || location.search.includes("ay_perf=1");
+  } catch {
+    return false;
+  }
+}
+function perfLog(scope, event, data = {}, force = false) {
+  const rec = { t: Date.now(), p: perfNow(), scope, event, ...data };
+  const w = globalThis;
+  const buf = (w.__ayPerf = Array.isArray(w.__ayPerf) ? w.__ayPerf : []);
+  if (!w.__ayPerfReport)
+    w.__ayPerfReport = () => {
+      const rows = Array.isArray(w.__ayPerf) ? w.__ayPerf : [];
+      const byEvent = {};
+      for (const r of rows) {
+        const k = `${r.scope}:${r.event}`;
+        const b = (byEvent[k] ||= { count: 0, maxMs: 0, lastMs: 0 });
+        b.count++;
+        if (typeof r.ms === "number") {
+          b.lastMs = r.ms;
+          b.maxMs = Math.max(b.maxMs, r.ms);
+        }
+      }
+      return { count: rows.length, byEvent, last: rows.slice(-40) };
+    };
+  if (!w.__ayPerfClear) w.__ayPerfClear = () => (w.__ayPerf = []);
+  buf.push(rec);
+  if (buf.length > 500) buf.splice(0, buf.length - 500);
+  if (force || perfEnabled()) console.info("[ay-perf]", rec);
+}
+function maybeSlow(scope, event, startedAt, data = {}) {
+  const ms = Math.round(performance.now() - startedAt);
+  if (ms >= PERF_SLOW_MS) perfLog(scope, event, { ms, ...data }, true);
+  else perfLog(scope, event, { ms, ...data });
+}
+
 // Tunnels request/response + streaming over one DataChannel. Mirrors the
 // envelope in lab/ui/share-host.ts: {t:"req"|"abort"} out, {t:"res"|"data"|"end"} in.
 export class RTCClient {
@@ -64,6 +104,9 @@ export class RTCClient {
     });
   }
   async connect() {
+    const connectStartedAt = performance.now();
+    const mark = (event, data = {}) =>
+      perfLog("rtc", event, { room: this.room, host: this.host, ...data });
     // Parse the secret marker (fail-closed on malformed) and split into the
     // server-visible authToken vs the end-to-end keys the server never sees.
     const { s, v2 } = parseSecret(this.token);
@@ -75,11 +118,17 @@ export class RTCClient {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(`wss://${this.host}/${this.room}`, [SUB]);
       this.ws = ws; // kept so close() can drop the signaling registration too
+      mark("connect.start");
       let pc,
         settled = false;
       const fail = (e) => {
         if (!settled) {
           settled = true;
+          maybeSlow("rtc", "connect.fail", connectStartedAt, {
+            room: this.room,
+            host: this.host,
+            error: String(e?.message ?? e),
+          });
           reject(e);
         }
       };
@@ -88,20 +137,31 @@ export class RTCClient {
       const done = () => {
         if (!settled) {
           settled = true;
+          maybeSlow("rtc", "connect.open", connectStartedAt, {
+            room: this.room,
+            host: this.host,
+            state: this.pc?.connectionState,
+          });
           this.onstate("open");
           resolve();
         }
       };
-      ws.onopen = () =>
-        ws.send(JSON.stringify({ type: "hello", role: "client", v: 2, token: authToken }));
+      ws.onopen = () => (
+        mark("signal.open"),
+        ws.send(JSON.stringify({ type: "hello", role: "client", v: 2, token: authToken }))
+      );
       ws.onmessage = async (ev) => {
         const m = JSON.parse(ev.data);
         if (m.type === "welcome") {
+          mark("signal.welcome", { v: m.v });
           if (this._v2 && m.v !== 2)
             return fail(new Error("host is running an old agent-yes — ask it to upgrade"));
           // pc is created on the offer below so it can use the host-supplied
           // iceServers (incl. short-lived TURN creds for relaying behind NAT).
         } else if (m.type === "offer") {
+          mark("signal.offer", {
+            iceServers: Array.isArray(m.iceServers) ? m.iceServers.length : 0,
+          });
           if (!pc) {
             pc = new RTCPeerConnection({
               iceServers:
@@ -114,12 +174,16 @@ export class RTCClient {
               if (e.candidate)
                 ws.send(JSON.stringify({ type: "candidate", candidate: e.candidate }));
             };
-            pc.onconnectionstatechange = () => this.onstate(pc.connectionState);
+            pc.onconnectionstatechange = () => {
+              mark("pc.state", { state: pc.connectionState });
+              this.onstate(pc.connectionState);
+            };
             pc.ondatachannel = (e) => {
               this.dc = e.channel;
               this.dc.binaryType = "arraybuffer";
               this.dc.onopen = async () => {
                 try {
+                  mark("dc.open", { buffered: this.dc.bufferedAmount });
                   await this._keysReady;
                   // Open the bidirectional confirmation handshake.
                   this._dcSend(FLAG_CONFIRM, { t: "confirm", nonce: this._myNonce });
@@ -152,6 +216,7 @@ export class RTCClient {
             this._keyH2C = keyH2C;
             this._keyC2H = keyC2H;
             this._resolveKeys();
+            mark("keys.ready");
           } catch (err) {
             fail(err);
           }
@@ -166,8 +231,10 @@ export class RTCClient {
   }
   // Seal an envelope and send it, serialized so wire order == counter order.
   _dcSend(flags, obj) {
+    const queuedAt = performance.now();
     this._sendChain = this._sendChain.then(async () => {
       if (!this.dc || this.dc.readyState !== "open" || !this._keyC2H || !this._tHash) return;
+      const queuedMs = Math.round(performance.now() - queuedAt);
       let frame;
       try {
         frame = await e2eSeal(this._keyC2H, this._send, flags, this._tHash, packEnvelope(obj));
@@ -177,6 +244,19 @@ export class RTCClient {
       }
       try {
         this.dc.send(frame);
+        if (queuedMs >= PERF_SLOW_MS || this.dc.bufferedAmount > 1_000_000)
+          perfLog(
+            "rtc",
+            "send.slow",
+            {
+              room: this.room,
+              kind: obj?.t,
+              queuedMs,
+              buffered: this.dc.bufferedAmount,
+              bytes: frame.byteLength,
+            },
+            true,
+          );
       } catch {}
     });
     return this._sendChain;
@@ -223,17 +303,47 @@ export class RTCClient {
     const call = this.calls.get(r.id),
       stream = this.streams.get(r.id);
     if (r.t === "res") {
-      if (call) call.status = r.status;
+      if (call) {
+        call.status = r.status;
+        call.headAt = performance.now();
+        maybeSlow("rtc", "req.head", call.startedAt, {
+          room: this.room,
+          method: call.method,
+          path: call.path,
+          status: r.status,
+        });
+      }
     } else if (r.t === "data") {
       if (call) {
         call.body += r.chunk;
         call.dataCount = (call.dataCount || 0) + 1;
+        call.bytes = (call.bytes || 0) + r.chunk.length;
       }
-      if (stream) stream(r.chunk);
+      if (stream) {
+        if (!stream.firstAt) {
+          stream.firstAt = performance.now();
+          maybeSlow("rtc", "stream.first", stream.startedAt, {
+            room: this.room,
+            path: stream.path,
+          });
+        }
+        stream.chunks++;
+        stream.bytes += r.chunk.length;
+        stream.lastAt = performance.now();
+        stream(r.chunk);
+      }
     } else if (r.t === "end") {
       if (call) {
         clearTimeout(call.timer);
         this.calls.delete(r.id);
+        maybeSlow("rtc", "req.end", call.startedAt, {
+          room: this.room,
+          method: call.method,
+          path: call.path,
+          status: call.status,
+          chunks: call.dataCount || 0,
+          bytes: call.bytes || 0,
+        });
         // end.seq is the count of data frames the host sent; a mismatch means
         // the stream was truncated, so don't resolve it as complete.
         if (typeof r.seq === "number" && r.seq !== (call.dataCount || 0))
@@ -245,27 +355,62 @@ export class RTCClient {
   }
   req(method, path, body) {
     const id = randomHex(16);
+    const startedAt = performance.now();
     return new Promise((resolve, reject) => {
       // Without a deadline a request over a silently-dead DataChannel (host
       // gone, ICE not yet timed out) never settles, so the caller — and the
       // poll loop — hangs forever and the room never reconnects. Reject on a
       // timeout so listSource sees the failure and triggers backoff.
       const timer = setTimeout(() => {
-        if (this.calls.delete(id)) reject(new Error("request timed out"));
+        if (this.calls.delete(id)) {
+          maybeSlow("rtc", "req.timeout", startedAt, { room: this.room, method, path }, true);
+          reject(new Error("request timed out"));
+        }
       }, 12000);
-      this.calls.set(id, { status: 0, body: "", dataCount: 0, resolve, reject, timer });
+      this.calls.set(id, {
+        status: 0,
+        body: "",
+        dataCount: 0,
+        bytes: 0,
+        method,
+        path,
+        startedAt,
+        resolve,
+        reject,
+        timer,
+      });
+      perfLog("rtc", "req.start", { room: this.room, method, path });
       this._dcSend(0, { t: "req", id, method, path, body }).catch((e) => {
         clearTimeout(timer);
         this.calls.delete(id);
+        maybeSlow("rtc", "req.send_fail", startedAt, {
+          room: this.room,
+          method,
+          path,
+          error: String(e?.message ?? e),
+        });
         reject(e); // channel already torn down
       });
     });
   }
   subscribe(path, onRaw) {
     const id = randomHex(16);
-    this.streams.set(id, onRaw);
+    const startedAt = performance.now();
+    const wrapped = (chunk) => onRaw(chunk);
+    Object.assign(wrapped, { path, startedAt, firstAt: 0, lastAt: 0, chunks: 0, bytes: 0 });
+    this.streams.set(id, wrapped);
+    perfLog("rtc", "stream.start", { room: this.room, path });
     this._dcSend(0, { t: "req", id, method: "GET", path });
     return () => {
+      const stream = this.streams.get(id);
+      if (stream)
+        perfLog("rtc", "stream.close", {
+          room: this.room,
+          path,
+          ms: Math.round(performance.now() - startedAt),
+          chunks: stream.chunks,
+          bytes: stream.bytes,
+        });
       this.streams.delete(id);
       this._dcSend(0, { t: "abort", id });
     };

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -83,6 +83,9 @@ describe("console DOM behaviour", () => {
       expect(list).not.toMatch(/\bclaude\b/); // the word "claude" never appears
       // repo/wt mnemonic tags are derived from the cwd
       expect(list).toContain("snomiao/agent-yes");
+      expect(await page.locator('.list .row[data-key="local#101"] .statusline').innerText()).toBe(
+        "✶ Verifying calendar meetings with real data… (6m 30s · ↓ 19.5k tokens)",
+      );
     } finally {
       await ctx.close();
     }

--- a/tests/ui-dom/server.ts
+++ b/tests/ui-dom/server.ts
@@ -40,6 +40,7 @@ export const AGENTS = [
     cli: "claude",
     cwd: "/home/u/ws/snomiao/agent-yes/tree/main",
     title: "first agent",
+    status_text: "✶ Verifying calendar meetings with real data… (6m 30s · ↓ 19.5k tokens)",
     prompt: "",
     status: "active",
     started_at: T0,

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -33,6 +33,7 @@ import {
   parseSel,
   selSegments,
   fitTransform,
+  fitTransformCentered,
   docTitle,
   statusGlyph,
   omniScore,
@@ -834,6 +835,35 @@ describe("fitTransform", () => {
   it("guards bad dimensions", () => {
     expect(fitTransform(0, 480, 800, 480)).toBe("none");
     expect(fitTransform(800, 480, 0, 480)).toBe("none");
+  });
+});
+
+describe("fitTransformCentered", () => {
+  it("driver path stays crisp: none, no offset", () => {
+    expect(fitTransformCentered(800, 480, 800, 480)).toEqual({
+      transform: "none",
+      scale: 1,
+      dx: 0,
+      dy: 0,
+    });
+  });
+  it("fit-width (phone letterboxing a wide grid) centers vertically", () => {
+    // grid 2x wider than pane, same aspect pane taller → s=0.5, dy centers
+    const r = fitTransformCentered(1600, 480, 800, 480);
+    expect(r.transform).toBe("translate(0.0px, 120.0px) scale(0.5000)");
+    expect(r.scale).toBe(0.5);
+    expect(r.dx).toBe(0);
+    expect(r.dy).toBe(120);
+  });
+  it("fit-height (tall grid in a wide pane) centers horizontally", () => {
+    // s = min(800/400, 480/960) = 0.5 → scaled 200×480 → dx = (800-200)/2
+    const r = fitTransformCentered(400, 960, 800, 480);
+    expect(r.transform).toBe("translate(300.0px, 0.0px) scale(0.5000)");
+    expect(r.dx).toBe(300);
+    expect(r.dy).toBe(0);
+  });
+  it("guards bad dimensions like fitTransform", () => {
+    expect(fitTransformCentered(0, 480, 800, 480).transform).toBe("none");
   });
 });
 

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -1,6 +1,18 @@
 import { readFile } from "fs/promises";
 import { describe, expect, it } from "vitest";
-import { installerArgv, isNoNodeExecError, oxmgrVersionHasWindowsFix } from "./serve.ts";
+import {
+  installerArgv,
+  isNoNodeExecError,
+  oxmgrVersionHasWindowsFix,
+  portlessConsoleUrl,
+} from "./serve.ts";
+
+describe("portlessConsoleUrl", () => {
+  it("uses the stable local HTTPS hostname and keeps auth in the fragment", () => {
+    expect(portlessConsoleUrl()).toBe("https://agent-yes.localhost/");
+    expect(portlessConsoleUrl("a b")).toBe("https://agent-yes.localhost/#k=a%20b");
+  });
+});
 
 // Guards the Windows daemon-manager selection: on Windows we only PREFER oxmgr
 // when the installed build carries the daemon-socket-inheritance fix. Stock

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -48,6 +48,7 @@ import { findSpawnHiddenLauncher } from "./rustBinary.ts";
 import { pgidForWrapper } from "./reaper.ts";
 import { SUPPORTED_CLIS } from "./SUPPORTED_CLIS.ts";
 import { getInstalledPackage } from "./versionChecker.ts";
+import { negotiateSize, sanitizeCap, type SizeCap } from "./sizeNego.ts";
 import { listStrayServeProcesses } from "./strayServe.ts";
 import {
   getProvisionHook,
@@ -1850,9 +1851,86 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // never a security surface — viewers self-report. Pruned by TTL on read.
   const presence = new Map<
     string,
-    { viewer: string; agent: string; cols: number; rows: number; sel: string | null; ts: number }
+    {
+      viewer: string;
+      agent: string;
+      cols: number;
+      rows: number;
+      sel: string | null;
+      cap: SizeCap | null;
+      ts: number;
+    }
   >();
   const PRESENCE_TTL_MS = 12_000;
+
+  // ── PTY size negotiation — tmux's "smallest client wins" ──────────────────
+  // Writable viewers report their readable capacity (`cap`) alongside their
+  // presence; we resize the agent's PTY to the elementwise min across live caps
+  // (see sizeNego.ts), so a phone gets a grid it can read while wider viewers
+  // letterbox the shared canvas. Uses the same winsize-file + SIGWINCH path as
+  // POST /api/resize. When the last cap leaves (viewer switched agent, tab
+  // died → TTL), the size is withdrawn: the file is deleted ONLY if its content
+  // is still our own last write (so `ay attach`'s pushed size is never
+  // clobbered) and the wrapper falls back to the real tty size.
+  const negoApplied = new Map<number, { cols: number; rows: number; content: string }>();
+  const negoTimers = new Map<number, ReturnType<typeof setTimeout>>();
+  const NEGO_DEBOUNCE_MS = 350;
+  const winsizePathFor = (pid: number) =>
+    path.join(process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes"), "winsize", String(pid));
+  const liveCapsFor = (pid: number): SizeCap[] => {
+    const now = Date.now();
+    const caps: SizeCap[] = [];
+    for (const v of presence.values())
+      if (now - v.ts <= PRESENCE_TTL_MS && String(v.agent) === String(pid) && v.cap)
+        caps.push(v.cap);
+    return caps;
+  };
+  const applyNego = async (pid: number) => {
+    negoTimers.delete(pid);
+    const eff = negotiateSize(liveCapsFor(pid));
+    const file = winsizePathFor(pid);
+    const prev = negoApplied.get(pid);
+    try {
+      if (eff) {
+        if (prev && prev.cols === eff.cols && prev.rows === eff.rows) return;
+        const content = `${eff.cols} ${eff.rows} ${Date.now()}\n`;
+        await mkdir(path.dirname(file), { recursive: true });
+        await writeFile(file, content);
+        negoApplied.set(pid, { ...eff, content });
+      } else {
+        if (!prev) return;
+        negoApplied.delete(pid);
+        try {
+          // withdraw only what we wrote — a different content means ay attach
+          // (or a direct /api/resize) owns the size now; leave it alone.
+          if ((await readFile(file, "utf-8")) !== prev.content) return;
+          await unlink(file);
+        } catch {
+          return; // already gone — nothing to signal
+        }
+      }
+      try {
+        process.kill(pid, "SIGWINCH");
+      } catch {
+        /* agent gone */
+      }
+    } catch {
+      /* best-effort: a failed write just leaves the previous size in place */
+    }
+  };
+  const scheduleNego = (pid: number) => {
+    if (!Number.isFinite(pid) || pid <= 0 || negoTimers.has(pid)) return;
+    negoTimers.set(
+      pid,
+      setTimeout(() => void applyNego(pid), NEGO_DEBOUNCE_MS),
+    );
+  };
+  // TTL grow-back sweep: a viewer that vanished without clearing its presence
+  // (tab killed, phone locked) stops refreshing; once its entry expires the
+  // negotiated size must be recomputed even though no presence POST arrives.
+  setInterval(() => {
+    for (const pid of negoApplied.keys()) scheduleNego(pid);
+  }, 5_000);
 
   // The whole API as a plain handler: served over HTTP by Bun.serve (--http)
   // and called in-process by the WebRTC bridge (--webrtc) — the latter needs
@@ -2330,6 +2408,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
           pid: record.pid,
           cols: size?.cols ?? null,
           rows: size?.rows ?? null,
+          // This host negotiates the PTY size from viewer capacities (presence
+          // `cap`) — a capable console should report its cap instead of pushing
+          // /api/resize directly, so viewers stop fighting last-writer-wins.
+          nego: true,
         });
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });
@@ -2735,6 +2817,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         cols?: number;
         rows?: number;
         sel?: string;
+        cap?: { cols?: number; rows?: number };
       };
       try {
         b = (await req.json()) as typeof b;
@@ -2743,6 +2826,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
       }
       const viewer = String(b.viewer ?? "").slice(0, 64);
       if (!viewer) return new Response("missing viewer", { status: 400 });
+      // The agent this viewer WAS on — if the entry moves (agent switch) or
+      // clears, that agent's negotiated size must be recomputed (grow-back).
+      const prevAgent = presence.get(viewer)?.agent;
       if (b.agent == null) presence.delete(viewer);
       else
         presence.set(viewer, {
@@ -2751,8 +2837,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
           cols: Math.max(0, Math.floor(Number(b.cols) || 0)),
           rows: Math.max(0, Math.floor(Number(b.rows) || 0)),
           sel: typeof b.sel === "string" ? b.sel.slice(0, 200) : null,
+          cap: sanitizeCap(b.cap),
           ts: Date.now(),
         });
+      if (b.agent != null) scheduleNego(Number(b.agent));
+      if (prevAgent != null && String(prevAgent) !== String(b.agent ?? ""))
+        scheduleNego(Number(prevAgent));
       return new Response(null, { status: 204 });
     }
     // GET /api/presence — all live viewers (TTL-pruned), for "who's watching".

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -38,6 +38,7 @@ import {
 } from "./subcommands.ts";
 import { TYPING_BADGE } from "./badges.ts";
 import { isTerminalReply } from "./terminalReply.ts";
+import { parseStatusText } from "./statusText.ts";
 import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
 import { acquireWebrtcHostLock, type ServeLockOwner } from "./serveLock.ts";
 import { type MailParty, recordInbox } from "./messageLog.ts";
@@ -1435,6 +1436,28 @@ export async function cmdServe(rest: string[]): Promise<number> {
     }
   };
 
+  // Per-agent live status description from the rendered screen. Claude Code
+  // paints a spinner/status line while working; surfacing it lets the left panel
+  // show "what it's doing" without opening the terminal.
+  const statusTextCache = new Map<
+    string,
+    { size: number; mtimeMs: number; statusText: string | null }
+  >();
+  const logStatusText = async (logFile: string | null | undefined): Promise<string | null> => {
+    if (!logFile) return null;
+    try {
+      const { size, mtimeMs } = await stat(logFile);
+      const hit = statusTextCache.get(logFile);
+      if (hit && hit.size === size && hit.mtimeMs === mtimeMs) return hit.statusText;
+      const lines = await renderLogTailLines(logFile, 40);
+      const statusText = lines ? parseStatusText(lines) : null;
+      statusTextCache.set(logFile, { size, mtimeMs, statusText });
+      return statusText;
+    } catch {
+      return null;
+    }
+  };
+
   // Per-agent "waiting on you" detection: the agent is parked on an interactive
   // menu it did NOT auto-resolve (config `needsInput` patterns). Same source and
   // classifier as `ay ls` / `ay status`, so the console's dot matches the CLI's
@@ -1701,6 +1724,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
       // WHAT the agent is waiting on. Null otherwise.
       question,
       title: await logTitle(r.log_file),
+      status_text: status === "exited" ? null : await logStatusText(r.log_file),
       git: status === "exited" ? null : await gitStatus(r.cwd),
       // Task progress from the rendered todo block (null when none detected → no
       // badge). Skipped for exited agents — their screen is no longer live.

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -59,7 +59,56 @@ import {
   resolveSpawnCwd,
 } from "./workspaceConfig.ts";
 
-const DEFAULT_PORT = 7432;
+const DEFAULT_PORT = 0;
+const PORTLESS_APP_NAME = "agent-yes";
+const PORTLESS_CHILD_ENV = "AGENT_YES_PORTLESS_CHILD";
+
+export function portlessConsoleUrl(token?: string): string {
+  return portlessConsoleUrlForOrigin(
+    process.env.PORTLESS_URL?.replace(/\/$/, "") || `https://${PORTLESS_APP_NAME}.localhost`,
+    token,
+  );
+}
+
+function portlessConsoleUrlForOrigin(origin: string, token?: string): string {
+  const fragment = token ? `/#k=${encodeURIComponent(token)}` : "/";
+  return `${origin}${fragment}`;
+}
+
+async function resolvedPortlessConsoleUrl(token?: string): Promise<string> {
+  if (process.env.PORTLESS_URL) return portlessConsoleUrl(token);
+  try {
+    const port = Number(
+      (await readFile(path.join(homedir(), ".portless", "proxy.port"), "utf-8")).trim(),
+    );
+    if (Number.isInteger(port) && port > 0)
+      return portlessConsoleUrlForOrigin(
+        `https://${PORTLESS_APP_NAME}.localhost${port === 443 ? "" : `:${port}`}`,
+        token,
+      );
+  } catch {
+    /* Portless has not created state yet. */
+  }
+  return portlessConsoleUrl(token);
+}
+
+async function runWithPortless(rest: string[]): Promise<number> {
+  const portless = Bun.which("portless");
+  if (!portless) {
+    process.stderr.write(
+      "ay serve: Portless is required for local HTTPS. Install it with: npm install -g portless\n",
+    );
+    return 1;
+  }
+  const script = process.argv[1];
+  const self =
+    script && /\.[cm]?[jt]s$/.test(script) ? [process.execPath, script] : [process.execPath];
+  const proc = Bun.spawn([portless, PORTLESS_APP_NAME, ...self, "serve", ...rest], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: { ...liveEnv(), [PORTLESS_CHILD_ENV]: "1" },
+  });
+  return (await proc.exited) ?? 1;
+}
 
 /**
  * Normalize a user-supplied GitHub-ish source into the standard
@@ -705,9 +754,28 @@ async function readDaemonServeArgs(mgr: DaemonManager): Promise<string[] | null>
   }
 }
 
-function portFromArgs(args: string[]): number {
+function portFromArgs(args: string[]): number | null {
   const m = /--port[=\s](\d+)/.exec(args.join(" "));
-  return m ? Number(m[1]) : DEFAULT_PORT;
+  return m ? Number(m[1]) : null;
+}
+
+function argsUsePortless(args: string[]): boolean {
+  const wantsHttp =
+    args.some((a) => a.startsWith("--http") || a.startsWith("--share")) ||
+    !args.some((a) => a.startsWith("--webrtc"));
+  return wantsHttp && portFromArgs(args) === null;
+}
+
+async function portlessAppPort(): Promise<number | null> {
+  try {
+    const routes = JSON.parse(
+      await readFile(path.join(homedir(), ".portless", "routes.json"), "utf-8"),
+    ) as { hostname?: string; port?: number }[];
+    const route = routes.find((r) => r.hostname === `${PORTLESS_APP_NAME}.localhost`);
+    return typeof route?.port === "number" ? route.port : null;
+  } catch {
+    return null;
+  }
 }
 
 async function warnStrayServeProcesses(): Promise<void> {
@@ -742,7 +810,8 @@ function explicitWebrtcUrl(args: string[]): string | undefined {
 // Ask the live daemon its version over the local HTTP API. null if it's not
 // listening (webrtc-only) or too old to expose /api/version — both of which we
 // treat as "outdated" so a re-install rolls it forward.
-async function fetchDaemonVersion(port: number, token: string): Promise<string | null> {
+async function fetchDaemonVersion(port: number | null, token: string): Promise<string | null> {
+  if (port === null) return null;
   try {
     const r = await fetch(`http://127.0.0.1:${port}/api/version`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -890,7 +959,8 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
       // share link for a WebRTC bridge that isn't actually running. A bare re-run
       // passes no args, so effArgs === priorArgs and this stays a no-op as before.
       const sameConfig = JSON.stringify(effArgs) === JSON.stringify(priorArgs);
-      const runningVer = await fetchDaemonVersion(portFromArgs(effArgs), token);
+      const daemonPort = argsUsePortless(effArgs) ? await portlessAppPort() : portFromArgs(effArgs);
+      const runningVer = await fetchDaemonVersion(daemonPort, token);
       if (runningVer === current && sameConfig) {
         await ensureBootAutostart(mgr);
         process.stdout.write(`'${DAEMON_NAME}' already running v${current} (up to date)\n`);
@@ -983,7 +1053,8 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
     const code = await proc.exited;
     if (code === 0) {
       const onBoot = await ensureBootAutostart(mgr);
-      const port = portFromArgs(effArgs);
+      const port = argsUsePortless(effArgs) ? await portlessAppPort() : portFromArgs(effArgs);
+      const localUrl = argsUsePortless(effArgs) ? await resolvedPortlessConsoleUrl(token) : null;
       // Mirror cmdServe's mode resolution: webrtc-only daemons open no HTTP port.
       const httpish =
         effArgs.some((a) => a.startsWith("--http") || a.startsWith("--share")) ||
@@ -1021,8 +1092,12 @@ async function cmdServeDaemon(sub: string, args: string[]): Promise<number> {
         );
       process.stdout.write(`token: ${token}\n\n`);
       if (httpish) {
-        process.stdout.write(`  ay ls   ${token}@<host>:${port}\n`);
-        process.stdout.write(`  ay remote add <alias> http://${token}@<host>:${port}\n`);
+        if (argsUsePortless(effArgs)) {
+          process.stdout.write(`  web console: ${localUrl}\n`);
+        } else if (port !== null) {
+          process.stdout.write(`  ay ls   ${token}@<host>:${port}\n`);
+          process.stdout.write(`  ay remote add <alias> http://${token}@<host>:${port}\n`);
+        }
       }
       process.stdout.write(`  ay serve logs                # view server logs\n`);
       process.stdout.write(`  ay serve uninstall           # remove daemon\n`);
@@ -1055,7 +1130,9 @@ async function cmdServeStatus(args: string[]): Promise<number> {
   const daemonArgs = mgr ? await readDaemonServeArgs(mgr) : null;
   const installed = daemonArgs !== null;
   const a = daemonArgs ?? [];
-  const port = portFromArgs(a);
+  const local = argsUsePortless(a);
+  const port = local ? await portlessAppPort() : portFromArgs(a);
+  const localUrl = local ? await resolvedPortlessConsoleUrl(token ?? undefined) : null;
   // Mirror cmdServe/install mode resolution: webrtc when --webrtc/--share; http
   // when --http/--share OR no --webrtc at all (http is the implicit default).
   const webrtcish = a.some((x) => x.startsWith("--webrtc") || x.startsWith("--share"));
@@ -1077,6 +1154,7 @@ async function cmdServeStatus(args: string[]): Promise<number> {
           installed,
           mode,
           port: httpish ? port : null,
+          localUrl: httpish ? localUrl : null,
           reachable: runningVersion !== null,
           runningVersion,
           currentVersion: current,
@@ -1097,25 +1175,32 @@ async function cmdServeStatus(args: string[]): Promise<number> {
   w(`manager:      ${mgr ? mgr.id : "none — install pm2 or oxmgr to daemonize"}`);
   if (installed) {
     w(`installed:    yes (via ${mgr!.id})`);
-    w(`mode:         ${mode}${httpish ? `  (port ${port})` : ""}`);
+    w(`mode:         ${mode}${httpish ? (local ? `  (${localUrl})` : `  (port ${port})`) : ""}`);
     if (a.length) w(`args:         ${a.join(" ")}`);
   } else {
     w(`installed:    no — start a daemon with:  ay serve install [--share]`);
   }
   if (runningVersion !== null) {
     const tag = runningVersion === current ? "up to date" : `outdated (current v${current})`;
-    w(`http api:     reachable on 127.0.0.1:${port} — v${runningVersion} (${tag})`);
+    w(
+      `http api:     reachable ${local ? `via ${localUrl}` : `on 127.0.0.1:${port}`} — v${runningVersion} (${tag})`,
+    );
   } else if (mode === "webrtc") {
     w(`http api:     none (webrtc-only)`);
   } else {
-    w(`http api:     not reachable on 127.0.0.1:${port} (not running)`);
+    w(
+      `http api:     not reachable ${local ? `via ${localUrl}` : `on 127.0.0.1:${port}`} (not running)`,
+    );
   }
   w(`token:        ${token ?? "(none yet — created on first serve)"}`);
   if (shareLink) w(`share link:   ${shareLink}`);
   if (token && httpish) {
     w();
-    w(`connect:  ay ls   ${token}@<host>:${port}`);
-    w(`          ay remote add <alias> http://${token}@<host>:${port}`);
+    if (local) w(`console:  ${localUrl}`);
+    else if (port !== null) {
+      w(`connect:  ay ls   ${token}@<host>:${port}`);
+      w(`          ay remote add <alias> http://${token}@<host>:${port}`);
+    }
   }
   return 0;
 }
@@ -1139,11 +1224,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
         `                    (stable link across restarts; delete the file to rotate).\n` +
         `  --share [URL]     Legacy alias for --http --webrtc\n\n` +
         `Options:\n` +
-        `  --port N          Port to listen on (default: ${DEFAULT_PORT})\n` +
+        `  --port N          Bypass Portless and listen on a fixed HTTP port\n` +
         `  --host HOST       Interface to bind (default: 127.0.0.1; use 0.0.0.0 to expose)\n` +
         `  --token TOKEN     Auth token (auto-generated and saved if omitted)\n` +
         `  -d, --daemon      Install these flags as a background daemon (pm2/oxmgr)\n` +
         `                    (same as: ay serve install <flags>)\n` +
+        `  --local           Explicitly use Portless (the default for HTTP mode)\n` +
+        `                    ${portlessConsoleUrl()}\n` +
         `  --allow-spawn     Deprecated no-op — the console can always spawn agents\n` +
         `  --tls-cert FILE   TLS certificate PEM\n` +
         `  --tls-key  FILE   TLS private key PEM\n\n` +
@@ -1153,8 +1240,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
         `  ay serve uninstall  remove daemon\n` +
         `  ay serve logs       view daemon logs\n\n` +
         `Once running, connect from another machine:\n` +
-        `  ay ls   <token>@<host>:${DEFAULT_PORT}\n` +
-        `  ay remote add <alias> http://<token>@<host>:${DEFAULT_PORT}\n`,
+        `  ay ls   <token>@<host>:<port>\n` +
+        `  ay remote add <alias> http://<token>@<host>:<port>\n`,
     );
     return 0;
   }
@@ -1190,7 +1277,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
 
   const y = yargs(rest)
     .usage("Usage: ay serve [options]")
-    .option("port", { type: "number", default: DEFAULT_PORT, description: "Port to listen on" })
+    .option("port", { type: "number", description: "Bypass Portless and listen on a fixed port" })
     .option("host", {
       type: "string",
       default: "127.0.0.1",
@@ -1218,6 +1305,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
       default: false,
       description: "Install as a background daemon (same as: ay serve install <flags>)",
     })
+    .option("local", {
+      type: "boolean",
+      default: false,
+      description: `Use Portless at ${portlessConsoleUrl()} (default for HTTP mode)`,
+    })
     .option("allow-spawn", {
       type: "boolean",
       default: false,
@@ -1226,7 +1318,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
     .option("takeover", {
       type: "boolean",
       default: false,
-      description: "If another ay serve already hosts this home's WebRTC room, stop it and take the room",
+      description:
+        "If another ay serve already hosts this home's WebRTC room, stop it and take the room",
     })
     .help(false)
     .version(false)
@@ -1239,6 +1332,18 @@ export async function cmdServe(rest: string[]): Promise<number> {
   if (argv.daemon) {
     const fwd = rest.filter((a) => a !== "--daemon" && a !== "-d");
     return cmdServeDaemon("install", fwd);
+  }
+
+  const wantWebrtc = argv.webrtc !== undefined || argv.share !== undefined;
+  const wantHttp = argv.http === true || argv.share !== undefined || argv.webrtc === undefined;
+  const fixedPort = typeof argv.port === "number";
+  const usePortless = wantHttp && !fixedPort;
+  if (argv.local === true && fixedPort) {
+    process.stderr.write("ay serve: --local and --port cannot be used together\n");
+    return 1;
+  }
+  if (usePortless && process.env[PORTLESS_CHILD_ENV] !== "1" && process.env.PORTLESS !== "0") {
+    return runWithPortless(rest);
   }
 
   // `ay serve` takes only flags (plus the install/uninstall/logs subcommands
@@ -1261,7 +1366,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // top-level agents regardless of the spawn path.
   delete process.env.AGENT_YES_PID;
 
-  const port = (argv.port as number) ?? DEFAULT_PORT;
+  const port = (argv.port as number | undefined) ?? (Number(process.env.PORT) || DEFAULT_PORT);
   const host = (argv.host as string) ?? "127.0.0.1";
   const tokenFlag = typeof argv.token === "string" ? argv.token : undefined;
   const certPath = typeof argv["tls-cert"] === "string" ? argv["tls-cert"] : undefined;
@@ -1277,8 +1382,6 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // Modes: --http (HTTP listener + web console), --webrtc (port-free WebRTC
   // share), or both. Bare `ay serve` stays HTTP-only; --share keeps its old
   // meaning (HTTP + WebRTC) for existing invocations.
-  const wantWebrtc = argv.webrtc !== undefined || argv.share !== undefined;
-  const wantHttp = argv.http === true || argv.share !== undefined || argv.webrtc === undefined;
 
   // Singleton WebRTC host per ~/.agent-yes: a second host joining the SAME
   // persisted room (~/.agent-yes/.share-room) fights the first over every
@@ -3232,17 +3335,20 @@ export async function cmdServe(rest: string[]): Promise<number> {
     // server is null only when we degraded to WebRTC-only above (port wedged);
     // skip the HTTP connection banner since nothing is listening on the port.
     if (server) {
+      const listenPort = server.port;
       const uiHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
-      process.stdout.write(`ay serve  ${scheme}://${host}:${port}\n`);
+      process.stdout.write(`ay serve  ${scheme}://${host}:${listenPort}\n`);
       process.stdout.write(`token:    ${token}\n\n`);
       process.stdout.write(`web console (token in the # is eaten on open):\n`);
-      process.stdout.write(`  ${scheme}://${uiHost}:${port}/#k=${token}\n\n`);
+      process.stdout.write(
+        `  ${usePortless ? portlessConsoleUrl(token) : `${scheme}://${uiHost}:${listenPort}/#k=${token}`}\n\n`,
+      );
       process.stdout.write(`connect from another machine:\n`);
-      process.stdout.write(`  ay ls   ${token}@<host>:${port}\n`);
-      process.stdout.write(`  ay tail ${token}@<host>:${port}:<keyword>\n`);
-      process.stdout.write(`  ay send ${token}@<host>:${port}:<keyword> "message"\n\n`);
+      process.stdout.write(`  ay ls   ${token}@<host>:${listenPort}\n`);
+      process.stdout.write(`  ay tail ${token}@<host>:${listenPort}:<keyword>\n`);
+      process.stdout.write(`  ay send ${token}@<host>:${listenPort}:<keyword> "message"\n\n`);
       process.stdout.write(`save as alias:\n`);
-      process.stdout.write(`  ay remote add <alias> ${scheme}://${token}@<host>:${port}\n\n`);
+      process.stdout.write(`  ay remote add <alias> ${scheme}://${token}@<host>:${listenPort}\n\n`);
       if (!useHttps) {
         process.stdout.write(
           `for HTTPS: ay serve --tls-cert cert.pem --tls-key key.pem\n` +

--- a/ts/share.ts
+++ b/ts/share.ts
@@ -66,9 +66,27 @@ const MAX_PEER_JOIN_QUEUE = 50;
 const IDLE_RESTART_UPTIME_MS = 25 * 60_000;
 const HARD_RESTART_UPTIME_MS = 45 * 60_000;
 const IDLE_RESTART_CHECK_MS = 60_000;
+const PERF_SLOW_MS = Number(process.env.AGENT_YES_WEBRTC_PERF_SLOW_MS) || 750;
+const PERF_BUFFERED_BYTES = Number(process.env.AGENT_YES_WEBRTC_PERF_BUFFERED_BYTES) || 1_000_000;
+const PERF_VERBOSE = process.env.AGENT_YES_WEBRTC_PERF === "1";
 
 type IceServer = { urls: string | string[]; username?: string; credential?: string };
 const STUN: IceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
+
+function perfLog(event: string, data: Record<string, unknown>, force = false) {
+  if (!force && !PERF_VERBOSE) return;
+  process.stderr.write(`[share:perf] ${JSON.stringify({ t: Date.now(), event, ...data })}\n`);
+}
+
+function maybeSlow(event: string, startedAt: number, data: Record<string, unknown> = {}) {
+  const ms = Math.round(performance.now() - startedAt);
+  perfLog(event, { ms, ...data }, ms >= PERF_SLOW_MS);
+}
+
+function dcBufferedAmount(dc: any): number {
+  const n = Number(dc?.bufferedAmount ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
 
 // Short-lived Cloudflare TURN credentials, minted from a long-term TURN key, so
 // browsers can RELAY when a direct P2P path is impossible (symmetric NAT /
@@ -428,6 +446,7 @@ export async function startShare(
     if (closed) return; // a reconnect timer queued before close() must not revive it
     const ws = new WebSocket(`${wsScheme}://${host}/${room}`, [SUB]);
     currentWs = ws;
+    const signalStartedAt = performance.now();
     let ready = false;
     let lastRecv = Date.now();
     let hb: ReturnType<typeof setInterval> | undefined;
@@ -443,6 +462,7 @@ export async function startShare(
       }
     };
     ws.onopen = () => {
+      maybeSlow("signal.open", signalStartedAt, { room, host });
       ws.send(JSON.stringify({ type: "hello", role: "host", v: 2, token: authToken }));
       ready = true;
       lastRecv = Date.now();
@@ -480,6 +500,12 @@ export async function startShare(
       const m = JSON.parse(ev.data as string);
       if (m.type === "pong") return; // heartbeat ack — liveness already recorded
       if (m.type === "peer-join") {
+        perfLog("peer.join", {
+          room,
+          peer: String(m.peer),
+          queue: peerJoinQueue.length,
+          peers: peers.size,
+        });
         // Serialized in drainPeerJoins() to avoid a storm. Skip dupes (already
         // queued or already an active peer) and cap the queue so a pathological
         // burst can't grow it unboundedly — dropped joins retry via the browser.
@@ -554,6 +580,7 @@ export async function startShare(
   };
 
   async function startPeer(ws: WebSocket, peerId: string) {
+    const startedAt = performance.now();
     const iceServers = await getIceServers();
     const pc = new RTCPeerConnection({ iceServers });
     let resolveKeys!: () => void;
@@ -584,6 +611,11 @@ export async function startShare(
     dc.binaryType = "arraybuffer";
     dc.onopen = async () => {
       try {
+        maybeSlow("peer.dc_open", startedAt, {
+          room,
+          peer: peerId,
+          buffered: dcBufferedAmount(dc),
+        });
         await peer.keysReady; // keys derived in the answer handler
         // Open the mandatory bidirectional key-confirmation handshake. Nothing
         // the peer sends is acted on until BOTH directions confirm (see onFrame).
@@ -624,6 +656,7 @@ export async function startShare(
     ws.send(
       JSON.stringify({ type: "offer", to: peerId, sdp: pc.localDescription.sdp, iceServers }),
     );
+    maybeSlow("peer.offer", startedAt, { room, peer: peerId, iceServers: iceServers.length });
   }
 
   function closePeer(peerId: string) {
@@ -642,8 +675,10 @@ export async function startShare(
   // Seal an envelope and send it, serialized per peer so the wire order matches
   // the nonce-counter order (so the receiver's monotonic check never trips).
   function enqueueSeal(peerId: string, dc: any, peer: Peer, flags: number, obj: object) {
+    const queuedAt = performance.now();
     peer.sendChain = peer.sendChain.then(async () => {
       if (dc.readyState !== "open" || !peer.keyH2C || !peer.th) return;
+      const queuedMs = Math.round(performance.now() - queuedAt);
       let frame: ArrayBuffer;
       try {
         frame = await e2eSeal(peer.keyH2C, peer.send, flags, peer.th, packEnvelope(obj));
@@ -653,6 +688,19 @@ export async function startShare(
       }
       try {
         dc.send(frame);
+        const buffered = dcBufferedAmount(dc);
+        perfLog(
+          "send",
+          {
+            room,
+            peer: peerId,
+            kind: (obj as any)?.t,
+            queuedMs,
+            buffered,
+            bytes: frame.byteLength,
+          },
+          queuedMs >= PERF_SLOW_MS || buffered >= PERF_BUFFERED_BYTES,
+        );
       } catch {
         /* peer vanished mid-send; dropping the frame is correct */
       }
@@ -703,6 +751,8 @@ export async function startShare(
     }
     if (req.t !== "req") return;
     const { id, method, path: p, body } = req;
+    const startedAt = performance.now();
+    perfLog("req.start", { room, peer: peerId, id, method, path: p });
     const ac = new AbortController();
     peer.aborts.set(id, ac);
     try {
@@ -718,6 +768,14 @@ export async function startShare(
           signal: ac.signal,
         }),
       );
+      maybeSlow("req.head", startedAt, {
+        room,
+        peer: peerId,
+        id,
+        method,
+        path: p,
+        status: res.status,
+      });
       enqueueSeal(peerId, dc, peer, 0, {
         t: "res",
         id,
@@ -727,9 +785,11 @@ export async function startShare(
       const reader = res.body!.getReader();
       const dec = new TextDecoder();
       let seq = 0;
+      let bytes = 0;
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
+        bytes += value.byteLength;
         const text = dec.decode(value, { stream: true });
         // Slice on UTF-16 boundaries: JSON round-trips lone surrogates as \uXXXX,
         // so the receiver reassembles the exact text by concatenating in seq order.
@@ -742,13 +802,32 @@ export async function startShare(
           });
       }
       enqueueSeal(peerId, dc, peer, 0, { t: "end", id, seq });
+      maybeSlow("req.end", startedAt, {
+        room,
+        peer: peerId,
+        id,
+        method,
+        path: p,
+        status: res.status,
+        chunks: seq,
+        bytes,
+      });
     } catch (e) {
-      if ((e as Error).name !== "AbortError")
+      if ((e as Error).name !== "AbortError") {
+        maybeSlow("req.error", startedAt, {
+          room,
+          peer: peerId,
+          id,
+          method,
+          path: p,
+          error: String((e as Error).message ?? e),
+        });
         enqueueSeal(peerId, dc, peer, 0, {
           t: "end",
           id,
           error: String((e as Error).message ?? e),
         });
+      }
     } finally {
       peer.aborts.delete(id);
     }

--- a/ts/sizeNego.spec.ts
+++ b/ts/sizeNego.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  NEGO_FLOOR_COLS,
+  NEGO_FLOOR_ROWS,
+  negotiateSize,
+  sanitizeCap,
+} from "./sizeNego.ts";
+
+describe("sanitizeCap", () => {
+  it("accepts a normal viewer capacity", () => {
+    expect(sanitizeCap({ cols: 80, rows: 24 })).toEqual({ cols: 80, rows: 24 });
+  });
+  it("floors fractional values", () => {
+    expect(sanitizeCap({ cols: 80.9, rows: 24.7 })).toEqual({ cols: 80, rows: 24 });
+  });
+  it("rejects null / non-object / missing fields", () => {
+    expect(sanitizeCap(null)).toBeNull();
+    expect(sanitizeCap(undefined)).toBeNull();
+    expect(sanitizeCap("80x24")).toBeNull();
+    expect(sanitizeCap({})).toBeNull();
+    expect(sanitizeCap({ cols: 80 })).toBeNull();
+  });
+  it("rejects out-of-range junk (mid-layout 0x0, absurd sizes)", () => {
+    expect(sanitizeCap({ cols: 0, rows: 0 })).toBeNull();
+    expect(sanitizeCap({ cols: 10, rows: 24 })).toBeNull(); // below min cols
+    expect(sanitizeCap({ cols: 80, rows: 2 })).toBeNull(); // below min rows
+    expect(sanitizeCap({ cols: 9999, rows: 24 })).toBeNull();
+    expect(sanitizeCap({ cols: 80, rows: 9999 })).toBeNull();
+    expect(sanitizeCap({ cols: NaN, rows: 24 })).toBeNull();
+  });
+});
+
+describe("negotiateSize", () => {
+  it("returns null with no caps (withdraw → tty size rules)", () => {
+    expect(negotiateSize([])).toBeNull();
+  });
+  it("single viewer: adopts its capacity", () => {
+    expect(negotiateSize([{ cols: 133, rows: 40 }])).toEqual({ cols: 133, rows: 40 });
+  });
+  it("phone + desktop: elementwise min (the tmux rule)", () => {
+    // phone is narrow but tall, desktop is wide but short → min of each axis
+    const phone = { cols: 51, rows: 60 };
+    const desktop = { cols: 200, rows: 50 };
+    expect(negotiateSize([phone, desktop])).toEqual({ cols: 51, rows: 50 });
+  });
+  it("clamps to the floor so a tiny viewer can't wedge the agent", () => {
+    expect(negotiateSize([{ cols: 20, rows: 5 }])).toEqual({
+      cols: NEGO_FLOOR_COLS,
+      rows: NEGO_FLOOR_ROWS,
+    });
+  });
+  it("three viewers: min wins per axis", () => {
+    expect(
+      negotiateSize([
+        { cols: 100, rows: 30 },
+        { cols: 80, rows: 50 },
+        { cols: 120, rows: 24 },
+      ]),
+    ).toEqual({ cols: 80, rows: 24 });
+  });
+});

--- a/ts/sizeNego.ts
+++ b/ts/sizeNego.ts
@@ -1,0 +1,59 @@
+/**
+ * Multi-viewer PTY size negotiation — the tmux "smallest client wins" rule.
+ *
+ * Every writable web viewer reports its readable capacity (the cols×rows its
+ * pane can render at its chosen font size) via /api/presence. The host resizes
+ * the agent's PTY to the elementwise minimum across live viewers, so the
+ * narrowest screen (a phone) gets a grid it can actually read while wider
+ * viewers simply render fewer columns. When the last capacity-reporting viewer
+ * leaves, the negotiated size is withdrawn and the PTY falls back to the real
+ * terminal's size (the wrapper re-reads the tty once the winsize file is gone).
+ *
+ * Pure logic only — the serve layer owns presence bookkeeping, the winsize
+ * file, and SIGWINCH delivery.
+ */
+
+export interface SizeCap {
+  cols: number;
+  rows: number;
+}
+
+/** Reject junk caps (a viewer mid-layout can report 0×0 or absurd numbers). */
+const CAP_MIN_COLS = 20;
+const CAP_MIN_ROWS = 5;
+const CAP_MAX_COLS = 500;
+const CAP_MAX_ROWS = 200;
+
+/** Never negotiate below this — TUIs (claude, codex) break down when the grid
+ * gets absurdly narrow, so a tiny watch-sized viewer can't wedge the agent. */
+export const NEGO_FLOOR_COLS = 40;
+export const NEGO_FLOOR_ROWS = 10;
+
+/** Parse a presence-reported cap into a sane SizeCap, or null if unusable. */
+export function sanitizeCap(cap: unknown): SizeCap | null {
+  if (typeof cap !== "object" || cap === null) return null;
+  const c = Math.floor(Number((cap as SizeCap).cols) || 0);
+  const r = Math.floor(Number((cap as SizeCap).rows) || 0);
+  if (c < CAP_MIN_COLS || c > CAP_MAX_COLS) return null;
+  if (r < CAP_MIN_ROWS || r > CAP_MAX_ROWS) return null;
+  return { cols: c, rows: r };
+}
+
+/**
+ * Elementwise minimum over the live viewers' capacities, clamped to the floor.
+ * Returns null when no viewer reports a capacity — meaning "withdraw the
+ * negotiated size, let the real tty size rule again".
+ */
+export function negotiateSize(caps: ReadonlyArray<SizeCap>): SizeCap | null {
+  let cols = Infinity;
+  let rows = Infinity;
+  for (const cap of caps) {
+    if (cap.cols < cols) cols = cap.cols;
+    if (cap.rows < rows) rows = cap.rows;
+  }
+  if (!Number.isFinite(cols) || !Number.isFinite(rows)) return null;
+  return {
+    cols: Math.max(NEGO_FLOOR_COLS, cols),
+    rows: Math.max(NEGO_FLOOR_ROWS, rows),
+  };
+}

--- a/ts/statusText.spec.ts
+++ b/ts/statusText.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { parseStatusText } from "./statusText.ts";
+
+describe("parseStatusText", () => {
+  it("returns the latest Claude spinner/status line", () => {
+    expect(
+      parseStatusText([
+        "older output",
+        "✶ Verifying calendar meetings with real data… (6m 30s · ↓ 19.5k tokens)",
+      ]),
+    ).toBe("✶ Verifying calendar meetings with real data… (6m 30s · ↓ 19.5k tokens)");
+  });
+
+  it("ignores non-status terminal prose", () => {
+    expect(parseStatusText(["hello", "Done", ""])).toBe(null);
+  });
+});

--- a/ts/statusText.ts
+++ b/ts/statusText.ts
@@ -1,0 +1,19 @@
+/**
+ * Extract a short "what is the agent doing right now?" line from the rendered
+ * terminal screen. Claude Code paints this as a spinner/status line, e.g.
+ * "✶ Verifying calendar meetings with real data… (6m 30s · ↓ 19.5k tokens)".
+ */
+
+const SPINNER_PREFIX = /^[\u2800-\u28ff✶✻✢✳✽✦✧✩✷✸✹✺✼·•●◐◓◒◑]\s+/u;
+const CONTROL = /[\x00-\x1f\x7f-\x9f]/g;
+
+export function parseStatusText(lines: string[]): string | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.replace(CONTROL, "").trim();
+    if (!line || line.length < 3) continue;
+    if (!SPINNER_PREFIX.test(line)) continue;
+    if (/^(?:[•·]\s*)?(?:esc|ctrl|enter|return|shift|tab)\b/i.test(line)) continue;
+    return line.slice(0, 220).trim();
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

On a phone, the /w/ terminal was unreadable: the shared canvas scaled a desktop-sized grid (e.g. 133 cols) down to fit a 390px pane (0.69× → ~8px glyphs), with no way to zoom. And with two writable viewers open, each pushed its own size to the PTY — last-writer-wins fights.

## PTY size negotiation — tmux's "smallest client wins" (`ts/sizeNego.ts`)

- Writable viewers report their **readable capacity** (the cols×rows their pane fits at their font size) as `cap` in `/api/presence`.
- The host resizes the PTY to the **elementwise min** across live caps (floor-clamped 40×10), via the existing winsize-file + SIGWINCH path. The narrowest screen gets a readable grid; wider viewers letterbox the shared canvas.
- **Grow-back**: viewer switches away / TTLs out → min recomputed; last cap gone → the winsize file is withdrawn (only if its content is still our own write, so `ay attach` is never clobbered) and the real tty size rules again.
- `/api/size` now carries `nego:true`; a capable console stops pushing `/api/resize` and reports capacity instead. Legacy hosts keep the old push path (feature-detected per response, zero races).

## Pinch on the terminal = zoom the terminal, not the page

- Two fingers over the log pane adjust the terminal **font size**: bigger font → smaller cap → the host shrinks the PTY → bigger crisp text; the reverse shows more rows/cols. Surrounding UI stays put.
- 1-finger gestures pass through to xterm (scroll/selection); the page keeps native pinch-zoom outside the terminal (WCAG 1.4.4).
- Live CSS preview during the gesture; a single reflow on commit (no SIGWINCH storm).

## Centered letterbox

`fitTransformCentered` (unit-tested): same scale selection as `fitTransform` plus a translate that centers the scaled grid — fit-width → vertically centered, fit-height → horizontally. Peer overlays read the transformed rect, so they need no changes.

## Verification

- Headless chromium at 390×844 against a live bash agent: open → PTY 80×24 → **51×49** (fit-width, centered `translate(5px,0) scale(0.978)`); synthetic pinch-in → font 12→24 → PTY **40×24**.
- Dual-viewer over the API: phone 51×44 + desktop 200×50 → **51×44**; phone leaves → **200×50**; all leave → winsize file deleted (tty fallback).
- 168 unit (`sizeNego` + `console-logic`) + 24 ui-dom + 15 serve tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)