### PR TITLE
feat: ay todo — Milestone 1.5, acceptance criteria field

### DIFF
--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -303,8 +303,55 @@ describe("ay todo CLI", () => {
 
   it("no verb at all fails naming every expected one, via demandCommand", async () => {
     await expect(run()).rejects.toThrow(
-      /unknown "ay todo" verb.*new\/ls\/get\/transition\/approve\/verify\/block\/unblock\/dep\/tree\/digest\/reconcile/,
+      /unknown "ay todo" verb.*new\/ls\/get\/transition\/approve\/verify\/set-criteria\/block\/unblock\/dep\/tree\/digest\/reconcile/,
     );
+  });
+
+  it("new --acceptance-criteria stores it, and get renders it; set-criteria updates it later (Milestone 1.5)", async () => {
+    const created = await run(
+      "new",
+      "ship",
+      "the",
+      "feature",
+      "--kind",
+      "code",
+      "--acceptance-criteria",
+      "all tests pass and the feature flag is off by default",
+    );
+    expect(created.out).toContain(
+      "acceptanceCriteria: all tests pass and the feature flag is off by default",
+    );
+    const updated = await run(
+      "set-criteria",
+      "T1",
+      "all",
+      "tests",
+      "pass",
+      "and",
+      "docs",
+      "are",
+      "updated",
+    );
+    expect(updated.out).toContain("set acceptance criteria on T1");
+    const got = await run("get", "T1");
+    expect(got.out).toContain("acceptanceCriteria: all tests pass and docs are updated");
+  });
+
+  it("approve() snapshots acceptanceCriteria into evidence, rendered in get's output", async () => {
+    await run(
+      "new",
+      "x",
+      "--kind",
+      "doc",
+      "--owner",
+      "worker",
+      "--acceptance-criteria",
+      "reviewed by a human",
+    );
+    await run("transition", "T1", "review");
+    await run("approve", "T1", "human-approved", "reviewer");
+    const got = await run("get", "T1");
+    expect(got.out).toContain("[criteria: reviewed by a human]");
   });
 
   it("--help resolves cleanly (exit 0, no throw) — a real yargs command tree auto-generates the verb listing (taku feedback); yargs' own help writer bypasses the stdout mock in this harness, so content is verified manually rather than asserted here", async () => {

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -108,7 +108,7 @@ const newCmd: CommandModule<
     kind: string | undefined;
     description: string | undefined;
     tier: string | undefined;
-    acceptanceCriteria: string | undefined;
+    "acceptance-criteria": string | undefined;
     owner: string | undefined;
     tag: string[] | undefined;
     dep: string[] | undefined;
@@ -128,7 +128,7 @@ const newCmd: CommandModule<
       .option("kind", { type: "string", describe: `one of: ${Object.keys(LIFECYCLES).join(", ")}` })
       .option("description", { type: "string" })
       .option("tier", { type: "string", describe: "targetTier, e.g. canary-done / shipped-done" })
-      .option("acceptanceCriteria", {
+      .option("acceptance-criteria", {
         type: "string",
         describe:
           "definition of done for this task — what an independent validator should check before approving/verifying it",
@@ -155,7 +155,7 @@ const newCmd: CommandModule<
       kind: parseKind(argv.kind),
       description: argv.description,
       targetTier: argv.tier,
-      acceptanceCriteria: argv.acceptanceCriteria,
+      acceptanceCriteria: argv["acceptance-criteria"],
       owner: argv.owner,
       tags: argv.tag ?? [],
       blockedBy: argv.dep ?? [],

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -62,13 +62,14 @@ function renderRecord(t: TodoRecord): string {
     `${t._id} [${t.state}] ${t.summary}`,
     `kind:    ${t.kind}${t.targetTier ? `  tier:${t.targetTier}` : ""}`,
     ...(t.owner ? [`owner:   ${t.owner}`] : []),
+    ...(t.acceptanceCriteria ? [`acceptanceCriteria: ${t.acceptanceCriteria}`] : []),
     ...(t.block ? [`block:   ${describeBlock(t.block)}`] : []),
     ...(t.blockedBy.length ? [`blockedBy: ${t.blockedBy.join(", ")}`] : []),
     ...(t.tags.length ? [`tags:    ${t.tags.join(", ")}`] : []),
     ...(t.satisfiedGates.length ? [`satisfiedGates: ${t.satisfiedGates.join(", ")}`] : []),
     ...(t.verifyEvidence.length
       ? [
-          `evidence: ${t.verifyEvidence.map((e) => `${e.gate} by ${e.validator}${e.link ? ` (${e.link})` : ""}`).join("; ")}`,
+          `evidence: ${t.verifyEvidence.map((e) => `${e.gate} by ${e.validator}${e.link ? ` (${e.link})` : ""}${e.acceptanceCriteriaAtApproval ? ` [criteria: ${e.acceptanceCriteriaAtApproval}]` : ""}`).join("; ")}`,
         ]
       : []),
     `created: ${t.createdAt}`,
@@ -107,6 +108,7 @@ const newCmd: CommandModule<
     kind: string | undefined;
     description: string | undefined;
     tier: string | undefined;
+    acceptanceCriteria: string | undefined;
     owner: string | undefined;
     tag: string[] | undefined;
     dep: string[] | undefined;
@@ -126,6 +128,11 @@ const newCmd: CommandModule<
       .option("kind", { type: "string", describe: `one of: ${Object.keys(LIFECYCLES).join(", ")}` })
       .option("description", { type: "string" })
       .option("tier", { type: "string", describe: "targetTier, e.g. canary-done / shipped-done" })
+      .option("acceptanceCriteria", {
+        type: "string",
+        describe:
+          "definition of done for this task — what an independent validator should check before approving/verifying it",
+      })
       .option("owner", { type: "string" })
       .option("tag", { type: "string", array: true })
       .option("dep", { type: "string", array: true, describe: "blocker task id(s)" }),
@@ -140,7 +147,7 @@ const newCmd: CommandModule<
     const summary = argv.summary.map(String).join(" ");
     if (!summary) {
       fail(
-        "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--owner ...] [--tag t]... [--dep id]...",
+        "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--acceptance-criteria ...] [--owner ...] [--tag t]... [--dep id]...",
       );
     }
     const rec = await store.create({
@@ -148,6 +155,7 @@ const newCmd: CommandModule<
       kind: parseKind(argv.kind),
       description: argv.description,
       targetTier: argv.tier,
+      acceptanceCriteria: argv.acceptanceCriteria,
       owner: argv.owner,
       tags: argv.tag ?? [],
       blockedBy: argv.dep ?? [],
@@ -342,6 +350,21 @@ const unblockCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string }> = {
   },
 };
 
+const setCriteriaCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string; text: string[] }> = {
+  command: "set-criteria <id> <text..>",
+  describe: "set or update a task's acceptance criteria (definition of done)",
+  builder: (y) =>
+    y
+      .positional("id", { type: "string", demandOption: true })
+      .positional("text", { type: "string", array: true, demandOption: true }),
+  handler: async (argv) => {
+    const store = await openStore(argv.root);
+    const text = argv.text.map(String).join(" ");
+    const rec = await store.setAcceptanceCriteria(argv.id, text);
+    emit(argv, rec, `set acceptance criteria on ${rec._id}\n${renderRecord(rec)}`);
+  },
+};
+
 const depCmd: CommandModule<
   GlobalOpts,
   GlobalOpts & { verb: "add" | "rm"; id: string; blockerId: string }
@@ -509,6 +532,7 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
     .command(transitionCmd)
     .command(approveCmd)
     .command(verifyCmd)
+    .command(setCriteriaCmd)
     .command(blockCmd)
     .command(unblockCmd)
     .command(depCmd)
@@ -517,7 +541,7 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
     .command(reconcileCmd)
     .demandCommand(
       1,
-      'unknown "ay todo" verb (expected: new/ls/get/transition/approve/verify/block/unblock/dep/tree/digest/reconcile)',
+      'unknown "ay todo" verb (expected: new/ls/get/transition/approve/verify/set-criteria/block/unblock/dep/tree/digest/reconcile)',
     )
     .strict()
     .help()

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -148,6 +148,23 @@ describe("TodoStore", () => {
     await expect(s.setAcceptanceCriteria("T99", "text")).rejects.toThrow(/no such task/);
   });
 
+  it("setAcceptanceCriteria() refuses WHITESPACE-only text too, and trims what it stores (codex-review round-8 Important: a blank-looking value must not silently pass as real criteria)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc" });
+    await expect(s.setAcceptanceCriteria(t._id, "   ")).rejects.toThrow(/must not be empty/);
+    await expect(s.setAcceptanceCriteria(t._id, "\t\n")).rejects.toThrow(/must not be empty/);
+    const updated = await s.setAcceptanceCriteria(t._id, "  real criteria  ");
+    expect(updated.acceptanceCriteria).toBe("real criteria");
+  });
+
+  it("create() treats a whitespace-only acceptanceCriteria as not provided (never stored), and trims a real one", async () => {
+    const s = await openStore(TEST_ROOT);
+    const blank = await s.create({ summary: "x", kind: "doc", acceptanceCriteria: "   " });
+    expect(blank.acceptanceCriteria).toBeUndefined();
+    const real = await s.create({ summary: "y", kind: "doc", acceptanceCriteria: "  real one  " });
+    expect(real.acceptanceCriteria).toBe("real one");
+  });
+
   it("approve() cannot have its audit trail falsified via the evidence argument — gate/validator/passedAt are trusted, never caller-overridable (codex-review round-6 Important)", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -107,6 +107,47 @@ describe("TodoStore", () => {
     expect(done.verifyEvidence).toHaveLength(1);
   });
 
+  it("create() stores acceptanceCriteria, and approve() snapshots it into GateEvidence at approval time — later edits don't retroactively change the recorded snapshot (Milestone 1.5)", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({
+      summary: "x",
+      kind: "doc",
+      owner: "worker",
+      acceptanceCriteria: "the spec covers all 5 lifecycle kinds",
+    });
+    expect(t.acceptanceCriteria).toBe("the spec covers all 5 lifecycle kinds");
+    await s.transition(t._id, "review");
+    const approved = await s.approve(t._id, "human-approved", "reviewer");
+    expect(approved.verifyEvidence[0]?.acceptanceCriteriaAtApproval).toBe(
+      "the spec covers all 5 lifecycle kinds",
+    );
+
+    // editing the criteria AFTER approval must not change the already-
+    // recorded snapshot — the audit trail is append-only history, not a
+    // live reference to the current field.
+    await s.setAcceptanceCriteria(t._id, "the spec ALSO covers the human kind");
+    const fresh = s.get(t._id)!;
+    expect(fresh.acceptanceCriteria).toBe("the spec ALSO covers the human kind");
+    expect(fresh.verifyEvidence[0]?.acceptanceCriteriaAtApproval).toBe(
+      "the spec covers all 5 lifecycle kinds",
+    );
+  });
+
+  it("approve() omits acceptanceCriteriaAtApproval entirely when the task never had criteria set", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });
+    await s.transition(t._id, "review");
+    const approved = await s.approve(t._id, "human-approved", "reviewer");
+    expect(approved.verifyEvidence[0]?.acceptanceCriteriaAtApproval).toBeUndefined();
+  });
+
+  it("setAcceptanceCriteria() refuses empty text and refuses an unknown task id", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "doc" });
+    await expect(s.setAcceptanceCriteria(t._id, "")).rejects.toThrow(/must not be empty/);
+    await expect(s.setAcceptanceCriteria("T99", "text")).rejects.toThrow(/no such task/);
+  });
+
   it("approve() cannot have its audit trail falsified via the evidence argument — gate/validator/passedAt are trusted, never caller-overridable (codex-review round-6 Important)", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "doc", owner: "worker" });

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -59,6 +59,8 @@ export interface GateEvidence {
   validator: string;
   note?: string;
   link?: string;
+  /** The task's `acceptanceCriteria` TEXT as it read at the moment this manual gate was approved (not merely a reference to the live field, which could be edited afterward) — durably records what the validator actually judged the work against. Absent if the task had no acceptance criteria set at approval time. Only set by `approve()`; a registered gate's own `check(record)` already receives the live `acceptanceCriteria` on the record it's passed, so no snapshot is needed there. */
+  acceptanceCriteriaAtApproval?: string;
 }
 
 export interface TodoRecord extends JsonlDoc {
@@ -68,6 +70,8 @@ export interface TodoRecord extends JsonlDoc {
   targetTier?: string;
   summary: string;
   description: string;
+  /** Free-text definition of done for THIS task — what an independent validator should check before approving/verifying it. Optional at this layer (Part A stays neutral on whether it's required; a consuming project enforces that itself, e.g. by validating it in its own CLI wrapper before calling `create`). Editable via `setAcceptanceCriteria` since criteria may firm up after a task starts. */
+  acceptanceCriteria?: string;
   /** A human name/handle, or a tracked agent's stable identifier. Opaque to this module. */
   owner?: string;
   /** `null` (not `undefined`) is the explicit "no block" value once a task has ever been blocked — JSON drops `undefined` keys entirely, so an update line with an omitted `block` would silently fail to clear a previous value on reload; `null` serializes and therefore actually overwrites (see `setBlock`). */
@@ -92,6 +96,7 @@ export interface CreateInput {
   kind: LifecycleKind;
   description?: string;
   targetTier?: string;
+  acceptanceCriteria?: string;
   owner?: string;
   tags?: string[];
   blockedBy?: string[];
@@ -290,6 +295,7 @@ export class TodoStore {
         createdAt: now,
         updatedAt: now,
         ...(input.targetTier ? { targetTier: input.targetTier } : {}),
+        ...(input.acceptanceCriteria ? { acceptanceCriteria: input.acceptanceCriteria } : {}),
         ...(input.owner ? { owner: input.owner } : {}),
       };
       await this.jsonl.append({ ...doc, _id: id });
@@ -409,6 +415,11 @@ export class TodoStore {
         gate: gateName,
         passedAt: new Date().toISOString(),
         validator,
+        // Snapshot the FRESH record's acceptanceCriteria text, not a
+        // reference to the live field — the criteria could be edited after
+        // this approval, and the audit trail should durably show what the
+        // validator actually judged the work against at the time.
+        ...(rec.acceptanceCriteria ? { acceptanceCriteriaAtApproval: rec.acceptanceCriteria } : {}),
       };
       await this.jsonl.updateById(id, {
         satisfiedGates: [...satisfied],
@@ -568,6 +579,23 @@ export class TodoStore {
       await this.jsonl.updateById(id, patch);
       return this.mustGet(id);
     });
+  }
+
+  /**
+   * Set or update a task's acceptance criteria (free text) after creation —
+   * criteria may firm up once a task is underway, not just at `create()`
+   * time. Requires non-empty text: this method updates criteria, it does
+   * not clear them (clearing would need a `null`-vs-`undefined` sentinel
+   * distinction, like `block` has, which isn't needed for the "set/update"
+   * use case this exists for).
+   */
+  async setAcceptanceCriteria(id: string, text: string): Promise<TodoRecord> {
+    // `async` (not a plain function returning rawUpdate's promise) so this
+    // guard's throw becomes a rejected promise like every other validating
+    // mutator here, rather than throwing synchronously before any promise
+    // exists — matching `addDep`'s same convention.
+    if (!text) throw new Error(`task ${id}: acceptance criteria text must not be empty`);
+    return this.rawUpdate(id, () => ({ acceptanceCriteria: text }));
   }
 
   setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -295,7 +295,13 @@ export class TodoStore {
         createdAt: now,
         updatedAt: now,
         ...(input.targetTier ? { targetTier: input.targetTier } : {}),
-        ...(input.acceptanceCriteria ? { acceptanceCriteria: input.acceptanceCriteria } : {}),
+        // Trimmed, and a whitespace-only value is treated as "not provided"
+        // (same reasoning as setAcceptanceCriteria's own guard, codex-review
+        // Important) — otherwise a blank-looking criteria string could be
+        // stored and later snapshotted into approval evidence.
+        ...(input.acceptanceCriteria?.trim()
+          ? { acceptanceCriteria: input.acceptanceCriteria.trim() }
+          : {}),
         ...(input.owner ? { owner: input.owner } : {}),
       };
       await this.jsonl.append({ ...doc, _id: id });
@@ -594,8 +600,16 @@ export class TodoStore {
     // guard's throw becomes a rejected promise like every other validating
     // mutator here, rather than throwing synchronously before any promise
     // exists — matching `addDep`'s same convention.
-    if (!text) throw new Error(`task ${id}: acceptance criteria text must not be empty`);
-    return this.rawUpdate(id, () => ({ acceptanceCriteria: text }));
+    //
+    // Trim BEFORE checking and store the trimmed value: a whitespace-only
+    // string (e.g. `ay todo set-criteria T1 "   "`) is truthy and would
+    // otherwise pass an `if (!text)` check, get stored, and later be
+    // snapshotted into approval evidence as if it were a real definition of
+    // done — violating this method's own "must not be empty" contract
+    // (codex-review Important).
+    const trimmed = text.trim();
+    if (!trimmed) throw new Error(`task ${id}: acceptance criteria text must not be empty`);
+    return this.rawUpdate(id, () => ({ acceptanceCriteria: trimmed }));
   }
 
   setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {


### PR DESCRIPTION
Milestone 1.5 of the `ay todo` ExecPlan: each task can carry its own acceptance criteria (definition of done), and the independent-verification gate durably records what was checked against.

## What this adds

- `TodoRecord`/`CreateInput` gain `acceptanceCriteria?: string` — free text, optional at this layer (Part A stays neutral on whether it's required; a consuming project enforces that itself).
- New `TodoStore.setAcceptanceCriteria(id, text)` to update it after creation.
- `GateEvidence` gains `acceptanceCriteriaAtApproval?: string`, snapshotted by `approve()` from the record's `acceptanceCriteria` AT approval time — not a live reference, so a later edit to the criteria doesn't retroactively change what the audit trail says was approved.
- `verify()`'s registered-gate `check(record)` already receives the full record (Milestone 1 round-6 fix), so `acceptanceCriteria` is visible there for free.
- CLI: `ay todo new --acceptance-criteria "<text>"`, new `ay todo set-criteria <id> <text..>` verb, and rendering in `get` (`acceptanceCriteria: ...` and each evidence entry's `[criteria: ...]`).

## Verification

- 102 tests total (up from 97), all passing. The core new invariant (approval snapshot survives a later edit to the live field) is mutation-tested: removing the snapshot line turned the regression test red, confirmed, restored.
- `tsgo --noEmit` clean.
- Manually smoke-tested end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
