### PR TITLE
fix: ay todo — codex-review round 6 (blocked-by-task inert, evidence spread bypass, gate check() lacks task context)

### DIFF
--- a/ts/todoDigest.spec.ts
+++ b/ts/todoDigest.spec.ts
@@ -39,6 +39,40 @@ describe("unblockedTasks", () => {
   });
 });
 
+describe("unblockedTasks with a blocked-by-task block", () => {
+  it("treats block:{type:blocked-by-task,taskId} as an additional dependency, so it self-clears once the target reaches done, matching todoBlock.ts's documented promise (codex-review round-6 Important — this was previously inert)", () => {
+    const tasks = [
+      task({ _id: "T1", state: "done" }),
+      task({
+        _id: "T2",
+        state: "doing",
+        block: { type: "blocked-by-task", taskId: "T1" },
+      }),
+      task({
+        _id: "T3",
+        state: "doing",
+        block: { type: "blocked-by-task", taskId: "T4" },
+      }),
+      task({ _id: "T4", state: "doing" }), // T3's target not done yet -> still blocked
+    ];
+    expect(unblockedTasks(tasks).map((t) => t._id)).toEqual(["T2"]);
+  });
+
+  it("folds a blocked-by-task block in ALONGSIDE blockedBy — both must clear", () => {
+    const tasks = [
+      task({ _id: "T1", state: "done" }),
+      task({ _id: "T2", state: "doing" }), // not done
+      task({
+        _id: "T3",
+        state: "doing",
+        blockedBy: ["T2"],
+        block: { type: "blocked-by-task", taskId: "T1" },
+      }),
+    ];
+    expect(unblockedTasks(tasks)).toEqual([]); // T2 still open
+  });
+});
+
 describe("openBlockers", () => {
   it("reports only the not-yet-done blockers, including a missing id as open", () => {
     const byId = new Map([

--- a/ts/todoDigest.ts
+++ b/ts/todoDigest.ts
@@ -15,8 +15,23 @@ import { DONE_STATE } from "./todoLifecycle.ts";
 import type { TodoRecord } from "./todoStore.ts";
 
 /**
- * A task is "unblocked" when it is not itself finished, it declares
- * `blockedBy` dependencies, and every one of them has reached `done`.
+ * The full set of task ids `t` is waiting on: the structural `blockedBy`
+ * array PLUS, if `t.block` is a `blocked-by-task` shape, that block's own
+ * `taskId`. Without folding the latter in, a task blocked via
+ * `ay todo block --type blocked-by-task --task X` would never be detected
+ * as resolved once X reaches `done` — contradicting `todoBlock.ts`'s own
+ * documented promise that this block type "clears itself... pure data, no
+ * monitor needed" (codex-review Important: the two mechanisms didn't
+ * actually talk to each other, making `blocked-by-task` blocks inert).
+ */
+function declaredTaskDeps(t: TodoRecord): string[] {
+  return t.block?.type === "blocked-by-task" ? [...t.blockedBy, t.block.taskId] : t.blockedBy;
+}
+
+/**
+ * A task is "unblocked" when it is not itself finished, it declares task
+ * dependencies (via `blockedBy` and/or a `blocked-by-task` block), and
+ * every one of them has reached `done`.
  * Surfaced for a caller to act on — never auto-applied here (deciding to
  * resume a task is left to automation, a later milestone, or a human).
  */
@@ -24,14 +39,15 @@ export function unblockedTasks(tasks: TodoRecord[]): TodoRecord[] {
   const byId = new Map(tasks.map((t) => [t._id, t]));
   return tasks.filter((t) => {
     if (t.state === DONE_STATE) return false;
-    if (t.blockedBy.length === 0) return false;
-    return t.blockedBy.every((d) => byId.get(d)?.state === DONE_STATE);
+    const deps = declaredTaskDeps(t);
+    if (deps.length === 0) return false;
+    return deps.every((d) => byId.get(d)?.state === DONE_STATE);
   });
 }
 
 /** Blockers of `t` that have not reached `done` yet (a missing id is reported as-is, still "open"). */
 export function openBlockers(t: TodoRecord, byId: Map<string, TodoRecord>): string[] {
-  return t.blockedBy.filter((d) => byId.get(d)?.state !== DONE_STATE);
+  return declaredTaskDeps(t).filter((d) => byId.get(d)?.state !== DONE_STATE);
 }
 
 function nodeLine(t: TodoRecord): string {

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -107,6 +107,30 @@ describe("TodoStore", () => {
     expect(done.verifyEvidence).toHaveLength(1);
   });
 
+  it("approve() cannot have its audit trail falsified via the evidence argument — gate/validator/passedAt are trusted, never caller-overridable (codex-review round-6 Important)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    // evidence is typed to only note/link, but an untyped JS caller (or a
+    // bug) could still pass extra fields at runtime; the store must not let
+    // them win regardless of what TypeScript alone would forbid, so this
+    // simulates that via an untyped value rather than fighting the compiler.
+    const forgedEvidence = {
+      note: "legit note",
+      link: "https://example/legit",
+      gate: "forged-gate",
+      validator: "forged-validator",
+      passedAt: "1999-01-01T00:00:00.000Z",
+    } as unknown as { note?: string; link?: string };
+    const approved = await s.approve(t._id, "human-approved", "reviewer", forgedEvidence);
+    const entry = approved.verifyEvidence[0]!;
+    expect(entry.gate).toBe("human-approved");
+    expect(entry.validator).toBe("reviewer");
+    expect(entry.passedAt).not.toBe("1999-01-01T00:00:00.000Z");
+    expect(entry.note).toBe("legit note");
+    expect(entry.link).toBe("https://example/legit");
+  });
+
   it("approve() with an empty owner allows any validator (nothing to compare against) but still requires one", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "doc" }); // no owner
@@ -182,6 +206,30 @@ describe("TodoStore", () => {
       note: "canary green",
       link: "https://ci/run/1",
     });
+  });
+
+  it("verify() passes the task record being checked to the registered gate's check(), so one shared gate name can distinguish between concurrently-verified tasks (codex-review round-6 Important)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const seen: string[] = [];
+    s.registerGate({
+      name: "verify-green",
+      check: async (record) => {
+        seen.push(record._id);
+        return { passed: true, note: `checked ${record.summary}` };
+      },
+    });
+    const a = await s.create({ summary: "task a", kind: "code", owner: "worker" });
+    const b = await s.create({ summary: "task b", kind: "code", owner: "worker" });
+    for (const t of [a, b]) {
+      await s.transition(t._id, "merged");
+      await s.transition(t._id, "shipped");
+      await s.transition(t._id, "verifying");
+    }
+    const verifiedA = await s.verify(a._id);
+    const verifiedB = await s.verify(b._id);
+    expect(verifiedA.verifyEvidence.at(-1)?.note).toBe("checked task a");
+    expect(verifiedB.verifyEvidence.at(-1)?.note).toBe("checked task b");
+    expect(seen).toEqual([a._id, b._id]);
   });
 
   it("verify() with a failing check takes the SIBLING edge (verify-failed), not done — the failure is a real distinct state, not silently dropped", async () => {

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -103,7 +103,16 @@ export interface ListFilter {
 export interface GateRegistration {
   /** Opaque name supplied BY the consuming project — this module never inspects or hardcodes it. */
   name: string;
-  check: () => Promise<{ passed: boolean; note?: string; link?: string }>;
+  /**
+   * Receives the task record being verified (as of the moment `verify()`
+   * started checking it), so a project's gate implementation can act on the
+   * specific task — e.g. derive a commit/branch from its fields — instead of
+   * relying on external mutable state to figure out which task this call is
+   * for. Without the record, one registered gate name shared by concurrent
+   * verify() calls on DIFFERENT tasks would have no way to tell them apart
+   * (codex-review Important).
+   */
+  check: (record: TodoRecord) => Promise<{ passed: boolean; note?: string; link?: string }>;
 }
 
 export class CycleError extends Error {}
@@ -378,11 +387,18 @@ export class TodoStore {
       }
       const satisfied = new Set(rec.satisfiedGates);
       satisfied.add(gateName);
+      // Trusted fields (gate/passedAt/validator) are spread LAST so a
+      // caller-supplied `evidence` object cannot override them — only
+      // `note`/`link` are ever taken from it. Spreading `evidence` last (the
+      // previous order) let a caller pass e.g. `{ validator: "...", gate:
+      // "..." }` and silently falsify the audit trail (codex-review
+      // Important).
       const evidenceEntry: GateEvidence = {
+        note: evidence?.note,
+        link: evidence?.link,
         gate: gateName,
         passedAt: new Date().toISOString(),
         validator,
-        ...evidence,
       };
       await this.jsonl.updateById(id, {
         satisfiedGates: [...satisfied],
@@ -436,7 +452,7 @@ export class TodoStore {
       );
     const isPrimaryEdge = edges[0] === targetEdge;
     const stateAtCheckStart = rec.state;
-    const result = await impl.check(); // may be slow (a real CI/QA system) — the task's state can change while this runs
+    const result = await impl.check(rec); // may be slow (a real CI/QA system) — the task's state can change while this runs
     // `impl.check()` can take an arbitrarily long time (a real external
     // system), and another writer (a concurrent transition/verify/approve)
     // can change the task's state during that window. The precondition


### PR DESCRIPTION
Fast-follow on #298 (Milestone 1, already merged) addressing the 3 Important findings from codex-review round 6, which landed after that PR merged.

## What this fixes

1. **`blocked-by-task` blocks were inert.** `ay todo block T2 --type blocked-by-task --task T1` stored the dependency only in `record.block`, but `unblockedTasks()` (the function digest/CLI/future automation all rely on) only ever read `record.blockedBy`. The two mechanisms never talked to each other, so this block type could never self-clear once its target reached `done` — contradicting `todoBlock.ts`'s own documented promise. Fixed by folding a `blocked-by-task` block's `taskId` in as an additional dependency inside `unblockedTasks()`/`openBlockers()`.

2. **`approve()`'s evidence spread let a caller falsify the audit trail.** `{ gate, passedAt, validator, ...evidence }` spread the caller-supplied `evidence` argument LAST, so extra fields on that object could silently override the trusted `gate`/`validator`/`passedAt`. Fixed by only ever taking `note`/`link` from `evidence`, trusted fields placed last.

3. **`GateRegistration.check()` had no way to know which task it was checking.** Changed the signature to `check: (record: TodoRecord) => Promise<...>`, and `verify()` now passes the record being checked.

## Verification

- All 3 findings independently re-confirmed against current code before fixing.
- New regression tests for each; the first two are mutation-tested (reverted each fix in isolation, confirmed its test went red, restored).
- 72 tests total (up from 68 at merge time), all passing. `tsgo --noEmit` clean (pre-existing unrelated errors elsewhere in the repo untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
