### PR TITLE
feat: deprioritize agent CLIs (nice) so the web console wins CPU under load

### DIFF
--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -366,6 +366,30 @@ pub async fn spawn_agent(
     // Spawn the child
     let child = slave.spawn_command(cmd)?;
 
+    // Scheduler policy: deprioritize the agent CLI so it yields CPU to the
+    // interactive `ay serve` daemon (nice 0) under host load. RAISING serve's
+    // priority (negative nice) needs CAP_SYS_NICE — dropped in many containers —
+    // so we LOWER the agent's instead (always permitted for your own process).
+    // The child's threads/descendants inherit it. Configurable via
+    // AGENT_YES_AGENT_NICE (0..19, default 5, 0 = off). Mirrors ts/agentNice.ts.
+    //
+    // Unix only: on Windows the TS runtime's os.setPriority (which maps nice to a
+    // BELOW_NORMAL/IDLE priority class) covers agents launched via that runtime;
+    // a Windows-Rust SetPriorityClass branch is a follow-up (needs a Windows build
+    // to verify the FFI, which can't be done from this Linux toolchain).
+    #[cfg(unix)]
+    if let Some(child_pid) = child.process_id() {
+        let nice = std::env::var("AGENT_YES_AGENT_NICE")
+            .ok()
+            .and_then(|v| v.trim().parse::<i32>().ok())
+            .unwrap_or(5)
+            .clamp(0, 19);
+        if nice > 0 {
+            // Best-effort; ignore failures (a scheduling hint must never break a spawn).
+            unsafe { libc::setpriority(libc::PRIO_PROCESS, child_pid, nice) };
+        }
+    }
+
     // CRITICAL: Drop the slave after spawning!
     // On Unix, keeping the slave open in the parent can cause writes to fail
     // in the child because the parent still holds references to the slave PTY.

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -379,9 +379,13 @@ pub async fn spawn_agent(
     // to verify the FFI, which can't be done from this Linux toolchain).
     #[cfg(unix)]
     if let Some(child_pid) = child.process_id() {
+        // Parse as f64 then truncate toward zero (`as i32`) so a fractional value
+        // like "3.9" → 3 matches ts/agentNice.ts's Number()+Math.trunc(), rather
+        // than failing i32 parsing and silently falling back to the default.
         let nice = std::env::var("AGENT_YES_AGENT_NICE")
             .ok()
-            .and_then(|v| v.trim().parse::<i32>().ok())
+            .and_then(|v| v.trim().parse::<f64>().ok())
+            .map(|f| f as i32)
             .unwrap_or(5)
             .clamp(0, 19);
         if nice > 0 {

--- a/ts/agentNice.spec.ts
+++ b/ts/agentNice.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { agentNiceValue } from "./agentNice.ts";
+
+describe("agentNice.agentNiceValue", () => {
+  it("defaults to 5 when unset or empty", () => {
+    expect(agentNiceValue({})).toBe(5);
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "" })).toBe(5);
+  });
+
+  it("honors a valid positive value", () => {
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "10" })).toBe(10);
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "0" })).toBe(0); // 0 = disabled
+  });
+
+  it("clamps into the 0..19 nice range (never elevates)", () => {
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "-5" })).toBe(0); // no negative (needs CAP_SYS_NICE)
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "40" })).toBe(19);
+  });
+
+  it("falls back to the default on garbage", () => {
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "abc" })).toBe(5);
+    expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "3.9" })).toBe(3); // truncates
+  });
+});

--- a/ts/agentNice.ts
+++ b/ts/agentNice.ts
@@ -1,0 +1,49 @@
+/**
+ * Scheduler policy: agent CLIs run at a positive nice so they YIELD CPU to the
+ * interactive `ay serve` daemon (which stays at nice 0) under host load. This is
+ * why the web console (/w/) lags while the local terminal stays smooth: every
+ * byte for /w/ flows through the single `ay serve` event loop, which competes
+ * with N busy agent CLIs for CPU. We deprioritize the agents rather than raise
+ * serve because RAISING priority (negative nice) needs CAP_SYS_NICE, which is
+ * dropped in many containers (e.g. this one) — LOWERING priority is always
+ * allowed for your own processes, so this is portable.
+ *
+ * The value applies to the freshly-spawned CLI child; its threads and descendant
+ * processes inherit it. Standalone `ay claude` with no contention is unaffected
+ * (nice only matters when CPU is scarce).
+ *
+ * Configure with AGENT_YES_AGENT_NICE: an integer 0..19. Default 5. 0 disables.
+ * Mirrored in the Rust runtime (rs/src/pty_spawner.rs) — keep them in sync.
+ */
+
+const DEFAULT_AGENT_NICE = 5;
+
+/** Parse AGENT_YES_AGENT_NICE → a clamped positive nice (0..19). 0 = disabled. */
+export function agentNiceValue(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.AGENT_YES_AGENT_NICE;
+  if (raw === undefined || raw === "") return DEFAULT_AGENT_NICE;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_AGENT_NICE;
+  // Positive-only: we never elevate (negative needs CAP_SYS_NICE and would fight
+  // the daemon). Clamp into the standard nice range.
+  return Math.max(0, Math.min(19, Math.trunc(n)));
+}
+
+/**
+ * Best-effort: deprioritize a freshly-spawned agent process to the configured
+ * nice. Swallows all errors — a scheduling hint must never break a spawn (and on
+ * a platform/where setpriority is unavailable it simply no-ops).
+ */
+export async function applyAgentNice(
+  pid: number,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const nice = agentNiceValue(env);
+  if (nice <= 0) return;
+  try {
+    const os = await import("os");
+    os.setPriority(pid, nice);
+  } catch {
+    /* setpriority unavailable / raced with exit — ignore */
+  }
+}

--- a/ts/core/spawner.ts
+++ b/ts/core/spawner.ts
@@ -6,6 +6,7 @@ import type { AgentCliConfig } from "../index.ts";
 import type { SUPPORTED_CLIS } from "../SUPPORTED_CLIS.ts";
 import { execSync } from "node:child_process";
 import { getInstalledPackage } from "../versionChecker.ts";
+import { applyAgentNice } from "../agentNice.ts";
 
 /**
  * Agent spawning utilities
@@ -137,6 +138,11 @@ export function spawnAgent(options: SpawnOptions): IPty {
     logger.info(
       `[${cli}-yes] Spawned ${bin} with PID ${spawned.pid} (agent-yes v${getInstalledPackage().version})`,
     );
+    // Deprioritize the agent CLI so it yields CPU to the interactive `ay serve`
+    // daemon under load (see ts/agentNice.ts). Fire-and-forget; the child's
+    // threads/descendants inherit the nice. Covers the TS runtime; the Rust
+    // runtime applies the same in rs/src/pty_spawner.rs.
+    void applyAgentNice(spawned.pid);
     return spawned;
   };
 


### PR DESCRIPTION
## Problem
`agent-yes.com/w/` lags under heavy host load while the local terminal stays smooth. Root cause: every byte for `/w/` flows through the **single `ay serve` event loop**, which competes at **nice 0** with N busy agent CLIs. The local terminal is rendered by the agent writing directly to its PTY — it never touches `ay serve`, so it stays smooth.

## Why deprioritize agents instead of prioritizing serve
Raising `ay serve`'s priority (negative nice) needs `CAP_SYS_NICE`, which is **dropped in many containers** (verified absent here — `RLIMIT_NICE` ceiling 0/0). *Lowering* a process's own priority is always permitted, so pushing the agents below serve achieves the same relative effect portably. Background agents yielding to the interactive daemon is also the right policy.

## Change
Spawn each agent CLI at a positive nice; its threads/descendants inherit it. Standalone runs with spare CPU are unaffected (nice only bites under contention).
- `ts/agentNice.ts` — `AGENT_YES_AGENT_NICE` parser (0..19, default **5**, 0 = off) + `applyAgentNice(pid)` via `os.setPriority`; wired into `ts/core/spawner.ts` after `pty.spawn`.
- `rs/src/pty_spawner.rs` — `libc::setpriority(PRIO_PROCESS, child, nice)` after spawn, `#[cfg(unix)]`.

## Platform coverage
- **Linux / macOS** — both runtimes.
- **Windows** — via the TS runtime (`os.setPriority` maps nice → `BELOW_NORMAL`/`IDLE`). A Windows-Rust `SetPriorityClass` branch is a follow-up (needs a Windows build to verify the FFI).

## Tests
`ts/agentNice.spec.ts` (parse/clamp/default). 116 TS specs pass; Rust `build:rs` clean. Verified live: renicing agents to +5 while `ay serve` stays 0.

This is the foundational step of a larger plan (lag telemetry + lag-aware healthcheck → WebRTC fan-out backpressure → per-agent TailHub) to structurally fix `/w/` responsiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)