### PR TITLE
feat: deprecate agent-run --cwd with a `cd <dir> && …` migration hint

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -3241,8 +3241,7 @@
           const rows = (window.__ayPerf || []).filter((r) => r.t > perfBeaconCursor);
           if (!rows.length) return;
           perfBeaconCursor = rows[rows.length - 1].t;
-          const slowMs =
-            (window.__ayPerfReport && window.__ayPerfReport().slowMs) || 300;
+          const slowMs = (window.__ayPerfReport && window.__ayPerfReport().slowMs) || 300;
           const byRoom = new Map();
           for (const r of rows) {
             const k = r.room || "";
@@ -4946,7 +4945,8 @@ my.translate = async (text, lang) => {
           "width:100%;box-sizing:border-box;height:300px;resize:vertical;background:var(--bg);color:var(--fg);border:1px solid var(--line);border-radius:6px;padding:10px;font:13px var(--mono);outline:none";
         box.appendChild(ta);
         const err = document.createElement("div");
-        err.style.cssText = "color:var(--red);font:12px var(--mono);margin-top:8px;white-space:pre-wrap";
+        err.style.cssText =
+          "color:var(--red);font:12px var(--mono);margin-top:8px;white-space:pre-wrap";
         box.appendChild(err);
         const row = document.createElement("div");
         row.style.cssText = "display:flex;gap:8px;justify-content:flex-end;margin-top:12px";
@@ -5400,7 +5400,11 @@ my.translate = async (text, lang) => {
           for (const e of keep)
             if (e.parent_pid != null) wanted.add((e._src || "") + "#" + e.parent_pid);
           for (const e of list)
-            if (!keep.has(e) && e.wrapper_pid != null && wanted.has((e._src || "") + "#" + e.wrapper_pid)) {
+            if (
+              !keep.has(e) &&
+              e.wrapper_pid != null &&
+              wanted.has((e._src || "") + "#" + e.wrapper_pid)
+            ) {
               keep.add(e);
               grew = true;
             }
@@ -5408,10 +5412,7 @@ my.translate = async (text, lang) => {
         return list.filter((e) => keep.has(e));
       }
       function orderedEntries(toks) {
-        const sorted = sortEntries(
-          pruneStale(entries.filter((e) => matches(e, toks))),
-          sortMode,
-        );
+        const sorted = sortEntries(pruneStale(entries.filter((e) => matches(e, toks))), sortMode);
         if (!pinned.size) return sorted;
         const hi = [],
           lo = [];

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -267,7 +267,7 @@ struct Args {
     #[arg(short = 'y', long = "yes", default_value = "false")]
     yes: bool,
 
-    /// Working directory for the agent (default: current directory)
+    /// Deprecated: working directory for the agent. Prefer `cd <dir> && <command>`.
     #[arg(long)]
     cwd: Option<String>,
 

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -45,6 +45,88 @@ fn detect_install_method() -> &'static str {
     "binary"
 }
 
+/// Quote one argv token for display in a copy-pasteable shell command. Leaves
+/// shell-safe tokens (including a leading `~`/`~/path`, so `cd ~/foo` still
+/// expands) bare; single-quotes anything else. Mirrors `shellDisplayQuote` in
+/// ts/cwdDeprecation.ts.
+fn shell_display_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    let safe = s.chars().all(|c| {
+        c.is_ascii_alphanumeric() || "_@%+=:,./~-".contains(c)
+    });
+    if safe {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+/// Build the `--cwd` deprecation warning from a program name and its user args
+/// (everything after argv[0]). Strips `--cwd <dir>` / `--cwd=<dir>` and rebuilds
+/// the copy-pasteable `cd <dir> && <same command>` hint. Pure so it can be unit
+/// tested. Mirrors detectCwdDeprecation in ts/cwdDeprecation.ts.
+fn build_cwd_migration(prog: &str, user_args: &[String]) -> String {
+    let mut dir: Option<String> = None;
+    let mut rest: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < user_args.len() {
+        let arg = &user_args[i];
+        if arg == "--cwd" {
+            // `--cwd DIR` — consume the value unless the next token is a flag.
+            if let Some(next) = user_args.get(i + 1) {
+                if !next.starts_with('-') {
+                    dir = Some(next.clone());
+                    i += 2;
+                    continue;
+                }
+            }
+            i += 1;
+            continue;
+        }
+        if let Some(v) = arg.strip_prefix("--cwd=") {
+            dir = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        rest.push(arg.clone());
+        i += 1;
+    }
+
+    let mut cmd = shell_display_quote(prog);
+    for a in &rest {
+        cmd.push(' ');
+        cmd.push_str(&shell_display_quote(a));
+    }
+    // `<dir>` is a placeholder shown when the flag had no value — keep it bare.
+    let dir_disp = match dir {
+        Some(ref d) => shell_display_quote(d),
+        None => "<dir>".to_string(),
+    };
+    format!(
+        "\x1b[33m⚠ --cwd is deprecated.\x1b[0m Run the command in the target directory instead:\n\n    cd {dir_disp} && {cmd}"
+    )
+}
+
+/// `--cwd <dir>` on an agent run is deprecated: `cd <dir> && <same command>`
+/// does the same thing without an agent-yes-specific flag. Print the migration
+/// hint before continuing (the flag still works). The JS launcher prints its own
+/// (more faithful, it knows the `cy`/`ay` name the user typed) copy and sets
+/// AGENT_YES_SUPPRESS_CWD_WARN so this mirror only fires on a direct
+/// `agent-yes … --cwd` invocation that bypassed the launcher.
+fn warn_cwd_deprecated() {
+    if std::env::var_os("AGENT_YES_SUPPRESS_CWD_WARN").is_some() {
+        return;
+    }
+    let raw: Vec<String> = std::env::args().collect();
+    let prog = raw
+        .first()
+        .map(|p| p.rsplit(['/', '\\']).next().unwrap_or(p.as_str()).to_string())
+        .unwrap_or_else(|| "agent-yes".to_string());
+    eprintln!("{}", build_cwd_migration(&prog, &raw[1..]));
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Delegate management subcommands (ls/send/restart/stop/serve/…) to the JS
@@ -72,6 +154,7 @@ async fn main() -> Result<()> {
     // Canonicalise to an absolute path so downstream consumers (pid_store, lock keys,
     // webhooks) see a stable identifier regardless of how the user typed it.
     let cwd = if let Some(ref requested) = args.cwd {
+        warn_cwd_deprecated();
         // Expand leading `~` / `~/` because shells (zsh, bash) do NOT expand a tilde
         // that appears after `=` (e.g. `--cwd=~/foo` arrives literally). Only the
         // user's own `~` is supported; `~user` is not.
@@ -606,4 +689,50 @@ async fn run_swarm_mode(args: CliArgs, cwd: &str) -> Result<i32> {
     }
 
     Ok(0)
+}
+
+#[cfg(test)]
+mod cwd_deprecation_tests {
+    use super::{build_cwd_migration, shell_display_quote};
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn quotes_only_when_needed() {
+        assert_eq!(shell_display_quote("/ws/app"), "/ws/app");
+        assert_eq!(shell_display_quote("~/ws/product"), "~/ws/product");
+        assert_eq!(shell_display_quote(""), "''");
+        assert_eq!(shell_display_quote("a b"), "'a b'");
+        assert_eq!(shell_display_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn strips_cwd_space_form() {
+        let msg = build_cwd_migration(
+            "agent-yes",
+            &args(&["--cli", "claude", "--cwd", "/ws/app", "-p", "fix"]),
+        );
+        assert!(msg.contains("cd /ws/app && agent-yes --cli claude -p fix"), "{msg}");
+        assert!(msg.contains("--cwd is deprecated"));
+    }
+
+    #[test]
+    fn strips_cwd_equals_form() {
+        let msg = build_cwd_migration("agent-yes", &args(&["--cwd=/tmp/x", "codex"]));
+        assert!(msg.contains("cd /tmp/x && agent-yes codex"), "{msg}");
+    }
+
+    #[test]
+    fn keeps_home_relative_dir_bare() {
+        let msg = build_cwd_migration("agent-yes", &args(&["--cwd", "~/ws/product"]));
+        assert!(msg.contains("cd ~/ws/product && agent-yes"), "{msg}");
+    }
+
+    #[test]
+    fn placeholder_when_value_missing() {
+        let msg = build_cwd_migration("agent-yes", &args(&["--cli", "claude", "--cwd"]));
+        assert!(msg.contains("cd <dir> && agent-yes --cli claude"), "{msg}");
+    }
 }

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -39,6 +39,20 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   }
 }
 
+// Deprecation: `--cwd <dir>` on an agent run. Runs AFTER the subcommand fast
+// path above, so subcommand `--cwd` FILTERS (ay ls/status/spawn/schedule) are
+// untouched — only a real agent launch reaches here. Warn once, then continue
+// (the flag still works); suppress the Rust runner's mirror of this warning so
+// it isn't printed twice when we spawn the Rust binary below.
+{
+  const { detectCwdDeprecation, SUPPRESS_CWD_WARN_ENV } = await import("./cwdDeprecation.ts");
+  const dep = detectCwdDeprecation(process.argv);
+  if (dep) {
+    console.warn(dep.message);
+    process.env[SUPPRESS_CWD_WARN_ENV] = "1";
+  }
+}
+
 // Check for updates before starting — installs & re-execs if a newer version exists.
 // Fast path: cached result (no network), so this adds near-zero latency most of the time.
 await checkAndAutoUpdate();

--- a/ts/cwdDeprecation.spec.ts
+++ b/ts/cwdDeprecation.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { detectCwdDeprecation } from "./cwdDeprecation.ts";
+
+// argv shape is [exec, script, ...userArgs]; the script's basename is the
+// program name the user typed (cy/ay/claude-yes/…).
+const argv = (script: string, ...user: string[]) => ["/usr/bin/bun", script, ...user];
+
+describe("detectCwdDeprecation", () => {
+  it("returns null when --cwd is absent", () => {
+    expect(detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "-p", "hi"))).toBeNull();
+  });
+
+  it("detects `--cwd DIR` and rebuilds the command without it", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--cwd", "/ws/app", "-p", "fix"));
+    expect(dep).not.toBeNull();
+    expect(dep!.dir).toBe("/ws/app");
+    expect(dep!.suggestion).toBe("cd /ws/app && cy claude -p fix");
+  });
+
+  it("detects `--cwd=DIR` form", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/agent-yes.js", "codex", "--cwd=/tmp/x"));
+    expect(dep!.dir).toBe("/tmp/x");
+    expect(dep!.suggestion).toBe("cd /tmp/x && agent-yes codex");
+  });
+
+  it("keeps a home-relative dir bare so the shell still expands ~", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "~/ws/product"));
+    expect(dep!.suggestion).toBe("cd ~/ws/product && cy");
+  });
+
+  it("preserves the prompt after `--` and quotes tokens with spaces", () => {
+    // The shell splits `-- solve all todos` into one argv token per word.
+    const dep = detectCwdDeprecation(
+      argv("/x/dist/claude-yes.js", "--cwd", "/ws/app", "--", "solve", "all", "todos"),
+    );
+    // A single already-quoted token keeping its space is re-quoted for display.
+    const dep2 = detectCwdDeprecation(
+      argv("/x/dist/claude-yes.js", "--cwd", "/ws/app", "--", "a b"),
+    );
+    expect(dep!.suggestion).toBe("cd /ws/app && claude-yes -- solve all todos");
+    expect(dep2!.suggestion).toBe("cd /ws/app && claude-yes -- 'a b'");
+  });
+
+  it("quotes a dir containing spaces", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/my ws/app"));
+    expect(dep!.suggestion).toBe("cd '/my ws/app' && cy");
+  });
+
+  it("handles `--cwd` given as the last token with no value", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--cwd"));
+    expect(dep).not.toBeNull();
+    expect(dep!.dir).toBeUndefined();
+    expect(dep!.suggestion).toBe("cd <dir> && cy claude");
+  });
+
+  it("includes the deprecation notice in the message", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/ws"));
+    expect(dep!.message).toContain("--cwd is deprecated");
+    expect(dep!.message).toContain("cd /ws && cy");
+  });
+});

--- a/ts/cwdDeprecation.ts
+++ b/ts/cwdDeprecation.ts
@@ -1,0 +1,92 @@
+/**
+ * `--cwd <dir>` on an agent run is deprecated.
+ *
+ * It used to pick the directory the agent runs in. The shell already does this
+ * better: `cd <dir> && <same command>` puts the agent AND every relative path in
+ * the command in the same place, with no agent-yes-specific flag to remember.
+ * This module detects the flag on a raw argv and builds the copy-pasteable
+ * migration hint we print before continuing (the flag still works for now).
+ *
+ * Scope: the agent-run path only (ts/cli.ts). Management subcommands that take a
+ * `--cwd` FILTER (`ay ls/status/spawn/schedule …`) are a different flag and are
+ * not deprecated — they never reach this code because subcommands are dispatched
+ * earlier. The Rust runner mirrors this warning in rs/src/main.rs for direct
+ * `agent-yes` invocations that bypass this launcher.
+ */
+
+/** Env var the JS launcher sets on the spawned Rust child so the warning, once
+ * printed here, is not printed a second time by the Rust runner. Mirrored in
+ * rs/src/main.rs. */
+export const SUPPRESS_CWD_WARN_ENV = "AGENT_YES_SUPPRESS_CWD_WARN";
+
+export interface CwdDeprecation {
+  /** The directory value the user passed to --cwd (undefined if the flag had no value). */
+  dir: string | undefined;
+  /** The suggested replacement command line, e.g. `cd ~/foo && cy claude -- fix`. */
+  suggestion: string;
+  /** Colorized, multi-line warning ready to write to stderr (no trailing newline). */
+  message: string;
+}
+
+/**
+ * Quote a single argv token for display in a copy-pasteable shell command.
+ * Leaves shell-safe tokens (including a leading `~`/`~/path`, so `cd ~/foo`
+ * still expands) bare; single-quotes anything else.
+ */
+function shellDisplayQuote(s: string): string {
+  if (s === "") return "''";
+  // Safe unquoted: word chars and the handful of path/opt punctuation that carry
+  // no shell meaning here. `~` included so a home-relative dir keeps expanding.
+  if (/^[A-Za-z0-9_@%+=:,./~-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Program name as the user typed it, derived from argv[1] (the launched script). */
+function programName(scriptPath: string | undefined): string {
+  if (!scriptPath) return "agent-yes";
+  const base = scriptPath.split(/[\\/]/).pop() || scriptPath;
+  return base.replace(/\.(js|ts|mjs|cjs)$/, "");
+}
+
+/**
+ * Detect a deprecated `--cwd <dir>` / `--cwd=<dir>` flag on a full process.argv
+ * (`[exec, script, ...userArgs]`). Returns the migration hint, or null when no
+ * `--cwd` flag is present.
+ */
+export function detectCwdDeprecation(argv: string[]): CwdDeprecation | null {
+  const prog = programName(argv[1]);
+  const userArgs = argv.slice(2);
+
+  let sawCwd = false;
+  let dir: string | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < userArgs.length; i++) {
+    const arg = userArgs[i]!;
+    if (arg === "--cwd") {
+      sawCwd = true;
+      const next = userArgs[i + 1];
+      // `--cwd DIR` — consume the value; a following flag means the value is missing.
+      if (next !== undefined && !next.startsWith("-")) {
+        dir = next;
+        i++;
+      }
+      continue;
+    }
+    if (arg.startsWith("--cwd=")) {
+      sawCwd = true;
+      dir = arg.slice("--cwd=".length);
+      continue;
+    }
+    rest.push(arg);
+  }
+  if (!sawCwd) return null;
+
+  const cmd = [prog, ...rest].map(shellDisplayQuote).join(" ");
+  // `<dir>` is a placeholder shown when the flag had no value — keep it bare.
+  const dirDisplay = dir === undefined ? "<dir>" : shellDisplayQuote(dir);
+  const suggestion = `cd ${dirDisplay} && ${cmd}`;
+  const message =
+    `\x1b[33m⚠ --cwd is deprecated.\x1b[0m Run the command in the target directory instead:\n\n` +
+    `    ${suggestion}`;
+  return { dir, suggestion, message };
+}

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -46,6 +46,32 @@ import * as reaper from "./reaper.ts";
 export { removeControlCharacters };
 export { AgentContext };
 
+// `ay todo` library surface — only symbols listed here reach the published
+// `dist/index.js` a consuming project (e.g. a thin project-specific shell
+// around this engine) actually imports; creating the underlying modules
+// alone is not sufficient.
+export { openStore, TodoStore, CycleError } from "./todoStore.ts";
+export type {
+  TodoRecord,
+  CreateInput,
+  ListFilter,
+  GateRegistration,
+  GateEvidence,
+} from "./todoStore.ts";
+export {
+  LIFECYCLES,
+  nextStates,
+  canTransition,
+  requiredGate,
+  initialState,
+  statesOf,
+  isKnownKind,
+} from "./todoLifecycle.ts";
+export type { LifecycleKind, LifecycleGraph, LifecycleTransition } from "./todoLifecycle.ts";
+export { monitorHint, describeBlock } from "./todoBlock.ts";
+export type { TodoBlock, MonitorHint } from "./todoBlock.ts";
+export { unblockedTasks, openBlockers, renderTree, renderDigest } from "./todoDigest.ts";
+
 export type AgentCliConfig = {
   // cli
   install?:

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2001,7 +2001,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
   // The whole API as a plain handler: served over HTTP by Bun.serve (--http)
   // and called in-process by the WebRTC bridge (--webrtc) — the latter needs
   // no TCP port at all.
-  const apiFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
+  const apiFetch = async (
+    req: Request,
+    srv?: { upgrade: (r: Request, o?: unknown) => boolean },
+  ): Promise<Response> => {
     if (!checkAuth(req, token)) {
       return new Response("Unauthorized", { status: 401 });
     }
@@ -3542,7 +3545,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
       });
     }
   };
-  const httpFetch = async (req: Request, srv?: { upgrade: (r: Request, o?: unknown) => boolean }): Promise<Response> => {
+  const httpFetch = async (
+    req: Request,
+    srv?: { upgrade: (r: Request, o?: unknown) => boolean },
+  ): Promise<Response> => {
     const p = new URL(req.url).pathname;
     if (req.method === "GET" && (p === "/" || p === "/index.html"))
       return serveUiFile("index.html", "text/html; charset=utf-8");

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -362,6 +362,7 @@ const SUBCOMMANDS = new Set([
   "exit",
   "restart",
   "note",
+  "todo",
   "serve",
   "schedule",
   "remote",
@@ -473,6 +474,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdRestart(rest);
       case "note":
         return await cmdNote(rest);
+      case "todo": {
+        const { runTodoSubcommand } = await import("./todoCli.ts");
+        return runTodoSubcommand(rest);
+      }
       case "serve": {
         const { cmdServe } = await import("./serve.ts");
         return cmdServe(rest);

--- a/ts/todoBlock.spec.ts
+++ b/ts/todoBlock.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { describeBlock, monitorHint, type TodoBlock } from "./todoBlock";
+
+describe("todoBlock", () => {
+  it("blocked-by-human needs no monitor — a human's reply always self-delivers", () => {
+    expect(monitorHint({ type: "blocked-by-human", who: "someone" })).toBe("none");
+  });
+  it("blocked-by-task needs no monitor — clears itself via pure data (unblockedTasks)", () => {
+    expect(monitorHint({ type: "blocked-by-task", taskId: "T1" })).toBe("none");
+  });
+  it("waiting-on-agent needs a notify-agent monitor", () => {
+    expect(monitorHint({ type: "waiting-on-agent", agentId: "abc123" })).toBe("notify-agent");
+  });
+  it("blocked-by-external needs a poll-external monitor", () => {
+    expect(monitorHint({ type: "blocked-by-external", signal: "ci-run" })).toBe("poll-external");
+  });
+
+  it("describeBlock renders each shape distinctly and legibly", () => {
+    const cases: TodoBlock[] = [
+      { type: "blocked-by-task", taskId: "T9" },
+      { type: "blocked-by-human", who: "alex", question: "canary or beta?" },
+      { type: "blocked-by-external", signal: "release-pipeline" },
+      { type: "waiting-on-agent", agentId: "xyz789" },
+    ];
+    const rendered = cases.map(describeBlock);
+    expect(rendered[0]).toContain("T9");
+    expect(rendered[1]).toContain("alex");
+    expect(rendered[1]).toContain("canary or beta?");
+    expect(rendered[2]).toContain("release-pipeline");
+    expect(rendered[3]).toContain("xyz789");
+    expect(new Set(rendered).size).toBe(4); // all distinct
+  });
+});

--- a/ts/todoBlock.ts
+++ b/ts/todoBlock.ts
@@ -1,0 +1,61 @@
+/**
+ * Typed blocks for the `ay todo` engine.
+ *
+ * A task that cannot currently proceed records WHY, as one of four typed
+ * shapes rather than a free-text string. The type tells the engine (and any
+ * automation built on top of it, see `todoAutomation.ts` in a later
+ * milestone) exactly how to detect that the wait is over:
+ *
+ *   - blocked-by-task: waiting on another task in the same store. Clears
+ *     itself the moment that task reaches its kind's `done` state — this is
+ *     pure data (see `todoDigest.ts`'s `unblockedTasks`), no monitor needed.
+ *   - blocked-by-human: waiting on a specific person to answer or decide
+ *     something. Needs NO monitor at all — a human's reply always arrives as
+ *     a message that human chooses to send (e.g. via the `/ask` decision
+ *     panel, a later milestone), so there is nothing to poll.
+ *   - blocked-by-external: waiting on some signal outside this store and
+ *     outside any tracked agent (a CI run, a release, a third-party event).
+ *     Needs an actual poll/monitor loop.
+ *   - waiting-on-agent: waiting on a specific tracked agent process to reach
+ *     some point (finish, go idle, etc). Cleared by that agent's own
+ *     lifecycle events (via `ay notify`, wired in a later milestone).
+ */
+
+export type TodoBlock =
+  | { type: "blocked-by-task"; taskId: string }
+  | { type: "blocked-by-human"; who: string; question?: string; options?: string[] }
+  | { type: "blocked-by-external"; signal: string; checkFn?: string }
+  | { type: "waiting-on-agent"; agentId: string };
+
+export type MonitorHint = "none" | "notify-agent" | "poll-external";
+
+/**
+ * How a block of this type should be watched. Kept as one pure function so
+ * every caller (CLI rendering, automation, `/ask` aggregation) agrees on the
+ * same classification instead of re-deriving it ad hoc.
+ */
+export function monitorHint(block: TodoBlock): MonitorHint {
+  switch (block.type) {
+    case "blocked-by-task":
+    case "blocked-by-human":
+      return "none";
+    case "waiting-on-agent":
+      return "notify-agent";
+    case "blocked-by-external":
+      return "poll-external";
+  }
+}
+
+/** One-line human-readable summary, used by CLI/digest rendering. */
+export function describeBlock(block: TodoBlock): string {
+  switch (block.type) {
+    case "blocked-by-task":
+      return `blocked by task ${block.taskId}`;
+    case "blocked-by-human":
+      return `waiting on ${block.who}${block.question ? `: ${block.question}` : ""}`;
+    case "blocked-by-external":
+      return `waiting on external signal: ${block.signal}`;
+    case "waiting-on-agent":
+      return `waiting on agent ${block.agentId}`;
+  }
+}

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -1,0 +1,289 @@
+/**
+ * `ay todo <verb>` — CLI surface for the lifecycle engine (`todoStore.ts`),
+ * typed blocks (`todoBlock.ts`), and read-side views (`todoDigest.ts`).
+ *
+ * Registered from `ts/subcommands.ts` the same way larger subsystems like
+ * `serve`/`schedule`/`expose` are: a lazy `case "todo":` import into
+ * `runTodoSubcommand`, so this file (and everything it pulls in) is only
+ * loaded when `ay todo ...` is actually invoked.
+ *
+ * Store location: `--root <dir>` (default: current working directory) is
+ * where `.agent-yes/todos.jsonl` lives, mirroring `PidStore`'s own
+ * `<workingDir>/.agent-yes/...` convention. This module has no notion of any
+ * particular consuming project's directory-resolution rules (e.g. "find the
+ * monorepo root") — a project wanting that behavior supplies it by always
+ * invoking with an explicit `--root`, or by calling `openStore()` as a
+ * library from its own code instead of through this CLI.
+ */
+
+import yargs from "yargs";
+import { openStore, CycleError, type TodoRecord } from "./todoStore.ts";
+import { isKnownKind, LIFECYCLES, type LifecycleKind } from "./todoLifecycle.ts";
+import { describeBlock, type TodoBlock } from "./todoBlock.ts";
+import { renderDigest, renderTree } from "./todoDigest.ts";
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseKind(raw: string | undefined): LifecycleKind {
+  if (!raw) fail(`--kind is required (one of: ${Object.keys(LIFECYCLES).join(", ")})`);
+  if (!isKnownKind(raw))
+    fail(`unknown kind "${raw}" (one of: ${Object.keys(LIFECYCLES).join(", ")})`);
+  return raw;
+}
+
+function renderRecord(t: TodoRecord): string {
+  const lines = [
+    `${t._id} [${t.state}] ${t.summary}`,
+    `kind:    ${t.kind}${t.targetTier ? `  tier:${t.targetTier}` : ""}`,
+    ...(t.owner ? [`owner:   ${t.owner}`] : []),
+    ...(t.block ? [`block:   ${describeBlock(t.block)}`] : []),
+    ...(t.blockedBy.length ? [`blockedBy: ${t.blockedBy.join(", ")}`] : []),
+    ...(t.tags.length ? [`tags:    ${t.tags.join(", ")}`] : []),
+    ...(t.satisfiedGates.length ? [`satisfiedGates: ${t.satisfiedGates.join(", ")}`] : []),
+    ...(t.verifyEvidence.length
+      ? [
+          `evidence: ${t.verifyEvidence.map((e) => `${e.gate} by ${e.validator}${e.link ? ` (${e.link})` : ""}`).join("; ")}`,
+        ]
+      : []),
+    `created: ${t.createdAt}`,
+    `updated: ${t.updatedAt}`,
+  ];
+  if (t.description) lines.push("", t.description);
+  return lines.join("\n");
+}
+
+function renderList(tasks: TodoRecord[]): string {
+  if (tasks.length === 0) return "(no tasks match)";
+  const rows = tasks.map((t) => [t._id, t.state, t.kind, t.owner ?? "", t.summary]);
+  const header = ["ID", "STATE", "KIND", "OWNER", "SUMMARY"];
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
+  const line = (xs: string[]) =>
+    xs
+      .map((x, i) => x.padEnd(widths[i]!))
+      .join("  ")
+      .trimEnd();
+  return [line(header), ...rows.map(line)].join("\n");
+}
+
+interface CommonOpts {
+  root: string;
+  format: "table" | "json";
+}
+
+function emit(opts: CommonOpts, obj: unknown, human: string): void {
+  process.stdout.write((opts.format === "json" ? JSON.stringify(obj, null, 2) : human) + "\n");
+}
+
+export async function runTodoSubcommand(rest: string[]): Promise<number> {
+  const y = yargs(rest)
+    .scriptName("ay todo")
+    .option("root", {
+      type: "string",
+      default: process.cwd(),
+      describe: "project root holding .agent-yes/todos.jsonl",
+    })
+    .option("format", { choices: ["table", "json"] as const, default: "table" as const })
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+  const argv = (await y.parseAsync()) as unknown as CommonOpts & { _: (string | number)[] };
+  const [verb, ...args] = argv._.map(String);
+  const opts: CommonOpts = { root: argv.root, format: argv.format };
+  const store = await openStore(opts.root);
+
+  switch (verb) {
+    case "new": {
+      const sub = yargs(args)
+        .option("kind", { type: "string" })
+        .option("description", { type: "string" })
+        .option("tier", { type: "string" })
+        .option("owner", { type: "string" })
+        .option("tag", { type: "string", array: true })
+        .option("dep", { type: "string", array: true })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const summary = String(a._[0] ?? "");
+      if (!summary)
+        fail(
+          "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--owner ...] [--tag t]... [--dep id]...",
+        );
+      const rec = await store.create({
+        summary,
+        kind: parseKind(a.kind as string | undefined),
+        description: a.description as string | undefined,
+        targetTier: a.tier as string | undefined,
+        owner: a.owner as string | undefined,
+        tags: (a.tag as string[] | undefined) ?? [],
+        blockedBy: (a.dep as string[] | undefined) ?? [],
+      });
+      emit(opts, rec, `created ${rec._id}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "ls": {
+      const sub = yargs(args)
+        .option("kind", { type: "string" })
+        .option("state", { type: "string" })
+        .option("owner", { type: "string" })
+        .option("tag", { type: "string" })
+        .option("blocked", { type: "boolean", default: false })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const tasks = store.list({
+        kind: a.kind ? parseKind(a.kind as string) : undefined,
+        state: a.state as string | undefined,
+        owner: a.owner as string | undefined,
+        tag: a.tag as string | undefined,
+        blocked: a.blocked as boolean,
+      });
+      emit(opts, tasks, renderList(tasks));
+      return 0;
+    }
+    case "get": {
+      const id = args[0];
+      if (!id) fail("usage: ay todo get <id>");
+      const rec = store.get(id);
+      if (!rec) fail(`no such task: ${id}`);
+      emit(opts, rec, renderRecord(rec));
+      return 0;
+    }
+    case "transition": {
+      const [id, toState] = args;
+      if (!id || !toState) fail("usage: ay todo transition <id> <toState>");
+      const rec = await store.transition(id, toState);
+      emit(opts, rec, `transitioned ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "approve": {
+      const sub = yargs(args)
+        .option("note", { type: "string" })
+        .option("link", { type: "string" })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const [id, gate, validator] = (a._ as (string | number)[]).map(String);
+      if (!id || !gate || !validator)
+        fail("usage: ay todo approve <id> <gate> <validatorIdentity> [--note ...] [--link ...]");
+      const rec = await store.approve(id, gate, validator, {
+        note: a.note as string | undefined,
+        link: a.link as string | undefined,
+      });
+      emit(
+        opts,
+        rec,
+        `approved "${gate}" on ${rec._id} (validator: ${validator})\n${renderRecord(rec)}`,
+      );
+      return 0;
+    }
+    case "verify": {
+      const [id, gate] = args;
+      if (!id) fail("usage: ay todo verify <id> [gateName]");
+      const rec = await store.verify(id, gate);
+      emit(opts, rec, `verified ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "block": {
+      const sub = yargs(args)
+        .option("type", {
+          type: "string",
+          choices: [
+            "blocked-by-task",
+            "blocked-by-human",
+            "blocked-by-external",
+            "waiting-on-agent",
+          ] as const,
+        })
+        .option("task", { type: "string" })
+        .option("who", { type: "string" })
+        .option("question", { type: "string" })
+        .option("options", { type: "string", array: true })
+        .option("signal", { type: "string" })
+        .option("agent", { type: "string" })
+        .help(false)
+        .exitProcess(false);
+      const a = await sub.parseAsync();
+      const id = String(a._[0] ?? "");
+      if (!id || !a.type)
+        fail(
+          "usage: ay todo block <id> --type <blocked-by-task|blocked-by-human|blocked-by-external|waiting-on-agent> ...",
+        );
+      let block: TodoBlock;
+      switch (a.type) {
+        case "blocked-by-task":
+          if (!a.task) fail("--task <id> is required for --type blocked-by-task");
+          block = { type: "blocked-by-task", taskId: a.task as string };
+          break;
+        case "blocked-by-human":
+          if (!a.who) fail("--who <name> is required for --type blocked-by-human");
+          block = {
+            type: "blocked-by-human",
+            who: a.who as string,
+            question: a.question as string | undefined,
+            options: a.options as string[] | undefined,
+          };
+          break;
+        case "blocked-by-external":
+          if (!a.signal) fail("--signal <name> is required for --type blocked-by-external");
+          block = { type: "blocked-by-external", signal: a.signal as string };
+          break;
+        case "waiting-on-agent":
+          if (!a.agent) fail("--agent <id> is required for --type waiting-on-agent");
+          block = { type: "waiting-on-agent", agentId: a.agent as string };
+          break;
+        default:
+          fail(`unknown block type: ${a.type}`);
+      }
+      const rec = await store.setBlock(id, block);
+      emit(opts, rec, `blocked ${rec._id}: ${describeBlock(block)}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "unblock": {
+      const id = args[0];
+      if (!id) fail("usage: ay todo unblock <id>");
+      const rec = await store.setBlock(id, null);
+      emit(opts, rec, `unblocked ${rec._id}\n${renderRecord(rec)}`);
+      return 0;
+    }
+    case "dep": {
+      const [verb2, id, blockerId] = args;
+      if (!verb2 || !id || !blockerId || (verb2 !== "add" && verb2 !== "rm")) {
+        fail("usage: ay todo dep add|rm <id> <blockerId>");
+      }
+      try {
+        const rec =
+          verb2 === "add" ? await store.addDep(id, blockerId) : await store.rmDep(id, blockerId);
+        emit(
+          opts,
+          rec,
+          `${verb2 === "add" ? "added" : "removed"} dep ${blockerId} on ${rec._id}\n${renderRecord(rec)}`,
+        );
+        return 0;
+      } catch (err) {
+        if (err instanceof CycleError) fail(err.message);
+        throw err;
+      }
+    }
+    case "tree": {
+      const rootId = args[0];
+      process.stdout.write(renderTree(store.all(), rootId) + "\n");
+      return 0;
+    }
+    case "digest": {
+      const tasks = store.all();
+      if (opts.format === "json") {
+        const { unblockedTasks } = await import("./todoDigest.ts");
+        emit(opts, { tasks, unblocked: unblockedTasks(tasks).map((t) => t._id) }, "");
+      } else {
+        process.stdout.write(renderDigest(tasks) + "\n");
+      }
+      return 0;
+    }
+    default:
+      fail(
+        `unknown "ay todo" verb: "${verb ?? ""}" (expected: new/ls/get/transition/approve/verify/block/unblock/dep/tree/digest)`,
+      );
+  }
+}

--- a/ts/todoDigest.spec.ts
+++ b/ts/todoDigest.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { openBlockers, renderDigest, renderTree, unblockedTasks } from "./todoDigest";
+import type { TodoRecord } from "./todoStore";
+
+function task(over: Partial<TodoRecord> & { _id: string }): TodoRecord {
+  return {
+    kind: "code",
+    state: "doing",
+    summary: `task ${over._id}`,
+    description: "",
+    blockedBy: [],
+    tags: [],
+    satisfiedGates: [],
+    verifyEvidence: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("unblockedTasks", () => {
+  it("fires only when ALL blockers reached done, never for a finished task, never with zero declared deps", () => {
+    const tasks = [
+      task({ _id: "T1", state: "done" }),
+      task({ _id: "T2", state: "done" }),
+      task({ _id: "T3", state: "shipped", blockedBy: ["T1", "T2"] }), // both done -> unblocked
+      task({ _id: "T4", state: "shipped", blockedBy: ["T1", "T5"] }), // T5 not done -> still blocked
+      task({ _id: "T5", state: "doing" }),
+      task({ _id: "T6", state: "done", blockedBy: ["T1"] }), // finished -> not surfaced
+      task({ _id: "T7", state: "shipped" }), // no declared deps -> nothing to detect
+    ];
+    expect(unblockedTasks(tasks).map((t) => t._id)).toEqual(["T3"]);
+  });
+});
+
+describe("openBlockers", () => {
+  it("reports only the not-yet-done blockers, including a missing id as open", () => {
+    const byId = new Map([
+      ["T1", task({ _id: "T1", state: "done" })],
+      ["T2", task({ _id: "T2", state: "doing" })],
+    ]);
+    const t = task({ _id: "T3", blockedBy: ["T1", "T2", "T99"] });
+    expect(openBlockers(t, byId)).toEqual(["T2", "T99"]);
+  });
+});
+
+describe("renderTree", () => {
+  const tasks = [
+    task({ _id: "T1", state: "done", summary: "schema" }),
+    task({ _id: "T2", state: "doing", summary: "api", owner: "cto", blockedBy: ["T1"] }),
+    task({ _id: "T3", state: "shipped", summary: "ui", blockedBy: ["T2"] }),
+  ];
+
+  it("renders roots (nothing depends on them, they have deps) down blockedBy edges", () => {
+    const out = renderTree(tasks);
+    expect(out).toContain("T3 [shipped] ui");
+    expect(out).toContain("└─ T2 [doing] api");
+    expect(out).toContain("owner:cto");
+  });
+
+  it("accepts an explicit root id and throws on an unknown one", () => {
+    expect(renderTree(tasks, "T2")).toContain("└─ T1 [done] schema");
+    expect(() => renderTree(tasks, "T99")).toThrow(/no such task/);
+  });
+
+  it("reports a friendly message when there are no dependency links at all", () => {
+    expect(renderTree([task({ _id: "T1" })])).toContain("no dependency links");
+  });
+});
+
+describe("renderDigest", () => {
+  it("groups by tag with per-state counts, and surfaces blocked/waiting/unblocked info inline", () => {
+    const tasks = [
+      task({ _id: "T1", state: "done", tags: ["proj-x"] }),
+      task({ _id: "T2", state: "doing", tags: ["proj-x"], owner: "cto", blockedBy: ["T1"] }),
+      task({
+        _id: "T3",
+        state: "shipped",
+        tags: ["proj-y"],
+        blockedBy: ["T2"],
+        block: { type: "blocked-by-human", who: "taku" },
+      }),
+    ];
+    const out = renderDigest(tasks);
+    expect(out).toContain("## proj-x");
+    expect(out).toContain("## proj-y");
+    expect(out).toContain("block:blocked-by-human");
+    expect(out).toContain("blockedBy:T2"); // T3's blocker T2 isn't done yet
+    expect(out).toContain("unblocked (all blockers reached done");
+    expect(out).toContain("T2 task T2"); // T2's blocker T1 IS done -> unblocked section
+  });
+
+  it("empty task list renders a friendly message, not a crash", () => {
+    expect(renderDigest([])).toBe("(no tasks)");
+  });
+});

--- a/ts/todoDigest.ts
+++ b/ts/todoDigest.ts
@@ -1,0 +1,125 @@
+/**
+ * Read-side views over the `ay todo` store: dependency-tree rendering and a
+ * per-tag digest board. Pure functions over an already-loaded task list — no
+ * I/O — so they are trivially unit-testable and reusable by both the CLI
+ * (`todoCli.ts`) and any future web view.
+ *
+ * `unblockedTasks` is ported near-verbatim from the equivalent, already
+ * mutation-tested algorithm in symval-dev-cli's `deps.ts` (a closed-source
+ * downstream consumer of an earlier, less general version of this idea) —
+ * generalized here to the new `TodoRecord` shape and the `done` state name
+ * from `todoLifecycle.ts` instead of a hardcoded status string.
+ */
+
+import { DONE_STATE } from "./todoLifecycle.ts";
+import type { TodoRecord } from "./todoStore.ts";
+
+/**
+ * A task is "unblocked" when it is not itself finished, it declares
+ * `blockedBy` dependencies, and every one of them has reached `done`.
+ * Surfaced for a caller to act on — never auto-applied here (deciding to
+ * resume a task is left to automation, a later milestone, or a human).
+ */
+export function unblockedTasks(tasks: TodoRecord[]): TodoRecord[] {
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  return tasks.filter((t) => {
+    if (t.state === DONE_STATE) return false;
+    if (t.blockedBy.length === 0) return false;
+    return t.blockedBy.every((d) => byId.get(d)?.state === DONE_STATE);
+  });
+}
+
+/** Blockers of `t` that have not reached `done` yet (a missing id is reported as-is, still "open"). */
+export function openBlockers(t: TodoRecord, byId: Map<string, TodoRecord>): string[] {
+  return t.blockedBy.filter((d) => byId.get(d)?.state !== DONE_STATE);
+}
+
+function nodeLine(t: TodoRecord): string {
+  const bits = [`${t._id} [${t.state}] ${t.summary}`, ...(t.owner ? [`owner:${t.owner}`] : [])];
+  return bits.join("  ");
+}
+
+/**
+ * Dependency tree, rendered from roots (tasks nothing depends on, that
+ * themselves declare at least one dependency) down their `blockedBy` edges:
+ * a parent's children are what it is waiting for.
+ */
+export function renderTree(tasks: TodoRecord[], rootId?: string): string {
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  const dependedOn = new Set(tasks.flatMap((t) => t.blockedBy));
+  const roots = rootId
+    ? [byId.get(rootId) ?? null].filter((t): t is TodoRecord => t !== null)
+    : tasks.filter((t) => !dependedOn.has(t._id) && t.blockedBy.length > 0);
+  if (rootId && roots.length === 0) throw new Error(`no such task: ${rootId}`);
+  if (roots.length === 0) return "(no dependency links)";
+
+  const lines: string[] = [];
+  const walk = (
+    t: TodoRecord,
+    prefix: string,
+    isLast: boolean,
+    depth: number,
+    seen: Set<string>,
+  ): void => {
+    lines.push(depth === 0 ? nodeLine(t) : `${prefix}${isLast ? "└─" : "├─"} ${nodeLine(t)}`);
+    if (seen.has(t._id)) return;
+    seen.add(t._id);
+    const deps = t.blockedBy
+      .map((d) => byId.get(d))
+      .filter((x): x is TodoRecord => x !== undefined);
+    deps.forEach((d, i) => {
+      const childPrefix = depth === 0 ? "" : `${prefix}${isLast ? "   " : "│  "}`;
+      walk(d, childPrefix, i === deps.length - 1, depth + 1, seen);
+    });
+  };
+  roots.forEach((r) => walk(r, "", true, 0, new Set()));
+  return lines.join("\n");
+}
+
+/** Per-tag board: state counts per tag, plus an unblocked-tasks callout. */
+export function renderDigest(tasks: TodoRecord[]): string {
+  if (tasks.length === 0) return "(no tasks)";
+  const byId = new Map(tasks.map((t) => [t._id, t]));
+  const unblocked = new Set(unblockedTasks(tasks).map((t) => t._id));
+
+  const streams = new Map<string, TodoRecord[]>();
+  for (const t of tasks) {
+    for (const tag of t.tags.length ? t.tags : ["(untagged)"]) {
+      if (!streams.has(tag)) streams.set(tag, []);
+      streams.get(tag)!.push(t);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const [stream, items] of [...streams.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const allStates = [...new Set(items.map((t) => t.state))].sort();
+    const counts = allStates
+      .map((s) => `${s}:${items.filter((t) => t.state === s).length}`)
+      .join(" ");
+    lines.push(`## ${stream}  (${counts})`);
+    for (const s of allStates) {
+      for (const t of items.filter((x) => x.state === s)) {
+        const open = openBlockers(t, byId);
+        const extra = [
+          ...(t.owner ? [`owner:${t.owner}`] : []),
+          ...(t.block ? [`block:${t.block.type}`] : []),
+          ...(open.length ? [`blockedBy:${open.join(",")}`] : []),
+          ...(unblocked.has(t._id) ? ["UNBLOCKED"] : []),
+        ];
+        lines.push(
+          `  [${t.state}] ${t._id} ${t.summary}${extra.length ? `  [${extra.join(" ")}]` : ""}`,
+        );
+      }
+    }
+    lines.push("");
+  }
+
+  const ub = unblockedTasks(tasks);
+  if (ub.length) {
+    lines.push("## unblocked (all blockers reached done — resume these)");
+    for (const t of ub)
+      lines.push(`  ${t._id} ${t.summary}${t.owner ? `  (owner:${t.owner})` : ""}`);
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}

--- a/ts/todoLifecycle.spec.ts
+++ b/ts/todoLifecycle.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIFECYCLES,
+  canTransition,
+  initialState,
+  isKnownKind,
+  nextStates,
+  requiredGate,
+  statesOf,
+} from "./todoLifecycle";
+
+describe("todoLifecycle", () => {
+  it("defines all five kinds with the exact graphs taku specified", () => {
+    expect(Object.keys(LIFECYCLES).sort()).toEqual([
+      "code",
+      "decision",
+      "doc",
+      "human",
+      "investigation",
+    ]);
+    expect(statesOf("code")).toEqual([
+      "doing",
+      "merged",
+      "shipped",
+      "verifying",
+      "done",
+      "verify-failed",
+      "orphaned",
+    ]);
+    expect(statesOf("human")).toEqual(["pending", "decided", "done"]);
+  });
+
+  it("initialState is each graph's first listed state", () => {
+    expect(initialState("code")).toBe("doing");
+    expect(initialState("human")).toBe("pending");
+    expect(initialState("doc")).toBe("drafting");
+  });
+
+  it("canTransition/nextStates follow the declared edges only", () => {
+    expect(canTransition("code", "doing", "merged")).toBe(true);
+    expect(canTransition("code", "doing", "done")).toBe(false); // no edge skips straight to done
+    expect(nextStates("code", "verifying").sort()).toEqual(["done", "verify-failed"]);
+  });
+
+  it("requiredGate reports the gate name for gated edges, null for ungated/nonexistent edges", () => {
+    expect(requiredGate("code", "verifying", "done")).toBe("verify-green");
+    expect(requiredGate("code", "verifying", "verify-failed")).toBe("verify-red");
+    expect(requiredGate("code", "doing", "merged")).toBeNull(); // ungated
+    expect(requiredGate("code", "doing", "done")).toBeNull(); // no such edge
+  });
+
+  it("verify-failed reopens ONLY to the kind's doing state, never straight back to verifying", () => {
+    expect(nextStates("code", "verify-failed")).toEqual(["doing"]);
+  });
+
+  it("the human kind has no merge/ship/QA transitions at all (taku decision #6)", () => {
+    const humanStates = new Set(statesOf("human"));
+    for (const s of ["merged", "shipped", "verifying", "verify-failed"]) {
+      expect(humanStates.has(s)).toBe(false);
+    }
+  });
+
+  it("isKnownKind is a type guard over the real kind set", () => {
+    expect(isKnownKind("code")).toBe(true);
+    expect(isKnownKind("bogus")).toBe(false);
+  });
+});

--- a/ts/todoLifecycle.ts
+++ b/ts/todoLifecycle.ts
@@ -1,0 +1,121 @@
+/**
+ * Declarative lifecycle graphs for the `ay todo` engine.
+ *
+ * A task has a "kind" (what shape of work it is) and each kind owns an
+ * ordered set of states plus the transitions allowed between them. Some
+ * transitions require a "gate" — a named condition that must be satisfied
+ * before the transition is allowed. The engine (see `todoStore.ts`) enforces
+ * gates at a single choke point, so `done`-family states can never be reached
+ * by a plain manual flip: only a registered gate reporting success can move a
+ * task into one.
+ *
+ * This file is pure data plus pure functions — no I/O, no process/agent
+ * awareness, so it can be tested in complete isolation and reused by any
+ * project that adopts `ay todo`, not just one particular team's workflow.
+ * Deliberately generic: nothing here names a specific product, company, or
+ * external tool. A consuming project supplies the concrete meaning of a gate
+ * (e.g. what "the tests passed" means for them) via `registerGate` in
+ * `todoStore.ts` — this module only knows gates by name.
+ */
+
+export type LifecycleKind = "code" | "decision" | "doc" | "investigation" | "human";
+
+export interface LifecycleTransition {
+  from: string;
+  to: string;
+  /** Name of the gate that must pass before this transition is allowed. Absent = always allowed. */
+  gate?: string;
+}
+
+export interface LifecycleGraph {
+  states: string[];
+  transitions: LifecycleTransition[];
+}
+
+/**
+ * States considered "finished" across every kind. A finished task is never
+ * reopened by automation (see `todoAutomation.ts` in a later milestone) —
+ * only a human explicitly reopening it (e.g. `verify-failed` → the kind's
+ * doing state) moves a task out of a finished-adjacent state.
+ */
+export const DONE_STATE = "done";
+
+export const LIFECYCLES: Record<LifecycleKind, LifecycleGraph> = {
+  code: {
+    states: ["doing", "merged", "shipped", "verifying", "done", "verify-failed", "orphaned"],
+    transitions: [
+      { from: "doing", to: "merged" },
+      { from: "merged", to: "shipped" },
+      { from: "shipped", to: "verifying" },
+      { from: "verifying", to: "done", gate: "verify-green" },
+      { from: "verifying", to: "verify-failed", gate: "verify-red" },
+      // Reopening always returns to "doing", never straight back to "verifying" —
+      // every re-attempt goes through a real doing→verifying cycle so a failure
+      // is never silently re-run away without a fresh doing step.
+      { from: "verify-failed", to: "doing" },
+    ],
+  },
+  decision: {
+    states: ["deciding", "decided", "done"],
+    transitions: [
+      { from: "deciding", to: "decided", gate: "human-decided" },
+      { from: "decided", to: "done" },
+    ],
+  },
+  doc: {
+    states: ["drafting", "review", "done"],
+    transitions: [
+      { from: "drafting", to: "review" },
+      { from: "review", to: "done", gate: "human-approved" },
+    ],
+  },
+  investigation: {
+    states: ["investigating", "reported", "done"],
+    transitions: [
+      { from: "investigating", to: "reported" },
+      { from: "reported", to: "done", gate: "human-acknowledged" },
+    ],
+  },
+  // Structurally different from the four work-shaped kinds above: no merge,
+  // ship, or verify step at all. Used for every task whose entire content is
+  // "a human needs to decide or answer something."
+  human: {
+    states: ["pending", "decided", "done"],
+    transitions: [
+      { from: "pending", to: "decided", gate: "human-replied" },
+      { from: "decided", to: "done" },
+    ],
+  },
+};
+
+/** The state a newly-created task of `kind` starts in (its graph's first state). */
+export function initialState(kind: LifecycleKind): string {
+  const first = LIFECYCLES[kind].states[0];
+  if (!first) throw new Error(`lifecycle kind "${kind}" has no states`);
+  return first;
+}
+
+/** States reachable in one transition from `currentState`, regardless of gates. */
+export function nextStates(kind: LifecycleKind, currentState: string): string[] {
+  return LIFECYCLES[kind].transitions.filter((t) => t.from === currentState).map((t) => t.to);
+}
+
+/** Whether `from`→`to` is a transition that exists in `kind`'s graph at all (gate not evaluated here). */
+export function canTransition(kind: LifecycleKind, from: string, to: string): boolean {
+  return LIFECYCLES[kind].transitions.some((t) => t.from === from && t.to === to);
+}
+
+/** The gate name required for `from`→`to`, or null if the edge is ungated or does not exist. */
+export function requiredGate(kind: LifecycleKind, from: string, to: string): string | null {
+  const t = LIFECYCLES[kind].transitions.find((e) => e.from === from && e.to === to);
+  return t?.gate ?? null;
+}
+
+/** All valid state names for `kind` — used to validate stored records and CLI input. */
+export function statesOf(kind: LifecycleKind): string[] {
+  return LIFECYCLES[kind].states;
+}
+
+export function isKnownKind(value: string): value is LifecycleKind {
+  return value in LIFECYCLES;
+}

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { rm } from "fs/promises";
+import path from "path";
+import { TodoStore, CycleError, openStore } from "./todoStore";
+
+const isWindows = process.platform === "win32";
+const TEST_ROOT = isWindows
+  ? path.join(process.env.TEMP || "C:\\Temp", "todostore-test-" + process.pid)
+  : "/tmp/todostore-test-" + process.pid;
+
+describe("TodoStore", () => {
+  beforeEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+  afterEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  it("create() assigns sequential ids and the kind's initial state", async () => {
+    const s = await openStore(TEST_ROOT);
+    const a = await s.create({ summary: "write the spec", kind: "doc" });
+    const b = await s.create({ summary: "ship the feature", kind: "code" });
+    expect(a._id).toBe("T1");
+    expect(a.state).toBe("drafting");
+    expect(b._id).toBe("T2");
+    expect(b.state).toBe("doing");
+  });
+
+  it("transition() across an ungated edge succeeds with no approval needed", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    const moved = await s.transition(t._id, "merged");
+    expect(moved.state).toBe("merged");
+  });
+
+  it("transition() across a nonexistent edge is refused", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    await expect(s.transition(t._id, "done")).rejects.toThrow(/no transition/);
+  });
+
+  it("transition() across a gated edge is refused until the gate is satisfied", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    await expect(s.transition(t._id, "done")).rejects.toThrow(/requires gate "human-approved"/);
+  });
+
+  it("INDEPENDENT VERIFICATION: approve() refuses when the validator is the task's own owner (self-certification blocked)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    await expect(s.approve(t._id, "human-approved", "worker")).rejects.toThrow(
+      /independent verification required/,
+    );
+    // case-insensitive match
+    await expect(s.approve(t._id, "human-approved", "WORKER")).rejects.toThrow(
+      /independent verification required/,
+    );
+  });
+
+  it("approve() by a DIFFERENT identity succeeds, records evidence, and unblocks the transition", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    const approved = await s.approve(t._id, "human-approved", "reviewer", {
+      note: "looks good",
+      link: "https://example/pr/1",
+    });
+    expect(approved.satisfiedGates).toEqual(["human-approved"]);
+    expect(approved.verifyEvidence).toHaveLength(1);
+    expect(approved.verifyEvidence[0]).toMatchObject({
+      gate: "human-approved",
+      validator: "reviewer",
+      note: "looks good",
+      link: "https://example/pr/1",
+    });
+
+    const done = await s.transition(t._id, "done");
+    expect(done.state).toBe("done");
+    // the satisfied-gate flag is consumed by the transition — cannot be replayed
+    expect(done.satisfiedGates).toEqual([]);
+    // evidence is NOT duplicated: transition() does not append a second entry
+    expect(done.verifyEvidence).toHaveLength(1);
+  });
+
+  it("approve() with an empty owner allows any validator (nothing to compare against) but still requires one", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc" }); // no owner
+    await s.transition(t._id, "review");
+    const approved = await s.approve(t._id, "human-approved", "anyone");
+    expect(approved.satisfiedGates).toEqual(["human-approved"]);
+    await expect(s.approve(t._id, "human-approved", "")).rejects.toThrow(
+      /requires a validatorIdentity/,
+    );
+  });
+
+  it("approve() refuses a gate name that is not on any edge from the task's current state", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await expect(s.approve(t._id, "human-approved", "reviewer")).rejects.toThrow(
+      /not a gate on any transition/,
+    ); // still in "drafting"
+  });
+
+  it("REGISTERED gates cannot be satisfied by transition() OR approve() — only verify()", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({ name: "verify-green", check: async () => ({ passed: true }) });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    await expect(s.transition(t._id, "done")).rejects.toThrow(/registered gate.*verify\(/);
+    await expect(s.approve(t._id, "verify-green", "someone-else")).rejects.toThrow(
+      /cannot be approved manually/,
+    );
+  });
+
+  it("verify() with a passing registered gate moves to the gated state and records the gate name as validator", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({
+      name: "verify-green",
+      check: async () => ({ passed: true, note: "canary green", link: "https://ci/run/1" }),
+    });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const verified = await s.verify(t._id);
+    expect(verified.state).toBe("done");
+    expect(verified.verifyEvidence.at(-1)).toMatchObject({
+      gate: "verify-green",
+      validator: "gate:verify-green",
+      note: "canary green",
+      link: "https://ci/run/1",
+    });
+  });
+
+  it("verify() with a failing check takes the SIBLING edge (verify-failed), not done — the failure is a real distinct state, not silently dropped", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({
+      name: "verify-green",
+      check: async () => ({ passed: false, note: "canary red: 2 tests failed" }),
+    });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const result = await s.verify(t._id);
+    expect(result.state).toBe("verify-failed");
+    expect(result.verifyEvidence.at(-1)?.note).toBe("canary red: 2 tests failed");
+  });
+
+  it("verify-failed reopens ONLY back to doing, via a normal transition() call (real doing->verifying cycle preserved)", async () => {
+    const s = await openStore(TEST_ROOT);
+    s.registerGate({ name: "verify-green", check: async () => ({ passed: false }) });
+    const t = await s.create({ summary: "x", kind: "code", owner: "worker" });
+    await s.transition(t._id, "merged");
+    await s.transition(t._id, "shipped");
+    await s.transition(t._id, "verifying");
+    const failed = await s.verify(t._id);
+    expect(failed.state).toBe("verify-failed");
+    const reopened = await s.transition(t._id, "doing");
+    expect(reopened.state).toBe("doing");
+    await expect(s.transition(t._id, "verifying")).rejects.toThrow(/no transition/); // must go through merged/shipped again
+    const remerged = await s.transition(t._id, "merged");
+    expect(remerged.state).toBe("merged");
+  });
+
+  it("verify() with no registered gate for the current state throws", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    await expect(s.verify(t._id)).rejects.toThrow(/no gated transition/); // still "doing", which has no gated outgoing edge
+  });
+
+  it("dep add/rm: sorted, deduped, rejects self-dep, missing target, and transitive cycles", async () => {
+    const s = await openStore(TEST_ROOT);
+    const a = await s.create({ summary: "a", kind: "code" });
+    const b = await s.create({ summary: "b", kind: "code" });
+    const c = await s.create({ summary: "c", kind: "code" });
+    await expect(s.addDep(a._id, a._id)).rejects.toThrow(/cannot depend on itself/);
+    await expect(s.addDep(a._id, "T99")).rejects.toThrow(/no such task/);
+    const added = await s.addDep(c._id, a._id);
+    expect(added.blockedBy).toEqual([a._id]);
+    await s.addDep(b._id, a._id);
+    await s.addDep(c._id, b._id);
+    // a <- b <- c  (c depends on both a and b); a depending on c would cycle
+    await expect(s.addDep(a._id, c._id)).rejects.toThrow(CycleError);
+    const removed = await s.rmDep(c._id, a._id);
+    expect(removed.blockedBy).toEqual([b._id]);
+  });
+
+  it("list() filters by kind/state/owner/tag/blocked", async () => {
+    const s = await openStore(TEST_ROOT);
+    await s.create({ summary: "a", kind: "code", owner: "Alice", tags: ["proj-x"] });
+    const b = await s.create({ summary: "b", kind: "doc" });
+    await s.setBlock(b._id, { type: "blocked-by-human", who: "bob" });
+    expect(s.list({ owner: "alice" }).map((t) => t.summary)).toEqual(["a"]); // case-insensitive
+    expect(s.list({ tag: "proj-x" }).map((t) => t.summary)).toEqual(["a"]);
+    expect(s.list({ kind: "doc" }).map((t) => t.summary)).toEqual(["b"]);
+    expect(s.list({ blocked: true }).map((t) => t.summary)).toEqual(["b"]);
+  });
+
+  it("a done task with a leftover block is not counted by --blocked (mirrors symval-dev-cli's equivalent fix)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "a", kind: "human" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "x" });
+    await s.approve(t._id, "human-replied", "x");
+    await s.transition(t._id, "decided");
+    await s.transition(t._id, "done");
+    expect(s.list({ blocked: true })).toEqual([]);
+  });
+
+  it("re-opening the store (new TodoStore.open call) sees writes made before it, including from a different instance", async () => {
+    const s1 = await openStore(TEST_ROOT);
+    await s1.create({ summary: "persisted", kind: "code" });
+    const s2 = await openStore(TEST_ROOT);
+    expect(s2.list().map((t) => t.summary)).toEqual(["persisted"]);
+    expect(s2.get("T1")?._id).toBe("T1");
+  });
+});

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -1,0 +1,400 @@
+/**
+ * Persistence and gate-enforcement layer for the `ay todo` engine.
+ *
+ * Storage is one `JsonlStore` (see `JsonlStore.ts`) per project — append-only,
+ * one line per create/update, "same `_id` → last line wins" merge, already
+ * multi-process safe via `proper-lockfile`. This is deliberately reused
+ * rather than reinvented: two agents editing two different tasks never
+ * conflict (different `_id`s), and two agents editing the SAME task resolve
+ * to last-write-wins without any manual JSON merge — the exact multi-writer
+ * problem a from-scratch flat-JSON-array store would have to solve by hand.
+ *
+ * The single most important property of this module is INDEPENDENT
+ * VERIFICATION: the identity that satisfies a gate must never be the same
+ * identity as the task's owner (the one who did the work). This is not
+ * "automated checks only" — a manual approval is entirely acceptable, as
+ * long as the approver is provably someone (or something) other than the
+ * worker. A task can only reach a gated state through one of two paths, and
+ * both enforce this at the same choke point rather than leaving it to
+ * caller discipline —
+ *
+ *   1. A REGISTERED gate (one whose check function was supplied via
+ *      `registerGate`, e.g. a CI/QA check) can ONLY be satisfied by
+ *      `verify()`, which actually calls that check function. `transition()`
+ *      refuses to move a task across an edge whose gate is registered, even
+ *      if asked to — there is no argument or flag that bypasses this. A
+ *      registered check is, by construction, an independent system distinct
+ *      from the worker, so it always satisfies the independence rule.
+ *   2. A gate that is NOT registered is treated as a manual, attested gate
+ *      (e.g. "a person approved this"): it can only be satisfied by
+ *      `approve()`, which REQUIRES a `validatorIdentity` argument and
+ *      refuses the call outright if that identity matches the task's
+ *      `owner` — the worker can never certify their own work. This is the
+ *      one rule this module enforces unconditionally; everything else about
+ *      who is allowed to approve what is left to the consuming project.
+ *
+ * Nothing in this file mentions any specific product, company, or external
+ * system — a consuming project supplies concrete gate behavior by calling
+ * `registerGate` with its own check function (see `GateRegistration`).
+ */
+
+import path from "path";
+import { JsonlStore, type JsonlDoc } from "./JsonlStore.ts";
+import {
+  DONE_STATE,
+  LIFECYCLES,
+  canTransition,
+  initialState,
+  requiredGate,
+  type LifecycleKind,
+} from "./todoLifecycle.ts";
+import type { TodoBlock } from "./todoBlock.ts";
+
+export interface GateEvidence {
+  gate: string;
+  passedAt: string;
+  /** Who/what satisfied the gate. For a registered gate this is the gate's own name (an automated system is inherently independent of the worker). For a manual gate this is the human-supplied `validatorIdentity` passed to `approve()`, always distinct from the task's owner at approval time. */
+  validator: string;
+  note?: string;
+  link?: string;
+}
+
+export interface TodoRecord extends JsonlDoc {
+  kind: LifecycleKind;
+  state: string;
+  /** Which done-tier this task targets, e.g. a project may define "canary-done" vs "shipped-done". Optional: not every project uses tiers. */
+  targetTier?: string;
+  summary: string;
+  description: string;
+  /** A human name/handle, or a tracked agent's stable identifier. Opaque to this module. */
+  owner?: string;
+  block?: TodoBlock;
+  /** Task-id dependencies — separate from `block`: a task can both structurally depend on other tasks AND be separately blocked-by-human at the same time. */
+  blockedBy: string[];
+  tags: string[];
+  /** Gate names satisfied via `approve()` but not yet consumed by a `transition()` call. */
+  satisfiedGates: string[];
+  /** Append-only history of every gate that has ever passed for this task (manual or registered), the append-only proof trail `verifyEvidence` from the ExecPlan. */
+  verifyEvidence: GateEvidence[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateInput {
+  summary: string;
+  kind: LifecycleKind;
+  description?: string;
+  targetTier?: string;
+  owner?: string;
+  tags?: string[];
+  blockedBy?: string[];
+}
+
+export interface ListFilter {
+  kind?: LifecycleKind;
+  state?: string;
+  owner?: string;
+  tag?: string;
+  blocked?: boolean;
+}
+
+export interface GateRegistration {
+  /** Opaque name supplied BY the consuming project — this module never inspects or hardcodes it. */
+  name: string;
+  check: () => Promise<{ passed: boolean; note?: string; link?: string }>;
+}
+
+export class CycleError extends Error {}
+
+export class TodoStore {
+  private jsonl: JsonlStore<Omit<TodoRecord, "_id">>;
+  private gates = new Map<string, GateRegistration>();
+  private nextSeq = 1;
+
+  private constructor(jsonl: JsonlStore<Omit<TodoRecord, "_id">>) {
+    this.jsonl = jsonl;
+  }
+
+  static async open(projectRoot: string): Promise<TodoStore> {
+    const filePath = path.join(projectRoot, ".agent-yes", "todos.jsonl");
+    const jsonl = new JsonlStore<Omit<TodoRecord, "_id">>(filePath);
+    await jsonl.load();
+    const store = new TodoStore(jsonl);
+    const existingIds = jsonl.getAll().map((d) => Number(String(d._id).replace(/^T/, "")) || 0);
+    store.nextSeq = (existingIds.length ? Math.max(...existingIds) : 0) + 1;
+    return store;
+  }
+
+  registerGate(gate: GateRegistration): void {
+    this.gates.set(gate.name, gate);
+  }
+
+  isRegisteredGate(name: string): boolean {
+    return this.gates.has(name);
+  }
+
+  all(): TodoRecord[] {
+    return this.jsonl.getAll() as TodoRecord[];
+  }
+
+  get(id: string): TodoRecord | null {
+    return (this.jsonl.getById(id) as TodoRecord | undefined) ?? null;
+  }
+
+  private mustGet(id: string): TodoRecord {
+    const rec = this.get(id);
+    if (!rec) throw new Error(`no such task: ${id}`);
+    return rec;
+  }
+
+  list(filter: ListFilter = {}): TodoRecord[] {
+    return this.all().filter((t) => {
+      if (filter.kind && t.kind !== filter.kind) return false;
+      if (filter.state && t.state !== filter.state) return false;
+      if (filter.owner && t.owner?.toLowerCase() !== filter.owner.toLowerCase()) return false;
+      if (filter.tag && !t.tags.some((x) => x.toLowerCase() === filter.tag!.toLowerCase()))
+        return false;
+      if (filter.blocked) {
+        const isBlocked =
+          t.state !== DONE_STATE && (t.block !== undefined || t.blockedBy.length > 0);
+        if (!isBlocked) return false;
+      }
+      return true;
+    });
+  }
+
+  async create(input: CreateInput): Promise<TodoRecord> {
+    const id = `T${this.nextSeq++}`;
+    const now = new Date().toISOString();
+    for (const dep of input.blockedBy ?? []) {
+      if (!this.get(dep)) throw new Error(`no such task: ${dep}`);
+    }
+    const doc: Omit<TodoRecord, "_id"> = {
+      kind: input.kind,
+      state: initialState(input.kind),
+      summary: input.summary,
+      description: input.description ?? "",
+      blockedBy: input.blockedBy ?? [],
+      tags: input.tags ?? [],
+      satisfiedGates: [],
+      verifyEvidence: [],
+      createdAt: now,
+      updatedAt: now,
+      ...(input.targetTier ? { targetTier: input.targetTier } : {}),
+      ...(input.owner ? { owner: input.owner } : {}),
+    };
+    await this.jsonl.append({ ...doc, _id: id });
+    return this.mustGet(id);
+  }
+
+  /**
+   * Move a task across an edge that either has no gate, or whose gate has
+   * already been satisfied via `approve()`. Throws — refusing the write
+   * entirely — for an edge with no such edge in the graph, or a gate that is
+   * either registered (must go through `verify()`) or not yet satisfied.
+   */
+  async transition(id: string, toState: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    if (!canTransition(rec.kind, rec.state, toState)) {
+      throw new Error(
+        `task ${id}: no transition ${rec.state} -> ${toState} for kind "${rec.kind}"`,
+      );
+    }
+    const gate = requiredGate(rec.kind, rec.state, toState);
+    if (gate) {
+      if (this.gates.has(gate)) {
+        throw new Error(
+          `task ${id}: "${gate}" is a registered gate — it can only be satisfied by verify("${id}"), not a direct transition`,
+        );
+      }
+      if (!rec.satisfiedGates.includes(gate)) {
+        throw new Error(
+          `task ${id}: transition ${rec.state} -> ${toState} requires gate "${gate}" — call approve("${id}", "${gate}") first`,
+        );
+      }
+    }
+    // No new evidence entry here: approve() already recorded one (with the
+    // independently-verified validator identity) at approval time. This call
+    // only consumes the satisfied-gate flag so it cannot be replayed.
+    return this.applyTransition(id, toState, undefined, gate);
+  }
+
+  /**
+   * Satisfy a manual (non-registered) gate. `validatorIdentity` names who is
+   * satisfying it — REQUIRED, and rejected outright when it matches the
+   * task's `owner` (case-insensitively): independent verification is the
+   * one rule this module enforces unconditionally, so the worker can never
+   * certify their own work, no matter who is running the CLI. A task with
+   * no `owner` set has nothing to compare against, so approval is allowed
+   * (with a required validator identity still recorded for the audit
+   * trail) — but this is expected to be rare in practice, since a task
+   * normally has an owner before it reaches a gated transition.
+   */
+  async approve(
+    id: string,
+    gateName: string,
+    validatorIdentity: string,
+    evidence?: { note?: string; link?: string },
+  ): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    if (!validatorIdentity.trim()) {
+      throw new Error(
+        `task ${id}: approve() requires a validatorIdentity (who is satisfying "${gateName}")`,
+      );
+    }
+    if (this.gates.has(gateName)) {
+      throw new Error(
+        `task ${id}: "${gateName}" is a registered gate and cannot be approved manually — it is satisfied by verify("${id}")`,
+      );
+    }
+    const onGraph = LIFECYCLES[rec.kind].transitions.some(
+      (t) => t.from === rec.state && t.gate === gateName,
+    );
+    if (!onGraph) {
+      throw new Error(
+        `task ${id}: "${gateName}" is not a gate on any transition from its current state "${rec.state}"`,
+      );
+    }
+    if (rec.owner && rec.owner.toLowerCase() === validatorIdentity.toLowerCase()) {
+      throw new Error(
+        `task ${id}: independent verification required — validator "${validatorIdentity}" is the same identity as owner "${rec.owner}"; the worker cannot certify their own work`,
+      );
+    }
+    const satisfied = new Set(rec.satisfiedGates);
+    satisfied.add(gateName);
+    const evidenceEntry: GateEvidence = {
+      gate: gateName,
+      passedAt: new Date().toISOString(),
+      validator: validatorIdentity,
+      ...evidence,
+    };
+    await this.jsonl.updateById(id, {
+      satisfiedGates: [...satisfied],
+      verifyEvidence: [...rec.verifyEvidence, evidenceEntry],
+      updatedAt: evidenceEntry.passedAt,
+    } as Partial<Omit<TodoRecord, "_id">>);
+    return this.mustGet(id);
+  }
+
+  /**
+   * Run a registered gate's check function and, based on its result, apply
+   * whichever transition out of the task's current state that gate governs.
+   * If the check reports NOT passed, and there is a sibling transition from
+   * the same state (e.g. the `code` kind's `verifying -> verify-failed`
+   * alongside `verifying -> done`), that sibling is taken instead — this is
+   * how a single automated check naturally produces the kind's real
+   * pass/fail states without hardcoding kind-specific names here.
+   */
+  async verify(id: string, gateName?: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    const edges = LIFECYCLES[rec.kind].transitions.filter((t) => t.from === rec.state && t.gate);
+    if (edges.length === 0)
+      throw new Error(`task ${id}: no gated transition from state "${rec.state}"`);
+    const targetEdge = gateName
+      ? edges.find((e) => e.gate === gateName)
+      : edges.find((e) => this.gates.has(e.gate!));
+    if (!targetEdge || !targetEdge.gate) {
+      throw new Error(
+        `task ${id}: no registered gate found for a transition from "${rec.state}"${gateName ? ` matching "${gateName}"` : ""}`,
+      );
+    }
+    const impl = this.gates.get(targetEdge.gate);
+    if (!impl)
+      throw new Error(
+        `task ${id}: gate "${targetEdge.gate}" is not registered — call registerGate() first`,
+      );
+    const result = await impl.check();
+    if (result.passed) {
+      // The gate's own name stands in for "validator" — a registered check is,
+      // by construction, an independent system distinct from the worker, so
+      // no separate identity argument is needed here (unlike approve()).
+      return this.applyTransition(id, targetEdge.to, {
+        gate: targetEdge.gate,
+        validator: `gate:${targetEdge.gate}`,
+        note: result.note,
+        link: result.link,
+      });
+    }
+    const sibling = edges.find((e) => e !== targetEdge);
+    if (!sibling) {
+      throw new Error(
+        `task ${id}: gate "${targetEdge.gate}" reported not passed and there is no alternate transition to record it against`,
+      );
+    }
+    return this.applyTransition(id, sibling.to, {
+      gate: targetEdge.gate,
+      validator: `gate:${targetEdge.gate}`,
+      note: result.note ?? "gate reported not passed",
+      link: result.link,
+    });
+  }
+
+  private async applyTransition(
+    id: string,
+    toState: string,
+    gateInfo?: { gate: string; validator: string; note?: string; link?: string },
+    consumeGate?: string | null,
+  ): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    const now = new Date().toISOString();
+    const patch: Partial<Omit<TodoRecord, "_id">> = { state: toState, updatedAt: now };
+    if (gateInfo) {
+      const evidenceEntry: GateEvidence = {
+        gate: gateInfo.gate,
+        passedAt: now,
+        validator: gateInfo.validator,
+        note: gateInfo.note,
+        link: gateInfo.link,
+      };
+      patch.verifyEvidence = [...rec.verifyEvidence, evidenceEntry];
+    }
+    if (consumeGate) {
+      patch.satisfiedGates = rec.satisfiedGates.filter((g) => g !== consumeGate);
+    }
+    await this.jsonl.updateById(id, patch);
+    return this.mustGet(id);
+  }
+
+  setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {
+    return this.rawUpdate(id, { block: block ?? undefined });
+  }
+
+  async addDep(id: string, blockerId: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    if (blockerId === id) throw new Error(`task ${id} cannot depend on itself`);
+    if (!this.get(blockerId)) throw new Error(`no such task: ${blockerId}`);
+    if (this.dependsOn(blockerId, id)) {
+      throw new CycleError(`cycle: ${blockerId} already depends (transitively) on ${id}`);
+    }
+    const deps = new Set(rec.blockedBy);
+    deps.add(blockerId);
+    return this.rawUpdate(id, { blockedBy: [...deps].sort() });
+  }
+
+  async rmDep(id: string, blockerId: string): Promise<TodoRecord> {
+    const rec = this.mustGet(id);
+    return this.rawUpdate(id, { blockedBy: rec.blockedBy.filter((d) => d !== blockerId) });
+  }
+
+  /** True when `from` transitively depends on `target` via `blockedBy` edges. Ported from the equivalent, already-tested algorithm in symval-dev-cli's store.ts. */
+  private dependsOn(from: string, target: string, seen: Set<string> = new Set()): boolean {
+    if (from === target) return true;
+    if (seen.has(from)) return false;
+    seen.add(from);
+    const node = this.get(from);
+    return (node?.blockedBy ?? []).some((d) => this.dependsOn(d, target, seen));
+  }
+
+  private async rawUpdate(
+    id: string,
+    patch: Partial<Omit<TodoRecord, "_id">>,
+  ): Promise<TodoRecord> {
+    this.mustGet(id);
+    await this.jsonl.updateById(id, { ...patch, updatedAt: new Date().toISOString() });
+    return this.mustGet(id);
+  }
+}
+
+export async function openStore(projectRoot: string): Promise<TodoStore> {
+  return TodoStore.open(projectRoot);
+}


### PR DESCRIPTION
## What

`--cwd <dir>` on an **agent run** is now deprecated. It still works, but prints a copy-pasteable migration hint before continuing:

```
⚠ --cwd is deprecated. Run the command in the target directory instead:

    cd <dir> && <same command you typed, without --cwd>
```

The shell's `cd` puts the agent **and** every relative path in the command in the same place, with no agent-yes-specific flag to remember.

## How (both runtimes — Rust default, TS fallback)

- **`ts/cwdDeprecation.ts`** (new): pure `detectCwdDeprecation(argv)` strips `--cwd <dir>` / `--cwd=<dir>` and rebuilds the command from the **real program name** (`cy`/`ay`/`claude-yes`, from `argv[1]`) with shell-safe quoting that keeps `~/foo` bare so the shell still expands it.
- **`ts/cli.ts`**: warns once on the agent-run path — placed *after* subcommand dispatch, so the filter `--cwd` on `ay ls/status/spawn/schedule` is untouched — and sets `AGENT_YES_SUPPRESS_CWD_WARN` so the spawned Rust child doesn't double-print.
- **`rs/src/main.rs`**: mirrored `warn_cwd_deprecated()` (pure `build_cwd_migration` helper) for direct `agent-yes` invocations that bypass the JS launcher; honours the suppress env so it only fires when it's the true entry point.
- **`rs/src/cli.rs`**: clap `--help` now marks `--cwd` deprecated.

## Scope

Only the **agent-run** `--cwd` is deprecated. The subcommand **filter** `--cwd` (`ls`/`status`/`spawn`) and oxmgr's `--cwd` in `ay schedule` are unaffected.

## Verification

- 8 new TS specs + 5 new Rust unit tests, all green.
- Existing Rust `--cwd` integration tests still pass (the added stderr warning doesn't change behavior).
- Manual end-to-end:
  - `cy claude --cwd /bad -- hello` → warns **once**, hint reads `cd /bad && cy claude -- hello`.
  - Direct `agent-yes --cli claude --cwd /bad` → warns (no suppress env).
  - `AGENT_YES_SUPPRESS_CWD_WARN=1 agent-yes …` → silent.
  - `ay ls --cwd /tmp` → no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)