### PR TITLE
fix(ui): letterbox by font size, not transform — scaled-viewer drag selection lands where you point

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -701,23 +701,30 @@ export function fitTransform(gridW, gridH, paneW, paneH) {
   return s > 0.985 && s < 1.04 ? "none" : "scale(" + s.toFixed(4) + ")";
 }
 
-// Centered variant: same scale selection as fitTransform, plus a translate that
-// centers the scaled grid in the pane (fit-width → vertically centered,
-// fit-height → horizontally centered). transform-origin stays top-left, so the
-// translate is in pane px and consumers mapping grid→screen coords (peer
-// overlays) can read the offset back off this same object. "none" (the crisp
-// driver path) never gets a translate — grid ≈ pane, nothing to center.
-export function fitTransformCentered(gridW, gridH, paneW, paneH) {
-  const t = fitTransform(gridW, gridH, paneW, paneH);
-  if (t === "none") return { transform: "none", scale: 1, dx: 0, dy: 0 };
+// Fit-by-FONT: the render font size that makes a gridW×gridH-px grid fill the
+// pane. CSS transform:scale() breaks xterm's mouse→cell mapping (events arrive
+// in visual px but xterm divides by the UNSCALED cell metrics, so drag
+// selection lands 1/s off) — so the shared-canvas letterbox scales the font
+// instead: layout, hit-testing, selection, and peer-overlay math all stay
+// native, and glyphs render crisp at their real size rather than as shrunken
+// canvas bitmaps. Returns the new font (fractional px is fine for xterm) or
+// null when the current font already fits snugly — same 0.985–1.04 dead band
+// as fitTransform, so the crisp driver path never churns. Callers re-measure
+// after applying (cell metrics round per-font) and iterate to convergence.
+export function fitFontSize(gridW, gridH, paneW, paneH, currentFont, min = 6, max = 64) {
+  if (!gridW || !gridH || paneW <= 0 || paneH <= 0 || !(currentFont > 0)) return null;
   const s = Math.min(paneW / gridW, paneH / gridH);
-  const dx = Math.max(0, (paneW - gridW * s) / 2);
-  const dy = Math.max(0, (paneH - gridH * s) / 2);
+  if (s > 0.985 && s < 1.04) return null;
+  return Math.min(max, Math.max(min, currentFont * s));
+}
+
+// Residual centering after a font fit: translate-only, in whole px. Unlike a
+// scale, a translate moves the element's rect with it, so xterm's
+// event-coordinate math is unaffected (coords are taken relative to the rect).
+export function centerOffset(gridW, gridH, paneW, paneH) {
   return {
-    transform: `translate(${dx.toFixed(1)}px, ${dy.toFixed(1)}px) ` + t,
-    scale: s,
-    dx,
-    dy,
+    dx: Math.max(0, Math.round((paneW - gridW) / 2)),
+    dy: Math.max(0, Math.round((paneH - gridH) / 2)),
   };
 }
 

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2170,7 +2170,8 @@
         selFromBottom,
         parseSel,
         selSegments,
-        fitTransformCentered,
+        fitFontSize,
+        centerOffset,
         docTitle,
         omniScore,
       } from "./console-logic.js";
@@ -2227,6 +2228,10 @@
           localStorage.setItem("ay.fontSize", String(termFontSize));
         } catch {}
         if (term) {
+          // The user changed their DESIRED size — drop any fit-derived render
+          // font and restart the fit from the new desire (applyCanvasScale
+          // converges it; for the driver / min viewer it lands exactly here).
+          renderFontSize = 0;
           term.options.fontSize = termFontSize;
           // Negotiating host: the grid is canonical (host-owned) — a font change
           // here only alters our glyph px, so re-letterbox and report the new
@@ -3299,7 +3304,19 @@
         try {
           if (!isReadonlyEnt(cur.e) && fit) {
             const d = fit.proposeDimensions();
-            if (d && d.cols > 0 && d.rows > 0) cap = { cols: d.cols, rows: d.rows };
+            if (d && d.cols > 0 && d.rows > 0) {
+              // proposeDimensions measures at the RENDER font, which may be the
+              // fit-derived letterbox size — but capacity is defined at the
+              // user's DESIRED font (termFontSize). Rescale by the font ratio
+              // (cell px ∝ font px), else a letterboxed viewer's grown render
+              // font would shrink its reported cap and feed back into the
+              // negotiation as a death spiral.
+              const k = (renderFontSize || termFontSize) / termFontSize;
+              cap = {
+                cols: Math.max(1, Math.floor(d.cols * k)),
+                rows: Math.max(1, Math.floor(d.rows * k)),
+              };
+            }
           }
         } catch {}
         cur.tx
@@ -3611,18 +3628,29 @@
         ov.innerHTML = html.join("");
       }
 
-      // ---- shared canvas: scale (don't reflow) the grid to fit our pane --------
+      // ---- shared canvas: fit the grid to our pane BY FONT SIZE ---------------
       // When we render at the canonical (driver/agent) grid size and it doesn't
-      // match our pane, CSS-scale the whole .xterm to fit — so every viewer shows
-      // identical content and selections/overlays line up. For the driver / single
-      // viewer the grid already fits the pane (scale ≈ 1) → no transform, so the
-      // common path is byte-for-byte unchanged. Best-effort + guarded.
-      function applyCanvasScale() {
+      // match our pane, adjust the render FONT so the grid fills the pane —
+      // never a CSS transform:scale(). A scale breaks xterm's mouse→cell
+      // mapping (events arrive in visual px, xterm divides by the unscaled cell
+      // metrics → drag selection lands 1/s off); a font change keeps layout,
+      // hit-testing, and the peer overlay all native, and glyphs render crisp
+      // at their real size. The residual letterbox (cell rounding) is centered
+      // with a translate-only transform, which moves the rect and therefore
+      // does NOT disturb the coordinate math.
+      //
+      // renderFontSize is the fit-derived size actually rendered; termFontSize
+      // stays the USER's desired size — the pinch/menu zoom control and the
+      // capacity (presence cap) basis. For the driver / min viewer the grid
+      // matches the pane at the desired font (dead band) → renderFontSize
+      // converges back to termFontSize and no transform is applied, so the
+      // common path stays byte-for-byte crisp. Best-effort + guarded.
+      let renderFontSize = 0; // 0 = following termFontSize (no fit override)
+      function applyCanvasScale(depth = 0) {
         try {
           const logEl = $("log");
           const xt = logEl && logEl.querySelector(".xterm");
-          if (!xt) return;
-          xt.style.transform = "none"; // measure the natural (unscaled) grid
+          if (!xt || !term) return;
           const screen = xt.querySelector(".xterm-screen");
           if (!screen) return;
           const gw = screen.offsetWidth,
@@ -3631,12 +3659,18 @@
           const cs = getComputedStyle(logEl);
           const pw = logEl.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
           const ph = logEl.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
-          // fitTransformCentered (console-logic.js, unit-tested) decides
-          // none-vs-scale and centers the letterboxed grid in the pane (fit
-          // width → vertically centered, fit height → horizontally). The peer
-          // overlay reads the transformed screen rect back via
-          // getBoundingClientRect, so the translate needs no extra bookkeeping.
-          xt.style.transform = fitTransformCentered(gw, gh, pw, ph).transform;
+          const cur = renderFontSize || termFontSize;
+          const nf = fitFontSize(gw, gh, pw, ph, cur);
+          // Cell metrics round per font size, so one analytic step may land a
+          // hair off — re-measure and iterate (bounded) until inside the band.
+          if (nf != null && Math.abs(nf - cur) >= 0.25 && depth < 3) {
+            renderFontSize = nf;
+            term.options.fontSize = nf;
+            requestAnimationFrame(() => applyCanvasScale(depth + 1));
+            return;
+          }
+          const { dx, dy } = centerOffset(gw, gh, pw, ph);
+          xt.style.transform = dx || dy ? `translate(${dx}px, ${dy}px)` : "none";
         } catch {}
       }
       // Pane geometry changed (window resize, splitter drag, soft keyboard, tab
@@ -5159,6 +5193,7 @@
         }
         const logEl = $("log");
         logEl.innerHTML = "";
+        renderFontSize = 0; // fresh terminal starts at the desired font (no fit override)
         term = new Terminal({
           convertEol: false,
           disableStdin: false,

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -72,19 +72,23 @@ describe("console DOM behaviour", () => {
     close?.();
   });
 
-  it("renders one row per agent, leads with repo/branch identity, omits default claude", async () => {
+  it("renders one compact row per agent; identity capped to 3, default claude omitted", async () => {
     const { ctx, page } = await openConsole(browser, url);
     try {
-      expect(await page.locator(".list .row").count()).toBe(3);
+      // Since #268 the compact list is the ONLY view — every row is a .crow.
+      expect(await page.locator(".list .row.crow").count()).toBe(3);
+      // All local (no devices) → path-only identity owner/repo/branch, each ≤3 chars.
+      const idents = await page.locator(".crow .cident").allInnerTexts();
+      expect(idents).toContain("sno/age/mai"); // snomiao/agent-yes/main
+      expect(idents).toContain("acm/wid/dev"); // acme/widgets/dev
+      // codex row shows its cli; default-claude rows never say "claude"
+      const names = await page.locator(".crow .cname").allInnerTexts();
+      expect(names).toEqual(["codex"]);
       const list = (await page.locator("#list").innerText()).toLowerCase();
-      // default-claude rows show identity as the name, not "claude"
-      expect(list).toContain("agent-yes/main");
-      expect(list).toContain("codex"); // non-default cli is shown
-      expect(list).not.toMatch(/\bclaude\b/); // the word "claude" never appears
-      // repo/wt mnemonic tags are derived from the cwd
-      expect(list).toContain("snomiao/agent-yes");
-      expect(await page.locator('.list .row[data-key="local#101"] .statusline').innerText()).toBe(
-        "✶ Verifying calendar meetings with real data… (6m 30s · ↓ 19.5k tokens)",
+      expect(list).not.toMatch(/\bclaude\b/);
+      // the compact row's one-line title (title || status_text || prompt)
+      expect(await page.locator('.list .row[data-key="local#101"] .ctitle').innerText()).toBe(
+        "first agent",
       );
     } finally {
       await ctx.close();
@@ -166,18 +170,16 @@ describe("console DOM behaviour", () => {
     }
   });
 
-  it("compact toggle collapses rows; identity is owner/repo/branch capped to 3", async () => {
+  it("compact is the only view — the old ☰ toggle is gone (#268)", async () => {
     const { ctx, page } = await openConsole(browser, url);
     try {
-      await page.click("#viewbtn");
       await page.waitForSelector(".list .row.crow");
-      // All local (no devices) → path-only identity owner/repo/branch, each ≤3 chars.
-      const idents = await page.locator(".crow .cident").allInnerTexts();
-      expect(idents).toContain("sno/age/mai"); // snomiao/agent-yes/main
-      expect(idents).toContain("acm/wid/dev"); // acme/widgets/dev
-      // codex row shows its cli; claude rows don't
-      const names = await page.locator(".crow .cname").allInnerTexts();
-      expect(names).toEqual(["codex"]);
+      expect(await page.locator("#viewbtn").count()).toBe(0);
+      // the full identity survives as the hover title on the capped chip
+      const titles = await page
+        .locator(".crow .cident")
+        .evaluateAll((els) => els.map((e) => e.getAttribute("title")));
+      expect(titles).toContain("snomiao/agent-yes/main");
     } finally {
       await ctx.close();
     }

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -33,7 +33,8 @@ import {
   parseSel,
   selSegments,
   fitTransform,
-  fitTransformCentered,
+  fitFontSize,
+  centerOffset,
   docTitle,
   statusGlyph,
   omniScore,
@@ -838,32 +839,35 @@ describe("fitTransform", () => {
   });
 });
 
-describe("fitTransformCentered", () => {
-  it("driver path stays crisp: none, no offset", () => {
-    expect(fitTransformCentered(800, 480, 800, 480)).toEqual({
-      transform: "none",
-      scale: 1,
-      dx: 0,
-      dy: 0,
-    });
+describe("fitFontSize (letterbox by font, not transform — keeps mouse mapping)", () => {
+  it("returns null inside the dead band (crisp driver path, no churn)", () => {
+    expect(fitFontSize(800, 480, 800, 480, 12)).toBeNull();
+    expect(fitFontSize(800, 480, 810, 490, 12)).toBeNull(); // fit rounding slack
   });
-  it("fit-width (phone letterboxing a wide grid) centers vertically", () => {
-    // grid 2x wider than pane, same aspect pane taller → s=0.5, dy centers
-    const r = fitTransformCentered(1600, 480, 800, 480);
-    expect(r.transform).toBe("translate(0.0px, 120.0px) scale(0.5000)");
-    expect(r.scale).toBe(0.5);
-    expect(r.dx).toBe(0);
-    expect(r.dy).toBe(120);
+  it("shrinks the font for a grid wider than the pane", () => {
+    // s = 0.5 → 12px renders the same grid at half the px width
+    expect(fitFontSize(1600, 480, 800, 480, 12)).toBe(6);
   });
-  it("fit-height (tall grid in a wide pane) centers horizontally", () => {
-    // s = min(800/400, 480/960) = 0.5 → scaled 200×480 → dx = (800-200)/2
-    const r = fitTransformCentered(400, 960, 800, 480);
-    expect(r.transform).toBe("translate(300.0px, 0.0px) scale(0.5000)");
-    expect(r.dx).toBe(300);
-    expect(r.dy).toBe(0);
+  it("grows the font for a small grid in a big pane", () => {
+    expect(fitFontSize(400, 240, 800, 480, 12)).toBe(24);
   });
-  it("guards bad dimensions like fitTransform", () => {
-    expect(fitTransformCentered(0, 480, 800, 480).transform).toBe("none");
+  it("clamps to the min/max font bounds", () => {
+    expect(fitFontSize(4000, 480, 800, 480, 12)).toBe(6); // s=0.2 → 2.4 → clamped
+    expect(fitFontSize(100, 60, 800, 480, 12)).toBe(64); // s=8 → 96 → clamped
+  });
+  it("guards bad dimensions and fonts", () => {
+    expect(fitFontSize(0, 480, 800, 480, 12)).toBeNull();
+    expect(fitFontSize(800, 480, 0, 480, 12)).toBeNull();
+    expect(fitFontSize(800, 480, 800, 480, 0)).toBeNull();
+  });
+});
+
+describe("centerOffset (translate-only letterbox centering)", () => {
+  it("centers the residual gap on both axes, whole px", () => {
+    expect(centerOffset(790, 470, 800, 480)).toEqual({ dx: 5, dy: 5 });
+  });
+  it("never goes negative when the grid overflows", () => {
+    expect(centerOffset(900, 500, 800, 480)).toEqual({ dx: 0, dy: 0 });
   });
 });
 


### PR DESCRIPTION
## Problem

taku spotted it: with the auto-rescale (fit-to-pane) on the shared canvas, **mouse drag selection doesn't match the scale**. Exactly right — `transform: scale()` changes only the visual px; xterm.js maps mouse events by dividing by its **unscaled** cell metrics, so on any letterboxed viewer (scale ≠ 1 — now common since PTY size negotiation letterboxes the larger screen) a drag landed 1/s away from the pointer.

## Fix: fit by FONT, never by transform

- `fitFontSize` (console-logic.js, unit-tested): `applyCanvasScale` now converges the **render font** so the canonical grid fills the pane natively — layout, hit-testing, selection, and the peer overlay all stay in real px, and glyphs render **crisp** at true size instead of shrunken canvas bitmaps. Bounded rAF iteration absorbs per-font cell rounding; the same 0.985–1.04 dead band keeps the driver path churn-free.
- Residual letterbox is centered with a **translate-only** transform (moves the rect → can't skew coordinate math).
- `termFontSize` stays the *user's desired* size (pinch/menu zoom + capacity basis); the presence `cap` is rescaled by `renderFont/desiredFont` so a letterboxed viewer's grown render font can't feed back into negotiation as a shrink spiral.

## Also: repairs 2 ui-dom tests left red on main

#268 (compact list is the only view) removed the ☰ `#viewbtn` toggle but didn't update the two tests asserting it — `test:ui-dom` has been 22/24 on main since. Updated for the compact-only design.

## Verification

E2E (playwright): desktop viewer letterboxed to a phone-negotiated 51×20 grid, render font fit **12 → 22px**, `transform: translate(0px, 116px)` (no scale); drag across `CDEFGH…` paints the selection **0.7px** from the pointer span (old scale path would be ~2× off). 132 unit + 24 ui-dom tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)