### PR TITLE
perf(console): /api/mux WebSocket multiplexer — local API escapes the 6-connection HTTP/1.1 cap

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2667,24 +2667,108 @@
       // ---- transports: a uniform { fetchJSON, post, subscribe } over each wire ----
       // local (same-origin ay serve), an ay-share RTCClient, or a codehost room.
       // A codehost room builds one of these per machine in it (see chPeerTx).
+      //
+      // Local requests ride ONE multiplexed WebSocket (/api/mux) when the
+      // daemon offers it: HTTP/1.1 gives the origin ~6 concurrent connections
+      // and no multiplexing, so console bursts (a palette query fans out ~20
+      // tail reads + a history search) queued behind each other for seconds —
+      // the same trick the WebRTC / codehost transports already play. Plain
+      // fetch remains the fallback while the socket is down or the daemon
+      // predates /api/mux; subscribe() stays on EventSource (streams don't
+      // fit req/res frames — the server refuses them over the mux).
+      const localMux = {
+        ws: null,
+        state: "idle", // idle | connecting | open | dead (fallback until retryAt)
+        pend: new Map(), // id → {resolve, reject}
+        seq: 0,
+        retryAt: 0,
+        ensure() {
+          if (this.state === "open" || this.state === "connecting") return;
+          if (this.state === "dead" && Date.now() < this.retryAt) return;
+          this.state = "connecting";
+          try {
+            const proto = location.protocol === "https:" ? "wss://" : "ws://";
+            const ws = new WebSocket(proto + location.host + withTok("/api/mux"));
+            this.ws = ws;
+            ws.onopen = () => {
+              if (this.ws === ws) this.state = "open";
+            };
+            ws.onmessage = (ev) => {
+              let m;
+              try {
+                m = JSON.parse(ev.data);
+              } catch {
+                return;
+              }
+              const p = this.pend.get(m.id);
+              if (!p) return;
+              this.pend.delete(m.id);
+              p.resolve(m);
+            };
+            const drop = () => {
+              if (this.ws !== ws) return;
+              this.ws = null;
+              this.state = "dead";
+              this.retryAt = Date.now() + 5000; // plain-fetch fallback, retry soon
+              for (const [, p] of this.pend) p.reject(new Error("mux closed"));
+              this.pend.clear();
+            };
+            ws.onclose = drop;
+            ws.onerror = drop;
+          } catch {
+            this.state = "dead";
+            this.retryAt = Date.now() + 5000;
+          }
+        },
+        req(method, path, body) {
+          const id = ++this.seq;
+          return new Promise((resolve, reject) => {
+            this.pend.set(id, { resolve, reject });
+            try {
+              this.ws.send(JSON.stringify({ id, method, path, body }));
+            } catch (e) {
+              this.pend.delete(id);
+              reject(e);
+            }
+          });
+        },
+      };
+      // One request, mux-first: {status, text} from the socket when it's open
+      // (a mid-flight drop falls through), plain fetch otherwise.
+      async function localReq(method, path, bodyObj) {
+        localMux.ensure();
+        if (localMux.state === "open") {
+          try {
+            return await localMux.req(method, path, bodyObj);
+          } catch {
+            /* socket died mid-flight — fall through to plain fetch */
+          }
+        }
+        const opts =
+          method === "GET"
+            ? undefined
+            : {
+                method,
+                headers: bodyObj != null ? { "Content-Type": "application/json" } : undefined,
+                body: bodyObj != null ? JSON.stringify(bodyObj) : undefined,
+              };
+        const r = await fetch(withTok(path), opts);
+        return { status: r.status, text: await r.text() };
+      }
       const localTx = {
         async fetchJSON(path) {
-          return (await fetch(withTok(path))).json();
+          return JSON.parse((await localReq("GET", path)).text);
         },
         async fetchText(path) {
-          return (await fetch(withTok(path))).text();
+          return (await localReq("GET", path)).text;
         },
         async post(path, bodyObj) {
-          const r = await fetch(withTok(path), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(bodyObj),
-          });
-          return { ok: r.ok, text: await r.text() };
+          const r = await localReq("POST", path, bodyObj ?? {});
+          return { ok: r.status >= 200 && r.status < 300, text: r.text };
         },
         async del(path) {
-          const r = await fetch(withTok(path), { method: "DELETE" });
-          return { ok: r.ok, text: await r.text() };
+          const r = await localReq("DELETE", path);
+          return { ok: r.status >= 200 && r.status < 300, text: r.text };
         },
         subscribe(path, onText, onOpen, onError) {
           const ev = new EventSource(withTok(path));

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2001,13 +2001,27 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // The whole API as a plain handler: served over HTTP by Bun.serve (--http)
   // and called in-process by the WebRTC bridge (--webrtc) — the latter needs
   // no TCP port at all.
-  const apiFetch = async (req: Request): Promise<Response> => {
+  const apiFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
     if (!checkAuth(req, token)) {
       return new Response("Unauthorized", { status: 401 });
     }
 
     const url = new URL(req.url);
     const p = url.pathname;
+
+    // GET /api/mux — WebSocket request multiplexer. HTTP/1.1 gives a browser
+    // ~6 concurrent same-origin connections and no multiplexing, so console
+    // bursts (a palette query fans out ~20 tail reads + a history search)
+    // queue behind each other for seconds. The mux carries {id, method, path,
+    // body} frames over ONE socket and answers {id, status, text} — each frame
+    // is dispatched through THIS same handler (with the socket's token), so
+    // there is exactly one API surface. Streams (SSE) don't fit req/res
+    // frames and stay on EventSource; the handler refuses them.
+    if (p === "/api/mux" && srv && req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      const muxToken = url.searchParams.get("token") || "";
+      if (srv.upgrade(req, { data: { muxToken } })) return undefined as unknown as Response;
+      return new Response("expected websocket", { status: 426 });
+    }
 
     // GET /api/ls
     if (req.method === "GET" && p === "/api/ls") {
@@ -3487,7 +3501,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
       });
     }
   };
-  const httpFetch = async (req: Request): Promise<Response> => {
+  const httpFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
     const p = new URL(req.url).pathname;
     if (req.method === "GET" && (p === "/" || p === "/index.html"))
       return serveUiFile("index.html", "text/html; charset=utf-8");
@@ -3522,14 +3536,64 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return serveUiFile("manifest.webmanifest", "application/manifest+json");
     if (req.method === "GET" && p === "/icon.svg") return serveUiFile("icon.svg", "image/svg+xml");
     if (req.method === "GET" && p === "/favicon.ico") return new Response(null, { status: 204 });
-    return apiFetch(req);
+    return apiFetch(req, srv);
   };
 
   const serverOpts: any = {
     hostname: host,
     port,
     idleTimeout: 0, // never time out SSE/tail streams
-    fetch: httpFetch,
+    fetch: (req: Request, srv: unknown) =>
+      httpFetch(req, srv as { upgrade: (r: Request, o?: unknown) => boolean }),
+    // /api/mux frames — each one re-enters apiFetch as a synthetic Request
+    // carrying the socket's token, so auth and routing stay single-sourced.
+    websocket: {
+      // Bun's per-socket idle cap; the console reconnects lazily on drop, but
+      // don't let a quiet-but-alive console churn sockets every 2 minutes.
+      idleTimeout: 960,
+      message: async (ws: any, raw: string | Buffer) => {
+        let m: { id?: number; method?: string; path?: string; body?: unknown };
+        try {
+          m = JSON.parse(String(raw));
+        } catch {
+          return; // not a mux frame — drop
+        }
+        const { id, method, path, body } = m || {};
+        if (!id || typeof path !== "string" || !path.startsWith("/api/")) return;
+        try {
+          const tok = ws.data?.muxToken || "";
+          const u =
+            "http://mux.internal" +
+            path +
+            (tok ? (path.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(tok) : "");
+          const req = new Request(u, {
+            method: method || "GET",
+            headers: body != null ? { "content-type": "application/json" } : undefined,
+            body: body != null ? JSON.stringify(body) : undefined,
+          });
+          const res = await apiFetch(req);
+          // Streams can't ride a req/res frame — refuse instead of buffering an
+          // endless SSE body (subscribe stays on EventSource client-side).
+          if ((res.headers.get("content-type") || "").includes("text/event-stream")) {
+            try {
+              await res.body?.cancel();
+            } catch {
+              /* already closed */
+            }
+            ws.send(JSON.stringify({ id, status: 501, text: "streams not supported over mux" }));
+            return;
+          }
+          const text = await res.text();
+          ws.send(JSON.stringify({ id, status: res.status, text }));
+        } catch (e) {
+          try {
+            ws.send(JSON.stringify({ id, status: 599, text: String((e as Error)?.message ?? e) }));
+          } catch {
+            /* socket gone */
+          }
+        }
+      },
+    },
   };
   if (useHttps) {
     serverOpts.tls = { cert: Bun.file(certPath!), key: Bun.file(keyPath!) };


### PR DESCRIPTION
HTTP/1.1 gives a browser **~6 concurrent same-origin connections with no multiplexing**, so console bursts against a local `ay serve` (a palette query fans out ~20 tail reads + a history search; SSE holds slots too) queued behind each other for seconds — measured live while debugging the history-search "hang" in #290.

## Server

`GET /api/mux` upgrades to a WebSocket carrying `{id, method, path, body}` frames, each dispatched through the **same `apiFetch` handler** as a synthetic Request with the socket's token — one API surface, one auth path. Replies `{id, status, text}`. SSE responses are refused over the mux (streams don't fit req/res frames; `subscribe` stays on EventSource).

## Console

`localTx` goes **mux-first** through `localReq()` — lazy connect, auto-reconnect (5 s backoff), **plain fetch fallback** while the socket is down or the daemon predates `/api/mux` (ui-dom's stub server has no mux, so the suite exercises exactly that path). Remote transports already multiplex (WebRTC / codehost) — this brings the local wire up to par.

## Verified (headless vs `ay serve`)

| check | result |
|---|---|
| HTTP /api requests after socket opens | **0** (all frames on the mux; list keeps refreshing) ✅ |
| ⌘K history row latency | **367 ms** (was seconds-at-risk behind the pool) ✅ |
| terminal open + render + send over mux | ✅ |
| raw WS probe answers /api/search frames | ✅ |
| ui-dom (fallback path) 24/24 · serve unit 15/15 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)