### PR TITLE
fix(spawn): strip parent Claude Code session markers on direct `ay` launch

### DIFF
--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -9,6 +9,21 @@ use std::thread;
 use tokio::sync::mpsc;
 use tracing::{debug, info};
 
+/// Env vars that pin a process to a PARENT Claude Code session — stripped from
+/// every spawned CLI so the agent is a clean top-level session (its own saved
+/// transcript; no attach to a parent's stale SSE port/session id). Deliberately
+/// NARROW: other CLAUDE_CODE_* settings (provider/auth/limits) pass through.
+/// MIRRORS `CLAUDE_SESSION_PIN_ENV` in ts/sessionEnv.ts — keep the two in sync.
+/// `AGENT_YES_PID` is NOT here: it is re-stamped with our own pid to build the
+/// subagent tree, not dropped.
+pub const CLAUDE_SESSION_PIN_ENV: &[&str] = &[
+    "CLAUDECODE",
+    "CLAUDE_CODE_SSE_PORT",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDE_CODE_ENTRYPOINT",
+];
+
 /// Expand `${VAR}` references in `raw` against the current process environment.
 /// Sets `*unresolved = true` if any referenced variable is unset or empty, so
 /// callers can choose to skip the assignment rather than emit a blank value.
@@ -301,6 +316,17 @@ pub async fn spawn_agent(
     // ambiguous. Our own process env still carries it for new_agent_id().
     cmd.env_remove("AGENT_YES_AGENT_ID");
 
+    // Strip the parent Claude Code session markers so the wrapped CLI is a CLEAN
+    // top-level session. Without this, an `ay claude` launched from inside another
+    // Claude Code session inherits CLAUDE_CODE_CHILD_SESSION — the child claude then
+    // disables transcript saving ("⚠ Transcript saving is off …") — and
+    // CLAUDE_CODE_SSE_PORT/SESSION_ID make it attach to the parent's stale session.
+    // AGENT_YES_PID is re-stamped above (not stripped here). Mirrors
+    // CLAUDE_SESSION_PIN_ENV in ts/sessionEnv.ts (and freshAgentEnv in ts/serve.ts).
+    for key in CLAUDE_SESSION_PIN_ENV {
+        cmd.env_remove(key);
+    }
+
     // The agent runs in a PTY (a real terminal), so advertise terminal
     // capabilities. A console/daemon-spawned agent inherits an env with no TERM/
     // COLORTERM: neither the daemon (no controlling terminal) nor the recovered
@@ -493,6 +519,42 @@ mod tests {
         assert!(!unresolved);
 
         std::env::remove_var("AY_TEST_KEY");
+    }
+
+    #[test]
+    fn test_claude_session_pin_env_stripped() {
+        use std::ffi::OsStr;
+        // The claude marker that turns transcript saving off must be in the set.
+        assert!(CLAUDE_SESSION_PIN_ENV.contains(&"CLAUDE_CODE_CHILD_SESSION"));
+
+        let mut cmd = CommandBuilder::new("true");
+        // Simulate the env inherited from a parent Claude Code session…
+        for key in CLAUDE_SESSION_PIN_ENV {
+            cmd.env(key, "inherited");
+        }
+        // …alongside config that MUST survive (a non-pin CLAUDE_CODE_* var, and
+        // AGENT_YES_PID which is re-stamped, not stripped).
+        cmd.env("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "8000");
+        cmd.env("AGENT_YES_PID", "999");
+
+        // Same removal loop the spawn path runs.
+        for key in CLAUDE_SESSION_PIN_ENV {
+            cmd.env_remove(key);
+        }
+
+        for key in CLAUDE_SESSION_PIN_ENV {
+            assert!(cmd.get_env(key).is_none(), "{key} should be stripped");
+        }
+        assert_eq!(
+            cmd.get_env("CLAUDE_CODE_MAX_OUTPUT_TOKENS"),
+            Some(OsStr::new("8000")),
+            "non-pin CLAUDE_CODE_* config must pass through"
+        );
+        assert_eq!(
+            cmd.get_env("AGENT_YES_PID"),
+            Some(OsStr::new("999")),
+            "AGENT_YES_PID is re-stamped, not stripped"
+        );
     }
 
     #[test]

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -13,6 +13,7 @@ import {
 } from "./resume/codexSessionManager.ts";
 import pty, { ptyPackage } from "./pty.ts";
 import { removeControlCharacters } from "./removeControlCharacters.ts";
+import { stripClaudeSessionPin } from "./sessionEnv.ts";
 import { acquireLock, releaseLock, shouldUseLock } from "./runningLock.ts";
 import { logger } from "./logger.ts";
 import { createFifoStream } from "./beta/fifo.ts";
@@ -394,6 +395,16 @@ export default async function agentYes({
   // `ay`) don't inherit it and register under the same id (which would make that
   // id ambiguous). The wrapper's own process.env still carries it for pidStore.
   delete ptyEnv.AGENT_YES_AGENT_ID;
+  // Strip the parent Claude Code session markers so the wrapped CLI is a CLEAN
+  // top-level session. Without this, an `ay claude` launched from inside another
+  // Claude Code session (or this claude's Bash tool) inherits
+  // CLAUDE_CODE_CHILD_SESSION — the child claude then disables transcript saving
+  // ("⚠ Transcript saving is off …") — and CLAUDE_CODE_SSE_PORT/SESSION_ID make it
+  // attach to the parent's stale session. The daemon /api/spawn path already drops
+  // these via freshAgentEnv; this covers the direct-launch path. Idempotent, and
+  // AGENT_YES_PID is handled above (read for parentPid, then re-stamped). See
+  // ts/sessionEnv.ts (mirrored in rs/src/pty_spawner.rs for the Rust runtime).
+  stripClaudeSessionPin(ptyEnv);
   // Inject per-CLI env (e.g. glm → Z.AI endpoint). Expand ${VAR} against the
   // launching env; skip entries whose vars are unset so we never blank out an
   // inherited value (e.g. ANTHROPIC_AUTH_TOKEN when ZAI_API_KEY isn't exported).

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -39,6 +39,7 @@ import {
 } from "./subcommands.ts";
 import { TYPING_BADGE } from "./badges.ts";
 import { isCallbackRevoked, loadCallbackSecretReadOnly } from "./callback.ts";
+import { CLAUDE_SESSION_PIN_ENV } from "./sessionEnv.ts";
 import { MAX_CALLBACK_MSG_BYTES, frameVisitorMessage, verifyCapability } from "./callbackCore.ts";
 import { isTerminalReply } from "./terminalReply.ts";
 import { parseStatusText } from "./statusText.ts";
@@ -223,23 +224,17 @@ const defaultOpts = (overrides: Partial<CommonOpts> = {}): CommonOpts => ({
   ...overrides,
 });
 
-// The vars that pin a process to a PARENT Claude Code session — NOT the many
-// other CLAUDE_CODE_* settings that configure provider/auth/limits (USE_BEDROCK,
-// USE_VERTEX, MAX_OUTPUT_TOKENS, …), which must pass through untouched.
-const SESSION_PIN_ENV = new Set([
-  "CLAUDECODE",
-  "CLAUDE_CODE_SSE_PORT",
-  "CLAUDE_CODE_SESSION_ID",
-  "CLAUDE_CODE_CHILD_SESSION",
-  "CLAUDE_CODE_ENTRYPOINT",
-  // The agent-yes wrapper pid of the agent that launched `ay serve`. A daemon
-  // started from inside an agent's shell carries that agent's AGENT_YES_PID for
-  // its whole lifetime; without stripping it, every console-spawned agent would
-  // inherit it and be recorded with parent_pid = that stale agent, mis-rooting
-  // the whole subagent tree under an unrelated agent. Dropping it makes console
-  // spawns clean top-level agents (parent_pid = None).
-  "AGENT_YES_PID",
-]);
+// The vars that pin a process to a PARENT Claude Code session (the shared
+// CLAUDE_SESSION_PIN_ENV set, see ts/sessionEnv.ts) plus AGENT_YES_PID:
+//   The agent-yes wrapper pid of the agent that launched `ay serve`. A daemon
+//   started from inside an agent's shell carries that agent's AGENT_YES_PID for
+//   its whole lifetime; without stripping it, every console-spawned agent would
+//   inherit it and be recorded with parent_pid = that stale agent, mis-rooting
+//   the whole subagent tree under an unrelated agent. Dropping it makes console
+//   spawns clean top-level agents (parent_pid = None).
+// (The direct `ay …` launch path re-stamps AGENT_YES_PID with its own pid instead
+// — see ts/index.ts — so it strips only the shared claude set, not this one.)
+const SESSION_PIN_ENV = new Set<string>([...CLAUDE_SESSION_PIN_ENV, "AGENT_YES_PID"]);
 
 // The login-shell environment, captured once and cached for the daemon's
 // lifetime. `ay serve` is daemonized by oxmgr/launchd/pm2, which start it with a

--- a/ts/sessionEnv.spec.ts
+++ b/ts/sessionEnv.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { CLAUDE_SESSION_PIN_ENV, stripClaudeSessionPin } from "./sessionEnv.ts";
+
+describe("CLAUDE_SESSION_PIN_ENV", () => {
+  it("includes the markers that cause the child-session symptoms", () => {
+    // CLAUDE_CODE_CHILD_SESSION → "Transcript saving is off"; SSE_PORT/SESSION_ID
+    // → nested-attach "fail to connect". All must be in the strip set.
+    for (const k of [
+      "CLAUDECODE",
+      "CLAUDE_CODE_CHILD_SESSION",
+      "CLAUDE_CODE_SSE_PORT",
+      "CLAUDE_CODE_SESSION_ID",
+      "CLAUDE_CODE_ENTRYPOINT",
+    ]) {
+      expect(CLAUDE_SESSION_PIN_ENV).toContain(k);
+    }
+  });
+
+  it("does NOT include AGENT_YES_PID (re-stamped per path, not shared)", () => {
+    expect(CLAUDE_SESSION_PIN_ENV).not.toContain("AGENT_YES_PID");
+  });
+});
+
+describe("stripClaudeSessionPin", () => {
+  it("removes every pin var so the child is a clean top-level session", () => {
+    const env: Record<string, string | undefined> = {
+      CLAUDECODE: "1",
+      CLAUDE_CODE_SSE_PORT: "12345",
+      CLAUDE_CODE_SESSION_ID: "abc-123",
+      CLAUDE_CODE_CHILD_SESSION: "1",
+      CLAUDE_CODE_ENTRYPOINT: "cli",
+    };
+    stripClaudeSessionPin(env);
+    for (const k of CLAUDE_SESSION_PIN_ENV) expect(env[k]).toBeUndefined();
+  });
+
+  it("preserves non-pin CLAUDE_CODE_* config and unrelated vars", () => {
+    const env: Record<string, string | undefined> = {
+      CLAUDE_CODE_CHILD_SESSION: "1",
+      // provider/auth/limit config that must survive
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: "8000",
+      CLAUDE_EFFORT: "high",
+      ANTHROPIC_API_KEY: "sk-xxx",
+      PATH: "/usr/bin",
+      AGENT_YES_PID: "999",
+    };
+    stripClaudeSessionPin(env);
+    expect(env.CLAUDE_CODE_CHILD_SESSION).toBeUndefined();
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBe("1");
+    expect(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe("8000");
+    expect(env.CLAUDE_EFFORT).toBe("high");
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-xxx");
+    expect(env.PATH).toBe("/usr/bin");
+    // AGENT_YES_PID is this path's own concern (re-stamped), not stripped here.
+    expect(env.AGENT_YES_PID).toBe("999");
+  });
+
+  it("is idempotent and returns the same object (already-clean env)", () => {
+    const env: Record<string, string | undefined> = { PATH: "/bin" };
+    const out = stripClaudeSessionPin(env);
+    expect(out).toBe(env);
+    expect(out).toEqual({ PATH: "/bin" });
+  });
+});

--- a/ts/sessionEnv.ts
+++ b/ts/sessionEnv.ts
@@ -1,0 +1,37 @@
+// Env vars that PIN a process to a PARENT Claude Code session.
+//
+// When `ay` launches an agent, the wrapped CLI must be a CLEAN TOP-LEVEL session
+// — every agent-yes agent gets its own pid, its own log, and (for claude) its
+// own saved transcript. If these markers leak in from the launching env (e.g.
+// `ay claude` run from inside another Claude Code session, or from this claude's
+// Bash tool), the child claude:
+//   - sees CLAUDE_CODE_CHILD_SESSION and turns transcript saving OFF
+//     ("⚠ Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker"), and
+//   - sees CLAUDE_CODE_SSE_PORT / CLAUDE_CODE_SESSION_ID and tries to attach to
+//     the parent's stale session, surfacing as "fail to connect".
+//
+// So we strip exactly this set on every spawn path. It is deliberately NARROW —
+// the many OTHER CLAUDE_CODE_* settings configure provider/auth/limits
+// (CLAUDE_CODE_USE_BEDROCK, CLAUDE_CODE_USE_VERTEX, CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+// …) and MUST pass through untouched.
+//
+// MIRRORED in rs/src/pty_spawner.rs (`CLAUDE_SESSION_PIN_ENV`) — the Rust runtime
+// (the default) strips the same set; keep the two lists in sync. `AGENT_YES_PID`
+// is handled separately per spawn path (index.ts re-stamps it with its own pid to
+// build the subagent tree; serve.ts's freshAgentEnv drops it for clean console
+// roots), so it is NOT part of this shared set.
+export const CLAUDE_SESSION_PIN_ENV = [
+  "CLAUDECODE",
+  "CLAUDE_CODE_SSE_PORT",
+  "CLAUDE_CODE_SESSION_ID",
+  "CLAUDE_CODE_CHILD_SESSION",
+  "CLAUDE_CODE_ENTRYPOINT",
+] as const;
+
+/** Delete the parent Claude Code session-pin vars from a mutable env map, in
+ *  place. Idempotent (a no-op when they're already absent, e.g. a console spawn
+ *  whose env came from freshAgentEnv). Returns the same object for chaining. */
+export function stripClaudeSessionPin<T extends Record<string, string | undefined>>(env: T): T {
+  for (const k of CLAUDE_SESSION_PIN_ENV) delete env[k];
+  return env;
+}


### PR DESCRIPTION
## Problem

Launching `ay claude` (or `cy`) from **inside another Claude Code session** — including from a claude agent's Bash tool — leaked the parent's session-pin env vars into the child:

> ⚠ Transcript saving is off — inherited `CLAUDE_CODE_CHILD_SESSION` marker · restart with `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` to keep future transcripts

The child `claude` saw `CLAUDE_CODE_CHILD_SESSION` and disabled transcript saving; `CLAUDE_CODE_SSE_PORT` / `CLAUDE_CODE_SESSION_ID` also made it try to attach to the parent's stale session ("fail to connect").

The **daemon** `/api/spawn` path already scrubbed these via `freshAgentEnv` (`SESSION_PIN_ENV`), but the **direct-launch** runtimes (the everyday `ay …` path) did not — neither the TS runtime (`ts/index.ts`) nor the Rust runtime (`rs/src/pty_spawner.rs`, the default).

## Fix

Factor the pinning set into **`ts/sessionEnv.ts`** (`CLAUDE_SESSION_PIN_ENV` + `stripClaudeSessionPin`) and apply it on both agent-launch paths so every `ay`-launched agent is a **clean top-level session** that saves its own transcript:

- `ts/index.ts` — strip from `ptyEnv` after `AGENT_YES_PID` is read.
- `rs/src/pty_spawner.rs` — `env_remove` the mirrored `CLAUDE_SESSION_PIN_ENV` set.
- `ts/serve.ts` — reuse the shared list; `SESSION_PIN_ENV = [...CLAUDE_SESSION_PIN_ENV, "AGENT_YES_PID"]` (behavior unchanged).

The set is deliberately **narrow**: other `CLAUDE_CODE_*` config (`USE_BEDROCK`, `MAX_OUTPUT_TOKENS`, …) passes through untouched. `AGENT_YES_PID` is **not** in the shared set — each path handles it (index.ts re-stamps its own pid to build the subagent tree; `freshAgentEnv` drops it for clean console roots).

## Why strip, not `FORCE_SESSION_PERSISTENCE=1`

Force-persistence keeps the transcript but leaves `SSE_PORT`/`SESSION_ID` in place, so the nested-attach "fail to connect" bug remains. Stripping fixes both, and matches what agent-yes agents already are: independent top-level agents with their own pid/log/transcript.

## Testing

- **`ts/sessionEnv.spec.ts`** (5 tests, `sessionEnv.ts` 100% coverage): strips every pin var, preserves non-pin `CLAUDE_CODE_*` config + `PATH` + `AGENT_YES_PID`, idempotent. Full suite **968 passed**, coverage gate green.
- **`rs/src/pty_spawner.rs`** test `test_claude_session_pin_env_stripped`: verifies the removal loop via `CommandBuilder::get_env`, config + `AGENT_YES_PID` survive. `cargo test` **270 passed**.
- **End-to-end, both runtimes**: with `CLAUDE_CODE_CHILD_SESSION=1` / `SSE_PORT` / `SESSION_ID` set in the parent env, wrapped `bash` observes them **empty** (stripped) while `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000` survives — Rust: `CCS=[] SSE=[] SID=[] MAX=[8000]`; TS (`--no-rust`): stripped, config `8000` present.

Related: `SESSION_PIN_ENV` / `freshAgentEnv` in ts/serve.ts (the daemon path this brings the direct-launch path in line with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)