### PR TITLE
fix(console): translate quick command never fails silently; menu survives collapsed mobile selection

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -4397,6 +4397,12 @@
         // available; otherwise fall back to a Google Translate tab. Returns ""
         // when the fallback tab was opened (nothing to show inline).
         translate: async (text, lang) => {
+          // Never end silently: every path returns something the result
+          // overlay will show — an empty selection, the translation, or what
+          // the fallback did. (The first ship ended silently on mobile, where
+          // Android Chrome has NO Translator API and the fallback tab could be
+          // popup-blocked after the awaits consumed the tap's activation.)
+          if (!String(text || "").trim()) return "nothing selected — drag-select some text first";
           try {
             if (window.Translator && window.LanguageDetector) {
               const det = await LanguageDetector.create();
@@ -4409,13 +4415,16 @@
           } catch {
             /* model unavailable / language pair unsupported → tab fallback */
           }
-          quickCmdApi.open(
+          const url =
             "https://translate.google.com/?sl=auto&tl=" +
-              encodeURIComponent(lang) +
-              "&op=translate&text=" +
-              encodeURIComponent(String(text).slice(0, 5000)),
-          );
-          return "";
+            encodeURIComponent(lang) +
+            "&op=translate&text=" +
+            encodeURIComponent(String(text).slice(0, 5000));
+          const win = quickCmdApi.open(url);
+          // Popup blocked (window.open after an await has no activation left):
+          // surface the URL itself — the overlay text is selectable/copyable.
+          if (!win) return "on-device Translator unavailable and the popup was blocked — open manually:\n" + url;
+          return "no on-device Translator here — opened Google Translate in a new tab";
         },
         copy: (t) => copyText(String(t)),
         open: (u) => window.open(u, "_blank", "noopener,noreferrer"),
@@ -4521,6 +4530,9 @@
       }
 
       let ctxMenuEl = null;
+      // Last touch-drag selection ({text, at}) — the menu's fallback when the
+      // live xterm selection got collapsed by mobile tap emulation.
+      let recentTouchSel = null;
       function hideTermMenu() {
         if (!ctxMenuEl) return;
         ctxMenuEl.remove();
@@ -4617,7 +4629,15 @@
       function showTermMenu(ev, term) {
         ev.preventDefault();
         hideTermMenu();
-        const selText = term && term.hasSelection && term.hasSelection() ? term.getSelection() : "";
+        // Live xterm selection first; else fall back to the last touch-drag
+        // selection if it's fresh (≤20s) — mobile tap emulation can collapse
+        // the live selection between the drag and the long-press menu.
+        const selText =
+          term && term.hasSelection && term.hasSelection()
+            ? term.getSelection()
+            : recentTouchSel && Date.now() - recentTouchSel.at < 20_000
+              ? recentTouchSel.text
+              : "";
         const { menu, addItem, addSep } = ctxMenuShell();
 
         // Copy: disabled with nothing selected (mirrors the old behavior, minus
@@ -5670,7 +5690,14 @@
             const mt = t.modes && t.modes.mouseTrackingMode;
             if (mt && mt !== "none") return; // the TUI owns selection + OSC 52 copy
             if (t.hasSelection()) {
-              copyText(t.getSelection());
+              // Remember the selection for the long-press menu: on mobile the
+              // browser's tap/long-press emulation can collapse the xterm
+              // selection BEFORE the menu opens, which made selection-fed
+              // commands (Translate, [selection]) run against empty text.
+              const selTxt = t.getSelection();
+              // whitespace-only cell selections aren't worth remembering
+              if (selTxt.trim()) recentTouchSel = { text: selTxt, at: Date.now() };
+              copyText(selTxt);
               const pill = document.createElement("div");
               pill.className = "updatebar";
               pill.textContent = "copied";


### PR DESCRIPTION
Reported: *js translate doesn't seem to work* (on the phone). Live debugging on real Chrome showed the pipeline is sound — detector + create + translate all pass, zh model downloads on demand. The failures are environment edges, and **every one ended in silence**:

| edge | what happened |
|---|---|
| Android Chrome has **no Translator API** | fallback `window.open` ran **after the awaits consumed the tap's activation** → popup blocked → nothing visible |
| mobile tap emulation **collapses the xterm selection** between drag and long-press menu | `text:''` → translate returned `''` → empty results render nothing → silence |

## Fix

- every translate path now reports: `nothing selected…` / the translation / `opened Google Translate…` / when the popup is blocked, **the URL itself** in the selectable result overlay
- the menu's selection falls back to the **last touch-drag selection** (≤20 s fresh, whitespace-only ignored) when the live one collapsed — this also fixes `[selection]` template commands and re-enables **Copy** in the same case

## Verified (headless Playwright touch context)

- drag-select → collapse live selection → menu shows **Copy enabled**, translate renders the blocked-popup URL overlay ✅
- empty selection → `nothing selected — drag-select some text first` ✅
- real Chrome (this machine): full replica of the menu flow returns `克劳德完成了构建，所有测试都通过了` ✅
- ui-dom 24/24 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)