### PR TITLE
feat: ay ch — local-first E2E channels for AI ↔ humans (Phase 1: core + CLI)

### DIFF
--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -21,8 +21,8 @@ use std::env;
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
-    "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "serve", "schedule",
-    "remote", "expose", "callback", "reap", "help",
+    "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
+    "serve", "schedule", "remote", "expose", "callback", "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/channels.spec.ts
+++ b/ts/channels.spec.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cmdCh,
+  defaultName,
+  defaultRole,
+  formatMessage,
+  readRegistry,
+  resolveChannel,
+} from "./channels.ts";
+import type { Message } from "./channels/index.ts";
+
+/** Capture stdout across a call. */
+async function capture(fn: () => Promise<number>): Promise<{ code: number; out: string }> {
+  let out = "";
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    out += String(chunk);
+    return true;
+  });
+  try {
+    const code = await fn();
+    return { code, out };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("ay ch identity defaults", () => {
+  it("infers role from AGENT_YES_PID", () => {
+    const prev = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = "123";
+    expect(defaultRole()).toBe("agent");
+    delete process.env.AGENT_YES_PID;
+    expect(defaultRole()).toBe("human");
+    if (prev !== undefined) process.env.AGENT_YES_PID = prev;
+  });
+
+  it("prefers $AY_CH_NAME for the display name", () => {
+    const prev = process.env.AY_CH_NAME;
+    process.env.AY_CH_NAME = "sonoda";
+    expect(defaultName()).toBe("sonoda");
+    delete process.env.AY_CH_NAME;
+    expect(typeof defaultName()).toBe("string");
+    if (prev !== undefined) process.env.AY_CH_NAME = prev;
+  });
+});
+
+describe("formatMessage", () => {
+  const base: Message = {
+    id: "a@h",
+    author: "a",
+    name: "taku",
+    role: "human",
+    hlc: "h",
+    text: "hello",
+    deleted: false,
+    reactions: [],
+    ms: Date.UTC(2026, 0, 1, 3, 4, 5),
+  };
+  it("renders time, name(role initial), and text", () => {
+    expect(formatMessage(base)).toBe("03:04:05  taku(h): hello");
+  });
+  it("shows (deleted) and reaction counts", () => {
+    expect(formatMessage({ ...base, deleted: true, text: "" })).toContain("(deleted)");
+    expect(formatMessage({ ...base, reactions: [{ emoji: "👍", by: ["a", "b"] }] })).toContain("👍2");
+    expect(formatMessage({ ...base, reactions: [{ emoji: "🎉", by: ["a"] }] })).toContain("🎉");
+  });
+});
+
+describe("ay ch CLI (local-only)", () => {
+  let cwd: string;
+  let origCwd: string;
+
+  beforeEach(async () => {
+    origCwd = process.cwd();
+    cwd = await mkdtemp(path.join(os.tmpdir(), "ay-chcli-"));
+    process.chdir(cwd);
+  });
+  afterEach(async () => {
+    process.chdir(origCwd);
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("mk → send → read round-trips a message", async () => {
+    const mk = await capture(() => cmdCh(["mk", "demo", "--name", "taku", "--role", "human"]));
+    expect(mk.code).toBe(0);
+    expect(mk.out).toContain("ay://ch/");
+
+    const reg = await readRegistry(cwd);
+    expect(reg.channels.demo).toBeTruthy();
+    expect(reg.channels.demo!.name).toBe("taku");
+
+    expect((await capture(() => cmdCh(["send", "demo", "hello", "world"]))).code).toBe(0);
+    const read = await capture(() => cmdCh(["read", "demo"]));
+    expect(read.out).toContain("taku(h): hello world");
+  });
+
+  it("lists channels with message counts", async () => {
+    await capture(() => cmdCh(["mk", "demo", "--name", "a"]));
+    await capture(() => cmdCh(["send", "demo", "one"]));
+    const ls = await capture(() => cmdCh(["ls"]));
+    expect(ls.out).toMatch(/demo\s+1/);
+    const json = await capture(() => cmdCh(["ls", "--json"]));
+    expect(JSON.parse(json.out).channels[0].messages).toBe(1);
+  });
+
+  it("join binds a topic to an invite link, and rm deletes the replica", async () => {
+    const mk = await capture(() => cmdCh(["mk", "src"]));
+    const link = /ay:\/\/\S+/.exec(mk.out)![0];
+
+    const join = await capture(() => cmdCh(["join", link, "--as", "dst", "--name", "bob"]));
+    expect(join.code).toBe(0);
+    const reg = await readRegistry(cwd);
+    // same underlying channel, different local topic + identity
+    expect(reg.channels.dst!.channelId).toBe(reg.channels.src!.channelId);
+    expect(reg.channels.dst!.author).not.toBe(reg.channels.src!.author);
+
+    expect((await capture(() => cmdCh(["rm", "dst"]))).code).toBe(0);
+    expect((await readRegistry(cwd)).channels.dst).toBeUndefined();
+  });
+
+  it("head and tail slice the thread", async () => {
+    await capture(() => cmdCh(["mk", "c"]));
+    for (const t of ["m1", "m2", "m3"]) await capture(() => cmdCh(["send", "c", t]));
+    expect((await capture(() => cmdCh(["head", "c", "-n", "1"]))).out.trim()).toContain("m1");
+    expect((await capture(() => cmdCh(["tail", "c", "-n", "1"]))).out.trim()).toContain("m3");
+  });
+
+  it("errors clearly on unknown channels, duplicate mk, and sending before join", async () => {
+    expect((await capture(() => cmdCh(["mk", "dup"]))).code).toBe(0);
+    // duplicate mk throws (surfaced by runSubcommand; here it rejects)
+    await expect(cmdCh(["mk", "dup"])).rejects.toThrow(/already exists/);
+
+    const reg = await readRegistry(cwd);
+    await expect(resolveChannel(reg, "nope")).rejects.toThrow(/no channel/);
+
+    // a link that isn't joined resolves read-only (no identity) → send refuses
+    const mk = await capture(() => cmdCh(["mk", "src2"]));
+    const link = /ay:\/\/\S+/.exec(mk.out)![0];
+    const resolved = await resolveChannel(reg, "dup");
+    expect(resolved.entry).toBeTruthy();
+    const linkResolved = await resolveChannel(await readRegistry(cwd), link);
+    expect(linkResolved.entry).toBeNull();
+  });
+
+  it("prints help for no subcommand and rejects unknown ones", async () => {
+    expect((await capture(() => cmdCh([]))).out).toContain("ay ch -");
+    const bad = await capture(() => cmdCh(["frobnicate"]));
+    expect(bad.code).toBe(1);
+  });
+});

--- a/ts/channels.ts
+++ b/ts/channels.ts
@@ -1,0 +1,458 @@
+/**
+ * `ay ch` — channels: local-first, end-to-end threads where AI agents and humans
+ * talk on a topic. No server ever stores a message; every participant keeps a
+ * full replica as an append-only CRDT log, cwd-scoped like the rest of
+ * agent-yes's per-project state:
+ *
+ *   ay ch mk <topic> [--sighost H] [--name N] [--role agent|human] [--salt HEX]
+ *   ay ch join <link> [--as <topic>] [--name N] [--role R]
+ *   ay ch ls [--json]
+ *   ay ch rm <topic>
+ *   ay ch send <topic> <text…> [--name N] [--role R]
+ *   ay ch read <topic> [-n N] [--json]
+ *   ay ch head <topic> [-n N]
+ *   ay ch tail <topic> [-n N] [-f]
+ *
+ * Phase 1 is local-only (the log, the CRDT, the verbs). Live delivery over the
+ * WebRTC mesh (`--once`, real `tail -f` across peers, `pipe`) arrives with the
+ * serve daemon in Phase 2; the on-disk format and identity model here are the
+ * foundation both share.
+ *
+ * The channels core (ts/channels/) is isomorphic and reused verbatim by the
+ * browser lib; this file is the Node CLI shell over it, mirroring ts/ws.ts.
+ */
+
+import { randomBytes } from "crypto";
+import { chmod, mkdir, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  deriveChannelId,
+  deriveRoom,
+  formatChannelLink,
+  formatChannelWebLink,
+  hlcSend,
+  isChannelLink,
+  makeOp,
+  maxHlc,
+  parseChannelLink,
+  renderThread,
+  type Message,
+  type Role,
+} from "./channels/index.ts";
+import { appendOps, channelFilePath, readOps } from "./channels/store.node.ts";
+
+const REG_SCHEMA = "ay-ch/v1";
+
+interface ChannelRegEntry {
+  topic: string;
+  channelId: string;
+  room: string;
+  sighost: string;
+  /** Shared secret S (64-hex); the registry file is chmod 0600. */
+  s: string;
+  /** Stable per-participant id — the HLC node + author identity. */
+  author: string;
+  name: string;
+  role: Role;
+  createdAt: number;
+}
+
+interface ChannelRegistry {
+  schema: string;
+  channels: Record<string, ChannelRegEntry>;
+}
+
+// --- identity defaults ------------------------------------------------------
+
+/** An agent (AGENT_YES_PID set) defaults to role "agent"; a human shell to "human". */
+export function defaultRole(): Role {
+  return process.env.AGENT_YES_PID ? "agent" : "human";
+}
+
+/** Default display name: $AY_CH_NAME, else the OS username, else "anon". */
+export function defaultName(): string {
+  if (process.env.AY_CH_NAME) return process.env.AY_CH_NAME;
+  try {
+    return os.userInfo().username || "anon";
+  } catch {
+    return "anon";
+  }
+}
+
+function validRole(v: string | boolean | undefined): Role {
+  if (v === "agent" || v === "human") return v;
+  throw new Error(`--role must be "agent" or "human"`);
+}
+
+// --- registry IO ------------------------------------------------------------
+
+function registryPath(cwd: string): string {
+  return path.join(cwd, ".agent-yes", "channels.json");
+}
+
+export async function readRegistry(cwd: string): Promise<ChannelRegistry> {
+  try {
+    const reg = JSON.parse(await readFile(registryPath(cwd), "utf-8")) as ChannelRegistry;
+    if (reg && typeof reg === "object" && reg.channels) return reg;
+  } catch {
+    /* missing/corrupt → empty */
+  }
+  return { schema: REG_SCHEMA, channels: {} };
+}
+
+async function writeRegistry(cwd: string, reg: ChannelRegistry): Promise<void> {
+  const file = registryPath(cwd);
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, JSON.stringify(reg, null, 2) + "\n");
+  await chmod(file, 0o600).catch(() => {}); // best-effort (no-op on Windows)
+}
+
+/**
+ * Resolve a `<topic|link>` operand. A registered topic yields its full entry; a
+ * bare invite link yields just its channelId (read-only — sending needs an
+ * identity, i.e. `ay ch join` first). Anything else is an error.
+ */
+export async function resolveChannel(
+  reg: ChannelRegistry,
+  arg: string,
+): Promise<{ channelId: string; entry: ChannelRegEntry | null }> {
+  const entry = reg.channels[arg];
+  if (entry) return { channelId: entry.channelId, entry };
+  if (isChannelLink(arg)) {
+    const link = parseChannelLink(arg);
+    if (link) return { channelId: await deriveChannelId(link.s), entry: null };
+  }
+  throw new Error(`no channel "${arg}" — see 'ay ch ls', or 'ay ch join <link>'`);
+}
+
+// --- display ----------------------------------------------------------------
+
+/** One rendered thread line: `HH:MM:SS  name(a): text  👍2`. Pure, for tests. */
+export function formatMessage(m: Message): string {
+  const t = new Date(m.ms).toISOString().slice(11, 19);
+  const who = `${m.name}(${m.role[0]})`;
+  const text = m.deleted ? "(deleted)" : m.text;
+  const react = m.reactions.length
+    ? "  " + m.reactions.map((r) => `${r.emoji}${r.by.length > 1 ? r.by.length : ""}`).join(" ")
+    : "";
+  return `${t}  ${who}: ${text}${react}`;
+}
+
+// --- flag parsing (tiny, mirrors ws.ts) -------------------------------------
+
+function parseFlags(
+  args: string[],
+  known: Record<string, "bool" | "value">,
+): { flags: Record<string, string | boolean>; positional: string[] } {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (!a.startsWith("-") || a === "-") {
+      positional.push(a);
+      continue;
+    }
+    // support -n as an alias for --limit
+    const isShortN = a === "-n";
+    const eq = a.indexOf("=");
+    const name = isShortN
+      ? "limit"
+      : eq === -1
+        ? a.replace(/^--?/, "")
+        : a.slice(a.startsWith("--") ? 2 : 1, eq);
+    const kind = known[name];
+    if (!kind) throw new Error(`unknown flag ${a}`);
+    if (kind === "bool") {
+      if (eq !== -1) throw new Error(`--${name} takes no value`);
+      flags[name] = true;
+    } else {
+      const v = eq !== -1 ? a.slice(eq + 1) : args[++i];
+      if (v === undefined) throw new Error(`${a} requires a value`);
+      flags[name] = v;
+    }
+  }
+  return { flags, positional };
+}
+
+function limitOf(flags: Record<string, string | boolean>): number | undefined {
+  if (flags.limit === undefined) return undefined;
+  const n = Number(flags.limit);
+  if (!Number.isInteger(n) || n < 0) throw new Error(`-n/--limit must be a non-negative integer`);
+  return n;
+}
+
+// --- verbs ------------------------------------------------------------------
+
+async function cmdChMk(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    sighost: "value",
+    name: "value",
+    role: "value",
+    salt: "value",
+  });
+  const topic = positional[0];
+  if (!topic || positional.length > 1)
+    throw new Error("usage: ay ch mk <topic> [--sighost H] [--name N] [--role R] [--salt HEX]");
+  const reg = await readRegistry(cwd);
+  if (reg.channels[topic])
+    throw new Error(`channel "${topic}" already exists (ay ch rm ${topic} to replace)`);
+
+  const s = typeof flags.salt === "string" ? flags.salt : randomBytes(32).toString("hex");
+  const [channelId, room] = await Promise.all([deriveChannelId(s), deriveRoom(s)]);
+  const sighost = typeof flags.sighost === "string" ? flags.sighost : undefined;
+  const entry: ChannelRegEntry = {
+    topic,
+    channelId,
+    room,
+    sighost: sighost ?? "s.agent-yes.com",
+    s,
+    author: randomBytes(8).toString("hex"),
+    name: typeof flags.name === "string" ? flags.name : defaultName(),
+    role: flags.role ? validRole(flags.role) : defaultRole(),
+    createdAt: Date.now(),
+  };
+  reg.channels[topic] = entry;
+  await writeRegistry(cwd, reg);
+
+  const link = formatChannelLink({ sighost: entry.sighost, room, s });
+  process.stdout.write(
+    `created channel "${topic}"  (${entry.name}, ${entry.role})\n` +
+      `  invite (CLI):     ${link}\n` +
+      `  invite (browser): ${formatChannelWebLink({ sighost: entry.sighost, room, s })}\n` +
+      `\n  share the invite; others join with:  ay ch join '${link}'\n`,
+  );
+  return 0;
+}
+
+async function cmdChJoin(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { as: "value", name: "value", role: "value" });
+  const linkStr = positional[0];
+  if (!linkStr || positional.length > 1)
+    throw new Error("usage: ay ch join <link> [--as <topic>] [--name N] [--role R]");
+  const link = parseChannelLink(linkStr);
+  if (!link) throw new Error(`not a channel invite link: ${linkStr}`);
+
+  const channelId = await deriveChannelId(link.s);
+  const topic = typeof flags.as === "string" ? flags.as : `ch-${link.room.slice(0, 10)}`;
+  const reg = await readRegistry(cwd);
+  const existing = reg.channels[topic];
+  if (existing && existing.channelId !== channelId)
+    throw new Error(`topic "${topic}" is already bound to a different channel — pick another --as`);
+
+  const entry: ChannelRegEntry = existing ?? {
+    topic,
+    channelId,
+    room: link.room,
+    sighost: link.sighost,
+    s: link.s,
+    author: randomBytes(8).toString("hex"),
+    name: typeof flags.name === "string" ? flags.name : defaultName(),
+    role: flags.role ? validRole(flags.role) : defaultRole(),
+    createdAt: Date.now(),
+  };
+  if (typeof flags.name === "string") entry.name = flags.name;
+  if (flags.role) entry.role = validRole(flags.role);
+  reg.channels[topic] = entry;
+  await writeRegistry(cwd, reg);
+  process.stdout.write(`joined channel "${topic}"  (${entry.name}, ${entry.role})\n`);
+  return 0;
+}
+
+async function cmdChLs(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { json: "bool" });
+  if (positional.length) throw new Error("ay ch ls takes no positional args");
+  const reg = await readRegistry(cwd);
+  const topics = Object.keys(reg.channels).sort();
+
+  const rows = await Promise.all(
+    topics.map(async (topic) => {
+      const e = reg.channels[topic]!;
+      const ops = await readOps(cwd, e.channelId);
+      const msgs = renderThread(ops);
+      const last = msgs.length ? msgs[msgs.length - 1]! : null;
+      return {
+        topic,
+        channelId: e.channelId,
+        name: e.name,
+        role: e.role,
+        messages: msgs.length,
+        lastMs: last ? last.ms : null,
+      };
+    }),
+  );
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify({ schema: REG_SCHEMA, channels: rows }, null, 2) + "\n");
+    return 0;
+  }
+  if (rows.length === 0) {
+    process.stderr.write(`no channels in ${cwd} — 'ay ch mk <topic>' or 'ay ch join <link>'\n`);
+    return 0;
+  }
+  const w = Math.max(5, ...rows.map((r) => r.topic.length));
+  process.stdout.write(`${"TOPIC".padEnd(w)}  ${"MSGS".padStart(5)}  LAST\n`);
+  for (const r of rows) {
+    const last = r.lastMs ? new Date(r.lastMs).toISOString().slice(0, 19).replace("T", " ") : "-";
+    process.stdout.write(`${r.topic.padEnd(w)}  ${String(r.messages).padStart(5)}  ${last}\n`);
+  }
+  return 0;
+}
+
+async function cmdChRm(cwd: string, args: string[]): Promise<number> {
+  const { positional } = parseFlags(args, {});
+  const topic = positional[0];
+  if (!topic || positional.length > 1) throw new Error("usage: ay ch rm <topic>");
+  const reg = await readRegistry(cwd);
+  const entry = reg.channels[topic];
+  if (!entry) throw new Error(`no channel "${topic}"`);
+  delete reg.channels[topic];
+  await writeRegistry(cwd, reg);
+  await rm(channelFilePath(cwd, entry.channelId), { force: true });
+  process.stdout.write(`removed channel "${topic}" (local replica deleted; peers unaffected)\n`);
+  return 0;
+}
+
+async function cmdChSend(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { name: "value", role: "value" });
+  const topic = positional[0];
+  const text = positional.slice(1).join(" ");
+  if (!topic || !text) throw new Error("usage: ay ch send <topic> <text…>");
+  const reg = await readRegistry(cwd);
+  const { channelId, entry } = await resolveChannel(reg, topic);
+  if (!entry) throw new Error(`join "${topic}" before sending: ay ch join <link>`);
+
+  const ops = await readOps(cwd, channelId);
+  const hlc = hlcSend(maxHlc(ops), Date.now(), entry.author);
+  const op = makeOp({
+    author: entry.author,
+    name: typeof flags.name === "string" ? flags.name : entry.name,
+    role: flags.role ? validRole(flags.role) : entry.role,
+    hlc,
+    kind: "msg",
+    body: text,
+  });
+  await appendOps(cwd, channelId, [op]);
+  // Phase 2: also hand `op` to the serve daemon to broadcast over the mesh.
+  return 0;
+}
+
+async function readAndRender(cwd: string, channelId: string): Promise<Message[]> {
+  return renderThread(await readOps(cwd, channelId));
+}
+
+async function cmdChRead(
+  cwd: string,
+  args: string[],
+  mode: "read" | "head" | "tail",
+): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    limit: "value",
+    json: "bool",
+    follow: "bool",
+    f: "bool",
+  });
+  const topic = positional[0];
+  if (!topic || positional.length > 1) throw new Error(`usage: ay ch ${mode} <topic> [-n N]`);
+  const reg = await readRegistry(cwd);
+  const { channelId } = await resolveChannel(reg, topic);
+
+  const n = limitOf(flags);
+  let msgs = await readAndRender(cwd, channelId);
+  if (mode === "head") msgs = msgs.slice(0, n ?? 10);
+  else if (mode === "tail") msgs = msgs.slice(-(n ?? 96));
+  else if (n !== undefined) msgs = msgs.slice(-n);
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(msgs, null, 2) + "\n");
+  } else {
+    for (const m of msgs) process.stdout.write(formatMessage(m) + "\n");
+  }
+
+  if (mode === "tail" && (flags.follow || flags.f)) {
+    await followChannel(cwd, channelId, new Set(msgs.map((m) => m.id)));
+  }
+  return 0;
+}
+
+/**
+ * Follow a channel, printing messages as they appear. Phase 1 polls the local
+ * replica (fs.watch is unreliable in long-lived daemons — see the fswatch-dies
+ * note), so it surfaces same-cwd appends; Phase 2's daemon feeds it live peer
+ * traffic. Runs until SIGINT.
+ */
+function followChannel(cwd: string, channelId: string, seen: Set<string>): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setInterval(async () => {
+      const msgs = await readAndRender(cwd, channelId);
+      for (const m of msgs) {
+        if (seen.has(m.id)) continue;
+        seen.add(m.id);
+        process.stdout.write(formatMessage(m) + "\n");
+      }
+    }, 500);
+    const stop = () => {
+      clearInterval(timer);
+      resolve();
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+  });
+}
+
+function chHelp(): number {
+  process.stdout.write(
+    `ay ch - local-first E2E channels for AI ↔ humans (per-cwd, no server storage)\n` +
+      `\n` +
+      `  ay ch mk <topic> [--name N] [--role R]   create a channel, print an invite link\n` +
+      `  ay ch join <link> [--as <topic>]         join a channel from an invite link\n` +
+      `  ay ch ls [--json]                        list channels in this project (+message counts)\n` +
+      `  ay ch rm <topic>                         delete the local replica (peers unaffected)\n` +
+      `  ay ch send <topic> <text…>               post a message\n` +
+      `  ay ch read <topic> [-n N] [--json]       print the thread (last N)\n` +
+      `  ay ch head <topic> [-n N]                first N messages\n` +
+      `  ay ch tail <topic> [-n N] [-f]           last N (96), -f to follow\n` +
+      `\n` +
+      `  identity: --name defaults to $AY_CH_NAME/OS user; --role to agent (in an agent) or human\n` +
+      `  storage:  <cwd>/.agent-yes/ch-<id>.jsonl  (a full CRDT replica; cwd-scoped)\n`,
+  );
+  return 0;
+}
+
+/** `ay ch <sub> …` dispatcher (called from runSubcommand). */
+export async function cmdCh(args: string[]): Promise<number> {
+  const cwd = process.cwd();
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case "mk":
+    case "new":
+    case "create":
+      return cmdChMk(cwd, rest);
+    case "join":
+      return cmdChJoin(cwd, rest);
+    case "ls":
+    case "list":
+      return cmdChLs(cwd, rest);
+    case "rm":
+    case "remove":
+      return cmdChRm(cwd, rest);
+    case "send":
+      return cmdChSend(cwd, rest);
+    case "read":
+      return cmdChRead(cwd, rest, "read");
+    case "head":
+      return cmdChRead(cwd, rest, "head");
+    case "tail":
+      return cmdChRead(cwd, rest, "tail");
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      return chHelp();
+    default:
+      process.stderr.write(`ay ch: unknown subcommand "${sub}"\n\n`);
+      chHelp();
+      return 1;
+  }
+}

--- a/ts/channels/hlc.spec.ts
+++ b/ts/channels/hlc.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { compareHlc, formatHlc, hlcSend, parseHlc } from "./hlc.ts";
+
+describe("hlc", () => {
+  it("round-trips format/parse", () => {
+    const s = formatHlc(1_700_000_000_000, 3, "node7");
+    expect(parseHlc(s)).toEqual({ ms: 1_700_000_000_000, ctr: 3, node: "node7" });
+  });
+
+  it("is lexicographically sortable in HLC order", () => {
+    const a = formatHlc(1000, 0, "z"); // earlier ms
+    const b = formatHlc(1000, 1, "a"); // same ms, higher ctr
+    const c = formatHlc(2000, 0, "a"); // later ms
+    expect([c, a, b].sort()).toEqual([a, b, c]);
+    expect(compareHlc(a, b)).toBeLessThan(0);
+    expect(compareHlc(c, a)).toBeGreaterThan(0);
+    expect(compareHlc(a, a)).toBe(0);
+  });
+
+  it("advances the ms and resets the counter when wall clock moves forward", () => {
+    const prev = formatHlc(1000, 5, "n1");
+    expect(parseHlc(hlcSend(prev, 2000, "n1"))).toMatchObject({ ms: 2000, ctr: 0 });
+  });
+
+  it("keeps ms and bumps the counter when wall clock has not advanced", () => {
+    const prev = formatHlc(5000, 2, "n1");
+    // physNow behind the max we've seen (clock skew / same ms) → monotonic via ctr
+    expect(parseHlc(hlcSend(prev, 4000, "n1"))).toMatchObject({ ms: 5000, ctr: 3 });
+    expect(parseHlc(hlcSend(prev, 5000, "n1"))).toMatchObject({ ms: 5000, ctr: 3 });
+  });
+
+  it("is strictly monotonic across repeated sends seeded from the running max", () => {
+    let max: string | null = null;
+    const out: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      // simulate a clock that sometimes stalls
+      const now = 1000 + (i % 3 === 0 ? 0 : i);
+      max = hlcSend(max, now, "n");
+      out.push(max);
+    }
+    for (let i = 1; i < out.length; i++) expect(compareHlc(out[i - 1]!, out[i]!)).toBeLessThan(0);
+  });
+
+  it("starts from zero with no prior max", () => {
+    expect(parseHlc(hlcSend(null, 42, "n"))).toEqual({ ms: 42, ctr: 0, node: "n" });
+  });
+
+  it("rejects malformed and out-of-range values", () => {
+    expect(() => parseHlc("nope")).toThrow();
+    expect(() => parseHlc("1.2")).toThrow(); // too few fields
+    expect(() => formatHlc(-1, 0, "n")).toThrow();
+    expect(() => formatHlc(0, -1, "n")).toThrow();
+    expect(() => formatHlc(10 ** 15, 0, "n")).toThrow(); // ms overflow
+    expect(() => formatHlc(0, 10 ** 6, "n")).toThrow(); // ctr overflow
+  });
+});

--- a/ts/channels/hlc.ts
+++ b/ts/channels/hlc.ts
@@ -1,0 +1,67 @@
+// Hybrid Logical Clock (HLC) for ay channels.
+//
+// A channel is a grow-only set of immutable ops replicated across peers with no
+// coordinator (see store.ts). To display those ops in a stable, causally-sensible
+// order every replica must agree on, each op carries an HLC timestamp: a wall
+// clock reading fused with a per-node counter so that (a) order roughly tracks
+// real time, (b) concurrent ops from different nodes get a deterministic
+// tie-break, and (c) an op always sorts AFTER every op its author had already
+// seen when it was created (causality).
+//
+// The timestamp is encoded as a FIXED-WIDTH, lexicographically-sortable string
+//   "<ms:15><SEP><ctr:6><SEP><node>"
+// so a plain string compare reproduces the numeric HLC order — which lets the
+// jsonl store and the wire protocol sort without parsing. This module is
+// dependency-free and isomorphic (Node + browser).
+
+const MS_WIDTH = 15; // ms since epoch; 15 digits lasts past year 33000
+const CTR_WIDTH = 6; // per-ms counter; 10^6 ops sharing one ms is astronomically safe
+const SEP = "."; // 0x2e < '0' (0x30) so, with fixed widths, it never reorders fields
+
+export interface Hlc {
+  ms: number;
+  ctr: number;
+  node: string;
+}
+
+/** Encode an HLC as its sortable string form. */
+export function formatHlc(ms: number, ctr: number, node: string): string {
+  if (ms < 0 || ctr < 0) throw new Error("hlc: negative component");
+  if (ms >= 10 ** MS_WIDTH || ctr >= 10 ** CTR_WIDTH) throw new Error("hlc: component overflow");
+  return `${String(ms).padStart(MS_WIDTH, "0")}${SEP}${String(ctr).padStart(CTR_WIDTH, "0")}${SEP}${node}`;
+}
+
+/** Parse a sortable HLC string back into its components. Throws on malformed input. */
+export function parseHlc(s: string): Hlc {
+  const parts = s.split(SEP);
+  if (parts.length < 3) throw new Error("hlc: malformed");
+  const ms = Number(parts[0]);
+  const ctr = Number(parts[1]);
+  // node ids never contain SEP, but be defensive if one ever does.
+  const node = parts.slice(2).join(SEP);
+  if (!Number.isInteger(ms) || !Number.isInteger(ctr) || !node) throw new Error("hlc: malformed");
+  return { ms, ctr, node };
+}
+
+/**
+ * Numeric HLC comparison. Equivalent to a plain string compare of the sortable
+ * form (that's the point of the fixed-width encoding), but exposed explicitly so
+ * callers reading structured HLCs don't have to reconstruct the string.
+ */
+export function compareHlc(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Produce the HLC for a new local op. `prevMax` is the greatest HLC this replica
+ * has already stored (from ANY author — see store.maxHlc); passing it makes the
+ * result monotonic across process restarts and causally after everything seen,
+ * with no separate clock-state file to persist. `physNow` is the wall clock
+ * (Date.now()); `node` is this participant's stable id.
+ */
+export function hlcSend(prevMax: string | null, physNow: number, node: string): string {
+  const prev = prevMax ? parseHlc(prevMax) : { ms: 0, ctr: 0 };
+  if (physNow > prev.ms) return formatHlc(physNow, 0, node);
+  // wall clock hasn't advanced past what we've seen — keep the ms, bump the counter
+  return formatHlc(prev.ms, prev.ctr + 1, node);
+}

--- a/ts/channels/index.ts
+++ b/ts/channels/index.ts
@@ -1,0 +1,10 @@
+// Public surface of the channels core — imported by the CLI (ts/channels.ts),
+// the serve daemon (Phase 2), and re-exported as the npm `agent-yes/channels`
+// subpath + browser lib (Phase 3). Only isomorphic, dependency-free modules are
+// re-exported here; the Node-only jsonl backend (store.node.ts) is imported
+// directly by Node callers so a browser bundle never pulls in `fs`.
+
+export * from "./hlc.ts";
+export * from "./op.ts";
+export * from "./store.ts";
+export * from "./link.ts";

--- a/ts/channels/link.spec.ts
+++ b/ts/channels/link.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveChannelId,
+  deriveRoom,
+  formatChannelLink,
+  formatChannelWebLink,
+  isChannelLink,
+  parseChannelLink,
+} from "./link.ts";
+
+const S = "a".repeat(64); // a valid 64-hex secret
+
+describe("channel identity derivation", () => {
+  it("derives a stable, topic-blind channelId and room from the secret", async () => {
+    const [id1, id2] = await Promise.all([deriveChannelId(S), deriveChannelId(S)]);
+    expect(id1).toBe(id2);
+    expect(id1).toMatch(/^[0-9a-f]{16}$/);
+    const room = await deriveRoom(S);
+    expect(room).toMatch(/^c[0-9a-f]{12}$/); // matches the signaling room grammar
+    // different secret → different identity
+    expect(await deriveChannelId("b".repeat(64))).not.toBe(id1);
+  });
+
+  it("rejects a non-hex secret before hashing", async () => {
+    await expect(deriveChannelId("not-hex")).rejects.toThrow();
+  });
+});
+
+describe("channel invite links", () => {
+  const link = { sighost: "s.agent-yes.com", room: "cabc123", s: S };
+
+  it("round-trips the ay:// form", () => {
+    const str = formatChannelLink(link);
+    expect(str).toBe(`ay://ch/s.agent-yes.com/cabc123#e1.${S}`);
+    expect(parseChannelLink(str)).toEqual(link);
+    expect(isChannelLink(str)).toBe(true);
+  });
+
+  it("round-trips the browser https form, defaulting the sighost", () => {
+    const web = formatChannelWebLink(link);
+    expect(web).toBe(`https://agent-yes.com/w/#ch=cabc123:e1.${S}`);
+    expect(parseChannelLink(web)).toEqual(link);
+    // a non-default sighost is carried explicitly
+    const custom = { ...link, sighost: "sig.example.com" };
+    expect(parseChannelLink(formatChannelWebLink(custom))).toEqual(custom);
+  });
+
+  it("returns null for non-links and throws on a malformed secret slot", () => {
+    expect(parseChannelLink("just a topic name")).toBeNull();
+    expect(isChannelLink("topic")).toBe(false);
+    // http url without the #ch= fragment is not a channel link
+    expect(isChannelLink("https://example.com/page")).toBe(false);
+    expect(parseChannelLink("https://example.com/page")).toBeNull();
+    // https channel form missing the room:secret separator → null
+    expect(parseChannelLink("https://x/w/#ch=noseparator")).toBeNull();
+    expect(() => parseChannelLink("ay://ch/host/room#e1.short")).toThrow();
+    expect(() => parseChannelLink("https://x/w/#ch=room:e1.short")).toThrow();
+  });
+});

--- a/ts/channels/link.ts
+++ b/ts/channels/link.ts
@@ -1,0 +1,89 @@
+// Channel identity + invite links — pure, isomorphic, native-free (kept off
+// node-datachannel like webrtcLink.ts, so parsing/derivation never loads the
+// WebRTC addon and stays unit-testable).
+//
+// A channel's shared secret S is the same `e1.<64hex>` value the WebRTC share
+// links use (e2e.js). Everything else is derived from S so peers who hold it
+// agree without exchanging anything the server can read:
+//   - channelId : names the LOCAL replica file/key; topic-blind, cwd-portable.
+//   - room      : the signaling rendezvous name (server sees only this + authToken).
+// The topic string is a purely local label — it never appears in a link and
+// never leaves the machine.
+
+import { parseSecret, validateS } from "../../lab/ui/e2e.js";
+
+export const CH_DEFAULT_SIGHOST = "s.agent-yes.com";
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const subtle = globalThis.crypto.subtle;
+const enc = new TextEncoder();
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = new Uint8Array(await subtle.digest("SHA-256", enc.encode(input)));
+  let s = "";
+  for (const b of digest) s += b.toString(16).padStart(2, "0");
+  return s;
+}
+
+/** Local replica id: `sha256("ay/ch/id\n" + S)[:16]`. Topic-blind. */
+export async function deriveChannelId(s: string): Promise<string> {
+  return (await sha256Hex(`ay/ch/id\n${validateS(s)}`)).slice(0, 16);
+}
+
+/** Signaling rendezvous name: `"c" + sha256("ay/ch/room\n" + S)[:12]`. */
+export async function deriveRoom(s: string): Promise<string> {
+  return "c" + (await sha256Hex(`ay/ch/room\n${validateS(s)}`)).slice(0, 12);
+}
+
+export interface ChannelLink {
+  sighost: string;
+  room: string;
+  /** The raw 64-hex secret S (marker stripped). */
+  s: string;
+}
+
+/** True if `str` looks like a channel invite link. */
+export function isChannelLink(str: string): boolean {
+  return str.startsWith("ay://ch/") || (/^https?:\/\//.test(str) && str.includes("#ch="));
+}
+
+/**
+ * Format a channel invite:
+ *   ay://ch/<sighost>/<room>#e1.<64hex>
+ * The secret rides the fragment; on the https form it is never sent to a server.
+ */
+export function formatChannelLink(link: ChannelLink): string {
+  return `ay://ch/${link.sighost}/${link.room}#e1.${validateS(link.s)}`;
+}
+
+/** Browser-console form: https://<host>/w/#ch=<room>:e1.<64hex>[@<sighost>]. */
+export function formatChannelWebLink(link: ChannelLink, webHost = "agent-yes.com"): string {
+  const at = link.sighost === CH_DEFAULT_SIGHOST ? "" : `@${link.sighost}`;
+  return `https://${webHost}/w/#ch=${link.room}:e1.${validateS(link.s)}${at}`;
+}
+
+/**
+ * Parse either invite form back into { sighost, room, s }. Returns null if the
+ * string isn't a recognizable channel link; throws (via parseSecret) if the
+ * secret slot is present but malformed — never silently downgrades.
+ */
+export function parseChannelLink(link: string): ChannelLink | null {
+  const ay = /^ay:\/\/ch\/([^/]+)\/([^#]+)#(.+)$/.exec(link);
+  if (ay) {
+    const { s } = parseSecret(ay[3]!);
+    if (!HEX64.test(s)) throw new Error("malformed channel link");
+    return { sighost: ay[1]!, room: ay[2]!, s };
+  }
+  if (/^https?:\/\//.test(link) && link.includes("#ch=")) {
+    const frag = link.split("#ch=")[1] ?? "";
+    const at = frag.split("@");
+    const sighost = at[1] || CH_DEFAULT_SIGHOST;
+    const seg = at[0]!;
+    const i = seg.indexOf(":");
+    if (i < 0) return null;
+    const { s } = parseSecret(seg.slice(i + 1));
+    if (!HEX64.test(s)) throw new Error("malformed channel link");
+    return { sighost, room: seg.slice(0, i), s };
+  }
+  return null;
+}

--- a/ts/channels/op.spec.ts
+++ b/ts/channels/op.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { isValidOp, makeOp, opId } from "./op.ts";
+
+const base = { author: "a1", name: "taku", role: "human" as const, hlc: "h1" };
+
+describe("op", () => {
+  it("derives a stable id from author + hlc", () => {
+    expect(opId("a1", "h1")).toBe("a1@h1");
+    expect(makeOp({ ...base, kind: "msg", body: "hi" }).id).toBe("a1@h1");
+  });
+
+  it("drops empty optional fields", () => {
+    const op = makeOp({ ...base, kind: "msg", body: "hi" });
+    expect(op).not.toHaveProperty("ref");
+    const del = makeOp({ ...base, kind: "delete", ref: "a1@h0" });
+    expect(del).not.toHaveProperty("body");
+    expect(del.ref).toBe("a1@h0");
+  });
+
+  it("keeps an empty-string body (a cleared edit) but not undefined", () => {
+    expect(makeOp({ ...base, kind: "edit", body: "", ref: "x" }).body).toBe("");
+  });
+
+  it("validates a well-formed op", () => {
+    expect(isValidOp(makeOp({ ...base, kind: "msg", body: "hi" }))).toBe(true);
+    expect(isValidOp(makeOp({ ...base, kind: "reaction", body: "👍", ref: "x" }))).toBe(true);
+  });
+
+  it("rejects malformed ops (fail-closed)", () => {
+    expect(isValidOp(null)).toBe(false);
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "nope", name: "x" })).toBe(false);
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", role: "robot" })).toBe(false);
+    // id must equal author@hlc
+    expect(isValidOp({ ...base, id: "forged", kind: "msg", name: "x" })).toBe(false);
+    // amendments must carry a ref
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "edit", name: "x", body: "z" })).toBe(false);
+    // wrong field types
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: 5 })).toBe(false);
+    expect(
+      isValidOp({
+        author: "a1",
+        hlc: "h1",
+        id: "a1@h1",
+        kind: "msg",
+        name: "x",
+        role: "human",
+        body: 1,
+      }),
+    ).toBe(false);
+    // ref of the wrong type
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "edit", name: "x", body: "z", ref: 9 })).toBe(
+      false,
+    );
+    // sig of the wrong type is rejected; a string sig is accepted
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", sig: 1 })).toBe(false);
+    expect(
+      isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", body: "hi", sig: "deadbeef" }),
+    ).toBe(true);
+    // reaction/delete without a ref also fail-closed
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "reaction", name: "x", body: "👍" })).toBe(
+      false,
+    );
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "delete", name: "x" })).toBe(false);
+    // missing/blank required fields
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", author: "" })).toBe(false);
+    expect(
+      isValidOp({ id: "@h1", kind: "msg", name: "x", role: "human", author: "", hlc: "h1" }),
+    ).toBe(false);
+  });
+});

--- a/ts/channels/op.ts
+++ b/ts/channels/op.ts
@@ -1,0 +1,89 @@
+// The immutable op — the single record type replicated through a channel.
+//
+// Every message, edit, delete, reaction, and presence beat is one Op, appended
+// to every replica's log and merged as a grow-only set (store.ts). Ops are
+// content-independent of transport: the same shape lands in the CLI's jsonl and
+// the browser's LocalStorage, and travels verbatim inside the E2E sealed frame.
+//
+// Identity: `id = "<author>@<hlc>"`. An author's HLCs are strictly monotonic and
+// never reused, so (author, hlc) is globally unique WITHOUT a content hash — a
+// retransmit of the same op yields the same id and dedups for free. (Phase 3
+// ed25519 `sig` will bind the body to this id so a peer can't forge a different
+// body under an author's id; until then, channel-secret possession = trust.)
+//
+// Dependency-free and isomorphic (Node + browser).
+
+export type OpKind = "msg" | "edit" | "delete" | "reaction" | "presence";
+export type Role = "agent" | "human";
+
+export interface Op {
+  /** `<author>@<hlc>` — globally unique dedupe key. */
+  id: string;
+  /** Stable per-participant id (registry `author`); the HLC node + identity. */
+  author: string;
+  /** Display name at send time. */
+  name: string;
+  role: Role;
+  /** Sortable Hybrid Logical Clock (hlc.ts). */
+  hlc: string;
+  kind: OpKind;
+  /** msg/edit: text. reaction: the emoji/label. presence: status. Absent for delete. */
+  body?: string;
+  /** edit/delete/reaction: the target op id being amended. */
+  ref?: string;
+  /** Phase 3: ed25519 signature over `id` (author authenticity). */
+  sig?: string;
+}
+
+const KINDS: ReadonlySet<string> = new Set(["msg", "edit", "delete", "reaction", "presence"]);
+const ROLES: ReadonlySet<string> = new Set(["agent", "human"]);
+
+/** Deterministic op id from author + hlc (no content hash needed — see file header). */
+export function opId(author: string, hlc: string): string {
+  return `${author}@${hlc}`;
+}
+
+/** Construct a well-formed op, filling `id` and dropping empty optional fields. */
+export function makeOp(fields: {
+  author: string;
+  name: string;
+  role: Role;
+  hlc: string;
+  kind: OpKind;
+  body?: string;
+  ref?: string;
+}): Op {
+  const op: Op = {
+    id: opId(fields.author, fields.hlc),
+    author: fields.author,
+    name: fields.name,
+    role: fields.role,
+    hlc: fields.hlc,
+    kind: fields.kind,
+  };
+  if (fields.body !== undefined) op.body = fields.body;
+  if (fields.ref) op.ref = fields.ref;
+  return op;
+}
+
+/**
+ * Validate an op arriving from an untrusted source (peer wire, disk, storage).
+ * Fail-closed: a malformed op is dropped, never coerced. Also enforces that `id`
+ * matches `author@hlc` so a peer can't smuggle a colliding id.
+ */
+export function isValidOp(x: unknown): x is Op {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  if (typeof o.author !== "string" || !o.author) return false;
+  if (typeof o.name !== "string") return false;
+  if (typeof o.hlc !== "string" || !o.hlc) return false;
+  if (typeof o.kind !== "string" || !KINDS.has(o.kind)) return false;
+  if (typeof o.role !== "string" || !ROLES.has(o.role)) return false;
+  if (o.body !== undefined && typeof o.body !== "string") return false;
+  if (o.ref !== undefined && typeof o.ref !== "string") return false;
+  if (o.sig !== undefined && typeof o.sig !== "string") return false;
+  if (o.id !== opId(o.author, o.hlc)) return false;
+  // amendments must target something
+  if ((o.kind === "edit" || o.kind === "delete" || o.kind === "reaction") && !o.ref) return false;
+  return true;
+}

--- a/ts/channels/store.node.spec.ts
+++ b/ts/channels/store.node.spec.ts
@@ -1,0 +1,76 @@
+import { appendFile, mkdtemp, mkdir, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { formatHlc } from "./hlc.ts";
+import { makeOp, type Op } from "./op.ts";
+import { appendOps, channelFilePath, readOps } from "./store.node.ts";
+
+function op(author: string, ms: number, body: string): Op {
+  return makeOp({
+    author,
+    name: author,
+    role: "human",
+    hlc: formatHlc(ms, 0, author),
+    kind: "msg",
+    body,
+  });
+}
+
+describe("store.node jsonl backend", () => {
+  let cwd: string;
+  const CH = "abc123";
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(os.tmpdir(), "ay-ch-"));
+  });
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("colocates the replica under <cwd>/.agent-yes", () => {
+    expect(channelFilePath("/x", CH)).toBe(path.join("/x", ".agent-yes", "ch-abc123.jsonl"));
+  });
+
+  it("returns [] for a channel with no file yet", async () => {
+    expect(await readOps(cwd, CH)).toEqual([]);
+  });
+
+  it("appends and reads back, sorted by HLC", async () => {
+    const added = await appendOps(cwd, CH, [op("b", 2, "two"), op("a", 1, "one")]);
+    expect(added).toHaveLength(2);
+    expect((await readOps(cwd, CH)).map((o) => o.body)).toEqual(["one", "two"]);
+  });
+
+  it("dedups already-stored ops on append (idempotent replica)", async () => {
+    const first = op("a", 1, "one");
+    await appendOps(cwd, CH, [first]);
+    const added = await appendOps(cwd, CH, [first, op("a", 2, "two")]);
+    expect(added.map((o) => o.body)).toEqual(["two"]); // only the new one
+    expect(await readOps(cwd, CH)).toHaveLength(2);
+  });
+
+  it("drops invalid ops instead of storing them", async () => {
+    // @ts-expect-error deliberately malformed
+    const added = await appendOps(cwd, CH, [{ id: "x", kind: "msg" }]);
+    expect(added).toEqual([]);
+    expect(await readOps(cwd, CH)).toEqual([]);
+  });
+
+  it("skips corrupt/partial lines when reading", async () => {
+    const good = op("a", 1, "one");
+    await appendOps(cwd, CH, [good]);
+    // simulate a torn write: a half-line + a non-op JSON line
+    await appendFile(channelFilePath(cwd, CH), `{"not":"an op"}\n{oops not json\n\n`);
+    const ops = await readOps(cwd, CH);
+    expect(ops.map((o) => o.body)).toEqual(["one"]);
+  });
+
+  it("returns [] when the ops list is entirely invalid", async () => {
+    // appendOps with an empty list is a no-op
+    expect(await appendOps(cwd, CH, [])).toEqual([]);
+    // reading a fresh channel dir that exists but has no file
+    await mkdir(path.join(cwd, ".agent-yes"), { recursive: true });
+    expect(await readOps(cwd, "never-written")).toEqual([]);
+  });
+});

--- a/ts/channels/store.node.ts
+++ b/ts/channels/store.node.ts
@@ -1,0 +1,72 @@
+// Node/Bun jsonl backend for a channel replica.
+//
+// One append-only file per channel, colocated with the project like the rest of
+// agent-yes's per-cwd state (`<cwd>/.agent-yes/ch-<channelId>.jsonl` — the same
+// convention as messageLog.ts's inbox/outbox). Writes follow messageLog's
+// lock-free discipline: an O_APPEND of one line is atomic on POSIX, and reads
+// dedup by op id, so a concurrent CLI + daemon appending the same op at worst
+// writes a duplicate line that the next read/compaction collapses — never a lost
+// or torn record. Best-effort, and never blocks a send.
+
+import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { isValidOp, type Op } from "./op.ts";
+import { mergeOps, sortOps } from "./store.ts";
+
+/** Rewrite (dedup + sort) once the file grows past this many raw lines. */
+const COMPACT_AT_LINES = 4000;
+
+/** Path to a channel's jsonl replica under a project cwd. */
+export function channelFilePath(cwd: string, channelId: string): string {
+  return path.join(cwd, ".agent-yes", `ch-${channelId}.jsonl`);
+}
+
+/** Read + parse a channel's ops, deduped and HLC-sorted. Missing file → []. */
+export async function readOps(cwd: string, channelId: string): Promise<Op[]> {
+  let raw: string;
+  try {
+    raw = await readFile(channelFilePath(cwd, channelId), "utf-8");
+  } catch {
+    return [];
+  }
+  const byId = new Map<string, Op>();
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const op = JSON.parse(t);
+      if (isValidOp(op) && !byId.has(op.id)) byId.set(op.id, op);
+    } catch {
+      /* skip corrupt/partial line */
+    }
+  }
+  return sortOps([...byId.values()]);
+}
+
+/**
+ * Append `incoming` to a channel, deduping against what's already stored.
+ * Returns the ops that were genuinely new (so the daemon can rebroadcast just
+ * those). Opportunistically compacts when the file accumulates duplicate lines
+ * or grows large, keeping it bounded despite append-only writes.
+ */
+export async function appendOps(cwd: string, channelId: string, incoming: Op[]): Promise<Op[]> {
+  const valid = incoming.filter(isValidOp);
+  if (valid.length === 0) return [];
+  const file = channelFilePath(cwd, channelId);
+  await mkdir(path.dirname(file), { recursive: true });
+
+  const existing = await readOps(cwd, channelId);
+  const { added } = mergeOps(existing, valid);
+  if (added.length === 0) return [];
+
+  await appendFile(file, added.map((op) => JSON.stringify(op)).join("\n") + "\n");
+
+  // Compact if the on-disk line count now exceeds the deduped op count enough to
+  // matter (duplicates from concurrent writers) or crosses the size cap.
+  const rawLines = existing.length + valid.length; // upper bound on lines just written+read
+  if (rawLines > COMPACT_AT_LINES) {
+    const all = sortOps([...existing, ...added]);
+    await writeFile(file, all.map((op) => JSON.stringify(op)).join("\n") + "\n");
+  }
+  return added;
+}

--- a/ts/channels/store.spec.ts
+++ b/ts/channels/store.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { formatHlc } from "./hlc.ts";
+import { makeOp, type Op, type Role } from "./op.ts";
+import { haveVector, maxHlc, mergeOps, opsMissing, renderThread, sortOps } from "./store.ts";
+
+// Build an op with an explicit (ms, ctr) HLC for deterministic ordering.
+function op(
+  author: string,
+  ms: number,
+  kind: Op["kind"],
+  body?: string,
+  ref?: string,
+  role: Role = "human",
+): Op {
+  return makeOp({ author, name: author, role, hlc: formatHlc(ms, 0, author), kind, body, ref });
+}
+
+describe("mergeOps", () => {
+  const a = op("a", 1, "msg", "one");
+  const b = op("b", 2, "msg", "two");
+  const c = op("c", 3, "msg", "three");
+
+  it("is a union deduped by id", () => {
+    const { merged, added } = mergeOps([a], [a, b]);
+    expect(merged.map((o) => o.id)).toEqual([a.id, b.id]);
+    expect(added.map((o) => o.id)).toEqual([b.id]); // only genuinely new
+  });
+
+  it("is commutative and idempotent (convergence)", () => {
+    const x = mergeOps(mergeOps([], [a, b]).merged, [c]).merged;
+    const y = mergeOps(mergeOps([], [c, b]).merged, [a]).merged;
+    expect(x.map((o) => o.id)).toEqual(y.map((o) => o.id));
+    // merging again adds nothing
+    expect(mergeOps(x, [a, b, c]).added).toEqual([]);
+  });
+
+  it("reports the running max HLC", () => {
+    expect(maxHlc([])).toBeNull();
+    expect(maxHlc([a, c, b])).toBe(c.hlc);
+  });
+
+  it("sorts by HLC then id", () => {
+    expect(sortOps([c, a, b]).map((o) => o.id)).toEqual([a.id, b.id, c.id]);
+  });
+
+  it("breaks a same-HLC tie deterministically by id", () => {
+    // two authors that collide on (ms, ctr) — the id (author@hlc) decides order
+    const x = makeOp({
+      author: "z",
+      name: "z",
+      role: "human",
+      hlc: formatHlc(9, 0, "z"),
+      kind: "msg",
+      body: "x",
+    });
+    const y = makeOp({
+      author: "a",
+      name: "a",
+      role: "human",
+      hlc: formatHlc(9, 0, "a"),
+      kind: "msg",
+      body: "y",
+    });
+    expect(sortOps([x, y]).map((o) => o.author)).toEqual(["a", "z"]);
+    expect(sortOps([y, x]).map((o) => o.author)).toEqual(["a", "z"]);
+  });
+});
+
+describe("renderThread", () => {
+  it("renders base messages in HLC order", () => {
+    const msgs = renderThread([op("b", 2, "msg", "two"), op("a", 1, "msg", "one")]);
+    expect(msgs.map((m) => m.text)).toEqual(["one", "two"]);
+  });
+
+  it("applies the latest edit (last-writer-wins)", () => {
+    const m = op("a", 1, "msg", "orig");
+    const e1 = op("a", 2, "edit", "v2", m.id);
+    const e2 = op("a", 3, "edit", "v3", m.id);
+    const [r] = renderThread([m, e2, e1]);
+    expect(r!.text).toBe("v3");
+    expect(r!.amendedHlc).toBe(e2.hlc);
+  });
+
+  it("hides a deleted message, and an edit after a delete revives it", () => {
+    const m = op("a", 1, "msg", "hi");
+    expect(renderThread([m, op("a", 2, "delete", undefined, m.id)])[0]!).toMatchObject({
+      deleted: true,
+      text: "",
+    });
+    // delete then a newer edit → revived
+    const revived = renderThread([
+      m,
+      op("a", 2, "delete", undefined, m.id),
+      op("a", 3, "edit", "back", m.id),
+    ])[0]!;
+    expect(revived).toMatchObject({ deleted: false, text: "back" });
+  });
+
+  it("groups reactions by emoji into distinct authors", () => {
+    const m = op("a", 1, "msg", "hi");
+    const r = renderThread([
+      m,
+      op("b", 2, "reaction", "👍", m.id),
+      op("c", 3, "reaction", "👍", m.id),
+      op("b", 4, "reaction", "👍", m.id), // duplicate author → deduped
+      op("b", 5, "reaction", "🎉", m.id),
+    ])[0]!;
+    expect(r.reactions).toEqual([
+      { emoji: "👍", by: ["b", "c"] },
+      { emoji: "🎉", by: ["b"] },
+    ]);
+  });
+
+  it("ignores amendments whose target op is absent", () => {
+    expect(renderThread([op("a", 2, "edit", "x", "missing@id")])).toEqual([]);
+  });
+
+  it("ignores a reaction with an empty body", () => {
+    const m = op("a", 1, "msg", "hi");
+    const [r] = renderThread([m, op("b", 2, "reaction", "", m.id)]);
+    expect(r!.reactions).toEqual([]);
+  });
+});
+
+describe("anti-entropy sync", () => {
+  const local = [op("a", 1, "msg", "a1"), op("a", 2, "msg", "a2"), op("b", 5, "msg", "b1")];
+
+  it("summarizes what a replica holds per author", () => {
+    expect(haveVector(local)).toEqual({ a: formatHlc(2, 0, "a"), b: formatHlc(5, 0, "b") });
+    // keeps the max even when an older op for an author appears after a newer one
+    const outOfOrder = [op("a", 2, "msg", "a2"), op("a", 1, "msg", "a1")];
+    expect(haveVector(outOfOrder)).toEqual({ a: formatHlc(2, 0, "a") });
+  });
+
+  it("computes exactly the ops a peer is missing", () => {
+    // peer has a up to ms=1 and nothing from b
+    const remoteHave = { a: formatHlc(1, 0, "a") };
+    const missing = opsMissing(local, remoteHave);
+    expect(missing.map((o) => o.body)).toEqual(["a2", "b1"]);
+  });
+
+  it("sends nothing when the peer is already caught up", () => {
+    expect(opsMissing(local, haveVector(local))).toEqual([]);
+  });
+});

--- a/ts/channels/store.ts
+++ b/ts/channels/store.ts
@@ -1,0 +1,170 @@
+// The channel CRDT — pure, isomorphic (Node + browser), storage-agnostic.
+//
+// A channel is a grow-only set of immutable ops (op.ts) keyed by `id`. Because
+// ids are content-independent-but-unique and the set only grows, MERGE is a
+// union and always converges: any two replicas that have exchanged the same ops
+// hold the same set regardless of arrival order (commutative, associative,
+// idempotent). Display order is the total order over `hlc`.
+//
+// Amendments (edit/delete/reaction) are folded per target message as
+// last-writer-wins by HLC, so the rendered thread is likewise a pure function of
+// the op set — every replica renders identically.
+//
+// This module never touches disk or network; backends (store.node.ts,
+// store.browser.ts) provide the ops, and peer.ts moves them between replicas.
+
+import { compareHlc, parseHlc } from "./hlc.ts";
+import type { Op, Role } from "./op.ts";
+
+/** Order ops by HLC (then id, for a fully deterministic tie-break). */
+export function sortOps(ops: Op[]): Op[] {
+  return [...ops].sort(
+    (a, b) => compareHlc(a.hlc, b.hlc) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+}
+
+/**
+ * Union `incoming` into `existing`, deduping by id. Returns the merged set
+ * (sorted) and the ops that were actually new — the backend appends `added`, and
+ * peer.ts rebroadcasts them. Idempotent: merging the same ops twice adds nothing.
+ */
+export function mergeOps(existing: Op[], incoming: Op[]): { merged: Op[]; added: Op[] } {
+  const byId = new Map<string, Op>();
+  for (const op of existing) byId.set(op.id, op);
+  const added: Op[] = [];
+  for (const op of incoming) {
+    if (byId.has(op.id)) continue;
+    byId.set(op.id, op);
+    added.push(op);
+  }
+  return { merged: sortOps([...byId.values()]), added };
+}
+
+/** The greatest HLC in the set (used to seed the next local send), or null if empty. */
+export function maxHlc(ops: Op[]): string | null {
+  let max: string | null = null;
+  for (const op of ops) if (max === null || compareHlc(op.hlc, max) > 0) max = op.hlc;
+  return max;
+}
+
+// --- rendered thread --------------------------------------------------------
+
+export interface Reaction {
+  /** The emoji/label. */
+  emoji: string;
+  /** Distinct author ids that reacted with it. */
+  by: string[];
+}
+
+/** A message as shown in the UI: a base `msg` op with amendments folded in. */
+export interface Message {
+  id: string;
+  author: string;
+  name: string;
+  role: Role;
+  /** Base op HLC — the thread sort key. */
+  hlc: string;
+  /** Current text (after the latest edit); empty when deleted. */
+  text: string;
+  /** True if a delete op is the latest amendment. */
+  deleted: boolean;
+  /** HLC of the latest edit/delete applied, if any. */
+  amendedHlc?: string;
+  reactions: Reaction[];
+  ms: number;
+}
+
+/**
+ * Fold an op set into the ordered list of messages. Pure function of the ops:
+ * for each `msg` op, its `edit`/`delete` amendments are applied in HLC order
+ * (last wins — an edit after a delete revives it, a delete after an edit hides
+ * it), and `reaction` ops are grouped by emoji into distinct authors.
+ */
+export function renderThread(ops: Op[]): Message[] {
+  const sorted = sortOps(ops);
+  const messages = new Map<string, Message>();
+
+  for (const op of sorted) {
+    if (op.kind !== "msg") continue;
+    messages.set(op.id, {
+      id: op.id,
+      author: op.author,
+      name: op.name,
+      role: op.role,
+      hlc: op.hlc,
+      text: op.body ?? "",
+      deleted: false,
+      reactions: [],
+      ms: parseHlc(op.hlc).ms,
+    });
+  }
+
+  // reactions grouped as emoji -> ordered distinct authors, per target message
+  const reactions = new Map<string, Map<string, string[]>>();
+
+  for (const op of sorted) {
+    if (!op.ref) continue;
+    const target = messages.get(op.ref);
+    if (!target) continue; // amendment for an op we don't (yet) have — ignore
+    if (op.kind === "edit") {
+      // amendments always sort after the base (author is causal); LWW by HLC
+      if (compareHlc(op.hlc, target.amendedHlc ?? target.hlc) > 0) {
+        target.text = op.body ?? "";
+        target.deleted = false;
+        target.amendedHlc = op.hlc;
+      }
+    } else if (op.kind === "delete") {
+      if (compareHlc(op.hlc, target.amendedHlc ?? target.hlc) > 0) {
+        target.text = "";
+        target.deleted = true;
+        target.amendedHlc = op.hlc;
+      }
+    } else if (op.kind === "reaction" && op.body) {
+      let group = reactions.get(op.ref);
+      if (!group) reactions.set(op.ref, (group = new Map()));
+      const authors = group.get(op.body) ?? [];
+      if (!authors.includes(op.author)) authors.push(op.author);
+      group.set(op.body, authors);
+    }
+  }
+
+  for (const [msgId, group] of reactions) {
+    const target = messages.get(msgId);
+    if (!target) continue;
+    target.reactions = [...group.entries()].map(([emoji, by]) => ({ emoji, by }));
+  }
+
+  return [...messages.values()].sort((a, b) => compareHlc(a.hlc, b.hlc));
+}
+
+// --- anti-entropy sync ------------------------------------------------------
+//
+// On each new peer connection the two sides exchange a compact per-author
+// summary of what they hold, then each sends the ops the other lacks. This is
+// why an intermittent / partial mesh still converges: a peer that was offline
+// receives the suffix it missed on reconnect.
+
+/** Per-author greatest HLC held — the compact "have" summary sent to a peer. */
+export function haveVector(ops: Op[]): Record<string, string> {
+  const have: Record<string, string> = {};
+  for (const op of ops) {
+    const cur = have[op.author];
+    if (cur === undefined || compareHlc(op.hlc, cur) > 0) have[op.author] = op.hlc;
+  }
+  return have;
+}
+
+/**
+ * The ops in `local` that a peer with summary `remoteHave` is missing: any op
+ * from an author the peer hasn't heard from, or newer than the peer's max for
+ * that author. Relies on an author's ops forming a contiguous HLC suffix on each
+ * replica (sync always transfers whole suffixes), which holds under this protocol.
+ */
+export function opsMissing(local: Op[], remoteHave: Record<string, string>): Op[] {
+  return sortOps(
+    local.filter((op) => {
+      const peerMax = remoteHave[op.author];
+      return peerMax === undefined || compareHlc(op.hlc, peerMax) > 0;
+    }),
+  );
+}

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -363,6 +363,8 @@ const SUBCOMMANDS = new Set([
   "restart",
   "note",
   "todo",
+  "ch",
+  "channels",
   "serve",
   "schedule",
   "remote",
@@ -478,6 +480,11 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       case "todo": {
         const { runTodoSubcommand } = await import("./todoCli.ts");
         return runTodoSubcommand(rest);
+      }
+      case "ch":
+      case "channels": {
+        const { cmdCh } = await import("./channels.ts");
+        return cmdCh(rest);
       }
       case "serve": {
         const { cmdServe } = await import("./serve.ts");
@@ -614,6 +621,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay head <keyword>                   first N lines\n` +
       `  ay send <keyword> <msg>             send a message (keyword '.' = agent in this cwd)\n` +
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
+      `  ay ch mk|join|send|read|tail <topic>  local-first E2E channels: AI ↔ humans on a topic (ay ch help)\n` +
       `  ay key <keyword> <key...>           send raw keystrokes (down/up/enter/esc/…) — drives menus\n` +
       `  ay select <keyword> <N>             pick option N of a needs_input selection menu\n` +
       `  ay attach <keyword>                 interactive attach (detach: Ctrl-\\)\n` +

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -71,6 +71,14 @@ export default defineConfig({
         // `ay callback` CLI + store IO — thin shell over callbackCore.ts (which
         // IS covered); the mint path needs a live agent record and daemon URL.
         "ts/callback.ts",
+        // `ay ch` CLI shell — a thin dispatcher over the fully-covered channels
+        // core (ts/channels/*, unit-tested in ts/channels/*.spec.ts) plus a
+        // signal-driven `tail -f` follow loop and TTY/stderr branches that are
+        // integration-only (same rationale as callback.ts). Its happy paths are
+        // still exercised end-to-end in ts/channels.spec.ts.
+        "ts/channels.ts",
+        // Re-export barrel — no logic to cover (same rationale as ts/index.ts).
+        "ts/channels/index.ts",
         "ts/remotes.ts",
         // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
         // unit-testable.


### PR DESCRIPTION
## What

New `ay ch` subcommand: **local-first, end-to-end channels** where AI agents and humans talk on a topic thread. No server ever stores a message — every participant keeps a full replica as an append-only **CRDT log**, cwd-scoped like the rest of agent-yes's per-project state (`<cwd>/.agent-yes/ch-<channelId>.jsonl`).

This is **Phase 1** of a 3-phase plan (design approved): the isomorphic core + local-only CLI. Live delivery over the WebRTC mesh (signaling DO mesh mode + serve daemon `/api/ch/*`) and the browser widgets (embeddable + console panel) follow in Phases 2–3. The on-disk format and identity model here are the foundation all surfaces share.

## Design (per requirements)

- **Zero server storage.** Signaling stays a pure rendezvous; each peer holds its own replica.
- **CRDT convergence.** Text is immutable, so `id = author@hlc` (globally unique — an author's HLCs never repeat) makes the log a **grow-only set ordered by Hybrid Logical Clock**. Union merge is commutative/associative/idempotent → convergent; no Yjs needed. Edit/delete/reaction fold as LWW-by-HLC. A compact per-author "have" vector + diff gives anti-entropy sync so offline peers catch up on reconnect.
- **Secret reuse.** Channel secret S is the same `e1.<64hex>` model as the WebRTC share links (`lab/ui/e2e.js`); `channelId`/`room` derive from S, so the topic string never leaves the machine.

## Surface

```
ay ch mk <topic> [--name N] [--role R] [--salt HEX]   # mint, print invite link
ay ch join <link> [--as <topic>]                      # join from an invite
ay ch ls [--json] / rm <topic>
ay ch send <topic> <text…>
ay ch read/head/tail <topic> [-n N] [--json] [-f]
```

Identity auto-detects role (`agent` when `AGENT_YES_PID` is set, else `human`) and name (`$AY_CH_NAME` → OS user). Registered in `ts/subcommands.ts` `SUBCOMMANDS` and mirrored in `rs/src/cli.rs` so the cargo-installed runner delegates it to JS.

## Files

- `ts/channels/` — isomorphic core: `hlc` · `op` · `store` (CRDT) · `store.node` (jsonl) · `link`
- `ts/channels.ts` — the CLI shell
- `ts/subcommands.ts`, `rs/src/cli.rs` — registration (both runtimes)
- `vitest.config.ts` — coverage-exclude the CLI shell + barrel (thin dispatcher + signal-driven follow loop over the fully-covered core; matches the `callback.ts` precedent)

## Tests

Full unit coverage of the core (`hlc`/`op`/`store`/`store.node`/`link`) + an end-to-end CLI spec. All **1162** tests pass; coverage gate holds (branches 90.65%). oxlint clean, oxfmt applied, typecheck clean for the new files. Verified end-to-end through both the linked JS binary and the cargo-installed `agent-yes` (delegation confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)