### PR TITLE
feat: ay todo — Milestone 1, lifecycle engine + typed blocks + independent-verification store + CLI

### DIFF
--- a/lab/ui/blog/ay-callback/index.html
+++ b/lab/ui/blog/ay-callback/index.html
@@ -226,17 +226,17 @@
       <p class="sub">
         Your agent just published a report. The person reading it has a question. Until now the
         answer was "find the console, find the right terminal, type there." Now the report page
-        itself can carry a tiny widget that delivers the reader's message straight into that
-        agent's terminal — through a signed, send-only, single-agent capability that expires on a
-        date you chose, and never through your master token.
+        itself can carry a tiny widget that delivers the reader's message straight into that agent's
+        terminal — through a signed, send-only, single-agent capability that expires on a date you
+        chose, and never through your master token.
       </p>
 
       <h2 id="what">What it does <a class="anchor" href="#what">#</a></h2>
       <p>
         <code>ay callback</code> mints a capability for <strong>one agent</strong> and prints a
         self-contained HTML snippet — one inline <code>&lt;script&gt;</code>, zero external
-        requests. Paste it into any page your agent publishes (a status dashboard, a nightly
-        report, a postmortem) and readers get a floating button:
+        requests. Paste it into any page your agent publishes (a status dashboard, a nightly report,
+        a postmortem) and readers get a floating button:
       </p>
       <pre><code>$ ay callback --expires 7d
 callback 3b6f23e7 → claude #46555 @ ~/ws/reports
@@ -259,11 +259,13 @@ revoke:   ay callback revoke 3b6f23e7
       </div>
       <p>
         When a reader hits <em>Send</em>, the message lands in the agent's terminal wrapped in an
-        explicit "untrusted visitor" frame, and in its inbox. One way, by design — the visitor
-        never sees the terminal.
+        explicit "untrusted visitor" frame, and in its inbox. One way, by design — the visitor never
+        sees the terminal.
       </p>
 
-      <h2 id="capability">The capability is a hash, not a key <a class="anchor" href="#capability">#</a></h2>
+      <h2 id="capability">
+        The capability is a hash, not a key <a class="anchor" href="#capability">#</a>
+      </h2>
       <p>
         The obvious-but-wrong implementation is to put your daemon's serve token in the snippet.
         That token is a master key: whoever holds it can read every terminal, send to every agent,
@@ -293,8 +295,7 @@ revoke:   ay callback revoke 3b6f23e7
         <tr>
           <td>Delete the daemon's bookkeeping to "resurrect" an expired token</td>
           <td>
-            <span class="no">✗</span> expiry is in the token itself, not in local state — still
-            410
+            <span class="no">✗</span> expiry is in the token itself, not in local state — still 410
           </td>
         </tr>
         <tr>
@@ -311,7 +312,9 @@ revoke:   ay callback revoke 3b6f23e7
         other.
       </p>
 
-      <h2 id="expiry">--expires is required. There is no "never" <a class="anchor" href="#expiry">#</a></h2>
+      <h2 id="expiry">
+        --expires is required. There is no "never" <a class="anchor" href="#expiry">#</a>
+      </h2>
       <p>
         Every capability API eventually grows a default lifetime, and every default lifetime
         eventually becomes "forever, because nobody thinks about it." We refuse the default:
@@ -324,8 +327,8 @@ an embed capability must carry an explicit lifetime</code></pre>
         <code>2w</code> — and caps at 365 days. There is no <code>--expires never</code> and there
         never will be. The point is a moment of deliberate friction: whoever pastes a capability
         into a public page must answer "how long should this live?" while they still remember the
-        page exists. When it lapses, the widget doesn't fail silently — it tells the reader the
-        link expired and to ask the owner for a fresh one.
+        page exists. When it lapses, the widget doesn't fail silently — it tells the reader the link
+        expired and to ask the owner for a fresh one.
       </p>
       <p>For everything before the deadline, there's the kill switch:</p>
       <pre><code>$ ay callback ls
@@ -333,16 +336,18 @@ an embed capability must carry an explicit lifetime</code></pre>
 $ ay callback revoke 3b6f23e7
 revoked 3b6f23e7</code></pre>
 
-      <h2 id="hardening">A public route that leaks nothing <a class="anchor" href="#hardening">#</a></h2>
+      <h2 id="hardening">
+        A public route that leaks nothing <a class="anchor" href="#hardening">#</a>
+      </h2>
       <p>
-        <code>POST /cb/&lt;cap&gt;</code> is the daemon's only unauthenticated write route, so it
-        is deliberately paranoid:
+        <code>POST /cb/&lt;cap&gt;</code> is the daemon's only unauthenticated write route, so it is
+        deliberately paranoid:
       </p>
       <ul>
         <li>
           <strong>Info-tight responses.</strong> The page learns <code>ok</code>,
-          <code>expired</code>, or a generic failure — never a pid, a cwd, a hostname, or whether
-          a given agent exists. Malformed and forged tokens are indistinguishable 404s.
+          <code>expired</code>, or a generic failure — never a pid, a cwd, a hostname, or whether a
+          given agent exists. Malformed and forged tokens are indistinguishable 404s.
         </li>
         <li>
           <strong>Untrusted framing.</strong> Visitor text is stripped of control characters (no
@@ -356,8 +361,8 @@ revoked 3b6f23e7</code></pre>
         </li>
         <li>
           <strong>One-way.</strong> The route writes to the agent's stdin and records the inbox
-          entry. It never reads the terminal back — a public embed must not become a viewport
-          into your machine.
+          entry. It never reads the terminal back — a public embed must not become a viewport into
+          your machine.
         </li>
       </ul>
       <div class="note">
@@ -372,8 +377,8 @@ $ ay serve            # local daemon
 $ ay expose …         # or put the daemon on a public URL first
 $ ay callback --expires 7d --title "Ask the report bot"</code></pre>
       <p>
-        Paste the printed snippet at the end of anything your agent publishes. Ship the report;
-        keep the conversation.
+        Paste the printed snippet at the end of anything your agent publishes. Ship the report; keep
+        the conversation.
       </p>
 
       <footer>

--- a/lab/ui/blog/index.html
+++ b/lab/ui/blog/index.html
@@ -160,9 +160,9 @@
         <span class="tag">Feature</span>
         <h2>ay callback — let readers message your agent from any web page</h2>
         <p>
-          A signed, send-only, single-agent capability plus a one-script embed widget: report
-          pages that can talk back, with a required expiry and a revoke kill-switch — never your
-          serve token.
+          A signed, send-only, single-agent capability plus a one-script embed widget: report pages
+          that can talk back, with a required expiry and a revoke kill-switch — never your serve
+          token.
         </p>
       </a>
 

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3241,8 +3241,7 @@
           const rows = (window.__ayPerf || []).filter((r) => r.t > perfBeaconCursor);
           if (!rows.length) return;
           perfBeaconCursor = rows[rows.length - 1].t;
-          const slowMs =
-            (window.__ayPerfReport && window.__ayPerfReport().slowMs) || 300;
+          const slowMs = (window.__ayPerfReport && window.__ayPerfReport().slowMs) || 300;
           const byRoom = new Map();
           for (const r of rows) {
             const k = r.room || "";
@@ -4946,7 +4945,8 @@ my.translate = async (text, lang) => {
           "width:100%;box-sizing:border-box;height:300px;resize:vertical;background:var(--bg);color:var(--fg);border:1px solid var(--line);border-radius:6px;padding:10px;font:13px var(--mono);outline:none";
         box.appendChild(ta);
         const err = document.createElement("div");
-        err.style.cssText = "color:var(--red);font:12px var(--mono);margin-top:8px;white-space:pre-wrap";
+        err.style.cssText =
+          "color:var(--red);font:12px var(--mono);margin-top:8px;white-space:pre-wrap";
         box.appendChild(err);
         const row = document.createElement("div");
         row.style.cssText = "display:flex;gap:8px;justify-content:flex-end;margin-top:12px";
@@ -5400,7 +5400,11 @@ my.translate = async (text, lang) => {
           for (const e of keep)
             if (e.parent_pid != null) wanted.add((e._src || "") + "#" + e.parent_pid);
           for (const e of list)
-            if (!keep.has(e) && e.wrapper_pid != null && wanted.has((e._src || "") + "#" + e.wrapper_pid)) {
+            if (
+              !keep.has(e) &&
+              e.wrapper_pid != null &&
+              wanted.has((e._src || "") + "#" + e.wrapper_pid)
+            ) {
               keep.add(e);
               grew = true;
             }
@@ -5408,10 +5412,7 @@ my.translate = async (text, lang) => {
         return list.filter((e) => keep.has(e));
       }
       function orderedEntries(toks) {
-        const sorted = sortEntries(
-          pruneStale(entries.filter((e) => matches(e, toks))),
-          sortMode,
-        );
+        const sorted = sortEntries(pruneStale(entries.filter((e) => matches(e, toks))), sortMode);
         if (!pinned.size) return sorted;
         const hi = [],
           lo = [];

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -46,6 +46,32 @@ import * as reaper from "./reaper.ts";
 export { removeControlCharacters };
 export { AgentContext };
 
+// `ay todo` library surface — only symbols listed here reach the published
+// `dist/index.js` a consuming project (e.g. a thin project-specific shell
+// around this engine) actually imports; creating the underlying modules
+// alone is not sufficient.
+export { openStore, TodoStore, CycleError } from "./todoStore.ts";
+export type {
+  TodoRecord,
+  CreateInput,
+  ListFilter,
+  GateRegistration,
+  GateEvidence,
+} from "./todoStore.ts";
+export {
+  LIFECYCLES,
+  nextStates,
+  canTransition,
+  requiredGate,
+  initialState,
+  statesOf,
+  isKnownKind,
+} from "./todoLifecycle.ts";
+export type { LifecycleKind, LifecycleGraph, LifecycleTransition } from "./todoLifecycle.ts";
+export { monitorHint, describeBlock } from "./todoBlock.ts";
+export type { TodoBlock, MonitorHint } from "./todoBlock.ts";
+export { unblockedTasks, openBlockers, renderTree, renderDigest } from "./todoDigest.ts";
+
 export type AgentCliConfig = {
   // cli
   install?:

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -3634,7 +3634,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
       return cbJson(409, { error: "agent unavailable" });
     }
   };
-  const httpFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
+  const httpFetch = async (
+    req: Request,
+    srv?: { upgrade: (r: Request, o?: unknown) => boolean },
+  ): Promise<Response> => {
     const p = new URL(req.url).pathname;
     if (req.method === "GET" && (p === "/" || p === "/index.html"))
       return serveUiFile("index.html", "text/html; charset=utf-8");

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2001,7 +2001,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // The whole API as a plain handler: served over HTTP by Bun.serve (--http)
   // and called in-process by the WebRTC bridge (--webrtc) — the latter needs
   // no TCP port at all.
-  const apiFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
+  const apiFetch = async (
+    req: Request,
+    srv?: { upgrade: (r: Request, o?: unknown) => boolean },
+  ): Promise<Response> => {
     if (!checkAuth(req, token)) {
       return new Response("Unauthorized", { status: 401 });
     }
@@ -3542,7 +3545,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
       });
     }
   };
-  const httpFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
+  const httpFetch = async (
+    req: Request,
+    srv?: { upgrade: (r: Request, o?: unknown) => boolean },
+  ): Promise<Response> => {
     const p = new URL(req.url).pathname;
     if (req.method === "GET" && (p === "/" || p === "/index.html"))
       return serveUiFile("index.html", "text/html; charset=utf-8");

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -362,6 +362,7 @@ const SUBCOMMANDS = new Set([
   "exit",
   "restart",
   "note",
+  "todo",
   "serve",
   "schedule",
   "remote",
@@ -473,6 +474,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdRestart(rest);
       case "note":
         return await cmdNote(rest);
+      case "todo": {
+        const { runTodoSubcommand } = await import("./todoCli.ts");
+        return runTodoSubcommand(rest);
+      }
       case "serve": {
         const { cmdServe } = await import("./serve.ts");
         return cmdServe(rest);

--- a/ts/todoBlock.spec.ts
+++ b/ts/todoBlock.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { describeBlock, monitorHint, type TodoBlock } from "./todoBlock";
+
+describe("todoBlock", () => {
+  it("blocked-by-human needs no monitor — a human's reply always self-delivers", () => {
+    expect(monitorHint({ type: "blocked-by-human", who: "someone" })).toBe("none");
+  });
+  it("blocked-by-task needs no monitor — clears itself via pure data (unblockedTasks)", () => {
+    expect(monitorHint({ type: "blocked-by-task", taskId: "T1" })).toBe("none");
+  });
+  it("waiting-on-agent needs a notify-agent monitor", () => {
+    expect(monitorHint({ type: "waiting-on-agent", agentId: "abc123" })).toBe("notify-agent");
+  });
+  it("blocked-by-external needs a poll-external monitor", () => {
+    expect(monitorHint({ type: "blocked-by-external", signal: "ci-run" })).toBe("poll-external");
+  });
+
+  it("describeBlock renders each shape distinctly and legibly", () => {
+    const cases: TodoBlock[] = [
+      { type: "blocked-by-task", taskId: "T9" },
+      { type: "blocked-by-human", who: "alex", question: "canary or beta?" },
+      { type: "blocked-by-external", signal: "release-pipeline" },
+      { type: "waiting-on-agent", agentId: "xyz789" },
+    ];
+    const rendered = cases.map(describeBlock);
+    expect(rendered[0]).toContain("T9");
+    expect(rendered[1]).toContain("alex");
+    expect(rendered[1]).toContain("canary or beta?");
+    expect(rendered[2]).toContain("release-pipeline");
+    expect(rendered[3]).toContain("xyz789");
+    expect(new Set(rendered).size).toBe(4); // all distinct
+  });
+});

--- a/ts/todoBlock.ts
+++ b/ts/todoBlock.ts
@@ -1,0 +1,61 @@
+/**
+ * Typed blocks for the `ay todo` engine.
+ *
+ * A task that cannot currently proceed records WHY, as one of four typed
+ * shapes rather than a free-text string. The type tells the engine (and any
+ * automation built on top of it, see `todoAutomation.ts` in a later
+ * milestone) exactly how to detect that the wait is over:
+ *
+ *   - blocked-by-task: waiting on another task in the same store. Clears
+ *     itself the moment that task reaches its kind's `done` state — this is
+ *     pure data (see `todoDigest.ts`'s `unblockedTasks`), no monitor needed.
+ *   - blocked-by-human: waiting on a specific person to answer or decide
+ *     something. Needs NO monitor at all — a human's reply always arrives as
+ *     a message that human chooses to send (e.g. via the `/ask` decision
+ *     panel, a later milestone), so there is nothing to poll.
+ *   - blocked-by-external: waiting on some signal outside this store and
+ *     outside any tracked agent (a CI run, a release, a third-party event).
+ *     Needs an actual poll/monitor loop.
+ *   - waiting-on-agent: waiting on a specific tracked agent process to reach
+ *     some point (finish, go idle, etc). Cleared by that agent's own
+ *     lifecycle events (via `ay notify`, wired in a later milestone).
+ */
+
+export type TodoBlock =
+  | { type: "blocked-by-task"; taskId: string }
+  | { type: "blocked-by-human"; who: string; question?: string; options?: string[] }
+  | { type: "blocked-by-external"; signal: string; checkFn?: string }
+  | { type: "waiting-on-agent"; agentId: string };
+
+export type MonitorHint = "none" | "notify-agent" | "poll-external";
+
+/**
+ * How a block of this type should be watched. Kept as one pure function so
+ * every caller (CLI rendering, automation, `/ask` aggregation) agrees on the
+ * same classification instead of re-deriving it ad hoc.
+ */
+export function monitorHint(block: TodoBlock): MonitorHint {
+  switch (block.type) {
+    case "blocked-by-task":
+    case "blocked-by-human":
+      return "none";
+    case "waiting-on-agent":
+      return "notify-agent";
+    case "blocked-by-external":
+      return "poll-external";
+  }
+}
+
+/** One-line human-readable summary, used by CLI/digest rendering. */
+export function describeBlock(block: TodoBlock): string {
+  switch (block.type) {
+    case "blocked-by-task":
+      return `blocked by task ${block.taskId}`;
+    case "blocked-by-human":
+      return `waiting on ${block.who}${block.question ? `: ${block.question}` : ""}`;
+    case "blocked-by-external":
+      return `waiting on external signal: ${block.signal}`;
+    case "waiting-on-agent":
+      return `waiting on agent ${block.agentId}`;
+  }
+}

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -63,6 +63,23 @@ describe("ay todo CLI", () => {
     ).rejects.toThrow(/--format must be/);
   });
 
+  it("only TRAILING --root/--format are treated as the GLOBAL flag — a mid-command '--format' does not corrupt the actual output format or store location (codex-review round-4 Important)", async () => {
+    // The task's own sub-parser (yargs, non-strict) still separately consumes
+    // "--format output" into its own throwaway key regardless of this fix
+    // (a pre-existing, narrower limitation: an unquoted summary containing a
+    // literal "--flag" token is truncated there — quote the summary if it
+    // must contain one). What THIS fix guarantees is narrower and more
+    // important: that stray mid-command token is never mistaken for the
+    // REAL global --format/--root, which would have corrupted the store
+    // path or the output format for the WHOLE command.
+    const a = await run("new", "fix", "--format", "output", "--kind", "doc", "--format", "json");
+    expect(a.code).toBe(0);
+    // trailing --format json (appended AFTER the mid-command one) is the one
+    // that actually took effect — proving global-flag resolution is anchored
+    // to the true end of the command, not the first/any "--format" seen
+    expect(JSON.parse(a.out)._id).toBe("T1");
+  });
+
   it("new creates a task with kind/tier/owner/tags/deps and rejects a missing summary", async () => {
     const a = await run(
       "new",
@@ -243,6 +260,26 @@ describe("ay todo CLI", () => {
     cap.restore();
     const parsed = JSON.parse(cap.text());
     expect(parsed.unblocked).toEqual(["T3"]);
+  });
+
+  it("dep rejects a malformed invocation (missing blockerId, or a verb that isn't add|rm) with the usage line", async () => {
+    await run("new", "a", "--kind", "code");
+    await run("new", "b", "--kind", "code");
+    await expect(run("dep", "add", "T2")).rejects.toThrow(/usage: ay todo dep add\|rm/);
+    await expect(run("dep", "bogus", "T2", "T1")).rejects.toThrow(/usage: ay todo dep add\|rm/);
+  });
+
+  it("dep surfaces a non-cycle store error (unknown task id) by rethrowing it, not swallowing it as a cycle", async () => {
+    await run("new", "a", "--kind", "code");
+    // T99 doesn't exist: store.addDep throws a plain Error, NOT CycleError, so
+    // the CLI must rethrow (the catch only special-cases CycleError).
+    await expect(run("dep", "add", "T1", "T99")).rejects.toThrow(/T99/);
+  });
+
+  it("get renders the free-form description block when a task has one", async () => {
+    await run("new", "a", "--kind", "doc", "--description", "the long form details");
+    const got = await run("get", "T1");
+    expect(got.out).toContain("the long form details");
   });
 
   it("an unknown verb fails with a clear, enumerated error", async () => {

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -207,6 +207,24 @@ describe("ay todo CLI", () => {
     expect(removed.out).toContain("removed dep T1 on T2");
   });
 
+  it("tree --format json emits the actual nested structure, not the human text (codex-review Important)", async () => {
+    await run("new", "a", "--kind", "code", "--owner", "cto");
+    await run("new", "b", "--kind", "code");
+    await run("dep", "add", "T2", "T1");
+    const cap = captureStdout();
+    await runTodoSubcommand(["tree", "--root", TEST_ROOT, "--format", "json"]);
+    cap.restore();
+    const parsed = JSON.parse(cap.text());
+    expect(parsed).toEqual([
+      {
+        id: "T2",
+        state: "doing",
+        summary: "b",
+        children: [{ id: "T1", state: "doing", summary: "a", owner: "cto", children: [] }],
+      },
+    ]);
+  });
+
   it("digest --format json includes the unblocked list", async () => {
     await run("new", "a", "--kind", "code");
     await run("transition", "T1", "merged");

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -43,7 +43,7 @@ describe("ay todo CLI", () => {
     expect(got.out).toContain("T1 [drafting] write the spec");
   });
 
-  it("--root=val and --format=val (equals form) work the same as the space form; an invalid --format value fails clearly", async () => {
+  it("--root=val and --format=val (equals form, native to yargs) work the same as the space form; an invalid --format value fails clearly", async () => {
     const cap = captureStdout();
     try {
       const code = await runTodoSubcommand(["new", "x", "--kind", "code", `--root=${TEST_ROOT}`]);
@@ -60,24 +60,39 @@ describe("ay todo CLI", () => {
     }
     await expect(
       runTodoSubcommand(["get", "T1", "--root", TEST_ROOT, "--format", "yaml"]),
-    ).rejects.toThrow(/--format must be/);
+    ).rejects.toThrow();
   });
 
-  it("only TRAILING --root/--format are treated as the GLOBAL flag — a mid-command '--format' does not corrupt the actual output format or store location (codex-review round-4 Important)", async () => {
-    // The task's own sub-parser (yargs, non-strict) still separately consumes
-    // "--format output" into its own throwaway key regardless of this fix
-    // (a pre-existing, narrower limitation: an unquoted summary containing a
-    // literal "--flag" token is truncated there — quote the summary if it
-    // must contain one). What THIS fix guarantees is narrower and more
-    // important: that stray mid-command token is never mistaken for the
-    // REAL global --format/--root, which would have corrupted the store
-    // path or the output format for the WHOLE command.
-    const a = await run("new", "fix", "--format", "output", "--kind", "doc", "--format", "json");
+  it("--format/--root work regardless of position — NOT just at the end of the command (codex-review round-5 Important: a prior design broke ordinary invocations like this one)", async () => {
+    // --format BEFORE --owner (neither is trailing) — a real, entirely
+    // ordinary way to type this command.
+    await run("new", "a", "--kind", "code", "--owner", "alice");
+    const a = await run("ls", "--format", "json", "--owner", "alice");
     expect(a.code).toBe(0);
-    // trailing --format json (appended AFTER the mid-command one) is the one
-    // that actually took effect — proving global-flag resolution is anchored
-    // to the true end of the command, not the first/any "--format" seen
-    expect(JSON.parse(a.out)._id).toBe("T1");
+    expect(JSON.parse(a.out)).toHaveLength(1);
+    // --root itself not at the end either (a verb-specific flag follows it)
+    const cap = captureStdout();
+    try {
+      const code = await runTodoSubcommand([
+        "ls",
+        "--root",
+        TEST_ROOT,
+        "--owner",
+        "alice",
+        "--format",
+        "json",
+      ]);
+      expect(code).toBe(0);
+      expect(JSON.parse(cap.text())).toHaveLength(1);
+    } finally {
+      cap.restore();
+    }
+  });
+
+  it("--root cannot be the empty string (codex-review round-4 nitpick)", async () => {
+    await expect(runTodoSubcommand(["ls", "--root", ""])).rejects.toThrow(
+      /--root must not be empty/,
+    );
   });
 
   it("new creates a task with kind/tier/owner/tags/deps and rejects a missing summary", async () => {

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { rm } from "fs/promises";
+import path from "path";
+import { runTodoSubcommand } from "./todoCli";
+
+const isWindows = process.platform === "win32";
+const TEST_ROOT = isWindows
+  ? path.join(process.env.TEMP || "C:\\Temp", "todocli-test-" + process.pid)
+  : "/tmp/todocli-test-" + process.pid;
+
+function captureStdout(): { text: () => string; restore: () => void } {
+  let buf = "";
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    buf += String(chunk);
+    return true;
+  });
+  return { text: () => buf, restore: () => spy.mockRestore() };
+}
+
+async function run(...args: string[]): Promise<{ code: number; out: string }> {
+  const cap = captureStdout();
+  try {
+    const code = await runTodoSubcommand([...args, "--root", TEST_ROOT]);
+    return { code, out: cap.text() };
+  } finally {
+    cap.restore();
+  }
+}
+
+describe("ay todo CLI", () => {
+  beforeEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("new creates a task with kind/tier/owner/tags/deps and rejects a missing summary", async () => {
+    const a = await run(
+      "new",
+      "write the spec",
+      "--kind",
+      "doc",
+      "--owner",
+      "writer",
+      "--tag",
+      "proj-x",
+    );
+    expect(a.code).toBe(0);
+    expect(a.out).toContain("created T1");
+    expect(a.out).toContain("kind:    doc");
+    expect(a.out).toContain("owner:   writer");
+
+    const b = await run(
+      "new",
+      "ship it",
+      "--kind",
+      "code",
+      "--tier",
+      "shipped-done",
+      "--dep",
+      "T1",
+    );
+    expect(b.code).toBe(0);
+    expect(b.out).toContain("created T2");
+    expect(b.out).toContain("tier:shipped-done");
+    expect(b.out).toContain("blockedBy: T1");
+
+    await expect(run("new", "", "--kind", "doc")).rejects.toThrow(/usage: ay todo new/);
+    await expect(run("new", "x")).rejects.toThrow(/--kind is required/);
+    await expect(run("new", "x", "--kind", "bogus")).rejects.toThrow(/unknown kind/);
+  });
+
+  it("ls lists and filters; get shows one task or fails cleanly on an unknown id", async () => {
+    await run("new", "a", "--kind", "code", "--owner", "alice", "--tag", "proj-x");
+    await run("new", "b", "--kind", "doc");
+    const all = await run("ls");
+    expect(all.out).toContain("T1");
+    expect(all.out).toContain("T2");
+    const filtered = await run("ls", "--owner", "alice");
+    expect(filtered.out).toContain("T1");
+    expect(filtered.out).not.toContain("T2");
+
+    const got = await run("get", "T1");
+    expect(got.code).toBe(0);
+    expect(got.out).toContain("T1 [doing] a");
+    await expect(run("get", "T99")).rejects.toThrow(/no such task/);
+  });
+
+  it("--format json emits parseable JSON for ls/get", async () => {
+    await run("new", "a", "--kind", "code");
+    const cap = captureStdout();
+    await runTodoSubcommand(["get", "T1", "--root", TEST_ROOT, "--format", "json"]);
+    cap.restore();
+    const parsed = JSON.parse(cap.text());
+    expect(parsed._id).toBe("T1");
+    expect(parsed.kind).toBe("code");
+  });
+
+  it("transition moves state directly across an ungated edge and fails naming the missing gate otherwise", async () => {
+    await run("new", "a", "--kind", "code", "--owner", "worker");
+    const moved = await run("transition", "T1", "merged");
+    expect(moved.out).toContain("transitioned T1 -> merged");
+    await run("transition", "T1", "shipped");
+    await run("transition", "T1", "verifying");
+    await expect(run("transition", "T1", "done")).rejects.toThrow(/requires gate "verify-green"/);
+  });
+
+  it("approve satisfies a manual gate as a DIFFERENT validator, then transition succeeds; self-approval is refused end-to-end via the CLI", async () => {
+    await run("new", "a", "--kind", "doc", "--owner", "worker");
+    await run("transition", "T1", "review");
+    await expect(run("approve", "T1", "human-approved", "worker")).rejects.toThrow(
+      /independent verification required/,
+    );
+    const approved = await run("approve", "T1", "human-approved", "reviewer", "--note", "lgtm");
+    expect(approved.out).toContain('approved "human-approved" on T1 (validator: reviewer)');
+    const done = await run("transition", "T1", "done");
+    expect(done.out).toContain("transitioned T1 -> done");
+  });
+
+  it("verify runs a registered gate end-to-end (only exercisable by a project that calls store.registerGate — the bare CLI has none registered, so it reports that honestly)", async () => {
+    await run("new", "a", "--kind", "code", "--owner", "worker");
+    await run("transition", "T1", "merged");
+    await run("transition", "T1", "shipped");
+    await run("transition", "T1", "verifying");
+    await expect(run("verify", "T1")).rejects.toThrow(/no registered gate found/);
+  });
+
+  it("block/unblock round-trip every typed shape", async () => {
+    await run("new", "a", "--kind", "code");
+    const human = await run(
+      "block",
+      "T1",
+      "--type",
+      "blocked-by-human",
+      "--who",
+      "taku",
+      "--question",
+      "canary or beta?",
+    );
+    expect(human.out).toContain("waiting on taku: canary or beta?");
+    const unblocked = await run("unblock", "T1");
+    expect(unblocked.out).toContain("unblocked T1");
+
+    await run("new", "b", "--kind", "code");
+    await run("block", "T2", "--type", "blocked-by-task", "--task", "T1");
+    await run("new", "c", "--kind", "code");
+    await run("block", "T3", "--type", "blocked-by-external", "--signal", "release-pipeline");
+    await run("new", "d", "--kind", "code");
+    const agentBlocked = await run(
+      "block",
+      "T4",
+      "--type",
+      "waiting-on-agent",
+      "--agent",
+      "abc123",
+    );
+    expect(agentBlocked.out).toContain("waiting on agent abc123");
+
+    await expect(run("block", "T1", "--type", "blocked-by-human")).rejects.toThrow(/--who/);
+    await expect(run("block", "T1")).rejects.toThrow(/usage: ay todo block/);
+  });
+
+  it("dep add/rm, tree, and digest render real output and surface cycles as a clean error", async () => {
+    await run("new", "a", "--kind", "code");
+    await run("new", "b", "--kind", "code");
+    const added = await run("dep", "add", "T2", "T1");
+    expect(added.out).toContain("added dep T1 on T2");
+    await expect(run("dep", "add", "T1", "T2")).rejects.toThrow(/cycle/);
+
+    const tree = await run("tree");
+    expect(tree.out).toContain("T2");
+    expect(tree.out).toContain("└─ T1");
+
+    const digest = await run("digest");
+    expect(digest.out).toContain("(untagged)");
+
+    const removed = await run("dep", "rm", "T2", "T1");
+    expect(removed.out).toContain("removed dep T1 on T2");
+  });
+
+  it("digest --format json includes the unblocked list", async () => {
+    await run("new", "a", "--kind", "code");
+    await run("transition", "T1", "merged");
+    // no gate registered by the bare CLI, but transition to a terminal-ish
+    // state isn't required to prove the unblocked computation wires through —
+    // create a second task depending on a THIRD, separately-completed one via
+    // the human kind (reaches done with no registered gate at all)
+    await run("new", "h", "--kind", "human");
+    await run("block", "T2", "--type", "blocked-by-human", "--who", "x");
+    await run("approve", "T2", "human-replied", "x");
+    await run("transition", "T2", "decided");
+    await run("transition", "T2", "done");
+    await run("new", "waits-on-h", "--kind", "code", "--dep", "T2");
+    const cap = captureStdout();
+    await runTodoSubcommand(["digest", "--root", TEST_ROOT, "--format", "json"]);
+    cap.restore();
+    const parsed = JSON.parse(cap.text());
+    expect(parsed.unblocked).toEqual(["T3"]);
+  });
+
+  it("an unknown verb fails with a clear, enumerated error", async () => {
+    await expect(run("bogus")).rejects.toThrow(/unknown "ay todo" verb/);
+  });
+});

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -35,6 +35,34 @@ describe("ay todo CLI", () => {
     await rm(TEST_ROOT, { recursive: true, force: true });
   });
 
+  it("new joins ALL positional words into the summary — an unquoted multi-word summary is not silently truncated to its first word (codex-review Important)", async () => {
+    const a = await run("new", "write", "the", "spec", "--kind", "doc");
+    expect(a.code).toBe(0);
+    expect(a.out).toContain("created T1");
+    const got = await run("get", "T1");
+    expect(got.out).toContain("T1 [drafting] write the spec");
+  });
+
+  it("--root=val and --format=val (equals form) work the same as the space form; an invalid --format value fails clearly", async () => {
+    const cap = captureStdout();
+    try {
+      const code = await runTodoSubcommand(["new", "x", "--kind", "code", `--root=${TEST_ROOT}`]);
+      expect(code).toBe(0);
+    } finally {
+      cap.restore();
+    }
+    const cap2 = captureStdout();
+    try {
+      await runTodoSubcommand(["get", "T1", "--root", TEST_ROOT, "--format=json"]);
+      expect(JSON.parse(cap2.text())._id).toBe("T1");
+    } finally {
+      cap2.restore();
+    }
+    await expect(
+      runTodoSubcommand(["get", "T1", "--root", TEST_ROOT, "--format", "yaml"]),
+    ).rejects.toThrow(/--format must be/);
+  });
+
   it("new creates a task with kind/tier/owner/tags/deps and rejects a missing summary", async () => {
     const a = await run(
       "new",

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -90,11 +90,23 @@ function extractCommonOpts(argv: string[]): { opts: CommonOpts; rest: string[] }
   let format: CommonOpts["format"] = "table";
   for (let i = 0; i < argv.length; i++) {
     const tok = argv[i]!;
-    if (tok === "--root") {
-      root = argv[++i] ?? root;
+    // Support both `--root val` and `--root=val` (and same for --format) —
+    // the `=` form is common enough elsewhere in this CLI's own flags that
+    // silently rejecting it here would read as inconsistent (codex nitpick).
+    const eq = tok.match(/^(--root|--format)=(.*)$/);
+    if (eq) {
+      if (eq[1] === "--root") root = eq[2]!;
+      else if (eq[2] === "table" || eq[2] === "json") format = eq[2];
+      else fail(`--format must be "table" or "json" (got "${eq[2]}")`);
+    } else if (tok === "--root") {
+      const v = argv[++i];
+      if (v === undefined) fail("--root requires a value");
+      root = v;
     } else if (tok === "--format") {
       const v = argv[++i];
-      if (v === "table" || v === "json") format = v;
+      if (v !== "table" && v !== "json")
+        fail(`--format must be "table" or "json" (got ${JSON.stringify(v)})`);
+      format = v;
     } else {
       rest.push(tok);
     }
@@ -119,7 +131,11 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
         .help(false)
         .exitProcess(false);
       const a = await sub.parseAsync();
-      const summary = String(a._[0] ?? "");
+      // Join ALL positional args, not just a._[0]: an unquoted summary like
+      // `ay todo new write the spec --kind doc` splits into three separate
+      // positionals under yargs, and using only the first silently stored
+      // "write" as the entire summary (codex-review Important).
+      const summary = (a._ as (string | number)[]).map(String).join(" ");
       if (!summary)
         fail(
           "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--owner ...] [--tag t]... [--dep id]...",

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -298,7 +298,13 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
     }
     case "tree": {
       const rootId = args[0];
-      process.stdout.write(renderTree(store.all(), rootId) + "\n");
+      const tasks = store.all();
+      if (opts.format === "json") {
+        const { buildTreeJSON } = await import("./todoDigest.ts");
+        emit(opts, buildTreeJSON(tasks, rootId), "");
+      } else {
+        process.stdout.write(renderTree(tasks, rootId) + "\n");
+      }
       return 0;
     }
     case "digest": {

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -76,21 +76,35 @@ function emit(opts: CommonOpts, obj: unknown, human: string): void {
   process.stdout.write((opts.format === "json" ? JSON.stringify(obj, null, 2) : human) + "\n");
 }
 
-export async function runTodoSubcommand(rest: string[]): Promise<number> {
-  const y = yargs(rest)
-    .scriptName("ay todo")
-    .option("root", {
-      type: "string",
-      default: process.cwd(),
-      describe: "project root holding .agent-yes/todos.jsonl",
-    })
-    .option("format", { choices: ["table", "json"] as const, default: "table" as const })
-    .help(false)
-    .version(false)
-    .exitProcess(false);
-  const argv = (await y.parseAsync()) as unknown as CommonOpts & { _: (string | number)[] };
-  const [verb, ...args] = argv._.map(String);
-  const opts: CommonOpts = { root: argv.root, format: argv.format };
+/**
+ * Pull `--root <dir>` and `--format <table|json>` out of `argv` WITHOUT a
+ * full yargs pass — a single yargs parser here would swallow every verb's
+ * own flags too (e.g. `--kind`) into the outer parse result, leaving the
+ * per-verb sub-parsers below nothing to see in their `args`. Only these two
+ * global, cross-verb options are special-cased this way; everything else is
+ * declared by each verb's own `yargs(args)` call further down.
+ */
+function extractCommonOpts(argv: string[]): { opts: CommonOpts; rest: string[] } {
+  const rest: string[] = [];
+  let root = process.cwd();
+  let format: CommonOpts["format"] = "table";
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]!;
+    if (tok === "--root") {
+      root = argv[++i] ?? root;
+    } else if (tok === "--format") {
+      const v = argv[++i];
+      if (v === "table" || v === "json") format = v;
+    } else {
+      rest.push(tok);
+    }
+  }
+  return { opts: { root, format }, rest };
+}
+
+export async function runTodoSubcommand(rest0: string[]): Promise<number> {
+  const { opts, rest } = extractCommonOpts(rest0);
+  const [verb, ...args] = rest;
   const store = await openStore(opts.root);
 
   switch (verb) {

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -14,9 +14,22 @@
  * monorepo root") — a project wanting that behavior supplies it by always
  * invoking with an explicit `--root`, or by calling `openStore()` as a
  * library from its own code instead of through this CLI.
+ *
+ * Argument parsing: exactly ONE yargs pass per invocation, at the verb
+ * level. `--root`/`--format` are declared as options on EVERY verb's own
+ * `yargs(args)` call (via `commonOptions()` below) alongside that verb's own
+ * options, rather than pre-scanned out of argv by a separate pass. An
+ * earlier design tried a separate outer parse (swallowed every verb's own
+ * flags — fixed) and then a "--root/--format only recognized at the very
+ * end of argv" scan (broke completely ordinary invocations like
+ * `ay todo ls --format json --owner alice`, where --format isn't the last
+ * token — codex-review Important). A single parse per verb, with every
+ * option — common and verb-specific — declared on the SAME yargs instance,
+ * is how yargs is meant to be used and has neither problem: it correctly
+ * separates recognized flags from positional text regardless of order.
  */
 
-import yargs from "yargs";
+import yargs, { type Argv } from "yargs";
 import { openStore, CycleError, type TodoRecord } from "./todoStore.ts";
 import { isKnownKind, LIFECYCLES, type LifecycleKind } from "./todoLifecycle.ts";
 import { describeBlock, type TodoBlock } from "./todoBlock.ts";
@@ -76,71 +89,28 @@ function emit(opts: CommonOpts, obj: unknown, human: string): void {
   process.stdout.write((opts.format === "json" ? JSON.stringify(obj, null, 2) : human) + "\n");
 }
 
-/**
- * Pull `--root <dir>` and `--format <table|json>` out of `argv` WITHOUT a
- * full yargs pass — a single yargs parser here would swallow every verb's
- * own flags too (e.g. `--kind`) into the outer parse result, leaving the
- * per-verb sub-parsers below nothing to see in their `args`. Only these two
- * global, cross-verb options are special-cased this way; everything else is
- * declared by each verb's own `yargs(args)` call further down.
- *
- * Scanned from the END of argv, and only consumed while each trailing token
- * keeps matching — NOT scanned anywhere in the array. `ay todo new` joins
- * every positional word into the summary (an intentional convenience for
- * unquoted summaries), so scanning the whole array for `--format`/`--root`
- * would misparse a literal `--format` or `--root` that happens to appear as
- * a WORD inside an unquoted summary earlier in the command (e.g.
- * `ay todo new fix --format output --kind doc`, codex-review Important) —
- * every documented/tested invocation of this CLI puts `--root`/`--format` at
- * the very end, so restricting extraction to that trailing position closes
- * the real ambiguity without adding a `--` end-of-options convention. A
- * summary that itself needs to literally END in the words "--format ..." is
- * a narrow, documented edge case: quote it as one positional instead.
- */
-function extractCommonOpts(argv: string[]): { opts: CommonOpts; rest: string[] } {
-  const tokens = [...argv];
-  let root = process.cwd();
-  let format: CommonOpts["format"] = "table";
-  for (;;) {
-    const last = tokens.at(-1);
-    if (last === undefined) break;
-    const eq = last.match(/^(--root|--format)=(.*)$/);
-    if (eq) {
-      if (eq[1] === "--root") root = eq[2]!;
-      else if (eq[2] === "table" || eq[2] === "json") format = eq[2];
-      else fail(`--format must be "table" or "json" (got "${eq[2]}")`);
-      tokens.pop();
-      continue;
-    }
-    if (tokens.length >= 2) {
-      const flag = tokens.at(-2)!;
-      if (flag === "--root") {
-        root = last;
-        tokens.splice(-2, 2);
-        continue;
-      }
-      if (flag === "--format") {
-        if (last !== "table" && last !== "json") {
-          fail(`--format must be "table" or "json" (got ${JSON.stringify(last)})`);
-        }
-        format = last;
-        tokens.splice(-2, 2);
-        continue;
-      }
-    }
-    break; // the trailing token isn't part of a recognized global option — stop
-  }
-  return { opts: { root, format }, rest: tokens };
+/** Adds `--root`/`--format` to a verb's own yargs builder — see the module doc comment for why every verb declares these itself rather than a separate outer parse. */
+function commonOptions<T>(y: Argv<T>) {
+  return y
+    .option("root", {
+      type: "string" as const,
+      default: process.cwd(),
+      describe: "project root holding .agent-yes/todos.jsonl",
+    })
+    .option("format", { choices: ["table", "json"] as const, default: "table" as const });
+}
+
+function commonOptsOf(a: { root: string; format: "table" | "json" }): CommonOpts {
+  if (a.root === "") fail("--root must not be empty");
+  return { root: a.root, format: a.format };
 }
 
 export async function runTodoSubcommand(rest0: string[]): Promise<number> {
-  const { opts, rest } = extractCommonOpts(rest0);
-  const [verb, ...args] = rest;
-  const store = await openStore(opts.root);
+  const [verb, ...args] = rest0;
 
   switch (verb) {
     case "new": {
-      const sub = yargs(args)
+      const sub = commonOptions(yargs(args))
         .option("kind", { type: "string" })
         .option("description", { type: "string" })
         .option("tier", { type: "string" })
@@ -150,15 +120,21 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
         .help(false)
         .exitProcess(false);
       const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
       // Join ALL positional args, not just a._[0]: an unquoted summary like
       // `ay todo new write the spec --kind doc` splits into three separate
       // positionals under yargs, and using only the first silently stored
-      // "write" as the entire summary (codex-review Important).
+      // "write" as the entire summary (codex-review Important). A summary
+      // that must itself contain a literal "--flag"-shaped word is a narrow,
+      // separate edge case (yargs will consume it as a flag regardless of
+      // which parser sees it) — quote the whole summary in that case.
       const summary = (a._ as (string | number)[]).map(String).join(" ");
-      if (!summary)
+      if (!summary) {
         fail(
           "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--owner ...] [--tag t]... [--dep id]...",
         );
+      }
       const rec = await store.create({
         summary,
         kind: parseKind(a.kind as string | undefined),
@@ -172,7 +148,7 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       return 0;
     }
     case "ls": {
-      const sub = yargs(args)
+      const sub = commonOptions(yargs(args))
         .option("kind", { type: "string" })
         .option("state", { type: "string" })
         .option("owner", { type: "string" })
@@ -181,6 +157,8 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
         .help(false)
         .exitProcess(false);
       const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
       const tasks = store.list({
         kind: a.kind ? parseKind(a.kind as string) : undefined,
         state: a.state as string | undefined,
@@ -192,7 +170,11 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       return 0;
     }
     case "get": {
-      const id = args[0];
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
+      const id = String(a._[0] ?? "");
       if (!id) fail("usage: ay todo get <id>");
       const rec = store.get(id);
       if (!rec) fail(`no such task: ${id}`);
@@ -200,22 +182,29 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       return 0;
     }
     case "transition": {
-      const [id, toState] = args;
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
+      const [id, toState] = (a._ as (string | number)[]).map(String);
       if (!id || !toState) fail("usage: ay todo transition <id> <toState>");
       const rec = await store.transition(id, toState);
       emit(opts, rec, `transitioned ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
       return 0;
     }
     case "approve": {
-      const sub = yargs(args)
+      const sub = commonOptions(yargs(args))
         .option("note", { type: "string" })
         .option("link", { type: "string" })
         .help(false)
         .exitProcess(false);
       const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
       const [id, gate, validator] = (a._ as (string | number)[]).map(String);
-      if (!id || !gate || !validator)
+      if (!id || !gate || !validator) {
         fail("usage: ay todo approve <id> <gate> <validatorIdentity> [--note ...] [--link ...]");
+      }
       const rec = await store.approve(id, gate, validator, {
         note: a.note as string | undefined,
         link: a.link as string | undefined,
@@ -228,14 +217,18 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       return 0;
     }
     case "verify": {
-      const [id, gate] = args;
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
+      const [id, gate] = (a._ as (string | number)[]).map(String);
       if (!id) fail("usage: ay todo verify <id> [gateName]");
-      const rec = await store.verify(id, gate);
+      const rec = await store.verify(id, gate || undefined);
       emit(opts, rec, `verified ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
       return 0;
     }
     case "block": {
-      const sub = yargs(args)
+      const sub = commonOptions(yargs(args))
         .option("type", {
           type: "string",
           choices: [
@@ -254,11 +247,14 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
         .help(false)
         .exitProcess(false);
       const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
       const id = String(a._[0] ?? "");
-      if (!id || !a.type)
+      if (!id || !a.type) {
         fail(
           "usage: ay todo block <id> --type <blocked-by-task|blocked-by-human|blocked-by-external|waiting-on-agent> ...",
         );
+      }
       let block: TodoBlock;
       switch (a.type) {
         case "blocked-by-task":
@@ -290,14 +286,22 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       return 0;
     }
     case "unblock": {
-      const id = args[0];
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
+      const id = String(a._[0] ?? "");
       if (!id) fail("usage: ay todo unblock <id>");
       const rec = await store.setBlock(id, null);
       emit(opts, rec, `unblocked ${rec._id}\n${renderRecord(rec)}`);
       return 0;
     }
     case "dep": {
-      const [verb2, id, blockerId] = args;
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
+      const [verb2, id, blockerId] = (a._ as (string | number)[]).map(String);
       if (!verb2 || !id || !blockerId || (verb2 !== "add" && verb2 !== "rm")) {
         fail("usage: ay todo dep add|rm <id> <blockerId>");
       }
@@ -316,7 +320,11 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       }
     }
     case "tree": {
-      const rootId = args[0];
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
+      const rootId = a._[0] !== undefined ? String(a._[0]) : undefined;
       const tasks = store.all();
       if (opts.format === "json") {
         const { buildTreeJSON } = await import("./todoDigest.ts");
@@ -327,6 +335,10 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       return 0;
     }
     case "digest": {
+      const sub = commonOptions(yargs(args)).help(false).exitProcess(false);
+      const a = await sub.parseAsync();
+      const opts = commonOptsOf(a);
+      const store = await openStore(opts.root);
       const tasks = store.all();
       if (opts.format === "json") {
         const { unblockedTasks } = await import("./todoDigest.ts");

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -1,0 +1,289 @@
+/**
+ * `ay todo <verb>` — CLI surface for the lifecycle engine (`todoStore.ts`),
+ * typed blocks (`todoBlock.ts`), and read-side views (`todoDigest.ts`).
+ *
+ * Registered from `ts/subcommands.ts` the same way larger subsystems like
+ * `serve`/`schedule`/`expose` are: a lazy `case "todo":` import into
+ * `runTodoSubcommand`, so this file (and everything it pulls in) is only
+ * loaded when `ay todo ...` is actually invoked.
+ *
+ * Store location: `--root <dir>` (default: current working directory) is
+ * where `.agent-yes/todos.jsonl` lives, mirroring `PidStore`'s own
+ * `<workingDir>/.agent-yes/...` convention. This module has no notion of any
+ * particular consuming project's directory-resolution rules (e.g. "find the
+ * monorepo root") — a project wanting that behavior supplies it by always
+ * invoking with an explicit `--root`, or by calling `openStore()` as a
+ * library from its own code instead of through this CLI.
+ */
+
+import yargs from "yargs";
+import { openStore, CycleError, type TodoRecord } from "./todoStore.ts";
+import { isKnownKind, LIFECYCLES, type LifecycleKind } from "./todoLifecycle.ts";
+import { describeBlock, type TodoBlock } from "./todoBlock.ts";
+import { renderDigest, renderTree } from "./todoDigest.ts";
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseKind(raw: string | undefined): LifecycleKind {
+  if (!raw) fail(`--kind is required (one of: ${Object.keys(LIFECYCLES).join(", ")})`);
+  if (!isKnownKind(raw))
+    fail(`unknown kind "${raw}" (one of: ${Object.keys(LIFECYCLES).join(", ")})`);
+  return raw;
+}
+
+function renderRecord(t: TodoRecord): string {
+  const lines = [
+    `${t._id} [${t.state}] ${t.summary}`,
+    `kind:    ${t.kind}${t.targetTier ? `  tier:${t.targetTier}` : ""}`,
+    ...(t.owner ? [`owner:   ${t.owner}`] : []),
+    ...(t.block ? [`block:   ${describeBlock(t.block)}`] : []),
+    ...(t.blockedBy.length ? [`blockedBy: ${t.blockedBy.join(", ")}`] : []),
+    ...(t.tags.length ? [`tags:    ${t.tags.join(", ")}`] : []),
+    ...(t.satisfiedGates.length ? [`satisfiedGates: ${t.satisfiedGates.join(", ")}`] : []),
+    ...(t.verifyEvidence.length
+      ? [
+          `evidence: ${t.verifyEvidence.map((e) => `${e.gate} by ${e.validator}${e.link ? ` (${e.link})` : ""}`).join("; ")}`,
+        ]
+      : []),
+    `created: ${t.createdAt}`,
+    `updated: ${t.updatedAt}`,
+  ];
+  if (t.description) lines.push("", t.description);
+  return lines.join("\n");
+}
+
+function renderList(tasks: TodoRecord[]): string {
+  if (tasks.length === 0) return "(no tasks match)";
+  const rows = tasks.map((t) => [t._id, t.state, t.kind, t.owner ?? "", t.summary]);
+  const header = ["ID", "STATE", "KIND", "OWNER", "SUMMARY"];
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
+  const line = (xs: string[]) =>
+    xs
+      .map((x, i) => x.padEnd(widths[i]!))
+      .join("  ")
+      .trimEnd();
+  return [line(header), ...rows.map(line)].join("\n");
+}
+
+interface CommonOpts {
+  root: string;
+  format: "table" | "json";
+}
+
+function emit(opts: CommonOpts, obj: unknown, human: string): void {
+  process.stdout.write((opts.format === "json" ? JSON.stringify(obj, null, 2) : human) + "\n");
+}
+
+export async function runTodoSubcommand(rest: string[]): Promise<number> {
+  const y = yargs(rest)
+    .scriptName("ay todo")
+    .option("root", {
+      type: "string",
+      default: process.cwd(),
+      describe: "project root holding .agent-yes/todos.jsonl",
+    })
+    .option("format", { choices: ["table", "json"] as const, default: "table" as const })
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+  const argv = (await y.parseAsync()) as unknown as CommonOpts & { _: (string | number)[] };
+  const [verb, ...args] = argv._.map(String);
+  const opts: CommonOpts = { root: argv.root, format: argv.format };
+  const store = await openStore(opts.root);
+
+  switch (verb) {
+    case "new": {
+      const sub = yargs(args)
+        .option("kind", { type: "string" })
+        .option("description", { type: "string" })
+        .option("tier", { type: "string" })
+        .option("owner", { type: "string" })
+        .option("tag", { type: "string", array: true })
+        .option("dep", { type: "string", array: true })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const summary = String(a._[0] ?? "");
+      if (!summary)
+        fail(
+          "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--owner ...] [--tag t]... [--dep id]...",
+        );
+      const rec = await store.create({
+        summary,
+        kind: parseKind(a.kind as string | undefined),
+        description: a.description as string | undefined,
+        targetTier: a.tier as string | undefined,
+        owner: a.owner as string | undefined,
+        tags: (a.tag as string[] | undefined) ?? [],
+        blockedBy: (a.dep as string[] | undefined) ?? [],
+      });
+      emit(opts, rec, `created ${rec._id}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "ls": {
+      const sub = yargs(args)
+        .option("kind", { type: "string" })
+        .option("state", { type: "string" })
+        .option("owner", { type: "string" })
+        .option("tag", { type: "string" })
+        .option("blocked", { type: "boolean", default: false })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const tasks = store.list({
+        kind: a.kind ? parseKind(a.kind as string) : undefined,
+        state: a.state as string | undefined,
+        owner: a.owner as string | undefined,
+        tag: a.tag as string | undefined,
+        blocked: a.blocked as boolean,
+      });
+      emit(opts, tasks, renderList(tasks));
+      return 0;
+    }
+    case "get": {
+      const id = args[0];
+      if (!id) fail("usage: ay todo get <id>");
+      const rec = store.get(id);
+      if (!rec) fail(`no such task: ${id}`);
+      emit(opts, rec, renderRecord(rec));
+      return 0;
+    }
+    case "transition": {
+      const [id, toState] = args;
+      if (!id || !toState) fail("usage: ay todo transition <id> <toState>");
+      const rec = await store.transition(id, toState);
+      emit(opts, rec, `transitioned ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "approve": {
+      const sub = yargs(args)
+        .option("note", { type: "string" })
+        .option("link", { type: "string" })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const [id, gate, validator] = (a._ as (string | number)[]).map(String);
+      if (!id || !gate || !validator)
+        fail("usage: ay todo approve <id> <gate> <validatorIdentity> [--note ...] [--link ...]");
+      const rec = await store.approve(id, gate, validator, {
+        note: a.note as string | undefined,
+        link: a.link as string | undefined,
+      });
+      emit(
+        opts,
+        rec,
+        `approved "${gate}" on ${rec._id} (validator: ${validator})\n${renderRecord(rec)}`,
+      );
+      return 0;
+    }
+    case "verify": {
+      const [id, gate] = args;
+      if (!id) fail("usage: ay todo verify <id> [gateName]");
+      const rec = await store.verify(id, gate);
+      emit(opts, rec, `verified ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "block": {
+      const sub = yargs(args)
+        .option("type", {
+          type: "string",
+          choices: [
+            "blocked-by-task",
+            "blocked-by-human",
+            "blocked-by-external",
+            "waiting-on-agent",
+          ] as const,
+        })
+        .option("task", { type: "string" })
+        .option("who", { type: "string" })
+        .option("question", { type: "string" })
+        .option("options", { type: "string", array: true })
+        .option("signal", { type: "string" })
+        .option("agent", { type: "string" })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const id = String(a._[0] ?? "");
+      if (!id || !a.type)
+        fail(
+          "usage: ay todo block <id> --type <blocked-by-task|blocked-by-human|blocked-by-external|waiting-on-agent> ...",
+        );
+      let block: TodoBlock;
+      switch (a.type) {
+        case "blocked-by-task":
+          if (!a.task) fail("--task <id> is required for --type blocked-by-task");
+          block = { type: "blocked-by-task", taskId: a.task as string };
+          break;
+        case "blocked-by-human":
+          if (!a.who) fail("--who <name> is required for --type blocked-by-human");
+          block = {
+            type: "blocked-by-human",
+            who: a.who as string,
+            question: a.question as string | undefined,
+            options: a.options as string[] | undefined,
+          };
+          break;
+        case "blocked-by-external":
+          if (!a.signal) fail("--signal <name> is required for --type blocked-by-external");
+          block = { type: "blocked-by-external", signal: a.signal as string };
+          break;
+        case "waiting-on-agent":
+          if (!a.agent) fail("--agent <id> is required for --type waiting-on-agent");
+          block = { type: "waiting-on-agent", agentId: a.agent as string };
+          break;
+        default:
+          fail(`unknown block type: ${a.type}`);
+      }
+      const rec = await store.setBlock(id, block);
+      emit(opts, rec, `blocked ${rec._id}: ${describeBlock(block)}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "unblock": {
+      const id = args[0];
+      if (!id) fail("usage: ay todo unblock <id>");
+      const rec = await store.setBlock(id, null);
+      emit(opts, rec, `unblocked ${rec._id}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "dep": {
+      const [verb2, id, blockerId] = args;
+      if (!verb2 || !id || !blockerId || (verb2 !== "add" && verb2 !== "rm")) {
+        fail("usage: ay todo dep add|rm <id> <blockerId>");
+      }
+      try {
+        const rec =
+          verb2 === "add" ? await store.addDep(id, blockerId) : await store.rmDep(id, blockerId);
+        emit(
+          opts,
+          rec,
+          `${verb2 === "add" ? "added" : "removed"} dep ${blockerId} on ${rec._id}\n${renderRecord(rec)}`,
+        );
+        return 0;
+      } catch (err) {
+        if (err instanceof CycleError) fail(err.message);
+        throw err;
+      }
+    }
+    case "tree": {
+      const rootId = args[0];
+      process.stdout.write(renderTree(store.all(), rootId) + "\n");
+      return 0;
+    }
+    case "digest": {
+      const tasks = store.all();
+      if (opts.format === "json") {
+        const { unblockedTasks } = await import("./todoDigest.ts");
+        emit(opts, { tasks, unblocked: unblockedTasks(tasks).map((t) => t._id) }, "");
+      } else {
+        process.stdout.write(renderDigest(tasks) + "\n");
+      }
+      return 0;
+    }
+    default:
+      fail(
+        `unknown "ay todo" verb: "${verb ?? ""}" (expected: new/ls/get/transition/approve/verify/block/unblock/dep/tree/digest)`,
+      );
+  }
+}

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -83,35 +83,54 @@ function emit(opts: CommonOpts, obj: unknown, human: string): void {
  * per-verb sub-parsers below nothing to see in their `args`. Only these two
  * global, cross-verb options are special-cased this way; everything else is
  * declared by each verb's own `yargs(args)` call further down.
+ *
+ * Scanned from the END of argv, and only consumed while each trailing token
+ * keeps matching — NOT scanned anywhere in the array. `ay todo new` joins
+ * every positional word into the summary (an intentional convenience for
+ * unquoted summaries), so scanning the whole array for `--format`/`--root`
+ * would misparse a literal `--format` or `--root` that happens to appear as
+ * a WORD inside an unquoted summary earlier in the command (e.g.
+ * `ay todo new fix --format output --kind doc`, codex-review Important) —
+ * every documented/tested invocation of this CLI puts `--root`/`--format` at
+ * the very end, so restricting extraction to that trailing position closes
+ * the real ambiguity without adding a `--` end-of-options convention. A
+ * summary that itself needs to literally END in the words "--format ..." is
+ * a narrow, documented edge case: quote it as one positional instead.
  */
 function extractCommonOpts(argv: string[]): { opts: CommonOpts; rest: string[] } {
-  const rest: string[] = [];
+  const tokens = [...argv];
   let root = process.cwd();
   let format: CommonOpts["format"] = "table";
-  for (let i = 0; i < argv.length; i++) {
-    const tok = argv[i]!;
-    // Support both `--root val` and `--root=val` (and same for --format) —
-    // the `=` form is common enough elsewhere in this CLI's own flags that
-    // silently rejecting it here would read as inconsistent (codex nitpick).
-    const eq = tok.match(/^(--root|--format)=(.*)$/);
+  for (;;) {
+    const last = tokens.at(-1);
+    if (last === undefined) break;
+    const eq = last.match(/^(--root|--format)=(.*)$/);
     if (eq) {
       if (eq[1] === "--root") root = eq[2]!;
       else if (eq[2] === "table" || eq[2] === "json") format = eq[2];
       else fail(`--format must be "table" or "json" (got "${eq[2]}")`);
-    } else if (tok === "--root") {
-      const v = argv[++i];
-      if (v === undefined) fail("--root requires a value");
-      root = v;
-    } else if (tok === "--format") {
-      const v = argv[++i];
-      if (v !== "table" && v !== "json")
-        fail(`--format must be "table" or "json" (got ${JSON.stringify(v)})`);
-      format = v;
-    } else {
-      rest.push(tok);
+      tokens.pop();
+      continue;
     }
+    if (tokens.length >= 2) {
+      const flag = tokens.at(-2)!;
+      if (flag === "--root") {
+        root = last;
+        tokens.splice(-2, 2);
+        continue;
+      }
+      if (flag === "--format") {
+        if (last !== "table" && last !== "json") {
+          fail(`--format must be "table" or "json" (got ${JSON.stringify(last)})`);
+        }
+        format = last;
+        tokens.splice(-2, 2);
+        continue;
+      }
+    }
+    break; // the trailing token isn't part of a recognized global option — stop
   }
-  return { opts: { root, format }, rest };
+  return { opts: { root, format }, rest: tokens };
 }
 
 export async function runTodoSubcommand(rest0: string[]): Promise<number> {

--- a/ts/todoDigest.spec.ts
+++ b/ts/todoDigest.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { openBlockers, renderDigest, renderTree, unblockedTasks } from "./todoDigest";
+import {
+  buildTreeJSON,
+  openBlockers,
+  renderDigest,
+  renderTree,
+  unblockedTasks,
+} from "./todoDigest";
 import type { TodoRecord } from "./todoStore";
 
 function task(over: Partial<TodoRecord> & { _id: string }): TodoRecord {
@@ -65,6 +71,54 @@ describe("renderTree", () => {
 
   it("reports a friendly message when there are no dependency links at all", () => {
     expect(renderTree([task({ _id: "T1" })])).toContain("no dependency links");
+  });
+});
+
+describe("buildTreeJSON", () => {
+  const tasks = [
+    task({ _id: "T1", state: "done", summary: "schema" }),
+    task({ _id: "T2", state: "doing", summary: "api", owner: "cto", blockedBy: ["T1"] }),
+    task({ _id: "T3", state: "shipped", summary: "ui", blockedBy: ["T2"] }),
+  ];
+
+  it("renders the same structure as renderTree, as nested data", () => {
+    expect(buildTreeJSON(tasks)).toEqual([
+      {
+        id: "T3",
+        state: "shipped",
+        summary: "ui",
+        children: [
+          {
+            id: "T2",
+            state: "doing",
+            summary: "api",
+            owner: "cto",
+            children: [{ id: "T1", state: "done", summary: "schema", children: [] }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("throws on an unknown explicit root, like renderTree", () => {
+    expect(() => buildTreeJSON(tasks, "T99")).toThrow(/no such task/);
+  });
+
+  it("faithfully expands a DIAMOND dependency under EACH branch, not just the first-visited one (codex-review nitpick)", () => {
+    // A depends on both B and C, which both depend on the same D
+    const diamond = [
+      task({ _id: "A", blockedBy: ["B", "C"] }),
+      task({ _id: "B", blockedBy: ["D"] }),
+      task({ _id: "C", blockedBy: ["D"] }),
+      task({ _id: "D", state: "done" }),
+    ];
+    const [root] = buildTreeJSON(diamond, "A");
+    const b = root!.children.find((c) => c.id === "B")!;
+    const c = root!.children.find((c) => c.id === "C")!;
+    // BOTH branches show D's full (childless-but-present) node — neither is
+    // a bare stub just because the other branch already "saw" D first.
+    expect(b.children).toEqual([{ id: "D", state: "done", summary: "task D", children: [] }]);
+    expect(c.children).toEqual([{ id: "D", state: "done", summary: "task D", children: [] }]);
   });
 });
 

--- a/ts/todoDigest.spec.ts
+++ b/ts/todoDigest.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { openBlockers, renderDigest, renderTree, unblockedTasks } from "./todoDigest";
+import type { TodoRecord } from "./todoStore";
+
+function task(over: Partial<TodoRecord> & { _id: string }): TodoRecord {
+  return {
+    kind: "code",
+    state: "doing",
+    summary: `task ${over._id}`,
+    description: "",
+    blockedBy: [],
+    tags: [],
+    satisfiedGates: [],
+    verifyEvidence: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("unblockedTasks", () => {
+  it("fires only when ALL blockers reached done, never for a finished task, never with zero declared deps", () => {
+    const tasks = [
+      task({ _id: "T1", state: "done" }),
+      task({ _id: "T2", state: "done" }),
+      task({ _id: "T3", state: "shipped", blockedBy: ["T1", "T2"] }), // both done -> unblocked
+      task({ _id: "T4", state: "shipped", blockedBy: ["T1", "T5"] }), // T5 not done -> still blocked
+      task({ _id: "T5", state: "doing" }),
+      task({ _id: "T6", state: "done", blockedBy: ["T1"] }), // finished -> not surfaced
+      task({ _id: "T7", state: "shipped" }), // no declared deps -> nothing to detect
+    ];
+    expect(unblockedTasks(tasks).map((t) => t._id)).toEqual(["T3"]);
+  });
+});
+
+describe("openBlockers", () => {
+  it("reports only the not-yet-done blockers, including a missing id as open", () => {
+    const byId = new Map([
+      ["T1", task({ _id: "T1", state: "done" })],
+      ["T2", task({ _id: "T2", state: "doing" })],
+    ]);
+    const t = task({ _id: "T3", blockedBy: ["T1", "T2", "T99"] });
+    expect(openBlockers(t, byId)).toEqual(["T2", "T99"]);
+  });
+});
+
+describe("renderTree", () => {
+  const tasks = [
+    task({ _id: "T1", state: "done", summary: "schema" }),
+    task({ _id: "T2", state: "doing", summary: "api", owner: "cto", blockedBy: ["T1"] }),
+    task({ _id: "T3", state: "shipped", summary: "ui", blockedBy: ["T2"] }),
+  ];
+
+  it("renders roots (nothing depends on them, they have deps) down blockedBy edges", () => {
+    const out = renderTree(tasks);
+    expect(out).toContain("T3 [shipped] ui");
+    expect(out).toContain("└─ T2 [doing] api");
+    expect(out).toContain("owner:cto");
+  });
+
+  it("accepts an explicit root id and throws on an unknown one", () => {
+    expect(renderTree(tasks, "T2")).toContain("└─ T1 [done] schema");
+    expect(() => renderTree(tasks, "T99")).toThrow(/no such task/);
+  });
+
+  it("reports a friendly message when there are no dependency links at all", () => {
+    expect(renderTree([task({ _id: "T1" })])).toContain("no dependency links");
+  });
+});
+
+describe("renderDigest", () => {
+  it("groups by tag with per-state counts, and surfaces blocked/waiting/unblocked info inline", () => {
+    const tasks = [
+      task({ _id: "T1", state: "done", tags: ["proj-x"] }),
+      task({ _id: "T2", state: "doing", tags: ["proj-x"], owner: "cto", blockedBy: ["T1"] }),
+      task({
+        _id: "T3",
+        state: "shipped",
+        tags: ["proj-y"],
+        blockedBy: ["T2"],
+        block: { type: "blocked-by-human", who: "taku" },
+      }),
+    ];
+    const out = renderDigest(tasks);
+    expect(out).toContain("## proj-x");
+    expect(out).toContain("## proj-y");
+    expect(out).toContain("block:blocked-by-human");
+    expect(out).toContain("blockedBy:T2"); // T3's blocker T2 isn't done yet
+    expect(out).toContain("unblocked (all blockers reached done");
+    expect(out).toContain("T2 task T2"); // T2's blocker T1 IS done -> unblocked section
+  });
+
+  it("empty task list renders a friendly message, not a crash", () => {
+    expect(renderDigest([])).toBe("(no tasks)");
+  });
+});

--- a/ts/todoDigest.ts
+++ b/ts/todoDigest.ts
@@ -1,0 +1,125 @@
+/**
+ * Read-side views over the `ay todo` store: dependency-tree rendering and a
+ * per-tag digest board. Pure functions over an already-loaded task list — no
+ * I/O — so they are trivially unit-testable and reusable by both the CLI
+ * (`todoCli.ts`) and any future web view.
+ *
+ * `unblockedTasks` is ported near-verbatim from the equivalent, already
+ * mutation-tested algorithm in symval-dev-cli's `deps.ts` (a closed-source
+ * downstream consumer of an earlier, less general version of this idea) —
+ * generalized here to the new `TodoRecord` shape and the `done` state name
+ * from `todoLifecycle.ts` instead of a hardcoded status string.
+ */
+
+import { DONE_STATE } from "./todoLifecycle.ts";
+import type { TodoRecord } from "./todoStore.ts";
+
+/**
+ * A task is "unblocked" when it is not itself finished, it declares
+ * `blockedBy` dependencies, and every one of them has reached `done`.
+ * Surfaced for a caller to act on — never auto-applied here (deciding to
+ * resume a task is left to automation, a later milestone, or a human).
+ */
+export function unblockedTasks(tasks: TodoRecord[]): TodoRecord[] {
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  return tasks.filter((t) => {
+    if (t.state === DONE_STATE) return false;
+    if (t.blockedBy.length === 0) return false;
+    return t.blockedBy.every((d) => byId.get(d)?.state === DONE_STATE);
+  });
+}
+
+/** Blockers of `t` that have not reached `done` yet (a missing id is reported as-is, still "open"). */
+export function openBlockers(t: TodoRecord, byId: Map<string, TodoRecord>): string[] {
+  return t.blockedBy.filter((d) => byId.get(d)?.state !== DONE_STATE);
+}
+
+function nodeLine(t: TodoRecord): string {
+  const bits = [`${t._id} [${t.state}] ${t.summary}`, ...(t.owner ? [`owner:${t.owner}`] : [])];
+  return bits.join("  ");
+}
+
+/**
+ * Dependency tree, rendered from roots (tasks nothing depends on, that
+ * themselves declare at least one dependency) down their `blockedBy` edges:
+ * a parent's children are what it is waiting for.
+ */
+export function renderTree(tasks: TodoRecord[], rootId?: string): string {
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  const dependedOn = new Set(tasks.flatMap((t) => t.blockedBy));
+  const roots = rootId
+    ? [byId.get(rootId) ?? null].filter((t): t is TodoRecord => t !== null)
+    : tasks.filter((t) => !dependedOn.has(t._id) && t.blockedBy.length > 0);
+  if (rootId && roots.length === 0) throw new Error(`no such task: ${rootId}`);
+  if (roots.length === 0) return "(no dependency links)";
+
+  const lines: string[] = [];
+  const walk = (
+    t: TodoRecord,
+    prefix: string,
+    isLast: boolean,
+    depth: number,
+    seen: Set<string>,
+  ): void => {
+    lines.push(depth === 0 ? nodeLine(t) : `${prefix}${isLast ? "└─" : "├─"} ${nodeLine(t)}`);
+    if (seen.has(t._id)) return;
+    seen.add(t._id);
+    const deps = t.blockedBy
+      .map((d) => byId.get(d))
+      .filter((x): x is TodoRecord => x !== undefined);
+    deps.forEach((d, i) => {
+      const childPrefix = depth === 0 ? "" : `${prefix}${isLast ? "   " : "│  "}`;
+      walk(d, childPrefix, i === deps.length - 1, depth + 1, seen);
+    });
+  };
+  roots.forEach((r) => walk(r, "", true, 0, new Set()));
+  return lines.join("\n");
+}
+
+/** Per-tag board: state counts per tag, plus an unblocked-tasks callout. */
+export function renderDigest(tasks: TodoRecord[]): string {
+  if (tasks.length === 0) return "(no tasks)";
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  const unblocked = new Set(unblockedTasks(tasks).map((t) => t._id));
+
+  const streams = new Map<string, TodoRecord[]>();
+  for (const t of tasks) {
+    for (const tag of t.tags.length ? t.tags : ["(untagged)"]) {
+      if (!streams.has(tag)) streams.set(tag, []);
+      streams.get(tag)!.push(t);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const [stream, items] of [...streams.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const allStates = [...new Set(items.map((t) => t.state))].sort();
+    const counts = allStates
+      .map((s) => `${s}:${items.filter((t) => t.state === s).length}`)
+      .join(" ");
+    lines.push(`## ${stream}  (${counts})`);
+    for (const s of allStates) {
+      for (const t of items.filter((x) => x.state === s)) {
+        const open = openBlockers(t, byId);
+        const extra = [
+          ...(t.owner ? [`owner:${t.owner}`] : []),
+          ...(t.block ? [`block:${t.block.type}`] : []),
+          ...(open.length ? [`blockedBy:${open.join(",")}`] : []),
+          ...(unblocked.has(t._id) ? ["UNBLOCKED"] : []),
+        ];
+        lines.push(
+          `  [${t.state}] ${t._id} ${t.summary}${extra.length ? `  [${extra.join(" ")}]` : ""}`,
+        );
+      }
+    }
+    lines.push("");
+  }
+
+  const ub = unblockedTasks(tasks);
+  if (ub.length) {
+    lines.push("## unblocked (all blockers reached done — resume these)");
+    for (const t of ub)
+      lines.push(`  ${t._id} ${t.summary}${t.owner ? `  (owner:${t.owner})` : ""}`);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}

--- a/ts/todoDigest.ts
+++ b/ts/todoDigest.ts
@@ -99,7 +99,15 @@ export function buildTreeJSON(tasks: TodoRecord[], rootId?: string): TreeNode[] 
     : tasks.filter((t) => !dependedOn.has(t._id) && t.blockedBy.length > 0);
   if (rootId && roots.length === 0) throw new Error(`no such task: ${rootId}`);
 
-  const build = (t: TodoRecord, seen: Set<string>): TreeNode => {
+  // `ancestors` tracks only the CURRENT root-to-node path, not every node
+  // visited anywhere in the tree — so a diamond dependency (e.g. both B and C
+  // depend on the same D) gets D's full subtree independently under EACH
+  // branch, a faithful expansion, rather than only the first-visited branch
+  // showing it and later ones getting a childless stub (codex nitpick). A
+  // fresh Set is passed down (not mutated in place) so sibling branches don't
+  // see each other's ancestry. Only a genuine cycle (impossible — the store
+  // rejects them — but checked defensively) would ever hit the `seen` guard.
+  const build = (t: TodoRecord, ancestors: Set<string>): TreeNode => {
     const node: TreeNode = {
       id: t._id,
       state: t.state,
@@ -107,12 +115,12 @@ export function buildTreeJSON(tasks: TodoRecord[], rootId?: string): TreeNode[] 
       ...(t.owner ? { owner: t.owner } : {}),
       children: [],
     };
-    if (seen.has(t._id)) return node; // cycles cannot exist (store rejects them), but stay robust
-    seen.add(t._id);
+    if (ancestors.has(t._id)) return node;
+    const nextAncestors = new Set(ancestors).add(t._id);
     node.children = t.blockedBy
       .map((d) => byId.get(d))
       .filter((x): x is TodoRecord => x !== undefined)
-      .map((d) => build(d, seen));
+      .map((d) => build(d, nextAncestors));
     return node;
   };
   return roots.map((r) => build(r, new Set()));

--- a/ts/todoDigest.ts
+++ b/ts/todoDigest.ts
@@ -76,6 +76,48 @@ export function renderTree(tasks: TodoRecord[], rootId?: string): string {
   return lines.join("\n");
 }
 
+export interface TreeNode {
+  id: string;
+  state: string;
+  summary: string;
+  owner?: string;
+  children: TreeNode[];
+}
+
+/**
+ * JSON-shaped equivalent of `renderTree` — same roots-and-edges logic, built
+ * as data instead of formatted lines, so a machine caller (`--format json`)
+ * gets the actual tree structure rather than a string it would have to
+ * re-parse (codex-review Important: the CLI previously ignored --format for
+ * this command entirely, always writing the human text with exit code 0).
+ */
+export function buildTreeJSON(tasks: TodoRecord[], rootId?: string): TreeNode[] {
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  const dependedOn = new Set(tasks.flatMap((t) => t.blockedBy));
+  const roots = rootId
+    ? [byId.get(rootId) ?? null].filter((t): t is TodoRecord => t !== null)
+    : tasks.filter((t) => !dependedOn.has(t._id) && t.blockedBy.length > 0);
+  if (rootId && roots.length === 0) throw new Error(`no such task: ${rootId}`);
+
+  const build = (t: TodoRecord, seen: Set<string>): TreeNode => {
+    const node: TreeNode = {
+      id: t._id,
+      state: t.state,
+      summary: t.summary,
+      ...(t.owner ? { owner: t.owner } : {}),
+      children: [],
+    };
+    if (seen.has(t._id)) return node; // cycles cannot exist (store rejects them), but stay robust
+    seen.add(t._id);
+    node.children = t.blockedBy
+      .map((d) => byId.get(d))
+      .filter((x): x is TodoRecord => x !== undefined)
+      .map((d) => build(d, seen));
+    return node;
+  };
+  return roots.map((r) => build(r, new Set()));
+}
+
 /** Per-tag board: state counts per tag, plus an unblocked-tasks callout. */
 export function renderDigest(tasks: TodoRecord[]): string {
   if (tasks.length === 0) return "(no tasks)";

--- a/ts/todoLifecycle.spec.ts
+++ b/ts/todoLifecycle.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIFECYCLES,
+  canTransition,
+  initialState,
+  isKnownKind,
+  nextStates,
+  requiredGate,
+  statesOf,
+} from "./todoLifecycle";
+
+describe("todoLifecycle", () => {
+  it("defines all five kinds with the exact graphs taku specified", () => {
+    expect(Object.keys(LIFECYCLES).sort()).toEqual([
+      "code",
+      "decision",
+      "doc",
+      "human",
+      "investigation",
+    ]);
+    expect(statesOf("code")).toEqual([
+      "doing",
+      "merged",
+      "shipped",
+      "verifying",
+      "done",
+      "verify-failed",
+      "orphaned",
+    ]);
+    expect(statesOf("human")).toEqual(["pending", "decided", "done"]);
+  });
+
+  it("initialState is each graph's first listed state", () => {
+    expect(initialState("code")).toBe("doing");
+    expect(initialState("human")).toBe("pending");
+    expect(initialState("doc")).toBe("drafting");
+  });
+
+  it("canTransition/nextStates follow the declared edges only", () => {
+    expect(canTransition("code", "doing", "merged")).toBe(true);
+    expect(canTransition("code", "doing", "done")).toBe(false); // no edge skips straight to done
+    expect(nextStates("code", "verifying").sort()).toEqual(["done", "verify-failed"]);
+  });
+
+  it("requiredGate reports the gate name for gated edges, null for ungated/nonexistent edges", () => {
+    expect(requiredGate("code", "verifying", "done")).toBe("verify-green");
+    expect(requiredGate("code", "verifying", "verify-failed")).toBe("verify-red");
+    expect(requiredGate("code", "doing", "merged")).toBeNull(); // ungated
+    expect(requiredGate("code", "doing", "done")).toBeNull(); // no such edge
+  });
+
+  it("verify-failed reopens ONLY to the kind's doing state, never straight back to verifying", () => {
+    expect(nextStates("code", "verify-failed")).toEqual(["doing"]);
+  });
+
+  it("the human kind has no merge/ship/QA transitions at all (taku decision #6)", () => {
+    const humanStates = new Set(statesOf("human"));
+    for (const s of ["merged", "shipped", "verifying", "verify-failed"]) {
+      expect(humanStates.has(s)).toBe(false);
+    }
+  });
+
+  it("isKnownKind is a type guard over the real kind set", () => {
+    expect(isKnownKind("code")).toBe(true);
+    expect(isKnownKind("bogus")).toBe(false);
+  });
+});

--- a/ts/todoLifecycle.ts
+++ b/ts/todoLifecycle.ts
@@ -1,0 +1,121 @@
+/**
+ * Declarative lifecycle graphs for the `ay todo` engine.
+ *
+ * A task has a "kind" (what shape of work it is) and each kind owns an
+ * ordered set of states plus the transitions allowed between them. Some
+ * transitions require a "gate" — a named condition that must be satisfied
+ * before the transition is allowed. The engine (see `todoStore.ts`) enforces
+ * gates at a single choke point, so `done`-family states can never be reached
+ * by a plain manual flip: only a registered gate reporting success can move a
+ * task into one.
+ *
+ * This file is pure data plus pure functions — no I/O, no process/agent
+ * awareness, so it can be tested in complete isolation and reused by any
+ * project that adopts `ay todo`, not just one particular team's workflow.
+ * Deliberately generic: nothing here names a specific product, company, or
+ * external tool. A consuming project supplies the concrete meaning of a gate
+ * (e.g. what "the tests passed" means for them) via `registerGate` in
+ * `todoStore.ts` — this module only knows gates by name.
+ */
+
+export type LifecycleKind = "code" | "decision" | "doc" | "investigation" | "human";
+
+export interface LifecycleTransition {
+  from: string;
+  to: string;
+  /** Name of the gate that must pass before this transition is allowed. Absent = always allowed. */
+  gate?: string;
+}
+
+export interface LifecycleGraph {
+  states: string[];
+  transitions: LifecycleTransition[];
+}
+
+/**
+ * States considered "finished" across every kind. A finished task is never
+ * reopened by automation (see `todoAutomation.ts` in a later milestone) —
+ * only a human explicitly reopening it (e.g. `verify-failed` → the kind's
+ * doing state) moves a task out of a finished-adjacent state.
+ */
+export const DONE_STATE = "done";
+
+export const LIFECYCLES: Record<LifecycleKind, LifecycleGraph> = {
+  code: {
+    states: ["doing", "merged", "shipped", "verifying", "done", "verify-failed", "orphaned"],
+    transitions: [
+      { from: "doing", to: "merged" },
+      { from: "merged", to: "shipped" },
+      { from: "shipped", to: "verifying" },
+      { from: "verifying", to: "done", gate: "verify-green" },
+      { from: "verifying", to: "verify-failed", gate: "verify-red" },
+      // Reopening always returns to "doing", never straight back to "verifying" —
+      // every re-attempt goes through a real doing→verifying cycle so a failure
+      // is never silently re-run away without a fresh doing step.
+      { from: "verify-failed", to: "doing" },
+    ],
+  },
+  decision: {
+    states: ["deciding", "decided", "done"],
+    transitions: [
+      { from: "deciding", to: "decided", gate: "human-decided" },
+      { from: "decided", to: "done" },
+    ],
+  },
+  doc: {
+    states: ["drafting", "review", "done"],
+    transitions: [
+      { from: "drafting", to: "review" },
+      { from: "review", to: "done", gate: "human-approved" },
+    ],
+  },
+  investigation: {
+    states: ["investigating", "reported", "done"],
+    transitions: [
+      { from: "investigating", to: "reported" },
+      { from: "reported", to: "done", gate: "human-acknowledged" },
+    ],
+  },
+  // Structurally different from the four work-shaped kinds above: no merge,
+  // ship, or verify step at all. Used for every task whose entire content is
+  // "a human needs to decide or answer something."
+  human: {
+    states: ["pending", "decided", "done"],
+    transitions: [
+      { from: "pending", to: "decided", gate: "human-replied" },
+      { from: "decided", to: "done" },
+    ],
+  },
+};
+
+/** The state a newly-created task of `kind` starts in (its graph's first state). */
+export function initialState(kind: LifecycleKind): string {
+  const first = LIFECYCLES[kind].states[0];
+  if (!first) throw new Error(`lifecycle kind "${kind}" has no states`);
+  return first;
+}
+
+/** States reachable in one transition from `currentState`, regardless of gates. */
+export function nextStates(kind: LifecycleKind, currentState: string): string[] {
+  return LIFECYCLES[kind].transitions.filter((t) => t.from === currentState).map((t) => t.to);
+}
+
+/** Whether `from`→`to` is a transition that exists in `kind`'s graph at all (gate not evaluated here). */
+export function canTransition(kind: LifecycleKind, from: string, to: string): boolean {
+  return LIFECYCLES[kind].transitions.some((t) => t.from === from && t.to === to);
+}
+
+/** The gate name required for `from`→`to`, or null if the edge is ungated or does not exist. */
+export function requiredGate(kind: LifecycleKind, from: string, to: string): string | null {
+  const t = LIFECYCLES[kind].transitions.find((e) => e.from === from && e.to === to);
+  return t?.gate ?? null;
+}
+
+/** All valid state names for `kind` — used to validate stored records and CLI input. */
+export function statesOf(kind: LifecycleKind): string[] {
+  return LIFECYCLES[kind].states;
+}
+
+export function isKnownKind(value: string): value is LifecycleKind {
+  return value in LIFECYCLES;
+}

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -297,6 +297,18 @@ describe("TodoStore", () => {
     expect(s.list()).toHaveLength(N); // every task actually persisted, not clobbered
   }, 30_000);
 
+  it("a held id lock makes create() throw a timeout, never silently proceed unlocked (codex-review round-2 Critical)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const { mkdirSync: mkSync } = await import("fs");
+    const lockDir = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
+    mkSync(lockDir, { recursive: true }); // simulate another process holding the lock, freshly
+    await expect(s.create({ summary: "x", kind: "code" })).rejects.toThrow(/timed out waiting for/);
+    // and the lock must NOT have been deleted by the failed attempt (that
+    // would let a second unlocked caller in right after this one)
+    const { existsSync } = await import("fs");
+    expect(existsSync(lockDir)).toBe(true);
+  }, 15_000);
+
   it("verify() on a NON-primary registered gate must not fall back to the sibling on failure (codex-review Critical exploit: register only the failure-oriented gate)", async () => {
     const s = await openStore(TEST_ROOT);
     // Only "verify-red" (the SECOND/non-primary gated edge from "verifying")

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { rm } from "fs/promises";
 import path from "path";
-import { TodoStore, CycleError, openStore, acquireIdLock, releaseIdLock } from "./todoStore";
+import { TodoStore, CycleError, openStore } from "./todoStore";
 
 const isWindows = process.platform === "win32";
 const TEST_ROOT = isWindows
@@ -125,6 +125,31 @@ describe("TodoStore", () => {
     );
   });
 
+  it("verify() refuses to apply a transition if the task's state changed WHILE the (possibly slow) gate check was running (codex-review round-4 Critical)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    // "verify-red" resolves instantly and true, completing a REAL, valid
+    // gated transition (verifying -> verify-failed) via the public API —
+    // simulating a second, concurrent caller (a different process/agent)
+    // finishing its own verify() call for the SAME task while our
+    // "verify-green" check is still in flight.
+    s.registerGate({ name: "verify-red", check: async () => ({ passed: true }) });
+    s.registerGate({
+      name: "verify-green",
+      check: async () => {
+        await s.verify(t._id, "verify-red"); // the "concurrent" verify()
+        return { passed: true };
+      },
+    });
+    await expect(s.verify(t._id, "verify-green")).rejects.toThrow(
+      /state changed from "verifying" to "verify-failed"/,
+    );
+    expect(s.get(t._id)?.state).toBe("verify-failed"); // the concurrent verify()'s result stands; the stale one did NOT stomp it
+  });
+
   it("verify() with a passing registered gate moves to the gated state and records the gate name as validator", async () => {
     const s = await openStore(TEST_ROOT);
     s.registerGate({
@@ -158,6 +183,11 @@ describe("TodoStore", () => {
     const result = await s.verify(t._id);
     expect(result.state).toBe("verify-failed");
     expect(result.verifyEvidence.at(-1)?.note).toBe("canary red: 2 tests failed");
+    // the evidence entry names the SIBLING edge's own gate ("verify-red"),
+    // never the checked gate that actually reported not-passed
+    // ("verify-green") — an evidence entry means "this gate passed"
+    // (codex-review Important)
+    expect(result.verifyEvidence.at(-1)?.gate).toBe("verify-red");
   });
 
   it("verify-failed reopens ONLY back to doing, via a normal transition() call (real doing->verifying cycle preserved)", async () => {
@@ -310,41 +340,38 @@ describe("TodoStore", () => {
     expect(rf(lockPath, "utf8")).toBe("someone-elses-token"); // untouched — not stolen, not released
   }, 15_000);
 
-  it("acquireIdLock/releaseIdLock: release is ownership-safe — a stolen-then-reissued lock survives the ORIGINAL holder's release call (codex-review round-3 Critical)", async () => {
+  it("a live (fresh, non-stale) id lock held by someone else makes create() wait and then throw a clear timeout — proper-lockfile's own retry budget, never a silent unlocked proceed (codex-review round-4 Critical: id-lock now delegates entirely to proper-lockfile instead of a hand-rolled mkdir/token scheme)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const { lock: lockfileLock } = await import("proper-lockfile");
+    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl");
+    const release = await lockfileLock(lockPath, {
+      lockfilePath: `${lockPath}.idlock`,
+      realpath: false,
+      stale: 10_000,
+    });
+    try {
+      await expect(s.create({ summary: "x", kind: "code" })).rejects.toThrow(
+        /task id allocation: timed out waiting for the id lock/,
+      );
+    } finally {
+      await release();
+    }
+    // once released, create() succeeds normally
+    const rec = await s.create({ summary: "after release", kind: "code" });
+    expect(rec.summary).toBe("after release");
+  }, 20_000);
+
+  it("a STALE id lock (older than proper-lockfile's stale window) is recovered automatically — a crashed holder never wedges future create() calls", async () => {
+    const s = await openStore(TEST_ROOT);
     const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
-    const { mkdirSync: mkSync } = await import("fs");
-    mkSync(path.dirname(lockPath), { recursive: true });
-
-    const tokenA = await acquireIdLock(lockPath, { staleMs: 10_000 });
-    expect(tokenA).not.toBeNull();
-
-    // Simulate: tokenA's holder ran long enough to go stale; a second
-    // acquirer legitimately steals and reissues the lock under tokenB.
-    const { utimesSync } = await import("fs");
-    utimesSync(lockPath, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000));
-    const tokenB = await acquireIdLock(lockPath, { staleMs: 10_000 });
-    expect(tokenB).not.toBeNull();
-    expect(tokenB).not.toBe(tokenA);
-
-    // The ORIGINAL (stale) holder now reaches its own release call. Without
-    // the ownership check, this would delete tokenB's live lock.
-    releaseIdLock(lockPath, tokenA!);
-    const { readFileSync: rf } = await import("fs");
-    expect(rf(lockPath, "utf8")).toBe(tokenB); // tokenB's lock is untouched
-
-    // tokenB's own release, by contrast, DOES remove it (it still owns it).
-    releaseIdLock(lockPath, tokenB!);
-    const { existsSync } = await import("fs");
-    expect(existsSync(lockPath)).toBe(false);
-  });
-
-  it("acquireIdLock returns null (never throws, never proceeds) when the wait budget is exhausted against a live lock", async () => {
-    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
-    const { mkdirSync: mkSync, writeFileSync: wf } = await import("fs");
-    mkSync(path.dirname(lockPath), { recursive: true });
-    wf(lockPath, "someone-elses-fresh-token");
-    const result = await acquireIdLock(lockPath, { staleMs: 10_000, maxAttempts: 3 });
-    expect(result).toBeNull();
+    const { mkdirSync: mkSync, utimesSync } = await import("fs");
+    // proper-lockfile's own lock representation IS a directory (mkdir-based
+    // locking) — simulate a lock left behind by a crashed process the same
+    // way proper-lockfile itself would have created one.
+    mkSync(lockPath, { recursive: true });
+    utimesSync(lockPath, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000)); // well past the 10s stale window
+    const rec = await s.create({ summary: "after stale recovery", kind: "code" });
+    expect(rec.summary).toBe("after stale recovery");
   });
 
   it("verify() on a NON-primary registered gate must not fall back to the sibling on failure (codex-review Critical exploit: register only the failure-oriented gate)", async () => {

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -57,6 +57,15 @@ describe("TodoStore", () => {
     await expect(s.approve(t._id, "human-approved", "WORKER")).rejects.toThrow(
       /independent verification required/,
     );
+    // whitespace must not bypass the check either direction (codex-review Important)
+    await expect(s.approve(t._id, "human-approved", "worker ")).rejects.toThrow(
+      /independent verification required/,
+    );
+    const t2 = await s.create({ summary: "y", kind: "doc", owner: " worker " });
+    await s.transition(t2._id, "review");
+    await expect(s.approve(t2._id, "human-approved", "worker")).rejects.toThrow(
+      /independent verification required/,
+    );
   });
 
   it("approve() by a DIFFERENT identity succeeds, records evidence, and unblocks the transition", async () => {
@@ -245,5 +254,79 @@ describe("TodoStore", () => {
     const s2 = await openStore(TEST_ROOT);
     expect(s2.list().map((t) => t.summary)).toEqual(["persisted"]);
     expect(s2.get("T1")?._id).toBe("T1");
+  });
+
+  it("a cleared block ACTUALLY clears after a fresh reload — not just in the instance that cleared it (codex-review Critical)", async () => {
+    const s1 = await openStore(TEST_ROOT);
+    const t = await s1.create({ summary: "x", kind: "code" });
+    await s1.setBlock(t._id, { type: "blocked-by-human", who: "someone" });
+    await s1.setBlock(t._id, null);
+    // the bug: JSON.stringify({block: undefined}) drops the key, so the
+    // clearing update line carried no `block` field at all, and the merge
+    // `{...existing, ...doc}` left the OLD block value in place once a
+    // DIFFERENT (or freshly reloaded) instance read it back from disk.
+    const s2 = await openStore(TEST_ROOT);
+    expect(s2.get(t._id)?.block).toBeFalsy();
+  });
+
+  it("N concurrent OS processes calling create() against the same store never collide on an id (codex-review Critical)", async () => {
+    const N = 8;
+    const script = path.join(TEST_ROOT, "create-once.ts");
+    const { writeFileSync, mkdirSync } = await import("fs");
+    mkdirSync(TEST_ROOT, { recursive: true });
+    writeFileSync(
+      script,
+      `import { openStore } from ${JSON.stringify(path.join(import.meta.dirname, "todoStore.ts"))};\n` +
+        `const s = await openStore(${JSON.stringify(TEST_ROOT)});\n` +
+        `const t = await s.create({ summary: "concurrent", kind: "code" });\n` +
+        `console.log(t._id);\n`,
+    );
+    // node:child_process, not Bun.spawn — vitest here runs under the node matrix too
+    const { spawn } = await import("node:child_process");
+    const runOne = () =>
+      new Promise<string>((resolve, reject) => {
+        const p = spawn("bun", [script], { stdio: ["ignore", "pipe", "inherit"] });
+        let out = "";
+        p.stdout.on("data", (chunk) => (out += chunk.toString()));
+        p.on("error", reject);
+        p.on("close", () => resolve(out.trim()));
+      });
+    const outputs = await Promise.all(Array.from({ length: N }, runOne));
+    expect(new Set(outputs).size).toBe(N); // every id distinct — none silently overwritten
+    const s = await openStore(TEST_ROOT);
+    expect(s.list()).toHaveLength(N); // every task actually persisted, not clobbered
+  }, 30_000);
+
+  it("verify() on a NON-primary registered gate must not fall back to the sibling on failure (codex-review Critical exploit: register only the failure-oriented gate)", async () => {
+    const s = await openStore(TEST_ROOT);
+    // Only "verify-red" (the SECOND/non-primary gated edge from "verifying")
+    // is registered — "verify-green" (the primary edge, listed first in
+    // todoLifecycle.ts) is NOT. A naive "always fall back to the sibling on
+    // not-passed" implementation would read this false as license to reach
+    // the sibling edge, which happens to be "done".
+    s.registerGate({
+      name: "verify-red",
+      check: async () => ({ passed: false, note: "not confirmed red" }),
+    });
+    const t = await s.create({ summary: "x", kind: "code" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    await expect(s.verify(t._id)).rejects.toThrow(/non-primary gate.*not passed/);
+    expect(s.get(t._id)?.state).toBe("verifying"); // unchanged — definitely not "done"
+  });
+
+  it("verify() on a non-primary gate DOES apply its own edge when it reports passed", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({
+      name: "verify-red",
+      check: async () => ({ passed: true, note: "confirmed red" }),
+    });
+    const t = await s.create({ summary: "x", kind: "code" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const result = await s.verify(t._id);
+    expect(result.state).toBe("verify-failed");
   });
 });

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { rm } from "fs/promises";
 import path from "path";
-import { TodoStore, CycleError, openStore } from "./todoStore";
+import { TodoStore, CycleError, openStore, acquireIdLock, releaseIdLock } from "./todoStore";
 
 const isWindows = process.platform === "win32";
 const TEST_ROOT = isWindows
@@ -299,15 +299,53 @@ describe("TodoStore", () => {
 
   it("a held id lock makes create() throw a timeout, never silently proceed unlocked (codex-review round-2 Critical)", async () => {
     const s = await openStore(TEST_ROOT);
-    const { mkdirSync: mkSync } = await import("fs");
-    const lockDir = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
-    mkSync(lockDir, { recursive: true }); // simulate another process holding the lock, freshly
+    const { mkdirSync: mkSync, writeFileSync: wf } = await import("fs");
+    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
+    mkSync(path.dirname(lockPath), { recursive: true });
+    wf(lockPath, "someone-elses-token"); // simulate another process holding the lock, freshly
     await expect(s.create({ summary: "x", kind: "code" })).rejects.toThrow(/timed out waiting for/);
     // and the lock must NOT have been deleted by the failed attempt (that
     // would let a second unlocked caller in right after this one)
-    const { existsSync } = await import("fs");
-    expect(existsSync(lockDir)).toBe(true);
+    const { readFileSync: rf } = await import("fs");
+    expect(rf(lockPath, "utf8")).toBe("someone-elses-token"); // untouched — not stolen, not released
   }, 15_000);
+
+  it("acquireIdLock/releaseIdLock: release is ownership-safe — a stolen-then-reissued lock survives the ORIGINAL holder's release call (codex-review round-3 Critical)", async () => {
+    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
+    const { mkdirSync: mkSync } = await import("fs");
+    mkSync(path.dirname(lockPath), { recursive: true });
+
+    const tokenA = await acquireIdLock(lockPath, { staleMs: 10_000 });
+    expect(tokenA).not.toBeNull();
+
+    // Simulate: tokenA's holder ran long enough to go stale; a second
+    // acquirer legitimately steals and reissues the lock under tokenB.
+    const { utimesSync } = await import("fs");
+    utimesSync(lockPath, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000));
+    const tokenB = await acquireIdLock(lockPath, { staleMs: 10_000 });
+    expect(tokenB).not.toBeNull();
+    expect(tokenB).not.toBe(tokenA);
+
+    // The ORIGINAL (stale) holder now reaches its own release call. Without
+    // the ownership check, this would delete tokenB's live lock.
+    releaseIdLock(lockPath, tokenA!);
+    const { readFileSync: rf } = await import("fs");
+    expect(rf(lockPath, "utf8")).toBe(tokenB); // tokenB's lock is untouched
+
+    // tokenB's own release, by contrast, DOES remove it (it still owns it).
+    releaseIdLock(lockPath, tokenB!);
+    const { existsSync } = await import("fs");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("acquireIdLock returns null (never throws, never proceeds) when the wait budget is exhausted against a live lock", async () => {
+    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
+    const { mkdirSync: mkSync, writeFileSync: wf } = await import("fs");
+    mkSync(path.dirname(lockPath), { recursive: true });
+    wf(lockPath, "someone-elses-fresh-token");
+    const result = await acquireIdLock(lockPath, { staleMs: 10_000, maxAttempts: 3 });
+    expect(result).toBeNull();
+  });
 
   it("verify() on a NON-primary registered gate must not fall back to the sibling on failure (codex-review Critical exploit: register only the failure-oriented gate)", async () => {
     const s = await openStore(TEST_ROOT);

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { rm } from "fs/promises";
+import path from "path";
+import { TodoStore, CycleError, openStore } from "./todoStore";
+
+const isWindows = process.platform === "win32";
+const TEST_ROOT = isWindows
+  ? path.join(process.env.TEMP || "C:\\Temp", "todostore-test-" + process.pid)
+  : "/tmp/todostore-test-" + process.pid;
+
+describe("TodoStore", () => {
+  beforeEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("create() assigns sequential ids and the kind's initial state", async () => {
+    const s = await openStore(TEST_ROOT);
+    const a = await s.create({ summary: "write the spec", kind: "doc" });
+    const b = await s.create({ summary: "ship the feature", kind: "code" });
+    expect(a._id).toBe("T1");
+    expect(a.state).toBe("drafting");
+    expect(b._id).toBe("T2");
+    expect(b.state).toBe("doing");
+  });
+
+  it("transition() across an ungated edge succeeds with no approval needed", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    const moved = await s.transition(t._id, "merged");
+    expect(moved.state).toBe("merged");
+  });
+
+  it("transition() across a nonexistent edge is refused", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    await expect(s.transition(t._id, "done")).rejects.toThrow(/no transition/);
+  });
+
+  it("transition() across a gated edge is refused until the gate is satisfied", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    await expect(s.transition(t._id, "done")).rejects.toThrow(/requires gate "human-approved"/);
+  });
+
+  it("INDEPENDENT VERIFICATION: approve() refuses when the validator is the task's own owner (self-certification blocked)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    await expect(s.approve(t._id, "human-approved", "worker")).rejects.toThrow(
+      /independent verification required/,
+    );
+    // case-insensitive match
+    await expect(s.approve(t._id, "human-approved", "WORKER")).rejects.toThrow(
+      /independent verification required/,
+    );
+  });
+
+  it("approve() by a DIFFERENT identity succeeds, records evidence, and unblocks the transition", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    const approved = await s.approve(t._id, "human-approved", "reviewer", {
+      note: "looks good",
+      link: "https://example/pr/1",
+    });
+    expect(approved.satisfiedGates).toEqual(["human-approved"]);
+    expect(approved.verifyEvidence).toHaveLength(1);
+    expect(approved.verifyEvidence[0]).toMatchObject({
+      gate: "human-approved",
+      validator: "reviewer",
+      note: "looks good",
+      link: "https://example/pr/1",
+    });
+
+    const done = await s.transition(t._id, "done");
+    expect(done.state).toBe("done");
+    // the satisfied-gate flag is consumed by the transition — cannot be replayed
+    expect(done.satisfiedGates).toEqual([]);
+    // evidence is NOT duplicated: transition() does not append a second entry
+    expect(done.verifyEvidence).toHaveLength(1);
+  });
+
+  it("approve() with an empty owner allows any validator (nothing to compare against) but still requires one", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc" }); // no owner
+    await s.transition(t._id, "review");
+    const approved = await s.approve(t._id, "human-approved", "anyone");
+    expect(approved.satisfiedGates).toEqual(["human-approved"]);
+    await expect(s.approve(t._id, "human-approved", "")).rejects.toThrow(
+      /requires a validatorIdentity/,
+    );
+  });
+
+  it("approve() refuses a gate name that is not on any edge from the task's current state", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await expect(s.approve(t._id, "human-approved", "reviewer")).rejects.toThrow(
+      /not a gate on any transition/,
+    ); // still in "drafting"
+  });
+
+  it("REGISTERED gates cannot be satisfied by transition() OR approve() — only verify()", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({ name: "verify-green", check: async () => ({ passed: true }) });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    await expect(s.transition(t._id, "done")).rejects.toThrow(/registered gate.*verify\(/);
+    await expect(s.approve(t._id, "verify-green", "someone-else")).rejects.toThrow(
+      /cannot be approved manually/,
+    );
+  });
+
+  it("verify() with a passing registered gate moves to the gated state and records the gate name as validator", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({
+      name: "verify-green",
+      check: async () => ({ passed: true, note: "canary green", link: "https://ci/run/1" }),
+    });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const verified = await s.verify(t._id);
+    expect(verified.state).toBe("done");
+    expect(verified.verifyEvidence.at(-1)).toMatchObject({
+      gate: "verify-green",
+      validator: "gate:verify-green",
+      note: "canary green",
+      link: "https://ci/run/1",
+    });
+  });
+
+  it("verify() with a failing check takes the SIBLING edge (verify-failed), not done — the failure is a real distinct state, not silently dropped", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({
+      name: "verify-green",
+      check: async () => ({ passed: false, note: "canary red: 2 tests failed" }),
+    });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const result = await s.verify(t._id);
+    expect(result.state).toBe("verify-failed");
+    expect(result.verifyEvidence.at(-1)?.note).toBe("canary red: 2 tests failed");
+  });
+
+  it("verify-failed reopens ONLY back to doing, via a normal transition() call (real doing->verifying cycle preserved)", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({ name: "verify-green", check: async () => ({ passed: false }) });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const failed = await s.verify(t._id);
+    expect(failed.state).toBe("verify-failed");
+    const reopened = await s.transition(t._id, "doing");
+    expect(reopened.state).toBe("doing");
+    await expect(s.transition(t._id, "verifying")).rejects.toThrow(/no transition/); // must go through merged/shipped again
+    const remerged = await s.transition(t._id, "merged");
+    expect(remerged.state).toBe("merged");
+  });
+
+  it("verify() with no registered gate for the current state throws", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    await expect(s.verify(t._id)).rejects.toThrow(/no gated transition/); // still "doing", which has no gated outgoing edge
+  });
+
+  it("dep add/rm: sorted, deduped, rejects self-dep, missing target, and transitive cycles", async () => {
+    const s = await openStore(TEST_ROOT);
+    const a = await s.create({ summary: "a", kind: "code" });
+    const b = await s.create({ summary: "b", kind: "code" });
+    const c = await s.create({ summary: "c", kind: "code" });
+    await expect(s.addDep(a._id, a._id)).rejects.toThrow(/cannot depend on itself/);
+    await expect(s.addDep(a._id, "T99")).rejects.toThrow(/no such task/);
+    const added = await s.addDep(c._id, a._id);
+    expect(added.blockedBy).toEqual([a._id]);
+    await s.addDep(b._id, a._id);
+    await s.addDep(c._id, b._id);
+    // a <- b <- c  (c depends on both a and b); a depending on c would cycle
+    await expect(s.addDep(a._id, c._id)).rejects.toThrow(CycleError);
+    const removed = await s.rmDep(c._id, a._id);
+    expect(removed.blockedBy).toEqual([b._id]);
+  });
+
+  it("list() filters by kind/state/owner/tag/blocked", async () => {
+    const s = await openStore(TEST_ROOT);
+    await s.create({ summary: "a", kind: "code", owner: "Alice", tags: ["proj-x"] });
+    const b = await s.create({ summary: "b", kind: "doc" });
+    await s.setBlock(b._id, { type: "blocked-by-human", who: "bob" });
+    expect(s.list({ owner: "alice" }).map((t) => t.summary)).toEqual(["a"]); // case-insensitive
+    expect(s.list({ tag: "proj-x" }).map((t) => t.summary)).toEqual(["a"]);
+    expect(s.list({ kind: "doc" }).map((t) => t.summary)).toEqual(["b"]);
+    expect(s.list({ blocked: true }).map((t) => t.summary)).toEqual(["b"]);
+  });
+
+  it("a done task with a leftover block is not counted by --blocked (mirrors symval-dev-cli's equivalent fix)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "a", kind: "human" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "x" });
+    await s.approve(t._id, "human-replied", "x");
+    await s.transition(t._id, "decided");
+    await s.transition(t._id, "done");
+    expect(s.list({ blocked: true })).toEqual([]);
+  });
+
+  it("re-opening the store (new TodoStore.open call) sees writes made before it, including from a different instance", async () => {
+    const s1 = await openStore(TEST_ROOT);
+    await s1.create({ summary: "persisted", kind: "code" });
+    const s2 = await openStore(TEST_ROOT);
+    expect(s2.list().map((t) => t.summary)).toEqual(["persisted"]);
+    expect(s2.get("T1")?._id).toBe("T1");
+  });
+});

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -68,6 +68,20 @@ describe("TodoStore", () => {
     );
   });
 
+  it("CONCURRENT array-field mutations on the SAME task both land — neither addDep() silently overwrites the other's blockedBy write (codex-review round-5 Important)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const target = await s.create({ summary: "target", kind: "code" });
+    const blockerA = await s.create({ summary: "a", kind: "code" });
+    const blockerB = await s.create({ summary: "b", kind: "code" });
+    // Fired concurrently (both start before either awaits its own lock) —
+    // without the write lock serializing the reload-recompute-write cycle,
+    // whichever addDep() call's jsonl.updateById landed SECOND would have
+    // built its blockedBy array from a snapshot taken before the FIRST
+    // call's write, silently dropping it.
+    await Promise.all([s.addDep(target._id, blockerA._id), s.addDep(target._id, blockerB._id)]);
+    expect(s.get(target._id)?.blockedBy.sort()).toEqual([blockerA._id, blockerB._id].sort());
+  });
+
   it("approve() by a DIFFERENT identity succeeds, records evidence, and unblocks the transition", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
@@ -327,31 +341,18 @@ describe("TodoStore", () => {
     expect(s.list()).toHaveLength(N); // every task actually persisted, not clobbered
   }, 30_000);
 
-  it("a held id lock makes create() throw a timeout, never silently proceed unlocked (codex-review round-2 Critical)", async () => {
-    const s = await openStore(TEST_ROOT);
-    const { mkdirSync: mkSync, writeFileSync: wf } = await import("fs");
-    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
-    mkSync(path.dirname(lockPath), { recursive: true });
-    wf(lockPath, "someone-elses-token"); // simulate another process holding the lock, freshly
-    await expect(s.create({ summary: "x", kind: "code" })).rejects.toThrow(/timed out waiting for/);
-    // and the lock must NOT have been deleted by the failed attempt (that
-    // would let a second unlocked caller in right after this one)
-    const { readFileSync: rf } = await import("fs");
-    expect(rf(lockPath, "utf8")).toBe("someone-elses-token"); // untouched — not stolen, not released
-  }, 15_000);
-
-  it("a live (fresh, non-stale) id lock held by someone else makes create() wait and then throw a clear timeout — proper-lockfile's own retry budget, never a silent unlocked proceed (codex-review round-4 Critical: id-lock now delegates entirely to proper-lockfile instead of a hand-rolled mkdir/token scheme)", async () => {
+  it("a live (fresh, non-stale) write lock held by someone else makes create() wait and then throw a clear timeout — proper-lockfile's own retry budget, never a silent unlocked proceed (codex-review round-4 Critical: the store's write lock now delegates entirely to proper-lockfile instead of a hand-rolled mkdir/token scheme)", async () => {
     const s = await openStore(TEST_ROOT);
     const { lock: lockfileLock } = await import("proper-lockfile");
     const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl");
     const release = await lockfileLock(lockPath, {
-      lockfilePath: `${lockPath}.idlock`,
+      lockfilePath: `${lockPath}.writelock`,
       realpath: false,
       stale: 10_000,
     });
     try {
       await expect(s.create({ summary: "x", kind: "code" })).rejects.toThrow(
-        /task id allocation: timed out waiting for the id lock/,
+        /store write: timed out waiting for the write lock/,
       );
     } finally {
       await release();
@@ -361,9 +362,9 @@ describe("TodoStore", () => {
     expect(rec.summary).toBe("after release");
   }, 20_000);
 
-  it("a STALE id lock (older than proper-lockfile's stale window) is recovered automatically — a crashed holder never wedges future create() calls", async () => {
+  it("a STALE write lock (older than proper-lockfile's stale window) is recovered automatically — a crashed holder never wedges future create() calls", async () => {
     const s = await openStore(TEST_ROOT);
-    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.idlock");
+    const lockPath = path.join(TEST_ROOT, ".agent-yes", "todos.jsonl.writelock");
     const { mkdirSync: mkSync, utimesSync } = await import("fs");
     // proper-lockfile's own lock representation IS a directory (mkdir-based
     // locking) — simulate a lock left behind by a crashed process the same

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -173,6 +173,34 @@ describe("TodoStore", () => {
     await expect(s.verify(t._id)).rejects.toThrow(/no gated transition/); // still "doing", which has no gated outgoing edge
   });
 
+  it("verify() with an explicit gateName that matches no edge from the current state throws", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({ name: "verify-green", check: async () => ({ passed: true }) });
+    const t = await s.create({ summary: "x", kind: "code" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    await expect(s.verify(t._id, "no-such-gate")).rejects.toThrow(/no registered gate found/);
+  });
+
+  it("verify() failing with no sibling edge to fall back to throws instead of silently dropping the failure", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({
+      name: "human-approved",
+      check: async () => ({ passed: false, note: "not ready" }),
+    });
+    const t = await s.create({ summary: "x", kind: "doc" });
+    await s.transition(t._id, "review"); // "review" has ONE outgoing gated edge (to done) — no sibling
+    await expect(s.verify(t._id)).rejects.toThrow(/no alternate transition/);
+  });
+
+  it("isRegisteredGate reports registration status by name", async () => {
+    const s = await openStore(TEST_ROOT);
+    expect(s.isRegisteredGate("verify-green")).toBe(false);
+    s.registerGate({ name: "verify-green", check: async () => ({ passed: true }) });
+    expect(s.isRegisteredGate("verify-green")).toBe(true);
+  });
+
   it("dep add/rm: sorted, deduped, rejects self-dep, missing target, and transitive cycles", async () => {
     const s = await openStore(TEST_ROOT);
     const a = await s.create({ summary: "a", kind: "code" });

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -38,6 +38,7 @@
  * `registerGate` with its own check function (see `GateRegistration`).
  */
 
+import { mkdirSync, rmdirSync, statSync } from "fs";
 import path from "path";
 import { JsonlStore, type JsonlDoc } from "./JsonlStore.ts";
 import {
@@ -68,7 +69,8 @@ export interface TodoRecord extends JsonlDoc {
   description: string;
   /** A human name/handle, or a tracked agent's stable identifier. Opaque to this module. */
   owner?: string;
-  block?: TodoBlock;
+  /** `null` (not `undefined`) is the explicit "no block" value once a task has ever been blocked — JSON drops `undefined` keys entirely, so an update line with an omitted `block` would silently fail to clear a previous value on reload; `null` serializes and therefore actually overwrites (see `setBlock`). */
+  block?: TodoBlock | null;
   /** Task-id dependencies — separate from `block`: a task can both structurally depend on other tasks AND be separately blocked-by-human at the same time. */
   blockedBy: string[];
   tags: string[];
@@ -108,21 +110,66 @@ export class CycleError extends Error {}
 
 export class TodoStore {
   private jsonl: JsonlStore<Omit<TodoRecord, "_id">>;
+  private filePath: string;
   private gates = new Map<string, GateRegistration>();
-  private nextSeq = 1;
 
-  private constructor(jsonl: JsonlStore<Omit<TodoRecord, "_id">>) {
+  private constructor(jsonl: JsonlStore<Omit<TodoRecord, "_id">>, filePath: string) {
     this.jsonl = jsonl;
+    this.filePath = filePath;
   }
 
   static async open(projectRoot: string): Promise<TodoStore> {
     const filePath = path.join(projectRoot, ".agent-yes", "todos.jsonl");
     const jsonl = new JsonlStore<Omit<TodoRecord, "_id">>(filePath);
     await jsonl.load();
-    const store = new TodoStore(jsonl);
-    const existingIds = jsonl.getAll().map((d) => Number(String(d._id).replace(/^T/, "")) || 0);
-    store.nextSeq = (existingIds.length ? Math.max(...existingIds) : 0) + 1;
-    return store;
+    return new TodoStore(jsonl, filePath);
+  }
+
+  /**
+   * Exclusive, cross-process id-allocation lock (mkdir-based: `mkdirSync` is
+   * atomic, so exactly one caller anywhere wins the race). This exists
+   * because `_id` allocation ("max existing + 1") must happen atomically
+   * with the append that claims it — computing the id from a snapshot and
+   * appending afterward, even with `JsonlStore`'s own internal per-write
+   * lock, leaves a window where two processes compute the SAME next id from
+   * the same snapshot and then both append it; JsonlStore's "same `_id` →
+   * last line wins" merge would silently make one of those two tasks
+   * disappear (its create() line is superseded by the other's). This lock is
+   * a SEPARATE file from JsonlStore's own internal `<path>.lock` (used by
+   * `append`/`updateById`) — it only ever needs to be held around id
+   * selection, not every write, and deliberately does not touch JsonlStore's
+   * internals. A lock whose directory has existed longer than staleMs is
+   * stolen (a crashed process must not wedge every future create() call).
+   */
+  private async withIdLock<T>(fn: () => Promise<T>): Promise<T> {
+    const lockDir = `${this.filePath}.idlock`;
+    const staleMs = 10_000;
+    for (let attempt = 0; attempt < 200; attempt++) {
+      try {
+        mkdirSync(lockDir);
+        break;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+        try {
+          if (Date.now() - statSync(lockDir).mtimeMs > staleMs) {
+            rmdirSync(lockDir); // stale — steal and retry
+            continue;
+          }
+        } catch {
+          continue; // lock vanished between attempts — retry immediately
+        }
+        await new Promise((resolve) => setTimeout(resolve, 15));
+      }
+    }
+    try {
+      return await fn();
+    } finally {
+      try {
+        rmdirSync(lockDir);
+      } catch {
+        // already gone (e.g. stolen after we went stale) — nothing to release
+      }
+    }
   }
 
   registerGate(gate: GateRegistration): void {
@@ -155,8 +202,9 @@ export class TodoStore {
       if (filter.tag && !t.tags.some((x) => x.toLowerCase() === filter.tag!.toLowerCase()))
         return false;
       if (filter.blocked) {
-        const isBlocked =
-          t.state !== DONE_STATE && (t.block !== undefined || t.blockedBy.length > 0);
+        // `!= null` (not `!== undefined`): block is explicitly cleared to
+        // `null`, not left as `undefined`, so both must read as "no block"
+        const isBlocked = t.state !== DONE_STATE && (t.block != null || t.blockedBy.length > 0);
         if (!isBlocked) return false;
       }
       return true;
@@ -164,27 +212,37 @@ export class TodoStore {
   }
 
   async create(input: CreateInput): Promise<TodoRecord> {
-    const id = `T${this.nextSeq++}`;
-    const now = new Date().toISOString();
-    for (const dep of input.blockedBy ?? []) {
-      if (!this.get(dep)) throw new Error(`no such task: ${dep}`);
-    }
-    const doc: Omit<TodoRecord, "_id"> = {
-      kind: input.kind,
-      state: initialState(input.kind),
-      summary: input.summary,
-      description: input.description ?? "",
-      blockedBy: input.blockedBy ?? [],
-      tags: input.tags ?? [],
-      satisfiedGates: [],
-      verifyEvidence: [],
-      createdAt: now,
-      updatedAt: now,
-      ...(input.targetTier ? { targetTier: input.targetTier } : {}),
-      ...(input.owner ? { owner: input.owner } : {}),
-    };
-    await this.jsonl.append({ ...doc, _id: id });
-    return this.mustGet(id);
+    return this.withIdLock(async () => {
+      // Reload from disk WHILE holding the id lock: another process may have
+      // appended tasks since this instance last loaded, and the id must be
+      // computed from the freshest possible state or two concurrent create()
+      // calls could still agree on the same "next" id before either writes.
+      await this.jsonl.load();
+      const existingIds = this.jsonl
+        .getAll()
+        .map((d) => Number(String(d._id).replace(/^T/, "")) || 0);
+      const id = `T${(existingIds.length ? Math.max(...existingIds) : 0) + 1}`;
+      const now = new Date().toISOString();
+      for (const dep of input.blockedBy ?? []) {
+        if (!this.get(dep)) throw new Error(`no such task: ${dep}`);
+      }
+      const doc: Omit<TodoRecord, "_id"> = {
+        kind: input.kind,
+        state: initialState(input.kind),
+        summary: input.summary,
+        description: input.description ?? "",
+        blockedBy: input.blockedBy ?? [],
+        tags: input.tags ?? [],
+        satisfiedGates: [],
+        verifyEvidence: [],
+        createdAt: now,
+        updatedAt: now,
+        ...(input.targetTier ? { targetTier: input.targetTier } : {}),
+        ...(input.owner ? { owner: input.owner } : {}),
+      };
+      await this.jsonl.append({ ...doc, _id: id });
+      return this.mustGet(id);
+    });
   }
 
   /**
@@ -237,7 +295,12 @@ export class TodoStore {
     evidence?: { note?: string; link?: string },
   ): Promise<TodoRecord> {
     const rec = this.mustGet(id);
-    if (!validatorIdentity.trim()) {
+    // Trim ONCE, up front, and use this value everywhere below — comparing a
+    // trimmed owner against an untrimmed validatorIdentity (or vice versa)
+    // would let "worker" vs "worker " sneak past the self-certification
+    // check, and would also record untrimmed noise in the audit trail.
+    const validator = validatorIdentity.trim();
+    if (!validator) {
       throw new Error(
         `task ${id}: approve() requires a validatorIdentity (who is satisfying "${gateName}")`,
       );
@@ -255,9 +318,9 @@ export class TodoStore {
         `task ${id}: "${gateName}" is not a gate on any transition from its current state "${rec.state}"`,
       );
     }
-    if (rec.owner && rec.owner.toLowerCase() === validatorIdentity.toLowerCase()) {
+    if (rec.owner && rec.owner.trim().toLowerCase() === validator.toLowerCase()) {
       throw new Error(
-        `task ${id}: independent verification required — validator "${validatorIdentity}" is the same identity as owner "${rec.owner}"; the worker cannot certify their own work`,
+        `task ${id}: independent verification required — validator "${validator}" is the same identity as owner "${rec.owner}"; the worker cannot certify their own work`,
       );
     }
     const satisfied = new Set(rec.satisfiedGates);
@@ -265,7 +328,7 @@ export class TodoStore {
     const evidenceEntry: GateEvidence = {
       gate: gateName,
       passedAt: new Date().toISOString(),
-      validator: validatorIdentity,
+      validator,
       ...evidence,
     };
     await this.jsonl.updateById(id, {
@@ -279,11 +342,25 @@ export class TodoStore {
   /**
    * Run a registered gate's check function and, based on its result, apply
    * whichever transition out of the task's current state that gate governs.
-   * If the check reports NOT passed, and there is a sibling transition from
-   * the same state (e.g. the `code` kind's `verifying -> verify-failed`
-   * alongside `verifying -> done`), that sibling is taken instead — this is
-   * how a single automated check naturally produces the kind's real
-   * pass/fail states without hardcoding kind-specific names here.
+   *
+   * The PRIMARY edge from a state is, by this graph's declaration-order
+   * convention (see `todoLifecycle.ts` — e.g. `code`'s `verifying` state
+   * lists `verify-green` before `verify-red`), the first gated edge. Only a
+   * check registered against the primary edge may fall back to a sibling
+   * edge on a not-passed result (e.g. `verifying -> verify-failed` alongside
+   * `verifying -> done`) — this is how a single automated check naturally
+   * produces the kind's real pass/fail states without hardcoding
+   * kind-specific gate names here.
+   *
+   * A check registered against a NON-primary edge (e.g. a project that
+   * registers "verify-red" instead of "verify-green") must itself report
+   * `passed: true` to take its own edge; if it reports not-passed, this
+   * throws rather than falling back to the sibling. A secondary/failure-
+   * oriented gate reporting "not passed" only means "the specific bad thing
+   * this check looks for did not happen" — that is a strictly weaker claim
+   * than "verified good," and silently treating it as license to reach a
+   * possibly `done`-bound sibling would be exactly the kind of unverified
+   * done state this whole module exists to prevent.
    */
   async verify(id: string, gateName?: string): Promise<TodoRecord> {
     const rec = this.mustGet(id);
@@ -303,6 +380,7 @@ export class TodoStore {
       throw new Error(
         `task ${id}: gate "${targetEdge.gate}" is not registered — call registerGate() first`,
       );
+    const isPrimaryEdge = edges[0] === targetEdge;
     const result = await impl.check();
     if (result.passed) {
       // The gate's own name stands in for "validator" — a registered check is,
@@ -314,6 +392,11 @@ export class TodoStore {
         note: result.note,
         link: result.link,
       });
+    }
+    if (!isPrimaryEdge) {
+      throw new Error(
+        `task ${id}: gate "${targetEdge.gate}" (a non-primary gate on this state) reported not passed — this alone is not evidence of success, so no transition was applied. Register and satisfy the primary gate for this state instead.`,
+      );
     }
     const sibling = edges.find((e) => e !== targetEdge);
     if (!sibling) {
@@ -356,7 +439,11 @@ export class TodoStore {
   }
 
   setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {
-    return this.rawUpdate(id, { block: block ?? undefined });
+    // `null`, never `undefined`: JSON.stringify drops `undefined` keys
+    // entirely, so an update line with an omitted `block` would fail to
+    // clear a previously-set value once merged on reload (see the field
+    // doc comment on TodoRecord.block).
+    return this.rawUpdate(id, { block });
   }
 
   async addDep(id: string, blockerId: string): Promise<TodoRecord> {

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -144,9 +144,11 @@ export class TodoStore {
   private async withIdLock<T>(fn: () => Promise<T>): Promise<T> {
     const lockDir = `${this.filePath}.idlock`;
     const staleMs = 10_000;
+    let acquired = false;
     for (let attempt = 0; attempt < 200; attempt++) {
       try {
         mkdirSync(lockDir);
+        acquired = true;
         break;
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
@@ -160,6 +162,16 @@ export class TodoStore {
         }
         await new Promise((resolve) => setTimeout(resolve, 15));
       }
+    }
+    // Falling through the loop without ever acquiring the lock must NOT
+    // silently proceed unlocked (codex-review Critical): with 200 attempts at
+    // a ~15ms backoff (~3s worst case) against a 10s staleMs, a legitimately
+    // long-held lock would previously let this caller both run the critical
+    // section AND rmdirSync the other holder's still-live lock in `finally`.
+    if (!acquired) {
+      throw new Error(
+        `task id allocation: timed out waiting for ${lockDir} (held by another process for over ~3s)`,
+      );
     }
     try {
       return await fn();

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -38,7 +38,7 @@
  * `registerGate` with its own check function (see `GateRegistration`).
  */
 
-import { mkdirSync, rmdirSync, statSync } from "fs";
+import { readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import path from "path";
 import { JsonlStore, type JsonlDoc } from "./JsonlStore.ts";
 import {
@@ -108,6 +108,47 @@ export interface GateRegistration {
 
 export class CycleError extends Error {}
 
+/**
+ * Ownership-safe file lock, extracted as standalone functions (rather than
+ * inlined where they're used) so the release-only-if-still-owned invariant
+ * is directly unit-testable without going through a full `create()` call —
+ * the same reason this repo's `notifyStore.ts` extracts `shouldStealLock`.
+ * See `TodoStore.withIdLock`'s doc comment for why this exists at all.
+ */
+export async function acquireIdLock(
+  lockPath: string,
+  opts: { staleMs: number; maxAttempts?: number },
+): Promise<string | null> {
+  const token = `${process.pid}:${Math.random().toString(36).slice(2, 10)}`;
+  for (let attempt = 0; attempt < (opts.maxAttempts ?? 200); attempt++) {
+    try {
+      writeFileSync(lockPath, token, { flag: "wx" });
+      return token;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > opts.staleMs) {
+          rmSync(lockPath, { force: true }); // stale — steal and retry
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between attempts — retry immediately
+      }
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    }
+  }
+  return null;
+}
+
+/** Release ONLY while `lockPath` still contains `token` — never delete a lock some other holder has since acquired. */
+export function releaseIdLock(lockPath: string, token: string): void {
+  try {
+    if (readFileSync(lockPath, "utf8") === token) rmSync(lockPath, { force: true });
+  } catch {
+    // already gone — nothing to release
+  }
+}
+
 export class TodoStore {
   private jsonl: JsonlStore<Omit<TodoRecord, "_id">>;
   private filePath: string;
@@ -126,10 +167,9 @@ export class TodoStore {
   }
 
   /**
-   * Exclusive, cross-process id-allocation lock (mkdir-based: `mkdirSync` is
-   * atomic, so exactly one caller anywhere wins the race). This exists
-   * because `_id` allocation ("max existing + 1") must happen atomically
-   * with the append that claims it — computing the id from a snapshot and
+   * Exclusive, cross-process, OWNERSHIP-SAFE id-allocation lock. This exists
+   * because `_id` allocation ("max existing + 1") must happen atomically with
+   * the append that claims it — computing the id from a snapshot and
    * appending afterward, even with `JsonlStore`'s own internal per-write
    * lock, leaves a window where two processes compute the SAME next id from
    * the same snapshot and then both append it; JsonlStore's "same `_id` →
@@ -138,49 +178,36 @@ export class TodoStore {
    * a SEPARATE file from JsonlStore's own internal `<path>.lock` (used by
    * `append`/`updateById`) — it only ever needs to be held around id
    * selection, not every write, and deliberately does not touch JsonlStore's
-   * internals. A lock whose directory has existed longer than staleMs is
-   * stolen (a crashed process must not wedge every future create() call).
+   * internals.
+   *
+   * Ownership-safe: the lock file's content is a random token unique to this
+   * acquisition. A lock older than `staleMs` is stolen (so a crashed holder
+   * cannot wedge every future create() call), but release ALWAYS re-checks
+   * that the file still contains OUR token before removing it. Without this
+   * check, a holder that merely ran slow (contention, not a crash) for
+   * longer than `staleMs` would have its still-live lock stolen by another
+   * process, and then — on finally reaching its own release — delete that
+   * NEW holder's lock, breaking exclusivity for a third caller. (This is the
+   * exact class of bug already fixed once in this lock's first draft, and
+   * independently in a downstream closed-source consumer's own lockfile.)
    */
   private async withIdLock<T>(fn: () => Promise<T>): Promise<T> {
-    const lockDir = `${this.filePath}.idlock`;
-    const staleMs = 10_000;
-    let acquired = false;
-    for (let attempt = 0; attempt < 200; attempt++) {
-      try {
-        mkdirSync(lockDir);
-        acquired = true;
-        break;
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-        try {
-          if (Date.now() - statSync(lockDir).mtimeMs > staleMs) {
-            rmdirSync(lockDir); // stale — steal and retry
-            continue;
-          }
-        } catch {
-          continue; // lock vanished between attempts — retry immediately
-        }
-        await new Promise((resolve) => setTimeout(resolve, 15));
-      }
-    }
-    // Falling through the loop without ever acquiring the lock must NOT
-    // silently proceed unlocked (codex-review Critical): with 200 attempts at
-    // a ~15ms backoff (~3s worst case) against a 10s staleMs, a legitimately
-    // long-held lock would previously let this caller both run the critical
-    // section AND rmdirSync the other holder's still-live lock in `finally`.
-    if (!acquired) {
+    const lockPath = `${this.filePath}.idlock`;
+    const token = await acquireIdLock(lockPath, { staleMs: 10_000 });
+    // Falling through without ever acquiring the lock must NOT silently
+    // proceed unlocked: with the default ~3s worst-case wait against a 10s
+    // staleMs, a legitimately long-held lock would otherwise let this caller
+    // both run the critical section AND (without the ownership check in
+    // releaseIdLock) delete the other holder's still-live lock.
+    if (token === null) {
       throw new Error(
-        `task id allocation: timed out waiting for ${lockDir} (held by another process for over ~3s)`,
+        `task id allocation: timed out waiting for ${lockPath} (held by another process for over ~3s)`,
       );
     }
     try {
       return await fn();
     } finally {
-      try {
-        rmdirSync(lockDir);
-      } catch {
-        // already gone (e.g. stolen after we went stale) — nothing to release
-      }
+      releaseIdLock(lockPath, token);
     }
   }
 

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -38,8 +38,8 @@
  * `registerGate` with its own check function (see `GateRegistration`).
  */
 
-import { readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import path from "path";
+import { lock } from "proper-lockfile";
 import { JsonlStore, type JsonlDoc } from "./JsonlStore.ts";
 import {
   DONE_STATE,
@@ -108,47 +108,6 @@ export interface GateRegistration {
 
 export class CycleError extends Error {}
 
-/**
- * Ownership-safe file lock, extracted as standalone functions (rather than
- * inlined where they're used) so the release-only-if-still-owned invariant
- * is directly unit-testable without going through a full `create()` call —
- * the same reason this repo's `notifyStore.ts` extracts `shouldStealLock`.
- * See `TodoStore.withIdLock`'s doc comment for why this exists at all.
- */
-export async function acquireIdLock(
-  lockPath: string,
-  opts: { staleMs: number; maxAttempts?: number },
-): Promise<string | null> {
-  const token = `${process.pid}:${Math.random().toString(36).slice(2, 10)}`;
-  for (let attempt = 0; attempt < (opts.maxAttempts ?? 200); attempt++) {
-    try {
-      writeFileSync(lockPath, token, { flag: "wx" });
-      return token;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-      try {
-        if (Date.now() - statSync(lockPath).mtimeMs > opts.staleMs) {
-          rmSync(lockPath, { force: true }); // stale — steal and retry
-          continue;
-        }
-      } catch {
-        continue; // lock vanished between attempts — retry immediately
-      }
-      await new Promise((resolve) => setTimeout(resolve, 15));
-    }
-  }
-  return null;
-}
-
-/** Release ONLY while `lockPath` still contains `token` — never delete a lock some other holder has since acquired. */
-export function releaseIdLock(lockPath: string, token: string): void {
-  try {
-    if (readFileSync(lockPath, "utf8") === token) rmSync(lockPath, { force: true });
-  } catch {
-    // already gone — nothing to release
-  }
-}
-
 export class TodoStore {
   private jsonl: JsonlStore<Omit<TodoRecord, "_id">>;
   private filePath: string;
@@ -167,47 +126,62 @@ export class TodoStore {
   }
 
   /**
-   * Exclusive, cross-process, OWNERSHIP-SAFE id-allocation lock. This exists
-   * because `_id` allocation ("max existing + 1") must happen atomically with
-   * the append that claims it — computing the id from a snapshot and
-   * appending afterward, even with `JsonlStore`'s own internal per-write
-   * lock, leaves a window where two processes compute the SAME next id from
-   * the same snapshot and then both append it; JsonlStore's "same `_id` →
-   * last line wins" merge would silently make one of those two tasks
-   * disappear (its create() line is superseded by the other's). This lock is
-   * a SEPARATE file from JsonlStore's own internal `<path>.lock` (used by
-   * `append`/`updateById`) — it only ever needs to be held around id
-   * selection, not every write, and deliberately does not touch JsonlStore's
-   * internals.
+   * Exclusive, cross-process id-allocation lock, delegated ENTIRELY to
+   * `proper-lockfile` (already a dependency here — `JsonlStore` itself uses
+   * it for `append`/`updateById`) rather than hand-rolled.
    *
-   * Ownership-safe: the lock file's content is a random token unique to this
-   * acquisition. A lock older than `staleMs` is stolen (so a crashed holder
-   * cannot wedge every future create() call), but release ALWAYS re-checks
-   * that the file still contains OUR token before removing it. Without this
-   * check, a holder that merely ran slow (contention, not a crash) for
-   * longer than `staleMs` would have its still-live lock stolen by another
-   * process, and then — on finally reaching its own release — delete that
-   * NEW holder's lock, breaking exclusivity for a third caller. (This is the
-   * exact class of bug already fixed once in this lock's first draft, and
-   * independently in a downstream closed-source consumer's own lockfile.)
+   * This exists because `_id` allocation ("max existing + 1") must happen
+   * atomically with the append that claims it — computing the id from a
+   * snapshot and appending afterward, even with JsonlStore's own internal
+   * per-write lock, leaves a window where two processes compute the SAME
+   * next id from the same snapshot and then both append it; JsonlStore's
+   * "same `_id` → last line wins" merge would silently make one of those two
+   * tasks disappear. A SEPARATE lockfile path (`<path>.idlock`, distinct from
+   * JsonlStore's own internal `<path>.lock`) guards only id selection, not
+   * every write.
+   *
+   * Two hand-rolled attempts at this lock (a plain mkdir-based lock, then a
+   * token-in-file "ownership-safe" variant) each independently rediscovered
+   * why advisory file locks are hard to get right from scratch: the second
+   * attempt's own stale-lock steal path — read the stale mtime, THEN
+   * separately unlink and recreate — has a time-of-check-to-time-of-use gap
+   * where a DIFFERENT waiter's fresh acquisition can land in between, so the
+   * first waiter's unlink (issued against what it still believes is the
+   * stale file) deletes that second waiter's live lock instead. `proper-
+   * lockfile` solves exactly this class of problem (atomic directory-based
+   * locking, its own carefully-reasoned staleness/compromise handling) and
+   * is already trusted elsewhere in this same file — reusing it here instead
+   * of a third from-scratch attempt is the correct fix, not another patch.
    */
   private async withIdLock<T>(fn: () => Promise<T>): Promise<T> {
-    const lockPath = `${this.filePath}.idlock`;
-    const token = await acquireIdLock(lockPath, { staleMs: 10_000 });
-    // Falling through without ever acquiring the lock must NOT silently
-    // proceed unlocked: with the default ~3s worst-case wait against a 10s
-    // staleMs, a legitimately long-held lock would otherwise let this caller
-    // both run the critical section AND (without the ownership check in
-    // releaseIdLock) delete the other holder's still-live lock.
-    if (token === null) {
+    let release: (() => Promise<void>) | undefined;
+    try {
+      // Lock `this.filePath` itself (the todos.jsonl FILE), not its
+      // containing directory — JsonlStore's own internal lock (used by
+      // append/updateById, invoked from inside `fn()` below) locks the
+      // DIRECTORY. proper-lockfile's internal bookkeeping keys by the `file`
+      // argument's resolved path, so locking the same directory for two
+      // independent purposes from the same process caused a spurious "Lock
+      // is not acquired/owned by you" on release; locking a distinct target
+      // (the file) avoids that collision entirely. `realpath: false` because
+      // this file may not exist yet on a brand-new store (JsonlStore only
+      // creates it on the first append) and default realpath resolution
+      // would fail on a nonexistent path.
+      release = await lock(this.filePath, {
+        lockfilePath: `${this.filePath}.idlock`,
+        realpath: false,
+        stale: 10_000,
+        retries: { retries: 200, minTimeout: 15, maxTimeout: 15 },
+      });
+    } catch (err) {
       throw new Error(
-        `task id allocation: timed out waiting for ${lockPath} (held by another process for over ~3s)`,
+        `task id allocation: timed out waiting for the id lock (${err instanceof Error ? err.message : String(err)})`,
       );
     }
     try {
       return await fn();
     } finally {
-      releaseIdLock(lockPath, token);
+      await release();
     }
   }
 
@@ -420,7 +394,24 @@ export class TodoStore {
         `task ${id}: gate "${targetEdge.gate}" is not registered — call registerGate() first`,
       );
     const isPrimaryEdge = edges[0] === targetEdge;
-    const result = await impl.check();
+    const stateAtCheckStart = rec.state;
+    const result = await impl.check(); // may be slow (a real CI/QA system) — the task's state can change while this runs
+    // Re-fetch and refuse to apply a transition computed against a state the
+    // task may no longer be in: `impl.check()` can take an arbitrarily long
+    // time (a real external system), and another writer (a concurrent
+    // transition/verify/approve) can change the task's state during that
+    // window. Applying targetEdge/sibling's `.to` regardless would silently
+    // move the task across an edge that may no longer even exist from its
+    // CURRENT state, bypassing the lifecycle graph entirely (codex-review
+    // Critical). This does not need its own lock — it is a staleness
+    // precondition on the write, not a mutual-exclusion problem — but it
+    // does need to be checked AFTER the await, immediately before writing.
+    const current = this.mustGet(id);
+    if (current.state !== stateAtCheckStart) {
+      throw new Error(
+        `task ${id}: state changed from "${stateAtCheckStart}" to "${current.state}" while gate "${targetEdge.gate}" was being checked — refusing to apply a transition computed against the old state; re-run verify()`,
+      );
+    }
     if (result.passed) {
       // The gate's own name stands in for "validator" — a registered check is,
       // by construction, an independent system distinct from the worker, so
@@ -443,10 +434,17 @@ export class TodoStore {
         `task ${id}: gate "${targetEdge.gate}" reported not passed and there is no alternate transition to record it against`,
       );
     }
+    // Record the SIBLING's own gate name as evidence (falling back to
+    // targetEdge's name only if the sibling declares none) — `verifyEvidence`
+    // entries are meant to be read as "this gate passed"; attributing this
+    // entry to targetEdge.gate (which reported NOT passed) would let a
+    // downstream reader scanning evidence by gate name misread a failed
+    // check as successful evidence for that gate (codex-review Important).
     return this.applyTransition(id, sibling.to, {
-      gate: targetEdge.gate,
+      // non-null: `edges` was filtered to only entries with a truthy `gate`
+      gate: sibling.gate!,
       validator: `gate:${targetEdge.gate}`,
-      note: result.note ?? "gate reported not passed",
+      note: result.note ?? `gate "${targetEdge.gate}" reported not passed`,
       link: result.link,
     });
   }

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -126,34 +126,54 @@ export class TodoStore {
   }
 
   /**
-   * Exclusive, cross-process id-allocation lock, delegated ENTIRELY to
+   * Exclusive, cross-process, whole-store write lock, delegated ENTIRELY to
    * `proper-lockfile` (already a dependency here — `JsonlStore` itself uses
    * it for `append`/`updateById`) rather than hand-rolled.
    *
-   * This exists because `_id` allocation ("max existing + 1") must happen
-   * atomically with the append that claims it — computing the id from a
-   * snapshot and appending afterward, even with JsonlStore's own internal
-   * per-write lock, leaves a window where two processes compute the SAME
-   * next id from the same snapshot and then both append it; JsonlStore's
-   * "same `_id` → last line wins" merge would silently make one of those two
-   * tasks disappear. A SEPARATE lockfile path (`<path>.idlock`, distinct from
-   * JsonlStore's own internal `<path>.lock`) guards only id selection, not
-   * every write.
+   * EVERY mutating method (`create`, `transition`/`applyTransition`,
+   * `approve`, `setBlock`, `addDep`, `rmDep`) runs its "reload from disk,
+   * recompute from the FRESH record, write" sequence entirely inside this
+   * lock. Two motivating races, both real and both found by review:
    *
-   * Two hand-rolled attempts at this lock (a plain mkdir-based lock, then a
-   * token-in-file "ownership-safe" variant) each independently rediscovered
-   * why advisory file locks are hard to get right from scratch: the second
-   * attempt's own stale-lock steal path — read the stale mtime, THEN
-   * separately unlink and recreate — has a time-of-check-to-time-of-use gap
-   * where a DIFFERENT waiter's fresh acquisition can land in between, so the
-   * first waiter's unlink (issued against what it still believes is the
-   * stale file) deletes that second waiter's live lock instead. `proper-
-   * lockfile` solves exactly this class of problem (atomic directory-based
-   * locking, its own carefully-reasoned staleness/compromise handling) and
-   * is already trusted elsewhere in this same file — reusing it here instead
-   * of a third from-scratch attempt is the correct fix, not another patch.
+   *   - `_id` allocation ("max existing + 1") must happen atomically with
+   *     the append that claims it — computing the id from a snapshot and
+   *     appending afterward, even with JsonlStore's own internal per-write
+   *     lock, leaves a window where two processes compute the SAME next id
+   *     from the same snapshot and then both append it; JsonlStore's "same
+   *     `_id` → last line wins" merge would silently make one of those two
+   *     tasks disappear.
+   *   - Every other mutator reads a record's array fields (`verifyEvidence`,
+   *     `satisfiedGates`, `blockedBy`) to build a new array and writes that
+   *     whole array back. Without a lock, two concurrent mutations on the
+   *     SAME task (e.g. two `approve()` calls, or an `approve()` racing a
+   *     `verify()`) each compute their patch from a snapshot taken before
+   *     either write lands; whichever write reaches JsonlStore SECOND
+   *     silently overwrites the first one's array contents (JsonlStore's
+   *     merge replaces whole fields, it does not merge array elements) —
+   *     losing gate evidence or a satisfied-gate flag with no error at all.
+   *
+   * This lock is intentionally coarse (the WHOLE store, not per-task): a
+   * per-task lock would need its own bookkeeping to avoid deadlock and
+   * leaks, for a local, low-throughput CLI tool where store-wide
+   * serialization of these fast (disk-only) critical sections has no
+   * meaningful cost. The one thing that must NEVER happen inside this lock
+   * is an arbitrarily slow external call (`verify()`'s `impl.check()`,
+   * which can be a real CI/QA system taking minutes) — that stays outside;
+   * only the fast reload-check-write that follows it is lock-protected.
+   *
+   * Two hand-rolled attempts at a narrower (id-only) version of this lock (a
+   * plain mkdir-based lock, then a token-in-file "ownership-safe" variant)
+   * each independently rediscovered why advisory file locks are hard to get
+   * right from scratch: the second attempt's own stale-lock steal path —
+   * read the stale mtime, THEN separately unlink and recreate — has a
+   * time-of-check-to-time-of-use gap where a DIFFERENT waiter's fresh
+   * acquisition can land in between, so the first waiter's unlink (issued
+   * against what it still believes is the stale file) deletes that second
+   * waiter's live lock instead. `proper-lockfile` solves exactly this class
+   * of problem and is already trusted elsewhere in this same file — reusing
+   * it here instead of a third from-scratch attempt is the correct fix.
    */
-  private async withIdLock<T>(fn: () => Promise<T>): Promise<T> {
+  private async withStoreLock<T>(fn: () => Promise<T>): Promise<T> {
     let release: (() => Promise<void>) | undefined;
     try {
       // Lock `this.filePath` itself (the todos.jsonl FILE), not its
@@ -168,14 +188,14 @@ export class TodoStore {
       // creates it on the first append) and default realpath resolution
       // would fail on a nonexistent path.
       release = await lock(this.filePath, {
-        lockfilePath: `${this.filePath}.idlock`,
+        lockfilePath: `${this.filePath}.writelock`,
         realpath: false,
         stale: 10_000,
         retries: { retries: 200, minTimeout: 15, maxTimeout: 15 },
       });
     } catch (err) {
       throw new Error(
-        `task id allocation: timed out waiting for the id lock (${err instanceof Error ? err.message : String(err)})`,
+        `store write: timed out waiting for the write lock (${err instanceof Error ? err.message : String(err)})`,
       );
     }
     try {
@@ -225,7 +245,7 @@ export class TodoStore {
   }
 
   async create(input: CreateInput): Promise<TodoRecord> {
-    return this.withIdLock(async () => {
+    return this.withStoreLock(async () => {
       // Reload from disk WHILE holding the id lock: another process may have
       // appended tasks since this instance last loaded, and the id must be
       // computed from the freshest possible state or two concurrent create()
@@ -263,6 +283,14 @@ export class TodoStore {
    * already been satisfied via `approve()`. Throws — refusing the write
    * entirely — for an edge with no such edge in the graph, or a gate that is
    * either registered (must go through `verify()`) or not yet satisfied.
+   *
+   * The check below (against `this.mustGet(id)`, a possibly-stale snapshot)
+   * is a fast, cheap, EARLY rejection for an obviously-invalid call — it is
+   * NOT the source of correctness. `applyTransition`'s `precondition`
+   * callback re-runs the SAME check against a record reloaded from disk
+   * while holding the write lock, immediately before writing, so a
+   * concurrent mutation that changed the state or consumed the gate between
+   * this early check and the lock being acquired is still caught.
    */
   async transition(id: string, toState: string): Promise<TodoRecord> {
     const rec = this.mustGet(id);
@@ -272,22 +300,26 @@ export class TodoStore {
       );
     }
     const gate = requiredGate(rec.kind, rec.state, toState);
-    if (gate) {
-      if (this.gates.has(gate)) {
-        throw new Error(
-          `task ${id}: "${gate}" is a registered gate — it can only be satisfied by verify("${id}"), not a direct transition`,
-        );
-      }
-      if (!rec.satisfiedGates.includes(gate)) {
-        throw new Error(
-          `task ${id}: transition ${rec.state} -> ${toState} requires gate "${gate}" — call approve("${id}", "${gate}") first`,
-        );
-      }
+    if (gate && this.gates.has(gate)) {
+      throw new Error(
+        `task ${id}: "${gate}" is a registered gate — it can only be satisfied by verify("${id}"), not a direct transition`,
+      );
     }
     // No new evidence entry here: approve() already recorded one (with the
     // independently-verified validator identity) at approval time. This call
     // only consumes the satisfied-gate flag so it cannot be replayed.
-    return this.applyTransition(id, toState, undefined, gate);
+    return this.applyTransition(id, toState, undefined, gate, (fresh) => {
+      if (!canTransition(fresh.kind, fresh.state, toState)) {
+        throw new Error(
+          `task ${id}: no transition ${fresh.state} -> ${toState} for kind "${fresh.kind}" (state changed concurrently)`,
+        );
+      }
+      if (gate && !fresh.satisfiedGates.includes(gate)) {
+        throw new Error(
+          `task ${id}: transition ${fresh.state} -> ${toState} requires gate "${gate}", which is no longer satisfied (consumed or reset by a concurrent write) — call approve("${id}", "${gate}") again`,
+        );
+      }
+    });
   }
 
   /**
@@ -307,7 +339,6 @@ export class TodoStore {
     validatorIdentity: string,
     evidence?: { note?: string; link?: string },
   ): Promise<TodoRecord> {
-    const rec = this.mustGet(id);
     // Trim ONCE, up front, and use this value everywhere below — comparing a
     // trimmed owner against an untrimmed validatorIdentity (or vice versa)
     // would let "worker" vs "worker " sneak past the self-certification
@@ -323,33 +354,43 @@ export class TodoStore {
         `task ${id}: "${gateName}" is a registered gate and cannot be approved manually — it is satisfied by verify("${id}")`,
       );
     }
-    const onGraph = LIFECYCLES[rec.kind].transitions.some(
-      (t) => t.from === rec.state && t.gate === gateName,
-    );
-    if (!onGraph) {
-      throw new Error(
-        `task ${id}: "${gateName}" is not a gate on any transition from its current state "${rec.state}"`,
+    return this.withStoreLock(async () => {
+      // Reload + re-fetch WHILE holding the lock: verifyEvidence/
+      // satisfiedGates are arrays rebuilt from the current record and
+      // written back whole, so building them from a stale snapshot would
+      // silently drop a concurrent write to the SAME arrays (codex-review
+      // Important — the same class of race id-allocation had, but for
+      // per-task array fields instead of the id sequence).
+      await this.jsonl.load();
+      const rec = this.mustGet(id);
+      const onGraph = LIFECYCLES[rec.kind].transitions.some(
+        (t) => t.from === rec.state && t.gate === gateName,
       );
-    }
-    if (rec.owner && rec.owner.trim().toLowerCase() === validator.toLowerCase()) {
-      throw new Error(
-        `task ${id}: independent verification required — validator "${validator}" is the same identity as owner "${rec.owner}"; the worker cannot certify their own work`,
-      );
-    }
-    const satisfied = new Set(rec.satisfiedGates);
-    satisfied.add(gateName);
-    const evidenceEntry: GateEvidence = {
-      gate: gateName,
-      passedAt: new Date().toISOString(),
-      validator,
-      ...evidence,
-    };
-    await this.jsonl.updateById(id, {
-      satisfiedGates: [...satisfied],
-      verifyEvidence: [...rec.verifyEvidence, evidenceEntry],
-      updatedAt: evidenceEntry.passedAt,
-    } as Partial<Omit<TodoRecord, "_id">>);
-    return this.mustGet(id);
+      if (!onGraph) {
+        throw new Error(
+          `task ${id}: "${gateName}" is not a gate on any transition from its current state "${rec.state}"`,
+        );
+      }
+      if (rec.owner && rec.owner.trim().toLowerCase() === validator.toLowerCase()) {
+        throw new Error(
+          `task ${id}: independent verification required — validator "${validator}" is the same identity as owner "${rec.owner}"; the worker cannot certify their own work`,
+        );
+      }
+      const satisfied = new Set(rec.satisfiedGates);
+      satisfied.add(gateName);
+      const evidenceEntry: GateEvidence = {
+        gate: gateName,
+        passedAt: new Date().toISOString(),
+        validator,
+        ...evidence,
+      };
+      await this.jsonl.updateById(id, {
+        satisfiedGates: [...satisfied],
+        verifyEvidence: [...rec.verifyEvidence, evidenceEntry],
+        updatedAt: evidenceEntry.passedAt,
+      } as Partial<Omit<TodoRecord, "_id">>);
+      return this.mustGet(id);
+    });
   }
 
   /**
@@ -396,32 +437,38 @@ export class TodoStore {
     const isPrimaryEdge = edges[0] === targetEdge;
     const stateAtCheckStart = rec.state;
     const result = await impl.check(); // may be slow (a real CI/QA system) — the task's state can change while this runs
-    // Re-fetch and refuse to apply a transition computed against a state the
-    // task may no longer be in: `impl.check()` can take an arbitrarily long
-    // time (a real external system), and another writer (a concurrent
-    // transition/verify/approve) can change the task's state during that
-    // window. Applying targetEdge/sibling's `.to` regardless would silently
-    // move the task across an edge that may no longer even exist from its
-    // CURRENT state, bypassing the lifecycle graph entirely (codex-review
-    // Critical). This does not need its own lock — it is a staleness
-    // precondition on the write, not a mutual-exclusion problem — but it
-    // does need to be checked AFTER the await, immediately before writing.
-    const current = this.mustGet(id);
-    if (current.state !== stateAtCheckStart) {
-      throw new Error(
-        `task ${id}: state changed from "${stateAtCheckStart}" to "${current.state}" while gate "${targetEdge.gate}" was being checked — refusing to apply a transition computed against the old state; re-run verify()`,
-      );
-    }
+    // `impl.check()` can take an arbitrarily long time (a real external
+    // system), and another writer (a concurrent transition/verify/approve)
+    // can change the task's state during that window. The precondition
+    // passed to `applyTransition` below re-checks this AFTER the await,
+    // atomically with the write, inside the store's write lock — not here,
+    // and not as a separate unlocked re-fetch (codex-review Critical, then
+    // strengthened again after review found the first fix's re-check was
+    // itself outside any lock and so could race a concurrent WRITE, not
+    // just be stale relative to one).
+    const precondition = (fresh: TodoRecord): void => {
+      if (fresh.state !== stateAtCheckStart) {
+        throw new Error(
+          `task ${id}: state changed from "${stateAtCheckStart}" to "${fresh.state}" while gate "${targetEdge.gate}" was being checked — refusing to apply a transition computed against the old state; re-run verify()`,
+        );
+      }
+    };
     if (result.passed) {
       // The gate's own name stands in for "validator" — a registered check is,
       // by construction, an independent system distinct from the worker, so
       // no separate identity argument is needed here (unlike approve()).
-      return this.applyTransition(id, targetEdge.to, {
-        gate: targetEdge.gate,
-        validator: `gate:${targetEdge.gate}`,
-        note: result.note,
-        link: result.link,
-      });
+      return this.applyTransition(
+        id,
+        targetEdge.to,
+        {
+          gate: targetEdge.gate,
+          validator: `gate:${targetEdge.gate}`,
+          note: result.note,
+          link: result.link,
+        },
+        undefined,
+        precondition,
+      );
     }
     if (!isPrimaryEdge) {
       throw new Error(
@@ -440,64 +487,97 @@ export class TodoStore {
     // entry to targetEdge.gate (which reported NOT passed) would let a
     // downstream reader scanning evidence by gate name misread a failed
     // check as successful evidence for that gate (codex-review Important).
-    return this.applyTransition(id, sibling.to, {
-      // non-null: `edges` was filtered to only entries with a truthy `gate`
-      gate: sibling.gate!,
-      validator: `gate:${targetEdge.gate}`,
-      note: result.note ?? `gate "${targetEdge.gate}" reported not passed`,
-      link: result.link,
-    });
+    return this.applyTransition(
+      id,
+      sibling.to,
+      {
+        // non-null: `edges` was filtered to only entries with a truthy `gate`
+        gate: sibling.gate!,
+        validator: `gate:${targetEdge.gate}`,
+        note: result.note ?? `gate "${targetEdge.gate}" reported not passed`,
+        link: result.link,
+      },
+      undefined,
+      precondition,
+    );
   }
 
+  /**
+   * Apply a state write, entirely inside the store write lock: reload from
+   * disk, re-fetch the record, run the caller's `precondition` (if any)
+   * against that FRESH record (throws to abort with no write), then build
+   * the patch from the fresh record's arrays and write it. Building the
+   * patch from a pre-lock snapshot (the previous design) let a concurrent
+   * mutation on the same task silently lose its own array write once this
+   * one landed — this method exists specifically so every caller (`verify`,
+   * `transition`) gets that protection uniformly rather than each
+   * reimplementing its own reload dance (codex-review Important).
+   */
   private async applyTransition(
     id: string,
     toState: string,
     gateInfo?: { gate: string; validator: string; note?: string; link?: string },
     consumeGate?: string | null,
+    precondition?: (fresh: TodoRecord) => void,
   ): Promise<TodoRecord> {
-    const rec = this.mustGet(id);
-    const now = new Date().toISOString();
-    const patch: Partial<Omit<TodoRecord, "_id">> = { state: toState, updatedAt: now };
-    if (gateInfo) {
-      const evidenceEntry: GateEvidence = {
-        gate: gateInfo.gate,
-        passedAt: now,
-        validator: gateInfo.validator,
-        note: gateInfo.note,
-        link: gateInfo.link,
-      };
-      patch.verifyEvidence = [...rec.verifyEvidence, evidenceEntry];
-    }
-    if (consumeGate) {
-      patch.satisfiedGates = rec.satisfiedGates.filter((g) => g !== consumeGate);
-    }
-    await this.jsonl.updateById(id, patch);
-    return this.mustGet(id);
+    return this.withStoreLock(async () => {
+      await this.jsonl.load();
+      const fresh = this.mustGet(id);
+      precondition?.(fresh);
+      const now = new Date().toISOString();
+      const patch: Partial<Omit<TodoRecord, "_id">> = { state: toState, updatedAt: now };
+      if (gateInfo) {
+        const evidenceEntry: GateEvidence = {
+          gate: gateInfo.gate,
+          passedAt: now,
+          validator: gateInfo.validator,
+          note: gateInfo.note,
+          link: gateInfo.link,
+        };
+        patch.verifyEvidence = [...fresh.verifyEvidence, evidenceEntry];
+      }
+      if (consumeGate) {
+        patch.satisfiedGates = fresh.satisfiedGates.filter((g) => g !== consumeGate);
+      }
+      await this.jsonl.updateById(id, patch);
+      return this.mustGet(id);
+    });
   }
 
   setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {
     // `null`, never `undefined`: JSON.stringify drops `undefined` keys
     // entirely, so an update line with an omitted `block` would fail to
     // clear a previously-set value once merged on reload (see the field
-    // doc comment on TodoRecord.block).
-    return this.rawUpdate(id, { block });
+    // doc comment on TodoRecord.block). `block` is a scalar-ish field (not
+    // built from the record's own prior array contents), so this needs no
+    // reload-and-recompute-from-fresh dance the way `blockedBy` does below —
+    // it still goes through the write lock via `rawUpdate` for existence
+    // validation to run against a fresh record.
+    return this.rawUpdate(id, () => ({ block }));
   }
 
   async addDep(id: string, blockerId: string): Promise<TodoRecord> {
-    const rec = this.mustGet(id);
     if (blockerId === id) throw new Error(`task ${id} cannot depend on itself`);
+    // Cheap early check outside the lock (missing-target is a fast, obvious
+    // rejection); `rawUpdate`'s `computePatch` re-validates the cycle check
+    // against the FRESH record below, since `blockedBy` is exactly the kind
+    // of array field a concurrent `addDep`/`rmDep` on the same task could
+    // race on otherwise (codex-review Important).
     if (!this.get(blockerId)) throw new Error(`no such task: ${blockerId}`);
-    if (this.dependsOn(blockerId, id)) {
-      throw new CycleError(`cycle: ${blockerId} already depends (transitively) on ${id}`);
-    }
-    const deps = new Set(rec.blockedBy);
-    deps.add(blockerId);
-    return this.rawUpdate(id, { blockedBy: [...deps].sort() });
+    return this.rawUpdate(id, (fresh) => {
+      if (this.dependsOn(blockerId, id)) {
+        throw new CycleError(`cycle: ${blockerId} already depends (transitively) on ${id}`);
+      }
+      const deps = new Set(fresh.blockedBy);
+      deps.add(blockerId);
+      return { blockedBy: [...deps].sort() };
+    });
   }
 
   async rmDep(id: string, blockerId: string): Promise<TodoRecord> {
-    const rec = this.mustGet(id);
-    return this.rawUpdate(id, { blockedBy: rec.blockedBy.filter((d) => d !== blockerId) });
+    return this.rawUpdate(id, (fresh) => ({
+      blockedBy: fresh.blockedBy.filter((d) => d !== blockerId),
+    }));
   }
 
   /** True when `from` transitively depends on `target` via `blockedBy` edges. Ported from the equivalent, already-tested algorithm in symval-dev-cli's store.ts. */
@@ -509,13 +589,23 @@ export class TodoStore {
     return (node?.blockedBy ?? []).some((d) => this.dependsOn(d, target, seen));
   }
 
+  /**
+   * Reload, re-fetch, run `computePatch` against the FRESH record (inside
+   * the write lock), then write whatever it returns. Every array-field
+   * mutator (`setBlock`/`addDep`/`rmDep`) goes through this so none of them
+   * has to hand-roll its own reload discipline.
+   */
   private async rawUpdate(
     id: string,
-    patch: Partial<Omit<TodoRecord, "_id">>,
+    computePatch: (fresh: TodoRecord) => Partial<Omit<TodoRecord, "_id">>,
   ): Promise<TodoRecord> {
-    this.mustGet(id);
-    await this.jsonl.updateById(id, { ...patch, updatedAt: new Date().toISOString() });
-    return this.mustGet(id);
+    return this.withStoreLock(async () => {
+      await this.jsonl.load();
+      const fresh = this.mustGet(id);
+      const patch = computePatch(fresh);
+      await this.jsonl.updateById(id, { ...patch, updatedAt: new Date().toISOString() });
+      return this.mustGet(id);
+    });
   }
 }
 

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -1,0 +1,400 @@
+/**
+ * Persistence and gate-enforcement layer for the `ay todo` engine.
+ *
+ * Storage is one `JsonlStore` (see `JsonlStore.ts`) per project — append-only,
+ * one line per create/update, "same `_id` → last line wins" merge, already
+ * multi-process safe via `proper-lockfile`. This is deliberately reused
+ * rather than reinvented: two agents editing two different tasks never
+ * conflict (different `_id`s), and two agents editing the SAME task resolve
+ * to last-write-wins without any manual JSON merge — the exact multi-writer
+ * problem a from-scratch flat-JSON-array store would have to solve by hand.
+ *
+ * The single most important property of this module is INDEPENDENT
+ * VERIFICATION: the identity that satisfies a gate must never be the same
+ * identity as the task's owner (the one who did the work). This is not
+ * "automated checks only" — a manual approval is entirely acceptable, as
+ * long as the approver is provably someone (or something) other than the
+ * worker. A task can only reach a gated state through one of two paths, and
+ * both enforce this at the same choke point rather than leaving it to
+ * caller discipline —
+ *
+ *   1. A REGISTERED gate (one whose check function was supplied via
+ *      `registerGate`, e.g. a CI/QA check) can ONLY be satisfied by
+ *      `verify()`, which actually calls that check function. `transition()`
+ *      refuses to move a task across an edge whose gate is registered, even
+ *      if asked to — there is no argument or flag that bypasses this. A
+ *      registered check is, by construction, an independent system distinct
+ *      from the worker, so it always satisfies the independence rule.
+ *   2. A gate that is NOT registered is treated as a manual, attested gate
+ *      (e.g. "a person approved this"): it can only be satisfied by
+ *      `approve()`, which REQUIRES a `validatorIdentity` argument and
+ *      refuses the call outright if that identity matches the task's
+ *      `owner` — the worker can never certify their own work. This is the
+ *      one rule this module enforces unconditionally; everything else about
+ *      who is allowed to approve what is left to the consuming project.
+ *
+ * Nothing in this file mentions any specific product, company, or external
+ * system — a consuming project supplies concrete gate behavior by calling
+ * `registerGate` with its own check function (see `GateRegistration`).
+ */
+
+import path from "path";
+import { JsonlStore, type JsonlDoc } from "./JsonlStore.ts";
+import {
+  DONE_STATE,
+  LIFECYCLES,
+  canTransition,
+  initialState,
+  requiredGate,
+  type LifecycleKind,
+} from "./todoLifecycle.ts";
+import type { TodoBlock } from "./todoBlock.ts";
+
+export interface GateEvidence {
+  gate: string;
+  passedAt: string;
+  /** Who/what satisfied the gate. For a registered gate this is the gate's own name (an automated system is inherently independent of the worker). For a manual gate this is the human-supplied `validatorIdentity` passed to `approve()`, always distinct from the task's owner at approval time. */
+  validator: string;
+  note?: string;
+  link?: string;
+}
+
+export interface TodoRecord extends JsonlDoc {
+  kind: LifecycleKind;
+  state: string;
+  /** Which done-tier this task targets, e.g. a project may define "canary-done" vs "shipped-done". Optional: not every project uses tiers. */
+  targetTier?: string;
+  summary: string;
+  description: string;
+  /** A human name/handle, or a tracked agent's stable identifier. Opaque to this module. */
+  owner?: string;
+  block?: TodoBlock;
+  /** Task-id dependencies — separate from `block`: a task can both structurally depend on other tasks AND be separately blocked-by-human at the same time. */
+  blockedBy: string[];
+  tags: string[];
+  /** Gate names satisfied via `approve()` but not yet consumed by a `transition()` call. */
+  satisfiedGates: string[];
+  /** Append-only history of every gate that has ever passed for this task (manual or registered), the append-only proof trail `verifyEvidence` from the ExecPlan. */
+  verifyEvidence: GateEvidence[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateInput {
+  summary: string;
+  kind: LifecycleKind;
+  description?: string;
+  targetTier?: string;
+  owner?: string;
+  tags?: string[];
+  blockedBy?: string[];
+}
+
+export interface ListFilter {
+  kind?: LifecycleKind;
+  state?: string;
+  owner?: string;
+  tag?: string;
+  blocked?: boolean;
+}
+
+export interface GateRegistration {
+  /** Opaque name supplied BY the consuming project — this module never inspects or hardcodes it. */
+  name: string;
+  check: () => Promise<{ passed: boolean; note?: string; link?: string }>;
+}
+
+export class CycleError extends Error {}
+
+export class TodoStore {
+  private jsonl: JsonlStore<Omit<TodoRecord, "_id">>;
+  private gates = new Map<string, GateRegistration>();
+  private nextSeq = 1;
+
+  private constructor(jsonl: JsonlStore<Omit<TodoRecord, "_id">>) {
+    this.jsonl = jsonl;
+  }
+
+  static async open(projectRoot: string): Promise<TodoStore> {
+    const filePath = path.join(projectRoot, ".agent-yes", "todos.jsonl");
+    const jsonl = new JsonlStore<Omit<TodoRecord, "_id">>(filePath);
+    await jsonl.load();
+    const store = new TodoStore(jsonl);
+    const existingIds = jsonl.getAll().map((d) => Number(String(d._id).replace(/^T/, "")) || 0);
+    store.nextSeq = (existingIds.length ? Math.max(...existingIds) : 0) + 1;
+    return store;
+  }
+
+  registerGate(gate: GateRegistration): void {
+    this.gates.set(gate.name, gate);
+  }
+
+  isRegisteredGate(name: string): boolean {
+    return this.gates.has(name);
+  }
+
+  all(): TodoRecord[] {
+    return this.jsonl.getAll() as TodoRecord[];
+  }
+
+  get(id: string): TodoRecord | null {
+    return (this.jsonl.getById(id) as TodoRecord | undefined) ?? null;
+  }
+
+  private mustGet(id: string): TodoRecord {
+    const rec = this.get(id);
+    if (!rec) throw new Error(`no such task: ${id}`);
+    return rec;
+  }
+
+  list(filter: ListFilter = {}): TodoRecord[] {
+    return this.all().filter((t) => {
+      if (filter.kind && t.kind !== filter.kind) return false;
+      if (filter.state && t.state !== filter.state) return false;
+      if (filter.owner && t.owner?.toLowerCase() !== filter.owner.toLowerCase()) return false;
+      if (filter.tag && !t.tags.some((x) => x.toLowerCase() === filter.tag!.toLowerCase()))
+        return false;
+      if (filter.blocked) {
+        const isBlocked =
+          t.state !== DONE_STATE && (t.block !== undefined || t.blockedBy.length > 0);
+        if (!isBlocked) return false;
+      }
+      return true;
+    });
+  }
+
+  async create(input: CreateInput): Promise<TodoRecord> {
+    const id = `T${this.nextSeq++}`;
+    const now = new Date().toISOString();
+    for (const dep of input.blockedBy ?? []) {
+      if (!this.get(dep)) throw new Error(`no such task: ${dep}`);
+    }
+    const doc: Omit<TodoRecord, "_id"> = {
+      kind: input.kind,
+      state: initialState(input.kind),
+      summary: input.summary,
+      description: input.description ?? "",
+      blockedBy: input.blockedBy ?? [],
+      tags: input.tags ?? [],
+      satisfiedGates: [],
+      verifyEvidence: [],
+      createdAt: now,
+      updatedAt: now,
+      ...(input.targetTier ? { targetTier: input.targetTier } : {}),
+      ...(input.owner ? { owner: input.owner } : {}),
+    };
+    await this.jsonl.append({ ...doc, _id: id });
+    return this.mustGet(id);
+  }
+
+  /**
+   * Move a task across an edge that either has no gate, or whose gate has
+   * already been satisfied via `approve()`. Throws — refusing the write
+   * entirely — for an edge with no such edge in the graph, or a gate that is
+   * either registered (must go through `verify()`) or not yet satisfied.
+   */
+  async transition(id: string, toState: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    if (!canTransition(rec.kind, rec.state, toState)) {
+      throw new Error(
+        `task ${id}: no transition ${rec.state} -> ${toState} for kind "${rec.kind}"`,
+      );
+    }
+    const gate = requiredGate(rec.kind, rec.state, toState);
+    if (gate) {
+      if (this.gates.has(gate)) {
+        throw new Error(
+          `task ${id}: "${gate}" is a registered gate — it can only be satisfied by verify("${id}"), not a direct transition`,
+        );
+      }
+      if (!rec.satisfiedGates.includes(gate)) {
+        throw new Error(
+          `task ${id}: transition ${rec.state} -> ${toState} requires gate "${gate}" — call approve("${id}", "${gate}") first`,
+        );
+      }
+    }
+    // No new evidence entry here: approve() already recorded one (with the
+    // independently-verified validator identity) at approval time. This call
+    // only consumes the satisfied-gate flag so it cannot be replayed.
+    return this.applyTransition(id, toState, undefined, gate);
+  }
+
+  /**
+   * Satisfy a manual (non-registered) gate. `validatorIdentity` names who is
+   * satisfying it — REQUIRED, and rejected outright when it matches the
+   * task's `owner` (case-insensitively): independent verification is the
+   * one rule this module enforces unconditionally, so the worker can never
+   * certify their own work, no matter who is running the CLI. A task with
+   * no `owner` set has nothing to compare against, so approval is allowed
+   * (with a required validator identity still recorded for the audit
+   * trail) — but this is expected to be rare in practice, since a task
+   * normally has an owner before it reaches a gated transition.
+   */
+  async approve(
+    id: string,
+    gateName: string,
+    validatorIdentity: string,
+    evidence?: { note?: string; link?: string },
+  ): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    if (!validatorIdentity.trim()) {
+      throw new Error(
+        `task ${id}: approve() requires a validatorIdentity (who is satisfying "${gateName}")`,
+      );
+    }
+    if (this.gates.has(gateName)) {
+      throw new Error(
+        `task ${id}: "${gateName}" is a registered gate and cannot be approved manually — it is satisfied by verify("${id}")`,
+      );
+    }
+    const onGraph = LIFECYCLES[rec.kind].transitions.some(
+      (t) => t.from === rec.state && t.gate === gateName,
+    );
+    if (!onGraph) {
+      throw new Error(
+        `task ${id}: "${gateName}" is not a gate on any transition from its current state "${rec.state}"`,
+      );
+    }
+    if (rec.owner && rec.owner.toLowerCase() === validatorIdentity.toLowerCase()) {
+      throw new Error(
+        `task ${id}: independent verification required — validator "${validatorIdentity}" is the same identity as owner "${rec.owner}"; the worker cannot certify their own work`,
+      );
+    }
+    const satisfied = new Set(rec.satisfiedGates);
+    satisfied.add(gateName);
+    const evidenceEntry: GateEvidence = {
+      gate: gateName,
+      passedAt: new Date().toISOString(),
+      validator: validatorIdentity,
+      ...evidence,
+    };
+    await this.jsonl.updateById(id, {
+      satisfiedGates: [...satisfied],
+      verifyEvidence: [...rec.verifyEvidence, evidenceEntry],
+      updatedAt: evidenceEntry.passedAt,
+    } as Partial<Omit<TodoRecord, "_id">>);
+    return this.mustGet(id);
+  }
+
+  /**
+   * Run a registered gate's check function and, based on its result, apply
+   * whichever transition out of the task's current state that gate governs.
+   * If the check reports NOT passed, and there is a sibling transition from
+   * the same state (e.g. the `code` kind's `verifying -> verify-failed`
+   * alongside `verifying -> done`), that sibling is taken instead — this is
+   * how a single automated check naturally produces the kind's real
+   * pass/fail states without hardcoding kind-specific names here.
+   */
+  async verify(id: string, gateName?: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    const edges = LIFECYCLES[rec.kind].transitions.filter((t) => t.from === rec.state && t.gate);
+    if (edges.length === 0)
+      throw new Error(`task ${id}: no gated transition from state "${rec.state}"`);
+    const targetEdge = gateName
+      ? edges.find((e) => e.gate === gateName)
+      : edges.find((e) => this.gates.has(e.gate!));
+    if (!targetEdge || !targetEdge.gate) {
+      throw new Error(
+        `task ${id}: no registered gate found for a transition from "${rec.state}"${gateName ? ` matching "${gateName}"` : ""}`,
+      );
+    }
+    const impl = this.gates.get(targetEdge.gate);
+    if (!impl)
+      throw new Error(
+        `task ${id}: gate "${targetEdge.gate}" is not registered — call registerGate() first`,
+      );
+    const result = await impl.check();
+    if (result.passed) {
+      // The gate's own name stands in for "validator" — a registered check is,
+      // by construction, an independent system distinct from the worker, so
+      // no separate identity argument is needed here (unlike approve()).
+      return this.applyTransition(id, targetEdge.to, {
+        gate: targetEdge.gate,
+        validator: `gate:${targetEdge.gate}`,
+        note: result.note,
+        link: result.link,
+      });
+    }
+    const sibling = edges.find((e) => e !== targetEdge);
+    if (!sibling) {
+      throw new Error(
+        `task ${id}: gate "${targetEdge.gate}" reported not passed and there is no alternate transition to record it against`,
+      );
+    }
+    return this.applyTransition(id, sibling.to, {
+      gate: targetEdge.gate,
+      validator: `gate:${targetEdge.gate}`,
+      note: result.note ?? "gate reported not passed",
+      link: result.link,
+    });
+  }
+
+  private async applyTransition(
+    id: string,
+    toState: string,
+    gateInfo?: { gate: string; validator: string; note?: string; link?: string },
+    consumeGate?: string | null,
+  ): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    const now = new Date().toISOString();
+    const patch: Partial<Omit<TodoRecord, "_id">> = { state: toState, updatedAt: now };
+    if (gateInfo) {
+      const evidenceEntry: GateEvidence = {
+        gate: gateInfo.gate,
+        passedAt: now,
+        validator: gateInfo.validator,
+        note: gateInfo.note,
+        link: gateInfo.link,
+      };
+      patch.verifyEvidence = [...rec.verifyEvidence, evidenceEntry];
+    }
+    if (consumeGate) {
+      patch.satisfiedGates = rec.satisfiedGates.filter((g) => g !== consumeGate);
+    }
+    await this.jsonl.updateById(id, patch);
+    return this.mustGet(id);
+  }
+
+  setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {
+    return this.rawUpdate(id, { block: block ?? undefined });
+  }
+
+  async addDep(id: string, blockerId: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    if (blockerId === id) throw new Error(`task ${id} cannot depend on itself`);
+    if (!this.get(blockerId)) throw new Error(`no such task: ${blockerId}`);
+    if (this.dependsOn(blockerId, id)) {
+      throw new CycleError(`cycle: ${blockerId} already depends (transitively) on ${id}`);
+    }
+    const deps = new Set(rec.blockedBy);
+    deps.add(blockerId);
+    return this.rawUpdate(id, { blockedBy: [...deps].sort() });
+  }
+
+  async rmDep(id: string, blockerId: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    return this.rawUpdate(id, { blockedBy: rec.blockedBy.filter((d) => d !== blockerId) });
+  }
+
+  /** True when `from` transitively depends on `target` via `blockedBy` edges. Ported from the equivalent, already-tested algorithm in symval-dev-cli's store.ts. */
+  private dependsOn(from: string, target: string, seen: Set<string> = new Set()): boolean {
+    if (from === target) return true;
+    if (seen.has(from)) return false;
+    seen.add(from);
+    const node = this.get(from);
+    return (node?.blockedBy ?? []).some((d) => this.dependsOn(d, target, seen));
+  }
+
+  private async rawUpdate(
+    id: string,
+    patch: Partial<Omit<TodoRecord, "_id">>,
+  ): Promise<TodoRecord> {
+    this.mustGet(id);
+    await this.jsonl.updateById(id, { ...patch, updatedAt: new Date().toISOString() });
+    return this.mustGet(id);
+  }
+}
+
+export async function openStore(projectRoot: string): Promise<TodoStore> {
+  return TodoStore.open(projectRoot);
+}


### PR DESCRIPTION
Generic, product-neutral task orchestration engine — no reference to any specific company/product anywhere in source, tests, or CLI help.

## What this adds

- `ts/todoLifecycle.ts` — five declarative lifecycle graphs (kind → ordered states + gated transitions): `code` (doing→merged→shipped→verifying→done/verify-failed→[reopen]doing), `decision`, `doc`, `investigation`, and `human` (a structurally distinct pending→decided→done kind with no merge/ship/QA steps at all).
- `ts/todoBlock.ts` — four typed block shapes (blocked-by-task/-human/-external, waiting-on-agent) + `monitorHint()` classifying how each should be watched.
- `ts/todoStore.ts` — persistence on the existing `JsonlStore` (already used by pidStore/messageLog — per-_id last-line-wins merge, already multi-process safe via proper-lockfile; reused rather than inventing a new merge scheme). **Core invariant: INDEPENDENT VERIFICATION** — a gate can never be satisfied by the task's own owner. A *registered* gate (`registerGate` + a `check()` function) can only be satisfied via `verify()`; `transition()` refuses a registered-gate edge under any argument. An *unregistered* gate is manual and can only be satisfied via `approve(id, gateName, validatorIdentity, ...)`, which throws if `validatorIdentity` matches the task's owner (case-insensitive). `verify()`'s failing path takes the sibling edge (e.g. `verifying→verify-failed`) rather than dropping the failure; `verify-failed` only reopens to the kind's `doing` state.
- `ts/todoDigest.ts` — `unblockedTasks`/`renderTree`/`renderDigest`, ported from an already-tested, less-general earlier version in a downstream closed-source consumer.
- `ts/todoCli.ts` — `ay todo new/ls/get/transition/approve/verify/block/unblock/dep/tree/digest`, registered in `subcommands.ts`'s existing lazy-import dispatch pattern.
- `ts/index.ts` re-exports the new library surface (only symbols listed there survive the tsdown build into the published `dist/index.js`).

## Tests

63 new tests (vitest), all passing. Found and fixed one real bug via the CLI-level spec (`todoCli.spec.ts`): the outer flag parser was swallowing every verb's own flags (`--kind`, `--owner`, ...) before the per-verb sub-parser ever saw them — caught only by exercising the actual CLI surface end-to-end, not by unit-testing the store alone.

## Design note

The independent-verification invariant (rather than 'registered-gate-only') reflects a refinement made mid-implementation: the core requirement is that the validator's identity differ from the worker/owner's identity, not that verification be automated. A concrete downstream consumer is expected to register a QA-agent-based gate as its independent validator — this repo has no knowledge of that or any other specific consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)