### PR TITLE
feat: perf beacon — slow viewers report to the daemon's perf-beacons.jsonl

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3224,6 +3224,63 @@
       // and can change (relay fallback); a light poll keeps every pill honest.
       setInterval(refreshConnKinds, 2500);
 
+      // ---- perf beacon: measured slowness reports itself to the daemon -------
+      // Counterpart of serve.ts /api/perf-beacon. Every minute, summarize the
+      // perf ring rows newer than the last beacon per SOURCE (rtc rows carry
+      // .room); a window with connect.fails or p95(req.end) at/over the slow
+      // threshold POSTs its summary to that source over whatever transport is
+      // already up (local fetch / mux / the room's WebRTC channel). The daemon
+      // appends to ~/.agent-yes/perf-beacons.jsonl — purely local — so a
+      // headless watcher (an agent tailing the file, a cron) learns about a
+      // slow phone or tab WITHOUT driving any browser. Quiet windows send
+      // nothing; older daemons 404 and are ignored.
+      const PERF_BEACON_MS = 60_000;
+      let perfBeaconCursor = Date.now();
+      setInterval(() => {
+        try {
+          const rows = (window.__ayPerf || []).filter((r) => r.t > perfBeaconCursor);
+          if (!rows.length) return;
+          perfBeaconCursor = rows[rows.length - 1].t;
+          const slowMs =
+            (window.__ayPerfReport && window.__ayPerfReport().slowMs) || 300;
+          const byRoom = new Map();
+          for (const r of rows) {
+            const k = r.room || "";
+            if (!byRoom.has(k)) byRoom.set(k, []);
+            byRoom.get(k).push(r);
+          }
+          for (const [room, rs] of byRoom) {
+            const fails = rs.filter((r) => /fail/.test(r.event || "")).length;
+            const ends = rs
+              .filter((r) => r.event === "req.end" && typeof r.ms === "number")
+              .map((r) => r.ms)
+              .sort((a, b) => a - b);
+            const pick = (q) => (ends.length ? ends[Math.floor((ends.length - 1) * q)] : 0);
+            const p95 = pick(0.95);
+            if (!fails && p95 < slowMs) continue; // healthy window — no beacon
+            const s = sources.get(room) || sources.get(LOCAL);
+            if (!s?.tx?.post || s.readonly) continue;
+            s.tx
+              .post("/api/perf-beacon", {
+                room,
+                viewer: myViewerId,
+                build: window.AY_BUILD || "",
+                ua: navigator.userAgent.slice(0, 120),
+                summary: {
+                  windowMs: PERF_BEACON_MS,
+                  rows: rs.length,
+                  fails,
+                  reqEnd: { n: ends.length, p50: pick(0.5), p95, max: ends[ends.length - 1] || 0 },
+                  slowMs,
+                },
+              })
+              .catch(() => {});
+          }
+        } catch {
+          /* beaconing must never break the console */
+        }
+      }, PERF_BEACON_MS);
+
       // ---- live performance HUD (opt-in via the ⋯ menu, hidden by default) -----
       // Surfaces the metrics that actually move when the console feels laggy: render
       // fps, keystroke throughput (xterm onData), agent output rate (term.write),

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
+import { appendFile, mkdir, open, readFile, stat, unlink, writeFile } from "fs/promises";
 import { existsSync, renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -2983,6 +2983,47 @@ export async function cmdServe(rest: string[]): Promise<number> {
 
     // POST /api/presence  body {viewer, agent, cols, rows, sel?} — a viewer
     // self-reports which agent it's watching + its viewport (agent=null clears).
+    // POST /api/perf-beacon — a viewer that MEASURED slowness reports it here.
+    // The console beacons (60s cadence, only when its window saw connect.fail
+    // or p95 ≥ its slow threshold) over whatever transport it already has —
+    // local fetch, /api/mux, or the room's WebRTC channel — so a slow PHONE
+    // lands in the same place as a slow same-PC tab. Rows append to
+    // <AGENT_YES_HOME>/perf-beacons.jsonl: purely local (no cloud/telemetry
+    // service), and anything headless — an agent tailing the file, a cron —
+    // can watch for slowness without driving a browser. Size-capped by
+    // truncate-to-recent so it can't grow unbounded.
+    if (req.method === "POST" && p === "/api/perf-beacon") {
+      let b: { summary?: unknown; build?: string; ua?: string; room?: string; viewer?: string };
+      try {
+        b = (await req.json()) as typeof b;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      try {
+        const home = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
+        const file = path.join(home, "perf-beacons.jsonl");
+        const line = JSON.stringify({
+          t: Date.now(),
+          room: String(b.room ?? "").slice(0, 64),
+          viewer: String(b.viewer ?? "").slice(0, 64),
+          build: String(b.build ?? "").slice(0, 16),
+          ua: String(b.ua ?? "").slice(0, 120),
+          summary: b.summary ?? null,
+        });
+        await mkdir(home, { recursive: true });
+        await appendFile(file, line + "\n");
+        // cap: keep the newest half once the file passes 4MB
+        const st = await stat(file).catch(() => null);
+        if (st && st.size > 4 * 1024 * 1024) {
+          const txt = await readFile(file, "utf-8");
+          await writeFile(file, txt.slice(Math.floor(txt.length / 2)).replace(/^[^\n]*\n/, ""));
+        }
+      } catch {
+        /* best-effort — a failed beacon write must never error the viewer */
+      }
+      return new Response(null, { status: 204 });
+    }
+
     if (req.method === "POST" && p === "/api/presence") {
       let b: {
         viewer?: string;


### PR DESCRIPTION
*"If it's slow again, how do you find out — without rechrome?"* → the viewer that **measured** the slowness tells the daemon itself. Purely local: no cloud DB, no third-party telemetry, no debug port.

## Console (sender)

Every 60 s, summarize perf-ring rows newer than the last beacon **per source** (rtc rows carry `.room`). A window containing `connect.fail`s or with **p95(req.end) ≥ the slow threshold** POSTs `{summary, viewer, build, ua}` to that source over whatever transport is already up — local fetch, `/api/mux`, or the room's WebRTC channel — so a **slow phone lands in the same file as a slow same-PC tab**. Healthy windows send nothing; older daemons 404 → ignored.

## Daemon (sink)

`POST /api/perf-beacon` appends to `<AGENT_YES_HOME>/perf-beacons.jsonl` (size-capped, newest half kept past 4 MB). Anything headless — an agent tailing the file, a cron — can now notice viewer-side slowness with **zero browser automation**.

## Verified (headless vs `ay serve`, isolated `AGENT_YES_HOME`)

- synthetic slow window (10× ~900 ms + a connect.fail) → exactly one beacon: `p50 904 / p95 908 / fails 1 / slowMs 300` + viewer id + build ✅
- healthy window → no beacon ✅ · direct POST smoke 204 ✅ · ui-dom 24/24 · serve unit 15/15 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)