### PR TITLE
perf(console): dead saved rooms back off to 5 min — stop the permanent reconnect storm

### DIFF
--- a/.github/workflows/matrix-test.yml
+++ b/.github/workflows/matrix-test.yml
@@ -42,7 +42,13 @@ jobs:
 
       - name: Install dependencies (Node)
         if: matrix.runtime == 'node'
-        run: npm install
+        # npm 10 (bundled with node 20/22) crashes on some freshly-published
+        # peer metadata ("Cannot read properties of null (reading 'edgesOut')"
+        # in arborist's #loadPeerSet — hit live 2026-07-21 via a dep's peer
+        # set; npm 11 and bun resolve the same tree fine). Pin npm ≥11.
+        run: |
+          npm install -g npm@^11
+          npm install
 
       - name: Install dependencies (Bun)
         if: matrix.runtime == 'bun'

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -7225,7 +7225,16 @@ my.translate = async (text, lang) => {
       // left the room dead until a manual reload. Retry with jittered backoff
       // until the room is forgotten.
       const RTC_BACKOFF_MIN = 1000,
-        RTC_BACKOFF_MAX = 30000;
+        RTC_BACKOFF_MAX = 30000,
+        // A room that keeps failing (its daemon is gone, not restarting) backs
+        // off much further: 5 dead saved rooms at the 30s cap meant an 8s
+        // connect attempt was in flight almost continuously — a permanent
+        // signaling + ICE storm that measurably slowed the LIVE rooms and
+        // flooded the console with [ay-perf] connect.fail logs. After
+        // RTC_DEAD_AFTER consecutive failures the cap grows to 5 minutes; one
+        // healthy connect resets everything.
+        RTC_BACKOFF_DEAD_MAX = 300000,
+        RTC_DEAD_AFTER = 5;
       async function connectRtcSource(s) {
         s.reconnecting = true; // block overlapping attempts while this one is in flight
         try {
@@ -7262,6 +7271,7 @@ my.translate = async (text, lang) => {
           s.client = c;
           s.tx = rtcTx(c);
           s.reconnectDelay = RTC_BACKOFF_MIN; // a healthy connect resets the backoff
+          s.failCount = 0; // …and the dead-room escalation (see RTC_BACKOFF_DEAD_MAX)
           clearTimeout(s.reconnectTimer); // cancel any reconnect queued during replace
           s.reconnectTimer = null;
           subscribeSource(s); // re-establish the live delta stream over the new wire
@@ -7309,7 +7319,8 @@ my.translate = async (text, lang) => {
         if (s.removed || s.reconnectTimer || s.reconnecting) return;
         const base = s.reconnectDelay || RTC_BACKOFF_MIN;
         const delay = Math.round(base * (0.75 + Math.random() * 0.5)); // jitter
-        s.reconnectDelay = Math.min(base * 2, RTC_BACKOFF_MAX);
+        const cap = (s.failCount || 0) >= RTC_DEAD_AFTER ? RTC_BACKOFF_DEAD_MAX : RTC_BACKOFF_MAX;
+        s.reconnectDelay = Math.min(base * 2, cap);
         s.reconnectTimer = setTimeout(async () => {
           s.reconnectTimer = null;
           if (s.removed || s.reconnecting) return;
@@ -7326,6 +7337,7 @@ my.translate = async (text, lang) => {
             if (sel && sel.startsWith(s.id + "#")) select(sel);
           } catch {
             s.live = false;
+            s.failCount = (s.failCount || 0) + 1; // dead-room escalation counter
             scheduleRtcReconnect(s); // keep trying
           }
         }, delay);
@@ -7376,6 +7388,7 @@ my.translate = async (text, lang) => {
           s.live = true;
         } catch (e) {
           s.live = false;
+          s.failCount = (s.failCount || 0) + 1; // dead-room escalation counter
           scheduleRtcReconnect(s);
         }
         s.tried = true;


### PR DESCRIPTION
Live debugging of *"this agent feels slow + the console floods perf logs"* (`rc19085:14082`): **the agent was innocent**. Five stale saved rooms (daemons long gone) were cycling `signal.open` → 8 s connect timeout → retry at the 30 s backoff cap — with 5 rooms staggered, **an ICE/signaling attempt was in flight almost continuously**:

- flooded `[ay-perf] connect.fail` logs (each is force-logged)
- degraded the **live** room — `req.head` measured at **1.3 s** during the churn
- signaling DO requests bill per attempt

## Fix

Track consecutive failures per source; after **5 straight failures** the backoff cap escalates **30 s → 5 min** (`RTC_BACKOFF_DEAD_MAX`). One healthy connect resets both the delay and the counter — a machine that comes back online reconnects within one long tick, and a briefly-restarting daemon (<5 consecutive failures) keeps today's snappy 30 s behavior.

Both failure entry points feed the counter (initial `addRoomSource` connect + the retry loop).

ui-dom 24/24 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)