### PR TITLE
fix(console): popstate suppression ate pasted #room:pid deep links (regression from #277)

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -5574,14 +5574,24 @@
       // openPreview()/select() push the entries this handler consumes.
       let suppressHash = false;
       window.addEventListener("popstate", () => {
+        // popstate ALSO fires on a plain location.hash assignment (a hash
+        // write is a same-document navigation), not just on back/forward — so
+        // only act, and only eat the paired hashchange, when there is actually
+        // a screen to close. Unconditional suppression here swallowed pasted
+        // #room:pid deep links into an open console (the ui-dom regression).
+        const ov = $("previewOverlay");
+        const preview = ov && !ov.hidden;
+        const detail =
+          window.innerWidth <= 720 &&
+          document.querySelector(".app").classList.contains("show-detail");
+        if (!preview && !detail) return; // nothing stacked — a real hash navigation
         // The back press may also rewind the #room:pid hash (select() rewrites
         // it in place). That press meant "close this screen", not "jump to the
         // previously-hashed agent" — eat the hashchange it triggers.
         suppressHash = true;
         setTimeout(() => (suppressHash = false), 0);
-        const ov = $("previewOverlay");
-        if (ov && !ov.hidden) return closePreviewNow();
-        if (window.innerWidth <= 720) goBackNow();
+        if (preview) return closePreviewNow();
+        goBackNow();
       });
       $("rback").addEventListener("click", goBack);
       // Swipe-right-from-the-left-edge → back, an alternative to the ‹ button.


### PR DESCRIPTION
## Problem

`popstate` fires on a **plain `location.hash` assignment** too (a hash write is a same-document navigation), not just on back/forward traversal. #277's back-key handler set `suppressHash` unconditionally on every popstate, so a `#room:pid` deep link pasted into an open console suppressed its own `hashchange` and selected nothing.

Caught by ui-dom's "resolves a #room:pid deep link" test — **which fails on current main**: ui-dom is not a required check, so #277 shipped the regression and #278 merged over the red check.

## Fix

Only suppress (and only close a screen) when something is actually stacked — the preview overlay is visible, or the mobile detail pane is showing. A bare hash navigation now passes through to the deep-link hashchange handler untouched. The back-key behavior from #277 is unchanged when a screen IS stacked.

## Verified

- `bun run test:ui-dom`: **24/24 pass** (was 23/24 on main)

## Note for repo hygiene

Consider making `ui-dom` a required status check — it's the only gate that exercises the real console DOM, and both #277 and #278 auto-merged past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)