### PR TITLE
feat(config): retry claude on "API Error: Stream idle timeout - no chunks received"

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -98,6 +98,14 @@ clis:
       # `\s+`/`\s*` tolerate wraps inside the phrase.
       - pattern: 'API Error:[\s\S]{0,40}Connection\s+closed\s+mid-\s*response'
         flags: i
+      # "API Error: Stream idle timeout - no chunks received." — the streamed
+      # response went idle (no chunks arrived within the client's window) and the
+      # client gave up. Same transient/server-side class as the stalled/closed
+      # cases above, so retry with backoff. Same "API Error:" chrome anchor keeps
+      # an agent merely *discussing* it from self-triggering; `[\s\S]{0,40}` spans
+      # the prefix→phrase gap across a line-wrap and `\s+` tolerates wraps.
+      - pattern: 'API Error:[\s\S]{0,40}Stream\s+idle\s+timeout'
+        flags: i
       # Any 5xx API error (e.g. "API Error: 529 Overloaded", "API Error: 503 …",
       # or a 529 rendered as a raw JSON error blob) is server-side + transient —
       # retry with backoff regardless of the wording. Anchored to "API Error" so


### PR DESCRIPTION
Adds the **stream-idle-timeout** streaming error to the `claude` CLI's `autoRetry` patterns, so agent-yes types `retry` with exponential backoff instead of letting the run die.

It's the same transient / server-side class already handled for `Response stalled mid-stream` and `Connection closed mid-response` — the stream went idle (no chunks arrived within the client's window) and the client gave up.

```yaml
- pattern: 'API Error:[\s\S]{0,40}Stream\s+idle\s+timeout'
  flags: i
```

- Anchored on the literal `API Error:` chrome so an agent merely *discussing* a stream idle timeout can't self-trigger a spurious retry — verified.
- Added to the **`claude` block only** (per request); `glm`/`openrouter` unchanged — verified they don't match.
- Matches the real banner `● API Error: Stream idle timeout - no chunks received` — verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)