### PR TITLE
Test beta source before prerelease stamping

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -32,6 +32,10 @@ jobs:
           registry-url: https://registry.npmjs.org
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
+      # Validate the checked-in stable version first. Several version-contract
+      # tests intentionally reject prerelease semver; the stamp below exists
+      # only for the publish artifact and its matching native binaries.
+      - run: bun run test
 
       - name: Set unique beta version
         id: version
@@ -48,7 +52,6 @@ jobs:
           echo "Publishing ${TAG} from ${GITHUB_SHA}"
 
       - run: bun run build
-      - run: bun run test
 
       - name: Create GitHub prerelease
         env:


### PR DESCRIPTION
## What changed

Run the full source test suite before stamping the ephemeral prerelease version used by npm and native binary artifacts.

## Why

The first beta publish correctly stopped before publishing because version-contract tests intentionally reject prerelease semver in the checked-in source. The stamp is a packaging concern and must happen after source validation.

## Validation

- actionlint .github/workflows/publish-beta.yml
- pre-push full suite: 948 passed
- shared Rust/TS e2e: 15 passed