### PR TITLE
feat: ay send '.' targets same-cwd agent, echoes recipient tail, + spawn-conflict warning

### DIFF
--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -83,6 +83,15 @@ if (!config.showVersion && !config.appendPrompt && !config.tray) {
   });
 }
 
+// Warn if another live agent already occupies this cwd — two agents in one
+// working tree clobber each other's files/builds/ports. Sits alongside the
+// spawn gate (real-launch only) and BEFORE the --rust dispatch so it covers both
+// runtimes. Best-effort, non-blocking; silence with AGENT_YES_NO_CWD_WARN=1.
+if (!config.showVersion && !config.appendPrompt && !config.tray) {
+  const { warnIfCwdOccupied } = await import("./cwdConflictWarn.ts");
+  await warnIfCwdOccupied(process.argv);
+}
+
 // Handle --rust: spawn the Rust binary instead, fall back to TypeScript if unavailable
 if (config.useRust) {
   let rustBinary: string | undefined;

--- a/ts/cwdConflictWarn.spec.ts
+++ b/ts/cwdConflictWarn.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { formatCwdConflictWarning, shQuote } from "./cwdConflictWarn.ts";
+
+describe("cwdConflictWarn.formatCwdConflictWarning", () => {
+  const cwd = "/code/proj/tree/main";
+
+  it("returns null when no peers occupy the cwd", () => {
+    expect(formatCwdConflictWarning([], cwd, "ay claude")).toBeNull();
+  });
+
+  it("warns and suggests a git-worktree command for a single peer", () => {
+    const msg = formatCwdConflictWarning([{ pid: 111, cli: "claude" }], cwd, "ay claude -- fix");
+    expect(msg).toContain("1 agent is already running in this directory (/code/proj/tree/main)");
+    expect(msg).toContain("111  claude");
+    // uses `git worktree add` (not `git clone .`) — worktree name = dir + branch
+    expect(msg).toContain("git worktree add -b main-work ../main-work && cd ../main-work");
+    expect(msg).not.toContain("git clone");
+    // original command is appended so the suggestion is copy-pasteable
+    expect(msg).toContain("&& ay claude -- fix");
+    expect(msg).toContain("AGENT_YES_NO_CWD_WARN=1");
+  });
+
+  it("pluralizes and lists at most 3 peers with an overflow count", () => {
+    const peers = [1, 2, 3, 4, 5].map((n) => ({ pid: n, cli: "codex" }));
+    const msg = formatCwdConflictWarning(peers, cwd, "ay codex")!;
+    expect(msg).toContain("5 agents are already running");
+    expect(msg).toContain("1  codex");
+    expect(msg).toContain("3  codex");
+    expect(msg).not.toContain("4  codex"); // capped at 3 listed
+    expect(msg).toContain("…and 2 more");
+  });
+
+  it("falls back to a placeholder when cwd has no basename or command is empty", () => {
+    const msg = formatCwdConflictWarning([{ pid: 9, cli: "gemini" }], "/", "   ")!;
+    expect(msg).toContain("../agent-work"); // basename('/') is empty → 'agent'
+    expect(msg).toContain("&& ay <cli> …"); // empty origCmd → placeholder
+  });
+});
+
+describe("cwdConflictWarn.shQuote", () => {
+  it("passes safe tokens through unquoted", () => {
+    expect(shQuote("ay")).toBe("ay");
+    expect(shQuote("claude")).toBe("claude");
+    expect(shQuote("--")).toBe("--");
+    expect(shQuote("../main-work")).toBe("../main-work");
+    expect(shQuote("main-work_2.3")).toBe("main-work_2.3");
+  });
+
+  it("single-quotes tokens with spaces or shell metacharacters", () => {
+    expect(shQuote("fix the bug")).toBe("'fix the bug'");
+    expect(shQuote("a;rm -rf b")).toBe("'a;rm -rf b'");
+    expect(shQuote("$HOME")).toBe("'$HOME'");
+    expect(shQuote("")).toBe("''");
+  });
+
+  it("escapes embedded single quotes safely", () => {
+    // POSIX close-quote / escaped-quote / reopen-quote dance
+    expect(shQuote("it's")).toBe(`'it'\\''s'`);
+  });
+});

--- a/ts/cwdConflictWarn.ts
+++ b/ts/cwdConflictWarn.ts
@@ -1,0 +1,97 @@
+/**
+ * Pre-launch warning: another live agent is already working in THIS exact
+ * directory. Two agents sharing one working tree clobber each other's edits,
+ * builds, and dev-server ports — so we warn (stderr, non-fatal) and hand the
+ * user a copy-pasteable git-worktree isolation command.
+ *
+ * Lives in cli.ts's launch path (before the --rust dispatch) so it covers BOTH
+ * the Rust and TypeScript runtimes with one check. The launching agent isn't
+ * registered in the pid index yet, so every same-cwd match here is a genuine
+ * pre-existing peer, never itself.
+ */
+import path from "path";
+import { readGlobalPids, type GlobalPidRecord } from "./globalPidIndex.ts";
+
+/** A pre-existing peer for the warning: just what we render. */
+export interface CwdOccupant {
+  pid: number;
+  cli: string;
+}
+
+/**
+ * POSIX single-quote a shell token so a copy-pasted recovery command survives
+ * spaces, quotes, `$`, `;`, `&`, etc. Safe-charset tokens pass through unquoted
+ * so the common case (`ay claude -- fix`) stays readable. Empty string → `''`.
+ */
+export function shQuote(s: string): string {
+  if (s === "") return "''";
+  if (/^[A-Za-z0-9,._+@%/:=-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Pure renderer — given the peers already in `cwd`, the cwd, and the original
+ * `ay …` command, produce the warning text (or null when there's no conflict).
+ * Separated from IO so the message/branching is unit-tested without a live index.
+ */
+export function formatCwdConflictWarning(
+  occupants: CwdOccupant[],
+  cwd: string,
+  origCmd: string,
+): string | null {
+  if (occupants.length === 0) return null;
+  // Worktree name doubles as the new dir AND the new branch. `git worktree add`
+  // (not `git clone .`) is the correct primitive: it resolves the repo root even
+  // from a subdir, shares the object store, and creates the branch in one step.
+  const wt = `${path.basename(cwd) || "agent"}-work`;
+  const list = occupants
+    .slice(0, 3)
+    .map((r) => `      ${r.pid}  ${r.cli}`)
+    .join("\n");
+  const more = occupants.length > 3 ? `\n      …and ${occupants.length - 3} more` : "";
+  const cmd = origCmd.trim() || "ay <cli> …";
+  const branch = shQuote(wt);
+  const dir = shQuote(`../${wt}`);
+  return (
+    `\n⚠  ${occupants.length} agent${occupants.length > 1 ? "s are" : " is"} already running in this directory (${cwd}):\n` +
+    `${list}${more}\n` +
+    `   Parallel agents in one working tree clobber each other's files, builds, and ports.\n` +
+    `   To isolate this run in its own git worktree, cancel (Ctrl-C) and instead:\n` +
+    `      git worktree add -b ${branch} ${dir} && cd ${dir} && ${cmd}\n` +
+    `   (set AGENT_YES_NO_CWD_WARN=1 to silence)\n\n`
+  );
+}
+
+/**
+ * IO wrapper: discover live same-cwd peers and print the warning to stderr.
+ * Best-effort and swallow-all — a discovery hiccup must NEVER block a launch.
+ * No-op when AGENT_YES_NO_CWD_WARN=1.
+ */
+export async function warnIfCwdOccupied(rawArgv: string[]): Promise<void> {
+  if (process.env.AGENT_YES_NO_CWD_WARN === "1") return;
+  try {
+    const here = path.resolve(process.cwd());
+    const occupants: CwdOccupant[] = (await readGlobalPids({ liveOnly: true }))
+      .filter((r: GlobalPidRecord) => path.resolve(r.cwd) === here)
+      .map((r) => ({ pid: r.pid, cli: r.cli }));
+    // Shell-quote each argv token so the suggested command reproduces the
+    // original launch even with spaces/quotes in a prompt (e.g. a multi-word
+    // `-- "fix the bug"`). We can't recover the user's exact original quoting
+    // from argv, but per-token quoting is copy-paste-correct.
+    const origCmd = ["ay", ...rawArgv.slice(2)].map(shQuote).join(" ");
+    const msg = formatCwdConflictWarning(occupants, here, origCmd);
+    if (msg) {
+      process.stderr.write(msg);
+      // Interactive CLIs (claude/codex/gemini) switch to the alternate screen
+      // buffer on startup, which clears the terminal — the warning would flash
+      // and vanish before a human could read it. Hold briefly (only on a real
+      // conflict, only when attached to a TTY) so they get a beat to Ctrl-C and
+      // switch to a worktree. Non-TTY / detached launches skip the pause.
+      if (process.stdout.isTTY) {
+        await new Promise((r) => setTimeout(r, 2500));
+      }
+    }
+  } catch {
+    // Non-fatal — never block launching the agent over a warning.
+  }
+}

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -336,6 +336,18 @@ describe("subcommands.matchKeyword", () => {
     expect(matchKeyword(r, "parser")).toBe(false);
   });
 
+  it("treats '.' / './' as the current working directory (exact cwd match)", async () => {
+    const { matchKeyword } = await loadModule();
+    const here = { ...baseRecord, cwd: process.cwd() };
+    const elsewhere = { ...baseRecord, cwd: "/some/other/place" };
+    // sibling agent in this exact cwd resolves
+    expect(matchKeyword(here, ".")).toBe(true);
+    expect(matchKeyword(here, "./")).toBe(true);
+    // an agent in a different cwd (even a subdir/parent) does not
+    expect(matchKeyword(elsewhere, ".")).toBe(false);
+    expect(matchKeyword({ ...baseRecord, cwd: process.cwd() + "/sub" }, ".")).toBe(false);
+  });
+
   it("matches by agent_id prefix", async () => {
     const { matchKeyword } = await loadModule();
     const r = { ...baseRecord, agent_id: "a1b2c3d4e5f6" };

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -612,7 +612,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `                                        --before-line L [--limit N]\n` +
       `  ay cat <keyword>                    full log\n` +
       `  ay head <keyword>                   first N lines\n` +
-      `  ay send <keyword> <msg>             send a message\n` +
+      `  ay send <keyword> <msg>             send a message (keyword '.' = agent in this cwd)\n` +
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
       `  ay key <keyword> <key...>           send raw keystrokes (down/up/enter/esc/…) — drives menus\n` +
       `  ay select <keyword> <N>             pick option N of a needs_input selection menu\n` +
@@ -675,6 +675,14 @@ export function matchKeyword(record: GlobalPidRecord, keyword: string): boolean 
   if (/^\d+$/.test(keyword)) {
     if (record.pid === Number(keyword)) return true;
     return !!(record.agent_id && record.agent_id.toLowerCase().startsWith(kw));
+  }
+  // 1b. `.` / `./` — shell convention for "the current directory": target the
+  // agent whose cwd IS process.cwd() (exact match). Lets `ay send .` reach the
+  // sibling agent running in this same dir without typing its pid or a path
+  // fragment. Repurposed from the (near-useless) substring behavior — a lone `.`
+  // was in almost every path, so it never selected anything meaningful.
+  if (kw === "." || kw === "./") {
+    return path.resolve(record.cwd) === path.resolve(process.cwd());
   }
   // 2. cwd contains keyword
   if (record.cwd.toLowerCase().includes(kw)) return true;
@@ -3190,6 +3198,24 @@ async function cmdSend(rest: string[]): Promise<number> {
           .join("\n") +
         "\n",
     );
+  }
+
+  // Echo the tail of the target's screen so the sender sees, inline, whether the
+  // message landed and how the agent reacted — no separate `ay tail` round-trip.
+  // Rendered fresh from the log after the settle/confirm wait above, so it
+  // reflects the post-submit state. Best-effort: a missing/empty log just skips.
+  if (record.log_file) {
+    const tail = (await renderLogTailLines(record.log_file, 10)) ?? [];
+    let end = tail.length;
+    while (end > 0 && tail[end - 1]!.trim() === "") end--; // drop trailing blanks
+    const trimmed = tail.slice(0, end);
+    if (trimmed.length) {
+      process.stderr.write(
+        `\n── pid ${record.pid} · last ${trimmed.length} line${trimmed.length === 1 ? "" : "s"} ──\n` +
+          trimmed.map((l) => `  ${l}`).join("\n") +
+          `\n`,
+      );
+    }
   }
 
   const replyHint = sender.agent


### PR DESCRIPTION
Three related ergonomics for driving co-located agents (all requested by @snomiao).

## 1. `ay send .` → the agent in this cwd
`.` / `./` now resolves (via `matchKeyword`) to the agent whose cwd **is** `process.cwd()` — so you can `ay send .` to reach the sibling agent running in your directory without looking up its pid. Applies to every keyword-resolving command (`tail`/`key`/`select`/…). Repurposes the near-useless `.`-as-substring behavior.

## 2. `ay send` echoes the recipient's tail
After sending, `ay send` prints the target's **last 10 rendered screen lines**, so you can see inline whether the message landed and how the agent reacted — no separate `ay tail` round-trip.

## 3. Spawn-conflict warning
Launching an agent in a cwd that already has a live agent prints a warning + a copy-pasteable `git worktree add` isolation command (two agents in one working tree clobber each other's files/builds/ports).
- Lives in `cli.ts` **before** the `--rust` dispatch, so it covers both the Rust and TS runtimes.
- Pauses ~2.5s on a TTY (an interactive CLI's alt-screen would otherwise wipe the message instantly); no pause when detached/non-TTY.
- Silence with `AGENT_YES_NO_CWD_WARN=1`.
- Uses `git worktree add` (resolves the repo root from a subdir, shares the object store) rather than `git clone .`, and shell-quotes the suggested command — both from **codex review round 1**.

## Tests
- New `ts/cwdConflictWarn.spec.ts` (formatter + `shQuote` shell-safety).
- New `matchKeyword` `.`/`./` cases in `ts/subcommands.spec.ts`.
- 116 unit specs pass. Verified live: `.` resolution, tail echo, and the warning firing from a repo subdirectory where `git clone .` would have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)