### PR TITLE
fix(serve): loginShellEnv uses -lc not -ilc — interactive shell hangs a headless daemon

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -235,10 +235,19 @@ const SESSION_PIN_ENV = new Set([
 // ~/.bun/bin, ~/.cargo/bin, Homebrew, nvm shims, etc. A console-spawned agent
 // that inherits that env can't find `bun`/`bunx`/etc. (the user reported "bunx:
 // command not found" when spawning a new agent from the web UI). We recover the
-// real environment by running the user's interactive login shell and dumping its
-// env, exactly as a fresh terminal would have it. Returns null on Windows (no
-// rc-file model — the process env is already the right one) or on any failure, so
-// callers fall back to process.env.
+// real environment by running the user's LOGIN shell and dumping its env.
+//
+// IMPORTANT: NON-interactive (`-lc`, not `-ilc`). An interactive shell (`-i`)
+// HANGS indefinitely when the daemon has no controlling TTY — exactly the case
+// under any process manager (oxmgr/systemd/launchd/pm2) — and Bun's `spawnSync`
+// `timeout` does NOT kill the hung interactive shell. Because this runs
+// synchronously on the event loop from the /api/spawn handler, the interactive
+// variant PERMANENTLY WEDGED the daemon on the first console spawn (heartbeat
+// froze → healthcheck restart → cache lost → next spawn wedged again), making
+// console spawns impossible on a headless daemon. `-l` still sources the profile
+// chain (`~/.profile`/`~/.bash_profile` → `~/.bashrc`), so the tool PATHs are
+// still recovered. Returns null on Windows (no rc-file model — the process env is
+// already the right one) or on any failure, so callers fall back to process.env.
 let loginShellEnvCache: Record<string, string> | null | undefined;
 function loginShellEnv(): Record<string, string> | null {
   if (loginShellEnvCache !== undefined) return loginShellEnvCache;
@@ -250,7 +259,7 @@ function loginShellEnv(): Record<string, string> | null {
     // print to stdout; `env -0` is NUL-separated so values with newlines survive.
     const delim = "_AY_SHELL_ENV_DELIM_";
     const res = Bun.spawnSync(
-      [shell, "-ilc", `printf %s "${delim}"; env -0; printf %s "${delim}"`],
+      [shell, "-lc", `printf %s "${delim}"; env -0; printf %s "${delim}"`],
       {
         stdin: "ignore",
         stderr: "ignore",

--- a/ts/serveLock.spec.ts
+++ b/ts/serveLock.spec.ts
@@ -140,7 +140,8 @@ describe("acquireWebrtcHostLock — held-lock lifecycle", () => {
   });
 
   const ownerFile = () => path.join(home, "webrtc-host.lock", "owner.json");
-  const readOwnerFile = async () => JSON.parse(await readFile(ownerFile(), "utf-8")) as ServeLockOwner;
+  const readOwnerFile = async () =>
+    JSON.parse(await readFile(ownerFile(), "utf-8")) as ServeLockOwner;
 
   it("heartbeats refresh beat_at while held", async () => {
     const got = await acquireWebrtcHostLock({ graceMs: 0, beatMs: 40 });
@@ -190,19 +191,19 @@ describe("acquireWebrtcHostLock — held-lock lifecycle", () => {
   it.skipIf(process.platform === "win32")(
     "escalates to SIGKILL when the owner ignores SIGTERM",
     async () => {
-    const { spawn } = await import("node:child_process");
-    const stubborn = spawn("/bin/sh", ["-c", "trap '' TERM; sleep 30"], { stdio: "ignore" });
-    const pid = stubborn.pid!;
-    await new Promise((r) => setTimeout(r, 100)); // let the trap install
-    const { mkdir: mkd, writeFile: wf } = await import("fs/promises");
-    await mkd(path.join(home, "webrtc-host.lock"), { recursive: true });
-    await wf(ownerFile(), JSON.stringify({ pid, started_at: Date.now(), beat_at: Date.now() }));
+      const { spawn } = await import("node:child_process");
+      const stubborn = spawn("/bin/sh", ["-c", "trap '' TERM; sleep 30"], { stdio: "ignore" });
+      const pid = stubborn.pid!;
+      await new Promise((r) => setTimeout(r, 100)); // let the trap install
+      const { mkdir: mkd, writeFile: wf } = await import("fs/promises");
+      await mkd(path.join(home, "webrtc-host.lock"), { recursive: true });
+      await wf(ownerFile(), JSON.stringify({ pid, started_at: Date.now(), beat_at: Date.now() }));
 
-    const got = await acquireWebrtcHostLock({ takeover: true, graceMs: 0, takeoverWaitMs: 200 });
-    expect(got.ok).toBe(true);
-    if (got.ok) releases.push(got.release);
-    await new Promise((r) => setTimeout(r, 100));
-    expect(stubborn.signalCode).toBe("SIGKILL");
+      const got = await acquireWebrtcHostLock({ takeover: true, graceMs: 0, takeoverWaitMs: 200 });
+      expect(got.ok).toBe(true);
+      if (got.ok) releases.push(got.release);
+      await new Promise((r) => setTimeout(r, 100));
+      expect(stubborn.signalCode).toBe("SIGKILL");
     },
   );
 

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -468,16 +468,14 @@ describe("collectWorkspaces / workspaceStatus (mocked provision)", () => {
   beforeEach(() => {
     root = realpathSync(mkdtempSync(path.join(os.tmpdir(), "ay-ws-api-")));
     prov.wsRoot = root;
-    prov.readStatus
-      .mockReset()
-      .mockResolvedValue({
-        branch: "main",
-        head: "abc123",
-        ahead: 1,
-        behind: 0,
-        dirty: true,
-        hasUpstream: true,
-      });
+    prov.readStatus.mockReset().mockResolvedValue({
+      branch: "main",
+      head: "abc123",
+      ahead: 1,
+      behind: 0,
+      dirty: true,
+      hasUpstream: true,
+    });
     homeBackup = process.env.AGENT_YES_HOME;
     process.env.AGENT_YES_HOME = path.join(root, ".ay-home");
   });


### PR DESCRIPTION
## The bug

`loginShellEnv()` (`ts/serve.ts`) recovered the login-shell env with a **synchronous** `Bun.spawnSync([$SHELL, "-ilc", …])`. The **`-i` (interactive)** flag makes the shell **hang indefinitely when the daemon has no controlling TTY** — the case under any process manager (oxmgr/systemd/launchd/pm2) — and Bun's `spawnSync` `timeout` does **not** kill the hung interactive shell.

Because this runs synchronously on the event loop inside the `/api/spawn` handler, the interactive variant **permanently wedged the daemon on the first console spawn**: heartbeat freezes → the `ay serve healthcheck` restarts the daemon → the env cache is lost → the next spawn wedges again. Net effect: **console spawns were impossible on a headless `ay serve`** (HTTP 000, no agent, ~30s-later restart).

## Fix

Drop `-i` (use `-lc`). `-l` still sources the profile chain (`~/.profile`/`~/.bash_profile` → `~/.bashrc`), so the tool PATHs (`~/.bun/bin`, `~/.cargo/bin`, nvm shims) are still recovered — verified with a minimal-env login shell on the affected host.

## Evidence

Minimal repro (heartbeat + `spawnSync` under a headless oxmgr service):

| variant | result |
|---|---|
| `-ilc` (before) | event loop **freezes forever**; `spawnSync` never returns, even past its 5s `timeout` |
| `-lc` (after) | `spawnSync` returns in **~256ms**, no stall |

Validated end-to-end against the live oxmgr daemon: `POST /api/spawn` now returns **200** and the agent launches and **survives** (visible in `ay ls`) with no event-loop wedge. Before the fix the same spawn returned HTTP 000 and the daemon restarted ~30s later.

Secondary note (not fixed here): Bun's `spawnSync` `timeout` failing to kill a hung interactive shell looks like an upstream bug worth a separate report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)