### PR TITLE
Publish installable beta channel from main

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -41,6 +41,9 @@ jobs:
       # one script, two consumers, zero drift.
       - name: Build site assets
         working-directory: lab/ui/cf
+        env:
+          AGENT_YES_CHANNEL: beta
+          AGENT_YES_ORIGIN: https://beta.agent-yes.pages.dev
         run: sh ./build-assets.sh
       - name: Deploy to Pages (beta branch alias)
         working-directory: lab/ui/cf

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,0 +1,117 @@
+name: Publish npm beta
+
+# Publish every tested main snapshot as an explicit npm prerelease channel.
+# Production npm releases remain owned by release.yml; this workflow only moves
+# the `beta` dist-tag. Each npm version has a matching GitHub prerelease and
+# native binaries, so rustBinary.ts can keep its strict version-pinned download.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-npm-beta
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+
+jobs:
+  publish-beta:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "latest"
+          registry-url: https://registry.npmjs.org
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+
+      - name: Set unique beta version
+        id: version
+        shell: bash
+        run: |
+          BASE=$(node -p "require('./package.json').version.split('-')[0]")
+          VERSION="${BASE}-beta.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          TAG="v${VERSION}"
+          npm pkg set version="${VERSION}"
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" rs/Cargo.toml
+          rm -f rs/Cargo.toml.bak
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${TAG} from ${GITHUB_SHA}"
+
+      - run: bun run build
+      - run: bun run test
+
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --prerelease \
+            --title "agent-yes ${VERSION} (beta)" \
+            --notes "Automated beta build from main at ${GITHUB_SHA}. Install with: npm install -g agent-yes@beta"
+
+      - name: Trigger matching native binary build
+        id: rust
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          BEFORE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run rust-build.yml --ref main --field tag="$TAG" --field upload_release=true
+          for attempt in $(seq 1 24); do
+            sleep 5
+            WANT="Build Rust Binaries $TAG"
+            RUN_ID=$(gh run list --workflow=rust-build.yml --event workflow_dispatch --limit=10 \
+              --json databaseId,createdAt,displayTitle \
+              -q ".[] | select(.createdAt >= \"$BEFORE\" and .displayTitle == \"$WANT\") | .databaseId" | head -1)
+            if [ -n "$RUN_ID" ]; then
+              echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Waiting for $WANT to appear... ($((attempt * 5))s elapsed)"
+          done
+          echo "Native binary workflow did not start within two minutes." >&2
+          exit 1
+
+      - name: Wait for native binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run watch "${{ steps.rust.outputs.run_id }}" --exit-status
+
+      - name: Verify prerelease assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
+          if [ "$COUNT" -lt 7 ]; then
+            echo "Expected at least 7 native archives on $TAG; found $COUNT." >&2
+            exit 1
+          fi
+
+      - name: Publish agent-yes@beta
+        run: npm publish --access public --tag beta --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish claude-yes@beta alias
+        shell: bash
+        run: |
+          npm pkg set name=claude-yes
+          npm publish --access public --tag beta --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,9 @@ jobs:
           # Poll until we see the new run (created after dispatch)
           for i in $(seq 1 24); do
             sleep 5
-            RUN_ID=$(gh run list --workflow=rust-build.yml --limit=10 --json databaseId,createdAt \
-              -q ".[] | select(.createdAt >= \"$BEFORE\") | .databaseId" | head -1)
+            WANT="Build Rust Binaries ${{ steps.get_tag.outputs.tag }}"
+            RUN_ID=$(gh run list --workflow=rust-build.yml --limit=10 --json databaseId,createdAt,displayTitle \
+              -q ".[] | select(.createdAt >= \"$BEFORE\" and .displayTitle == \"$WANT\") | .databaseId" | head -1)
             if [ -n "$RUN_ID" ]; then
               echo "Found run ID: $RUN_ID"
               echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,4 +1,5 @@
 name: Build Rust Binaries
+run-name: Build Rust Binaries ${{ inputs.tag || github.ref_name }}
 
 on:
   # PR builds for testing (no release upload)
@@ -93,6 +94,19 @@ jobs:
         run: |
           echo "Building from tag: ${{ inputs.tag }}"
           echo "RELEASE_TAG=${{ inputs.tag }}" >> $GITHUB_ENV
+
+      # Automated npm beta tags point at the tested main commit instead of a
+      # version-bump commit. Stamp Cargo.toml in the ephemeral runner so the
+      # binary reports the exact prerelease version used by agent-yes@beta.
+      - name: Stamp prerelease version
+        if: github.event_name == 'workflow_dispatch' && contains(inputs.tag, '-beta.')
+        shell: bash
+        run: |
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
+          sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" rs/Cargo.toml
+          rm -f rs/Cargo.toml.bak
+          grep -m1 '^version = ' rs/Cargo.toml
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -4,7 +4,7 @@ name: UI Test
 # Matrix Test suite. THIS workflow covers the rendered console, triggered by
 # changes to the UI or EITHER UI test suite (lab/ui, tests/ui-dom, tests/ui-test):
 #   - ui-dom: a deterministic, hermetic Playwright DOM test of the real console
-#     (blocking — the deploy job gates on it). tests/ui-dom/** must be in the
+#     (blocking — required before merge). tests/ui-dom/** must be in the
 #     trigger paths, else a change to the test or its stub server can silently
 #     rot without ever running (this is exactly how the /e2e.js stub gap slipped in).
 #   - ui-render: the heavier xterm.js render test — Playwright screenshots judged
@@ -68,41 +68,3 @@ jobs:
           name: ui-screenshots
           path: tests/ui-test/screenshots/
           if-no-files-found: ignore
-
-  # Deploy the console to agent-yes.com (Cloudflare Worker) — only on push to
-  # main, and only after the deterministic DOM test passes. Uses the
-  # CLOUDFLARE_API_TOKEN secret; scripts/cf.ts pins the SNOLAB account.
-  deploy:
-    needs: [ui-dom]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install
-      - name: Stage console assets
-        run: |
-          mkdir -p lab/ui/cf/public
-          cp lab/ui/index.html lab/ui/room-client.js lab/ui/console-logic.js \
-             lab/ui/setup.sh lab/ui/setup.ps1 lab/ui/cf/public/
-      # The SNOLAB token (`agent-yes-snolab`) lacks Workers Routes / User-Details
-      # read, so wrangler prints an "Authentication error [code: 10000]" and
-      # exits non-zero AFTER the Worker version + assets have already uploaded —
-      # harmless (the custom domains already exist). Gate success on the upload
-      # line instead of the exit code, else every deploy reports a false failure.
-      - name: Deploy Worker (agent-yes.com)
-        working-directory: lab/ui/cf
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: |
-          set -o pipefail
-          bun ../../../scripts/cf.ts deploy 2>&1 | tee deploy.log || true
-          if grep -Eq "Uploaded agent-yes-signal|Deployed agent-yes-signal|Current Version ID" deploy.log; then
-            echo "::notice::Worker uploaded — route/auth tail-error is harmless (token lacks Routes/User-Details read)."
-          else
-            echo "::error::Wrangler did not upload the Worker."
-            exit 1
-          fi

--- a/lab/ui/cf/build-assets.sh
+++ b/lab/ui/cf/build-assets.sh
@@ -19,6 +19,19 @@ cp ../architecture.html ./public/architecture.html
 rm -rf ./public/blog
 cp -R ../blog ./public/blog
 cp ../setup.sh ../setup.ps1 ./public/
+
+# Build a channel-specific installer without forking the canonical scripts.
+# Production leaves the defaults untouched. Beta Pages passes both variables,
+# so curl/PowerShell installs agent-yes@beta and prints the actual beta origin.
+if [ "${AGENT_YES_CHANNEL:-stable}" = "beta" ]; then
+  origin=${AGENT_YES_ORIGIN:-https://beta.agent-yes.pages.dev}
+  sed 's|AY_PACKAGE="agent-yes"|AY_PACKAGE="agent-yes@beta"|; s|AY_CONSOLE_ORIGIN="https://agent-yes.com"|AY_CONSOLE_ORIGIN="'"$origin"'"|' \
+    ./public/setup.sh > ./public/setup.sh.tmp
+  mv ./public/setup.sh.tmp ./public/setup.sh
+  sed "s|\$Package = 'agent-yes'|\$Package = 'agent-yes@beta'|; s|\$ConsoleOrigin = 'https://agent-yes.com'|\$ConsoleOrigin = '$origin'|" \
+    ./public/setup.ps1 > ./public/setup.ps1.tmp
+  mv ./public/setup.ps1.tmp ./public/setup.ps1
+fi
 cp _headers ./public/_headers
 bun ../../../scripts/build-rgui.ts ./public/r
 rm -rf ./public/rgui

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1837,10 +1837,10 @@
           </div>
           <div class="install" title="click to copy">
             install:
-            <code class="copy">curl -fsSL https://agent-yes.com/setup.sh | sh</code>
+            <code class="copy" id="setup-sh">curl -fsSL https://agent-yes.com/setup.sh | sh</code>
             <span class="winhint"
               >·&nbsp;Windows:
-              <code class="copy"
+              <code class="copy" id="setup-ps"
                 >powershell -c "irm https://agent-yes.com/setup.ps1 | iex"</code
               ></span
             >
@@ -2291,6 +2291,13 @@
       });
 
       const $ = (id) => document.getElementById(id);
+      const BETA_ORIGINS = new Set(["beta.agent-yes.pages.dev", "beta.agent-yes.com"]);
+      const installOrigin = location.origin;
+      const installPackage = BETA_ORIGINS.has(location.hostname) ? "agent-yes@beta" : "agent-yes";
+      $("setup-sh").textContent = `curl -fsSL ${installOrigin}/setup.sh | sh`;
+      $("setup-sh").title = `installs ${installPackage}`;
+      $("setup-ps").textContent = `powershell -c "irm ${installOrigin}/setup.ps1 | iex"`;
+      $("setup-ps").title = `installs ${installPackage}`;
       // Escape for HTML — including BOTH quote styles, because esc() is
       // interpolated into double-quoted attribute values (title="${esc(...)}",
       // data-key="${esc(...)}", …), not just element text. A remote host controls

--- a/lab/ui/landing.html
+++ b/lab/ui/landing.html
@@ -219,10 +219,10 @@
         </div>
         <div class="install">
           <pre><code># macOS / Linux
-curl -fsSL https://agent-yes.com/setup.sh | sh
+<span id="setup-sh">curl -fsSL https://agent-yes.com/setup.sh | sh</span>
 
 # Windows (PowerShell)
-powershell -c "irm https://agent-yes.com/setup.ps1 | iex"</code></pre>
+<span id="setup-ps">powershell -c "irm https://agent-yes.com/setup.ps1 | iex"</span></code></pre>
           <div class="clis">
             Wrappers: <b>claude-yes</b> · <b>codex-yes</b> · <b>gemini-yes</b> ·
             <b>copilot-yes</b> · <b>cursor-yes</b> · <b>qwen-yes</b> · <b>grok-yes</b> — or just
@@ -278,6 +278,14 @@ powershell -c "irm https://agent-yes.com/setup.ps1 | iex"</code></pre>
       // straight on it. `autofocus` on <a> isn't honored everywhere, so back it
       // up here — but skip on touch devices where focusing scroll-jumps the page.
       (function () {
+        var beta = /^(beta\.agent-yes\.pages\.dev|beta\.agent-yes\.com)$/.test(location.hostname);
+        var pkg = beta ? "agent-yes@beta" : "agent-yes";
+        document.getElementById("setup-sh").textContent =
+          "curl -fsSL " + location.origin + "/setup.sh | sh";
+        document.getElementById("setup-sh").title = "installs " + pkg;
+        document.getElementById("setup-ps").textContent =
+          'powershell -c "irm ' + location.origin + '/setup.ps1 | iex"';
+        document.getElementById("setup-ps").title = "installs " + pkg;
         if (matchMedia("(hover: none)").matches) return;
         var cta = document.querySelector(".hero .cta a.btn");
         if (cta) cta.focus({ preventScroll: true });

--- a/lab/ui/rgui/main.ts
+++ b/lab/ui/rgui/main.ts
@@ -373,8 +373,9 @@ const WRAP_W = 3400; // wrap top-level subtrees to a new band past this x
 const INFO_ID = "info:card";
 const INFO_W = 560;
 const INFO_H = 320;
-const SETUP_SH = "curl -fsSL https://agent-yes.com/setup.sh | sh";
-const SETUP_PS = 'powershell -c "irm https://agent-yes.com/setup.ps1 | iex"';
+const INSTALL_ORIGIN = location.origin;
+const SETUP_SH = `curl -fsSL ${INSTALL_ORIGIN}/setup.sh | sh`;
+const SETUP_PS = `powershell -c "irm ${INSTALL_ORIGIN}/setup.ps1 | iex"`;
 
 // User-set per-node magnify (rgui contentScale via shift+drag on the corner
 // grip), remembered by node id so a manual "magnify this agent to watch it"

--- a/lab/ui/setup.ps1
+++ b/lab/ui/setup.ps1
@@ -1,4 +1,4 @@
-# agent-yes installer (Windows) — powershell -c "irm https://agent-yes.com/setup.ps1 | iex"
+# agent-yes installer (Windows) — powershell -c "irm <site-origin>/setup.ps1 | iex"
 # (the powershell -c wrapper lets the same one-liner run from cmd too)
 #
 # Installs the agent-yes CLI (ay / cy / claude-yes / …) globally. agent-yes is a
@@ -6,14 +6,18 @@
 # bun / npm you already have, and install bun if you have neither.
 $ErrorActionPreference = 'Stop'
 
+# Beta site builds rewrite these defaults in build-assets.sh.
+$Package = 'agent-yes'
+$ConsoleOrigin = 'https://agent-yes.com'
+
 function Say($m) { Write-Host "▸ $m" -ForegroundColor Cyan }
 
 # --- pick a package manager -------------------------------------------------
 if (Get-Command bun -ErrorAction SilentlyContinue) {
-  $pm = { bun add -g agent-yes }
+  $pm = { bun add -g $Package }
   $rt = 'bun'
 } elseif (Get-Command npm -ErrorAction SilentlyContinue) {
-  $pm = { npm install -g agent-yes }
+  $pm = { npm install -g $Package }
   $rt = 'npm'
 } else {
   Say 'No bun or npm found — installing bun (https://bun.sh)…'
@@ -23,22 +27,22 @@ if (Get-Command bun -ErrorAction SilentlyContinue) {
     Write-Error "bun install finished but 'bun' is not on PATH — open a new terminal and re-run."
     exit 1
   }
-  $pm = { bun add -g agent-yes }
+  $pm = { bun add -g $Package }
   $rt = 'bun'
 }
 
 # --- install ----------------------------------------------------------------
-Say "Installing agent-yes with $rt…"
+Say "Installing $Package with $rt…"
 & $pm
 
 # --- next steps -------------------------------------------------------------
 Say 'agent-yes is ready. Quick start:'
-@'
+@"
 
     ay claude            # run Claude with auto-yes
     ay serve share       # start the web console + a shareable link
     ay ls                # list running agents
 
-  Console & docs: https://agent-yes.com
+  Console & docs: $ConsoleOrigin
   (If "ay" isn't found, open a new terminal — the package bin dir was just added to PATH.)
-'@ | Write-Host
+"@ | Write-Host

--- a/lab/ui/setup.sh
+++ b/lab/ui/setup.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
-# agent-yes installer — curl -fsSL https://agent-yes.com/setup.sh | sh
+# agent-yes installer — curl -fsSL <site-origin>/setup.sh | sh
 #
 # Installs the agent-yes CLI (ay / cy / claude-yes / …) globally. agent-yes is a
 # JS package, so it needs a JS runtime + package manager: we use whichever of
 # bun / npm you already have, and install bun if you have neither.
 set -eu
+
+# The canonical source installs stable. Beta site builds rewrite these defaults
+# in build-assets.sh so the exact same installer installs the beta npm channel
+# and points its next-step links back to the origin it was downloaded from.
+AY_PACKAGE="agent-yes"
+AY_CONSOLE_ORIGIN="https://agent-yes.com"
 
 say() { printf '\033[36m▸\033[0m %s\n' "$1"; }
 err() { printf '\033[31m✘ %s\033[0m\n' "$1" >&2; }
@@ -70,9 +76,9 @@ else
 fi
 
 # --- install ----------------------------------------------------------------
-say "Installing agent-yes with ${RT}…"
+say "Installing ${AY_PACKAGE} with ${RT}…"
 # shellcheck disable=SC2086
-$PM agent-yes
+$PM "$AY_PACKAGE"
 
 # bun blocks dependency postinstalls by default, which skips node-datachannel's
 # native build — the addon that powers `ay serve --webrtc` / `ay serve share`.
@@ -89,7 +95,7 @@ else
   say "Installed. If 'ay' isn't found, open a new shell (the package bin dir was just added to PATH)."
 fi
 
-cat <<'EOF'
+cat <<EOF
 
   agent-yes is ready. Quick start:
 
@@ -97,7 +103,7 @@ cat <<'EOF'
     ay serve --share     # start the web console + a shareable link
     ay ls                # list running agents
 
-  Console & docs: https://agent-yes.com
+  Console & docs: ${AY_CONSOLE_ORIGIN}
 EOF
 
 # --- offer to start sharing right away --------------------------------------

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -549,8 +549,9 @@ describe("console DOM behaviour", () => {
     const { ctx, page } = await openConsole(browser, url);
     try {
       const install = (await page.locator(".install").innerText()).toLowerCase();
-      expect(install).toContain("curl -fssl https://agent-yes.com/setup.sh | sh");
-      expect(install).toContain('powershell -c "irm https://agent-yes.com/setup.ps1 | iex"');
+      const origin = new URL(url).origin.toLowerCase();
+      expect(install).toContain(`curl -fssl ${origin}/setup.sh | sh`);
+      expect(install).toContain(`powershell -c "irm ${origin}/setup.ps1 | iex"`);
     } finally {
       await ctx.close();
     }


### PR DESCRIPTION
## What changed

- publish every tested main snapshot as agent-yes@beta and claude-yes@beta
- create matching GitHub prereleases and native binary assets
- make beta Pages installers origin-aware while stable remains agent-yes
- keep beta WebRTC signaling on the production signaling service
- remove the direct production deploy that bypassed the one-hour release soak

## Why

The beta console needs a matching installable CLI channel, and production deployment must remain gated by the existing one-hour soak instead of deploying immediately from UI Test.

## Validation

- bun run build
- bun run test (948 passed)
- bun run test:ui-dom (24 passed)
- bun run test:theme
- actionlint on changed workflows
- beta/stable installer smoke tests