### PR TITLE
fix: ay send tail — render at the agent's real PTY width

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -270,6 +270,47 @@ describe("subcommands.GRACEFUL_EXIT_COMMANDS", () => {
   });
 });
 
+describe("subcommands.readAgentPtysize (writer/reader pid fallback)", () => {
+  const rec = (pid: number, wrapper_pid: number | null) =>
+    ({
+      pid,
+      wrapper_pid,
+      cli: "claude",
+      prompt: null,
+      cwd: "/x",
+      log_file: null,
+      status: "active" as const,
+      exit_code: null,
+      exit_reason: null,
+      started_at: 0,
+    }) as any;
+
+  async function writeSidecar(pid: number, cols: number, rows: number) {
+    const dir = path.join(testHome, ".agent-yes", "ptysize");
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, String(pid)), `${cols} ${rows}\n`);
+  }
+
+  it("reads geometry keyed by the agent's own pid (Rust runtime)", async () => {
+    const { readAgentPtysize } = await loadModule();
+    await writeSidecar(500, 120, 40);
+    expect(await readAgentPtysize(rec(500, 499))).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it("falls back to wrapper_pid when the child pid has no sidecar (TS runtime)", async () => {
+    const { readAgentPtysize } = await loadModule();
+    // Only the wrapper pid's sidecar exists — mirrors ts/index.ts writing under process.pid
+    await writeSidecar(499, 200, 50);
+    expect(await readAgentPtysize(rec(500, 499))).toEqual({ cols: 200, rows: 50 });
+  });
+
+  it("returns null when neither pid has a sidecar", async () => {
+    const { readAgentPtysize } = await loadModule();
+    expect(await readAgentPtysize(rec(500, 499))).toBeNull();
+    expect(await readAgentPtysize(rec(500, null))).toBeNull();
+  });
+});
+
 describe("subcommands.matchKeyword", () => {
   const baseRecord = {
     pid: 1234,

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2025,7 +2025,7 @@ async function cmdRead(rest: string[], { mode }: ReadOpts): Promise<number> {
   }
 
   const buf = await readFile(logPath);
-  const size = await readPtysize(record.pid);
+  const size = await readAgentPtysize(record);
   const notes = await readNotes();
   const noteLabel = notes.get(record.pid);
   const header = noteLabel
@@ -2307,6 +2307,24 @@ export async function readPtysize(pid: number): Promise<{ cols: number; rows: nu
   } catch {
     /* no ptysize sidecar */
   }
+  return null;
+}
+
+/**
+ * An agent's real PTY geometry for log rendering, robust to a writer/reader pid
+ * mismatch. The Rust runtime keys the ptysize sidecar by the PTY child pid
+ * (= record.pid), so that lookup hits directly. But the TS runtime writes it
+ * under its wrapper's process.pid (= record.wrapper_pid; see writeCurrentPtysize
+ * in ts/index.ts), NOT the child — so a plain readPtysize(record.pid) misses for
+ * TS-launched agents and the log reflows at the default 200-col width. Fall back
+ * to wrapper_pid to cover that path. Returns null when neither has a sidecar.
+ */
+export async function readAgentPtysize(
+  record: GlobalPidRecord,
+): Promise<{ cols: number; rows: number } | null> {
+  const own = await readPtysize(record.pid);
+  if (own) return own;
+  if (record.wrapper_pid) return readPtysize(record.wrapper_pid);
   return null;
 }
 
@@ -3215,7 +3233,7 @@ async function cmdSend(rest: string[]): Promise<number> {
   // Rendered fresh from the log after the settle/confirm wait above, so it
   // reflects the post-submit state. Best-effort: a missing/empty log just skips.
   if (record.log_file) {
-    const geom = (await readPtysize(record.pid)) ?? undefined;
+    const geom = (await readAgentPtysize(record)) ?? undefined;
     const tail = (await renderLogTailLines(record.log_file, 10, geom)) ?? [];
     let end = tail.length;
     while (end > 0 && tail[end - 1]!.trim() === "") end--; // drop trailing blanks

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2530,7 +2530,11 @@ function cliDefaults(): Promise<Record<string, AgentCliConfig>> {
  * null on any read/render error or an empty log. Shared by the needs_input and
  * stuck classifiers so they don't each re-implement the tail read.
  */
-export async function renderLogTailLines(logPath: string, n = 40): Promise<string[] | null> {
+export async function renderLogTailLines(
+  logPath: string,
+  n = 40,
+  geom?: RenderGeom,
+): Promise<string[] | null> {
   const TAIL_BYTES = 32 * 1024;
   let buf: Uint8Array;
   try {
@@ -2553,7 +2557,13 @@ export async function renderLogTailLines(logPath: string, n = 40): Promise<strin
     return null;
   }
   try {
-    return (await renderRawLog(buf, { mode: "tail", n })).split("\n");
+    // Render at the agent's REAL PTY geometry when provided — the raw log is full
+    // of absolute cursor-positioning, so replaying at the wrong width reflows the
+    // TUI into garbage (chars land in the wrong columns). Callers with a pid pass
+    // readPtysize(pid); without it we fall back to the default width.
+    return (await renderRawLog(buf, { mode: "tail", n, cols: geom?.cols, rows: geom?.rows })).split(
+      "\n",
+    );
   } catch {
     return null;
   }
@@ -3205,7 +3215,8 @@ async function cmdSend(rest: string[]): Promise<number> {
   // Rendered fresh from the log after the settle/confirm wait above, so it
   // reflects the post-submit state. Best-effort: a missing/empty log just skips.
   if (record.log_file) {
-    const tail = (await renderLogTailLines(record.log_file, 10)) ?? [];
+    const geom = (await readPtysize(record.pid)) ?? undefined;
+    const tail = (await renderLogTailLines(record.log_file, 10, geom)) ?? [];
     let end = tail.length;
     while (end > 0 && tail[end - 1]!.trim() === "") end--; // drop trailing blanks
     const trimmed = tail.slice(0, end);


### PR DESCRIPTION
Follow-up to #303.

The last-10-lines echo added in #303 called `renderLogTailLines` **without** the target's PTY geometry, so it replayed the raw log at the default 200-col width. The raw PTY log is full of absolute cursor-positioning, so replaying at the wrong width reflows the TUI into garbage — characters land in the wrong columns and wrap mid-word:

```
── pid 556048 · last 10 lines ──
                                                              i
  n   hello
                                                              C
  od  </ay-msg 6d3a0621>
```

Fix: thread an optional `RenderGeom` through `renderLogTailLines` and pass `readPtysize(record.pid)` from `cmdSend`, exactly as `ay tail` already does. Now the echoed screen matches the agent's actual terminal:

```
── pid 556048 · last 10 lines ──
    ❯ <ay-msg 01a23775 from claude #556048 @ … — reply: ay send … "…">
      render-width-test
      </ay-msg 01a23775>
```

Verified live. Backward-compatible (geom is optional; other callers unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)