### PR TITLE
feat: ⌘K searches chat history — GET /api/search + palette tier 3

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -6819,6 +6819,14 @@ my.translate = async (text, lang) => {
         // Tier 2 — debounced output (tail) search for alive agents not already shown.
         if (omniTailTimer) clearTimeout(omniTailTimer);
         if (q.length >= 2) omniTailTimer = setTimeout(() => omniTailSearch(q), 320);
+        // Tier 3 — debounced CHAT-HISTORY search (server-side /api/search over
+        // each agent's rendered log tail; covers exited agents and scrollback
+        // the live-tail tier never sees). Fired just BEFORE tier 2's ~20
+        // parallel /api/read calls: on HTTP/1.1 the browser caps same-origin
+        // connections at ~6, so the single search request must enter the pool
+        // first or it queues behind every tail read (measured: seconds).
+        if (omniHistTimer) clearTimeout(omniHistTimer);
+        if (q.length >= 2) omniHistTimer = setTimeout(() => omniHistorySearch(q), 300);
       }
 
       async function omniTailSearch(q) {
@@ -6867,6 +6875,55 @@ my.translate = async (text, lang) => {
           }),
         );
         if (seq === omniTailSeq) renderOmni();
+      }
+
+      // Tier 3 — chat-history hits from GET /api/search on every writable live
+      // source (fleet fan-out, same shape as /api/ws). The server renders each
+      // agent's raw-log tail through headless xterm and caches it by
+      // (size, mtime), so repeat queries are cheap; partial:true responses
+      // (time budget hit while the cache warms) are simply what we show now —
+      // the next keystroke re-queries a warmer cache. Hits map back to list
+      // entries by (source, pid); agents already shown by tier 1/2 are skipped.
+      let omniHistSeq = 0;
+      let omniHistTimer = null;
+      async function omniHistorySearch(q) {
+        const seq = ++omniHistSeq;
+        const srcs = [...sources.values()].filter((s) => s.tx?.fetchJSON && s.live && !s.readonly);
+        const results = await Promise.all(
+          srcs.map(async (s) => {
+            try {
+              const r = await s.tx.fetchJSON("/api/search?q=" + encodeURIComponent(q));
+              return (r?.hits || []).map((h) => ({ h, srcId: s.id }));
+            } catch {
+              return []; // older daemon (404) / transport error — skip source
+            }
+          }),
+        );
+        if (seq !== omniHistSeq || !omniOpen()) return;
+        const ql = q.toLowerCase();
+        for (const { h, srcId } of results.flat()) {
+          const key = srcId + "#" + h.pid;
+          if (omniRows.some((r) => r.kind === "agent" && r.entry._key === key)) continue;
+          const e = entries.find((x) => x._key === key);
+          if (!e) continue; // hit for an agent the list doesn't know (raced away)
+          const raw = String(h.snippet || "");
+          const li = raw.toLowerCase().indexOf(ql);
+          const snippet =
+            li >= 0
+              ? esc(raw.slice(0, li)) +
+                "<b>" +
+                esc(raw.slice(li, li + q.length)) +
+                "</b>" +
+                esc(raw.slice(li + q.length))
+              : esc(raw);
+          const at = omniRows.findIndex((r) => r.kind === "spawn");
+          const row = { kind: "agent", entry: e, snippet };
+          if (at >= 0) {
+            omniRows.splice(at, 0, row);
+            if (at <= omniIdx) omniIdx++; // keep the highlight on the same row
+          } else omniRows.push(row);
+        }
+        renderOmni();
       }
 
       function omniMove(d) {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -31,6 +31,7 @@ import {
   recentReadEdges,
   renderLogTailLines,
   renderRawLog,
+  renderRawLogLines,
   resolveOne,
   snapshotStatus,
   writeToIpc,
@@ -152,6 +153,14 @@ function tokenPath(): string {
 function heartbeatPath(): string {
   return path.join(agentYesHome(), ".serve-heartbeat");
 }
+// /api/search — chat-history search (v1). Per-agent rendered-tail cache, keyed
+// on the log's (size, mtime): the expensive part is the headless-xterm replay,
+// so an unchanged log never re-renders. Map insertion order doubles as LRU.
+const SEARCH_TAIL_BYTES = 256 * 1024;
+const SEARCH_MAX_HITS = 20;
+const SEARCH_CACHE_MAX = 300;
+const searchTextCache = new Map<string, { size: number; mtimeMs: number; text: string }>();
+
 const HEARTBEAT_WRITE_MS = 5_000;
 const HEARTBEAT_STALE_MS = 15_000; // event loop is wedged if no stamp this long (3 missed)
 
@@ -2010,6 +2019,99 @@ export async function cmdServe(rest: string[]): Promise<number> {
       try {
         const records = await listRecords(keyword, opts);
         return Response.json(await Promise.all(records.map(withMeta)));
+      } catch (e) {
+        return new Response((e as Error).message, { status: 500 });
+      }
+    }
+
+    // GET /api/search?q= — chat-history search across every agent's log.
+    // v1 ("simple" scope, by design): no sidecar index yet — each agent's raw
+    // log TAIL (SEARCH_TAIL_BYTES) is rendered through the same headless-xterm
+    // path the reader uses (so TUI redraw spam collapses into real transcript
+    // lines) and cached by (size, mtime); only agents whose log moved re-render.
+    // Requests scan newest-first under a time budget and return partial:true
+    // when the budget ran out before the fleet was covered — the console just
+    // re-queries and hits the now-warm cache. Upgrade path: an incremental
+    // transcript sidecar + full-history index (see the /api/ws pattern).
+    if (req.method === "GET" && p === "/api/search") {
+      const q = (url.searchParams.get("q") || "").trim();
+      if (q.length < 2) return Response.json({ hits: [], scanned: 0, total: 0, partial: false });
+      const ql = q.toLowerCase();
+      const budget = Math.min(3000, Number(url.searchParams.get("budget_ms")) || 900);
+      const t0 = Date.now();
+      try {
+        const records = await listRecords(undefined, defaultOpts({ all: true }));
+        // newest activity first — the log mtime is the stop/activity clock.
+        const stats = await Promise.all(
+          records.map(async (r) => ({
+            r,
+            st: r.log_file ? await stat(r.log_file).catch(() => null) : null,
+          })),
+        );
+        const live = stats
+          .filter((x) => x.st)
+          .sort((a, b) => (b.st!.mtimeMs || 0) - (a.st!.mtimeMs || 0));
+        const hits: unknown[] = [];
+        let scanned = 0;
+        let partial = false;
+        for (const { r, st } of live) {
+          if (hits.length >= SEARCH_MAX_HITS) break;
+          if (Date.now() - t0 > budget) {
+            partial = true;
+            break;
+          }
+          const key = String(r.pid);
+          let ent = searchTextCache.get(key);
+          if (!ent || ent.size !== st!.size || ent.mtimeMs !== st!.mtimeMs) {
+            try {
+              const fh = await open(r.log_file!, "r");
+              let buf: Uint8Array;
+              try {
+                if (st!.size <= SEARCH_TAIL_BYTES) {
+                  const data = await fh.readFile();
+                  buf = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+                } else {
+                  const tmp = Buffer.alloc(SEARCH_TAIL_BYTES);
+                  const { bytesRead } = await fh.read(
+                    tmp,
+                    0,
+                    SEARCH_TAIL_BYTES,
+                    st!.size - SEARCH_TAIL_BYTES,
+                  );
+                  buf = new Uint8Array(tmp.buffer, 0, bytesRead);
+                }
+              } finally {
+                await fh.close();
+              }
+              const geom = (await readPtysize(r.pid).catch(() => null)) ?? undefined;
+              const lines = await renderRawLogLines(buf, geom ?? undefined);
+              ent = { size: st!.size, mtimeMs: st!.mtimeMs, text: lines.join("\n") };
+              searchTextCache.set(key, ent);
+              // bound the cache: drop the oldest entries past the cap
+              if (searchTextCache.size > SEARCH_CACHE_MAX) {
+                const k = searchTextCache.keys().next().value;
+                if (k !== undefined) searchTextCache.delete(k);
+              }
+            } catch {
+              continue; // unreadable log — skip this agent
+            }
+          } else {
+            // refresh LRU position
+            searchTextCache.delete(key);
+            searchTextCache.set(key, ent);
+          }
+          scanned++;
+          const tl = ent.text.toLowerCase();
+          const idx = tl.lastIndexOf(ql); // latest occurrence reads most relevant
+          if (idx < 0) continue;
+          const from = Math.max(0, idx - 60);
+          const snippet = ent.text
+            .slice(from, idx + ql.length + 60)
+            .replace(/\s+/g, " ")
+            .trim();
+          hits.push({ pid: r.pid, cli: r.cli, cwd: r.cwd, snippet, match_at: idx });
+        }
+        return Response.json({ hits, scanned, total: live.length, partial });
       } catch (e) {
         return new Response((e as Error).message, { status: 500 });
       }


### PR DESCRIPTION
v1 of chat-history search (per design review: the "simple" scope — no sidecar index yet; the upgrade path is an incremental transcript sidecar. Motivating numbers: raw logs are 2.2 GB / 102 files on this machine, so per-keystroke brute grep was never an option).

## Server — `GET /api/search?q=`

- Renders the **tail (256 KB)** of each agent's raw log through the same headless-xterm path the reader uses (TUI redraw spam collapses into real transcript lines), **cached by `(size, mtime)`** — an unchanged log never re-renders. Warm: **34 ms across 50 agents**; cold: ~340 ms.
- Newest-first (log mtime) under a **time budget** (900 ms default / 3 s cap) → `partial: true` when it runs out; Map insertion order doubles as LRU (cap 300).

## Console — ⌘K tier 3

- 300 ms after typing, fan out to every writable live source (the `/api/ws` pattern), map hits back by `(source, pid)`, insert **bolded-snippet rows** above the spawn rows — skipping agents tiers 1/2 already surfaced.
- Covers **exited agents** and scrollback beyond the live tail — which tier 2 never sees.
- Dispatched just **before** tier 2's ~20 parallel `/api/read` calls: HTTP/1.1 caps same-origin connections at ~6, and a search dispatched after them queues behind every tail read — measured live as a multi-second stall that looked exactly like a hang.

## Verified (headless Playwright vs `ay serve`, 50-agent fleet)

- a marker existing **only in a dead agent's log output** (base64-decoded at runtime, so absent from every title/prompt) surfaces as the first palette row with a bolded snippet within 2.5 s ✅
- `/api/search` 200 in 34 ms warm / 337 ms cold, query-token and header auth both ✅
- ui-dom 24/24, serve unit tests 15/15 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)