### PR TITLE
feat(ci): release train — beta from main, prod trails via release branch (1h soak)

### DIFF
--- a/.github/workflows/deploy-agent-yes.yml
+++ b/.github/workflows/deploy-agent-yes.yml
@@ -1,17 +1,22 @@
-name: Deploy agent-yes.com
+name: Deploy agent-yes.com (prod)
 
 # agent-yes.com + s.agent-yes.com run on the `agent-yes-signal` Cloudflare Worker
-# (SNOLAB account). Deploying from CI keeps the live console in lockstep with
-# lab/ui/* — wrangler's build step (lab/ui/cf/wrangler.jsonc) re-syncs the UI into
-# ./public on every deploy, so the deployed assets can't drift like they did when
-# deploys were manual (the console went ~1400 lines stale that way).
+# (SNOLAB account). PROD deploys from the `release` branch — a batch pointer that
+# promote-release.yml fast-forwards to main-as-of-1-hour-ago every hour. The
+# 1-hour soak means every change is live on beta.agent-yes.pages.dev (deployed
+# from main by deploy-beta.yml) before it reaches prod, and a bad merge can be
+# stopped by setting the repo variable HOLD_PROD=1 before the train departs.
+#
+# Rollback: workflow_dispatch this workflow from any older release-branch SHA,
+# or push release back to a known-good commit (promote-release.yml only ever
+# fast-forwards, so a manual reset holds until main moves past it again).
 #
 # Requires repo secret CLOUDFLARE_API_TOKEN — a token with Workers Scripts:Edit
 # (+ Workers Routes:Edit for the custom domains) on the SNOLAB account.
 
 on:
   push:
-    branches: [main]
+    branches: [release]
     paths:
       - "lab/ui/**"
       - "scripts/build-rgui.ts"
@@ -34,6 +39,12 @@ jobs:
           submodules: recursive
       # bun runs scripts/build-rgui.ts inside wrangler's build step.
       - uses: oven-sh/setup-bun@v2
+      # worker.ts imports `codehost/tunnel` (a root-package npm dep) — without
+      # this install wrangler's bundler fails with "Could not resolve
+      # 'codehost/tunnel'" (the failure mode that kept this workflow red and
+      # forced manual deploys for weeks).
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       - name: Deploy worker + synced UI to Cloudflare
         working-directory: lab/ui/cf
         env:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,0 +1,54 @@
+name: Deploy beta.agent-yes.pages.dev
+
+# Every UI-touching push to main goes STRAIGHT to the beta site — static assets
+# on the `agent-yes` Cloudflare Pages project, branch alias `beta` →
+# https://beta.agent-yes.pages.dev. This is the phone-testable preview of the
+# console (/w/) and the rgui forest (/r/): signaling is the origin-independent
+# constant s.agent-yes.com, so the beta UI drives real fleets over WebRTC rooms
+# just like prod. Prod (the agent-yes.com Worker) trails by ≥1 hour via the
+# release branch — see promote-release.yml / deploy-agent-yes.yml.
+#
+# NOTE: Pages hosts assets only. worker.ts / Durable Object changes are NOT
+# exercised by beta — they ship with the prod Worker deploy. If this job fails
+# with "Authentication error [code: 10000]", the CLOUDFLARE_API_TOKEN repo
+# secret needs Cloudflare Pages:Edit added (SNOLAB account).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "lab/ui/**"
+      - "scripts/build-rgui.ts"
+      - ".github/workflows/deploy-beta.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-beta
+  cancel-in-progress: true
+
+jobs:
+  deploy-beta:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive # build-rgui bundles from the lib/rgui submodule
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      # Same asset sync the prod worker deploy runs (wrangler build.command) —
+      # one script, two consumers, zero drift.
+      - name: Build site assets
+        working-directory: lab/ui/cf
+        run: sh ./build-assets.sh
+      - name: Deploy to Pages (beta branch alias)
+        working-directory: lab/ui/cf
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Pages commands don't read wrangler.jsonc's account_id — pin SNOLAB
+          # explicitly or wrangler may resolve a different membership.
+          CLOUDFLARE_ACCOUNT_ID: 0beef4cd2d2da6befa47d8d149d6e157
+        run: >
+          npx --yes wrangler@4 pages deploy ./public
+          --project-name agent-yes --branch beta --commit-dirty=true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,63 @@
+name: Promote main → release (1h soak)
+
+# The release train: every hour, fast-forward the `release` branch to where
+# main stood ONE HOUR AGO. Everything on main is already CI-gated pre-merge and
+# live on beta.agent-yes.pages.dev (deploy-beta.yml) the moment it lands, so the
+# hour is a soak window — time for a human or an agent to notice a bad change on
+# beta and stop the train before prod. The push to `release` then triggers
+# deploy-agent-yes.yml (prod Worker deploy), path-filtered so ts/-only batches
+# move the branch without redeploying the site.
+#
+# Stop the train:  gh variable set HOLD_PROD --body 1     (resume: --body 0)
+# Roll prod back:  git push origin <good-sha>:release --force
+#                  (this workflow only fast-forwards, so the reset holds until
+#                  main history moves past it and HOLD_PROD is clear)
+#
+# The push uses RELEASE_TOKEN (admin PAT, same as release.yml) — pushes made
+# with the default GITHUB_TOKEN would NOT trigger the deploy workflow.
+
+on:
+  schedule:
+    - cron: "7 * * * *" # hourly; :07 avoids the top-of-hour Actions rush
+  workflow_dispatch:
+
+concurrency:
+  group: promote-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need history to resolve "main as of 1 hour ago"
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Fast-forward release to main@{1 hour ago}
+        env:
+          HOLD_PROD: ${{ vars.HOLD_PROD }}
+        run: |
+          set -euo pipefail
+          if [ "${HOLD_PROD:-0}" = "1" ]; then
+            echo "HOLD_PROD=1 — train held, not promoting."
+            exit 0
+          fi
+          TARGET=$(git rev-list -1 --before="1 hour ago" origin/main)
+          if [ -z "$TARGET" ]; then
+            echo "No main commit older than 1h — nothing to promote."
+            exit 0
+          fi
+          CURRENT=$(git rev-parse -q --verify origin/release || true)
+          if [ "$TARGET" = "$CURRENT" ]; then
+            echo "release already at $TARGET — up to date."
+            exit 0
+          fi
+          # Fast-forward only: if release isn't an ancestor of the target (a
+          # manual rollback reset), leave it alone until main moves past it.
+          if [ -n "$CURRENT" ] && ! git merge-base --is-ancestor "$CURRENT" "$TARGET"; then
+            echo "release ($CURRENT) is not behind target ($TARGET) — manual state, skipping."
+            exit 0
+          fi
+          echo "Promoting release: ${CURRENT:-<new>} → $TARGET"
+          git push origin "$TARGET:refs/heads/release"

--- a/lab/ui/cf/build-assets.sh
+++ b/lab/ui/cf/build-assets.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Sync the canonical UI (lab/ui/*) into ./public — the single source of truth
+# for the site's static assets. Referenced from BOTH wrangler.jsonc's
+# build.command (worker deploys: prod agent-yes.com) and the beta Pages deploy
+# workflow (.github/workflows/deploy-beta.yml), so the two can never drift.
+# Runs from lab/ui/cf/ (wrangler runs build.command from the config's dir).
+#
+# Layout produced (see wrangler.jsonc for the full commentary):
+#   public/w/       — the console PWA (index.html + every UI script)
+#   public/index.html, architecture.html, blog/  — landing + docs
+#   public/setup.sh, setup.ps1                   — install one-liners
+#   public/_headers — CSP for static assets (served before the Worker)
+#   public/r/ + public/rgui/ — the rgui forest page (built from lib/rgui)
+set -e
+mkdir -p ./public/w
+cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/
+cp ../landing.html ./public/index.html
+cp ../architecture.html ./public/architecture.html
+rm -rf ./public/blog
+cp -R ../blog ./public/blog
+cp ../setup.sh ../setup.ps1 ./public/
+cp _headers ./public/_headers
+bun ../../../scripts/build-rgui.ts ./public/r
+rm -rf ./public/rgui
+cp -R ./public/r ./public/rgui

--- a/lab/ui/cf/wrangler.jsonc
+++ b/lab/ui/cf/wrangler.jsonc
@@ -25,7 +25,9 @@
     // The rgui variant of agent-yes (lab/ui/rgui) is bundled from the @snomiao/rgui
     // submodule source (scripts/build-rgui.ts) into ./public/r — served at
     // agent-yes.com/r/ (the rgui counterpart of the console at /w/), mirrored to /rgui.
-    "command": "mkdir -p ./public/w && cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/ && cp ../landing.html ./public/index.html && cp ../architecture.html ./public/architecture.html && rm -rf ./public/blog && cp -R ../blog ./public/blog && cp ../setup.sh ../setup.ps1 ./public/ && cp _headers ./public/_headers && bun ../../../scripts/build-rgui.ts ./public/r && rm -rf ./public/rgui && cp -R ./public/r ./public/rgui",
+    // The command body lives in build-assets.sh so the beta Pages workflow
+    // (deploy-beta.yml) reuses the exact same sync — keep it there, not here.
+    "command": "sh ./build-assets.sh",
   },
   // Static console UI (served for every non-WebSocket request).
   // run_worker_first: the Worker must see the request BEFORE the asset server,


### PR DESCRIPTION
## Why

The Deploy workflow has been red on every run for weeks — wrangler bundling fails with `Could not resolve "codehost/tunnel"` because CI never ran `bun install` (worker.ts imports it from the root package). Prod deploys have been manual ever since. While fixing it, restructure releases into the train taku proposed: **beta straight from main, prod trailing by a 1-hour soak**.

## The train

```
merge to main ──→ beta.agent-yes.pages.dev     (instantly, deploy-beta.yml)
      │
      └─ 1h later ──→ release branch ──→ agent-yes.com  (promote-release.yml → deploy-agent-yes.yml)
```

- **`deploy-beta.yml`** (new): every UI push to main → Pages `agent-yes` project, branch alias `beta`. Signaling is the origin-independent `s.agent-yes.com`, so beta drives real fleets over WebRTC rooms. *(Pages = assets only; worker.ts/DO changes ship with the prod Worker deploy.)*
- **`promote-release.yml`** (new): hourly cron fast-forwards `release` to `main@{1 hour ago}`.
  - Stop the train: `gh variable set HOLD_PROD --body 1`
  - Rollback: `git push origin <good-sha>:release --force` — ff-only promotion means the reset holds.
  - Pushes with `RELEASE_TOKEN` (default `GITHUB_TOKEN` pushes wouldn't trigger the deploy workflow).
- **`deploy-agent-yes.yml`**: prod deploy now triggers on push to `release` (was `main`) and runs `bun install --frozen-lockfile` first — the actual fix for the weeks of red runs.
- **`lab/ui/cf/build-assets.sh`**: asset sync extracted from `wrangler.jsonc` `build.command` so beta + prod share one script (zero drift).

## Notes

- After merge I'll seed the `release` branch at the merge commit — that fires the first automated prod deploy (ships the merged mobile-a11y + PTY-negotiation work, all CI-gated + beta-verified).
- If the beta job fails with CF auth error 10000, the `CLOUDFLARE_API_TOKEN` repo secret needs **Pages:Edit** added (SNOLAB account).

## Verification

- `sh build-assets.sh` produces the full public/ layout locally
- `wrangler deploy --dry-run` resolves the bundle (incl. `codehost/tunnel`) cleanly
- promote script logic is plain git — ff-check, 1h cutoff, hold guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)