### PR TITLE
feat: ay ch — local-first E2E channels for AI ↔ humans (WebRTC mesh + browser widget)

### DIFF
--- a/lab/ui/cf/build-assets.sh
+++ b/lab/ui/cf/build-assets.sh
@@ -13,7 +13,7 @@
 #   public/r/ + public/rgui/ — the rgui forest page (built from lib/rgui)
 set -e
 mkdir -p ./public/w
-cp ../index.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/
+cp ../index.html ../ch.html ../*.js ../manifest.webmanifest ../icon.svg ./public/w/
 cp ../landing.html ./public/index.html
 cp ../architecture.html ./public/architecture.html
 rm -rf ./public/blog
@@ -40,6 +40,12 @@ if [ "${AGENT_YES_CHANNEL:-stable}" = "beta" ]; then
     ./public/setup.ps1 > ./public/setup.ps1.tmp
   mv ./public/setup.ps1.tmp ./public/setup.ps1
 fi
+# Channel widget: bundle the browser AyChannel lib (`import AyChannel from
+# "agent-yes/channels"`) into a self-contained ESM the hosted chat page (w/ch.html)
+# and third-party embeds load. Built with bun (browser target) independent of the
+# npm dist build, so it exists even in a bare `wrangler dev` / beta Pages deploy.
+bun build ../../../ts/channels/browser.ts --outfile ./public/w/channels.js --format esm --target browser --minify
+
 cp _headers ./public/_headers
 bun ../../../scripts/build-rgui.ts ./public/r
 rm -rf ./public/rgui

--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -120,7 +120,7 @@ export default {
   },
 };
 
-type Attach = { authed: boolean; role?: "host" | "client"; peer?: string };
+type Attach = { authed: boolean; role?: "host" | "client"; peer?: string; mesh?: boolean };
 
 export class Room {
   constructor(private state: DurableObjectState) {
@@ -170,25 +170,40 @@ export class Room {
     }
 
     if (!self.authed) {
-      // First message must be the hello that carries role + token.
+      // First message must be the hello that carries role + token (+ optional mesh flag).
       if (msg.type !== "hello") return ws.close(1008, "expected hello");
       const role: "host" | "client" = msg.role === "host" ? "host" : "client";
       const token = String(msg.token ?? "");
       const proto = Number(msg.v ?? 1); // protocol generation (v2 = e2e)
+      // Mesh rooms (ay ch channels) are symmetric — every peer relays to every
+      // other peer, no single host. The mode is TOFU-pinned on room open, so the
+      // star (share) and mesh (channels) wires can never mix within one room and
+      // the existing host↔client path stays byte-identical for non-mesh clients.
+      const mesh = msg.mesh === true;
       const stored = await this.state.storage.get<string>("token");
       const storedProto = (await this.state.storage.get<number>("proto")) ?? 1;
+      const storedMesh = (await this.state.storage.get<boolean>("mesh")) ?? false;
       if (stored === undefined) {
-        if (role !== "host") return ws.close(1008, "room not open");
+        // Opening the room: a star room must be opened by its host; a mesh room
+        // is opened by whoever arrives first (all peers are equal).
+        if (!mesh && role !== "host") return ws.close(1008, "room not open");
         await this.state.storage.put("token", token);
         await this.state.storage.put("proto", proto);
+        await this.state.storage.put("mesh", mesh);
       } else {
         if (stored !== token) return ws.close(1008, "forbidden"); // token never echoed
         if (storedProto !== proto) return ws.close(1008, "protocol mismatch");
+        if (storedMesh !== mesh) return ws.close(1008, "room mode mismatch");
       }
-      const peer = role === "host" ? "host" : crypto.randomUUID().slice(0, 8);
-      ws.serializeAttachment({ authed: true, role, peer } satisfies Attach);
-      ws.send(JSON.stringify({ type: "welcome", peer, role, v: proto }));
-      if (role === "client") this.toHost({ type: "peer-join", peer });
+      const peer = mesh || role === "client" ? crypto.randomUUID().slice(0, 8) : "host";
+      // In a mesh, tell the newcomer who is already here (roster) and announce it
+      // to everyone else, so both sides can open a direct DataChannel. Who sends
+      // the offer (initiator = lower peer id) is decided client-side to avoid glare.
+      const roster = mesh ? this.peers(ws) : undefined;
+      ws.serializeAttachment({ authed: true, role, peer, mesh } satisfies Attach);
+      ws.send(JSON.stringify({ type: "welcome", peer, role, v: proto, mesh, peers: roster }));
+      if (mesh) this.broadcast(ws, { type: "peer-join", peer });
+      else if (role === "client") this.toHost({ type: "peer-join", peer });
       return;
     }
 
@@ -198,6 +213,13 @@ export class Room {
     // byte-for-byte; answer it directly rather than relay it onward.
     if (msg.type === "ping") return void ws.send(PONG);
 
+    if (self.mesh) {
+      // Symmetric relay: every message carries a `to`; forward it to that peer.
+      msg.from = self.peer; // tag so the recipient can reply/route back
+      const to = typeof msg.to === "string" ? msg.to : "";
+      if (to) this.toPeer(to, msg);
+      return;
+    }
     if (self.role === "client") {
       msg.from = self.peer; // tag so the host can route the reply back
       this.toHost(msg);
@@ -209,7 +231,9 @@ export class Room {
 
   webSocketClose(ws: WebSocket): void {
     const self = ws.deserializeAttachment() as Attach;
-    if (self.authed && self.role === "client") this.toHost({ type: "peer-leave", peer: self.peer });
+    if (!self.authed) return;
+    if (self.mesh) this.broadcast(ws, { type: "peer-leave", peer: self.peer });
+    else if (self.role === "client") this.toHost({ type: "peer-leave", peer: self.peer });
   }
 
   // Role isn't a hibernation tag (it's only known after the hello), so route by
@@ -227,5 +251,25 @@ export class Room {
       const a = s.deserializeAttachment() as Attach | null;
       if (a?.authed && a.peer === peer) s.send(data);
     }
+  }
+
+  // Mesh helpers: fan a frame out to every OTHER authed peer, and list the peers
+  // currently in the room (excluding `except` — the newcomer receiving the roster).
+  private broadcast(except: WebSocket, obj: unknown): void {
+    const data = JSON.stringify(obj);
+    for (const s of this.state.getWebSockets()) {
+      if (s === except) continue;
+      const a = s.deserializeAttachment() as Attach | null;
+      if (a?.authed) s.send(data);
+    }
+  }
+  private peers(except: WebSocket): string[] {
+    const out: string[] = [];
+    for (const s of this.state.getWebSockets()) {
+      if (s === except) continue;
+      const a = s.deserializeAttachment() as Attach | null;
+      if (a?.authed && a.peer) out.push(a.peer);
+    }
+    return out;
   }
 }

--- a/lab/ui/ch.html
+++ b/lab/ui/ch.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<!--
+  Hosted chat shell for ay channels. Open with a channel invite in the fragment:
+    https://agent-yes.com/w/ch.html#ch=<room>:e1.<S>
+  It loads the same AyChannel browser lib third-party embeds use (channels.js,
+  built from ts/channels/browser.ts by build-assets.sh) and mounts the floating
+  widget. No message ever touches a server — the page holds its own replica.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ay channel</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        margin: 0; min-height: 100vh; display: grid; place-items: center;
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #14151a; color: #e6e6ea;
+      }
+      .card {
+        max-width: 420px; padding: 28px; text-align: center;
+        background: #1b1d24; border: 1px solid #2c2f3a; border-radius: 16px; margin: 20px;
+      }
+      h1 { font-size: 18px; margin: 0 0 6px; }
+      p { opacity: .7; font-size: 14px; line-height: 1.5; }
+      form { display: flex; gap: 8px; margin-top: 16px; }
+      input {
+        flex: 1; background: #23262f; border: 1px solid #363a46; color: #e6e6ea;
+        border-radius: 8px; padding: 10px; font-size: 14px;
+      }
+      button {
+        background: #4f46e5; color: #fff; border: none; border-radius: 8px;
+        padding: 0 18px; cursor: pointer; font-size: 14px;
+      }
+      .err { color: #f87171; margin-top: 14px; font-size: 13px; }
+    </style>
+  </head>
+  <body>
+    <div class="card" id="card">
+      <h1>Join channel</h1>
+      <p>Pick a display name to start talking. Messages stay end-to-end between participants — nothing is stored on a server.</p>
+      <form id="join">
+        <input id="name" placeholder="Your name" autocomplete="off" required />
+        <button type="submit">Join</button>
+      </form>
+      <div class="err" id="err"></div>
+    </div>
+
+    <script type="module">
+      import AyChannel from "./channels.js";
+
+      const card = document.getElementById("card");
+      const err = document.getElementById("err");
+      const nameInput = document.getElementById("name");
+
+      // No channel in the fragment → explain and stop.
+      if (!location.hash.includes("ch=")) {
+        err.textContent = "No channel link. Open a ch.html#ch=<room>:e1.<secret> invite.";
+        document.getElementById("join").style.display = "none";
+      }
+
+      const savedName = localStorage.getItem("ay29ch-name");
+      if (savedName) nameInput.value = savedName;
+
+      document.getElementById("join").addEventListener("submit", async (e) => {
+        e.preventDefault();
+        err.textContent = "";
+        const name = nameInput.value.trim();
+        if (!name) return;
+        localStorage.setItem("ay29ch-name", name);
+        try {
+          const ch = new AyChannel({ link: location.href, name, role: "human" });
+          await ch.start();
+          card.remove();
+          ch.mount(document.body, { open: true });
+        } catch (e2) {
+          err.textContent = "Could not join: " + (e2?.message || e2);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -78,8 +78,14 @@
   "module": "ts/index.ts",
   "types": "./ts/index.ts",
   "exports": {
-    "types": "./ts/index.ts",
-    "import": "./dist/index.js"
+    ".": {
+      "types": "./ts/index.ts",
+      "import": "./dist/index.js"
+    },
+    "./channels": {
+      "types": "./ts/channels/browser.ts",
+      "import": "./dist/channels.js"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -21,8 +21,8 @@ use std::env;
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
-    "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "serve", "schedule",
-    "remote", "expose", "callback", "reap", "help",
+    "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
+    "serve", "schedule", "remote", "expose", "callback", "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/channels.spec.ts
+++ b/ts/channels.spec.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cmdCh,
+  defaultName,
+  defaultRole,
+  formatMessage,
+  readRegistry,
+  resolveChannel,
+} from "./channels.ts";
+import type { Message } from "./channels/index.ts";
+
+/** Capture stdout across a call. */
+async function capture(fn: () => Promise<number>): Promise<{ code: number; out: string }> {
+  let out = "";
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    out += String(chunk);
+    return true;
+  });
+  try {
+    const code = await fn();
+    return { code, out };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("ay ch identity defaults", () => {
+  it("infers role from AGENT_YES_PID", () => {
+    const prev = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = "123";
+    expect(defaultRole()).toBe("agent");
+    delete process.env.AGENT_YES_PID;
+    expect(defaultRole()).toBe("human");
+    if (prev !== undefined) process.env.AGENT_YES_PID = prev;
+  });
+
+  it("prefers $AY_CH_NAME for the display name", () => {
+    const prev = process.env.AY_CH_NAME;
+    process.env.AY_CH_NAME = "sonoda";
+    expect(defaultName()).toBe("sonoda");
+    delete process.env.AY_CH_NAME;
+    expect(typeof defaultName()).toBe("string");
+    if (prev !== undefined) process.env.AY_CH_NAME = prev;
+  });
+});
+
+describe("formatMessage", () => {
+  const base: Message = {
+    id: "a@h",
+    author: "a",
+    name: "taku",
+    role: "human",
+    hlc: "h",
+    text: "hello",
+    deleted: false,
+    reactions: [],
+    ms: Date.UTC(2026, 0, 1, 3, 4, 5),
+  };
+  it("renders time, name(role initial), and text", () => {
+    expect(formatMessage(base)).toBe("03:04:05  taku(h): hello");
+  });
+  it("shows (deleted) and reaction counts", () => {
+    expect(formatMessage({ ...base, deleted: true, text: "" })).toContain("(deleted)");
+    expect(formatMessage({ ...base, reactions: [{ emoji: "👍", by: ["a", "b"] }] })).toContain("👍2");
+    expect(formatMessage({ ...base, reactions: [{ emoji: "🎉", by: ["a"] }] })).toContain("🎉");
+  });
+});
+
+describe("ay ch CLI (local-only)", () => {
+  let cwd: string;
+  let origCwd: string;
+
+  beforeEach(async () => {
+    origCwd = process.cwd();
+    cwd = await mkdtemp(path.join(os.tmpdir(), "ay-chcli-"));
+    process.chdir(cwd);
+  });
+  afterEach(async () => {
+    process.chdir(origCwd);
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("mk → send → read round-trips a message", async () => {
+    const mk = await capture(() => cmdCh(["mk", "demo", "--name", "taku", "--role", "human"]));
+    expect(mk.code).toBe(0);
+    expect(mk.out).toContain("ay://ch/");
+
+    const reg = await readRegistry(cwd);
+    expect(reg.channels.demo).toBeTruthy();
+    expect(reg.channels.demo!.name).toBe("taku");
+
+    expect((await capture(() => cmdCh(["send", "demo", "hello", "world"]))).code).toBe(0);
+    const read = await capture(() => cmdCh(["read", "demo"]));
+    expect(read.out).toContain("taku(h): hello world");
+  });
+
+  it("lists channels with message counts", async () => {
+    await capture(() => cmdCh(["mk", "demo", "--name", "a"]));
+    await capture(() => cmdCh(["send", "demo", "one"]));
+    const ls = await capture(() => cmdCh(["ls"]));
+    expect(ls.out).toMatch(/demo\s+1/);
+    const json = await capture(() => cmdCh(["ls", "--json"]));
+    expect(JSON.parse(json.out).channels[0].messages).toBe(1);
+  });
+
+  it("join binds a topic to an invite link, and rm deletes the replica", async () => {
+    const mk = await capture(() => cmdCh(["mk", "src"]));
+    const link = /ay:\/\/\S+/.exec(mk.out)![0];
+
+    const join = await capture(() => cmdCh(["join", link, "--as", "dst", "--name", "bob"]));
+    expect(join.code).toBe(0);
+    const reg = await readRegistry(cwd);
+    // same underlying channel, different local topic + identity
+    expect(reg.channels.dst!.channelId).toBe(reg.channels.src!.channelId);
+    expect(reg.channels.dst!.author).not.toBe(reg.channels.src!.author);
+
+    expect((await capture(() => cmdCh(["rm", "dst"]))).code).toBe(0);
+    expect((await readRegistry(cwd)).channels.dst).toBeUndefined();
+  });
+
+  it("head and tail slice the thread", async () => {
+    await capture(() => cmdCh(["mk", "c"]));
+    for (const t of ["m1", "m2", "m3"]) await capture(() => cmdCh(["send", "c", t]));
+    expect((await capture(() => cmdCh(["head", "c", "-n", "1"]))).out.trim()).toContain("m1");
+    expect((await capture(() => cmdCh(["tail", "c", "-n", "1"]))).out.trim()).toContain("m3");
+  });
+
+  it("errors clearly on unknown channels, duplicate mk, and sending before join", async () => {
+    expect((await capture(() => cmdCh(["mk", "dup"]))).code).toBe(0);
+    // duplicate mk throws (surfaced by runSubcommand; here it rejects)
+    await expect(cmdCh(["mk", "dup"])).rejects.toThrow(/already exists/);
+
+    const reg = await readRegistry(cwd);
+    await expect(resolveChannel(reg, "nope")).rejects.toThrow(/no channel/);
+
+    // a link that isn't joined resolves read-only (no identity) → send refuses
+    const mk = await capture(() => cmdCh(["mk", "src2"]));
+    const link = /ay:\/\/\S+/.exec(mk.out)![0];
+    const resolved = await resolveChannel(reg, "dup");
+    expect(resolved.entry).toBeTruthy();
+    const linkResolved = await resolveChannel(await readRegistry(cwd), link);
+    expect(linkResolved.entry).toBeNull();
+  });
+
+  it("prints help for no subcommand and rejects unknown ones", async () => {
+    expect((await capture(() => cmdCh([]))).out).toContain("ay ch -");
+    const bad = await capture(() => cmdCh(["frobnicate"]));
+    expect(bad.code).toBe(1);
+  });
+});

--- a/ts/channels.ts
+++ b/ts/channels.ts
@@ -1,0 +1,458 @@
+/**
+ * `ay ch` — channels: local-first, end-to-end threads where AI agents and humans
+ * talk on a topic. No server ever stores a message; every participant keeps a
+ * full replica as an append-only CRDT log, cwd-scoped like the rest of
+ * agent-yes's per-project state:
+ *
+ *   ay ch mk <topic> [--sighost H] [--name N] [--role agent|human] [--salt HEX]
+ *   ay ch join <link> [--as <topic>] [--name N] [--role R]
+ *   ay ch ls [--json]
+ *   ay ch rm <topic>
+ *   ay ch send <topic> <text…> [--name N] [--role R]
+ *   ay ch read <topic> [-n N] [--json]
+ *   ay ch head <topic> [-n N]
+ *   ay ch tail <topic> [-n N] [-f]
+ *
+ * Phase 1 is local-only (the log, the CRDT, the verbs). Live delivery over the
+ * WebRTC mesh (`--once`, real `tail -f` across peers, `pipe`) arrives with the
+ * serve daemon in Phase 2; the on-disk format and identity model here are the
+ * foundation both share.
+ *
+ * The channels core (ts/channels/) is isomorphic and reused verbatim by the
+ * browser lib; this file is the Node CLI shell over it, mirroring ts/ws.ts.
+ */
+
+import { randomBytes } from "crypto";
+import { chmod, mkdir, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  deriveChannelId,
+  deriveRoom,
+  formatChannelLink,
+  formatChannelWebLink,
+  hlcSend,
+  isChannelLink,
+  makeOp,
+  maxHlc,
+  parseChannelLink,
+  renderThread,
+  type Message,
+  type Role,
+} from "./channels/index.ts";
+import { appendOps, channelFilePath, readOps } from "./channels/store.node.ts";
+
+const REG_SCHEMA = "ay-ch/v1";
+
+interface ChannelRegEntry {
+  topic: string;
+  channelId: string;
+  room: string;
+  sighost: string;
+  /** Shared secret S (64-hex); the registry file is chmod 0600. */
+  s: string;
+  /** Stable per-participant id — the HLC node + author identity. */
+  author: string;
+  name: string;
+  role: Role;
+  createdAt: number;
+}
+
+interface ChannelRegistry {
+  schema: string;
+  channels: Record<string, ChannelRegEntry>;
+}
+
+// --- identity defaults ------------------------------------------------------
+
+/** An agent (AGENT_YES_PID set) defaults to role "agent"; a human shell to "human". */
+export function defaultRole(): Role {
+  return process.env.AGENT_YES_PID ? "agent" : "human";
+}
+
+/** Default display name: $AY_CH_NAME, else the OS username, else "anon". */
+export function defaultName(): string {
+  if (process.env.AY_CH_NAME) return process.env.AY_CH_NAME;
+  try {
+    return os.userInfo().username || "anon";
+  } catch {
+    return "anon";
+  }
+}
+
+function validRole(v: string | boolean | undefined): Role {
+  if (v === "agent" || v === "human") return v;
+  throw new Error(`--role must be "agent" or "human"`);
+}
+
+// --- registry IO ------------------------------------------------------------
+
+function registryPath(cwd: string): string {
+  return path.join(cwd, ".agent-yes", "channels.json");
+}
+
+export async function readRegistry(cwd: string): Promise<ChannelRegistry> {
+  try {
+    const reg = JSON.parse(await readFile(registryPath(cwd), "utf-8")) as ChannelRegistry;
+    if (reg && typeof reg === "object" && reg.channels) return reg;
+  } catch {
+    /* missing/corrupt → empty */
+  }
+  return { schema: REG_SCHEMA, channels: {} };
+}
+
+async function writeRegistry(cwd: string, reg: ChannelRegistry): Promise<void> {
+  const file = registryPath(cwd);
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, JSON.stringify(reg, null, 2) + "\n");
+  await chmod(file, 0o600).catch(() => {}); // best-effort (no-op on Windows)
+}
+
+/**
+ * Resolve a `<topic|link>` operand. A registered topic yields its full entry; a
+ * bare invite link yields just its channelId (read-only — sending needs an
+ * identity, i.e. `ay ch join` first). Anything else is an error.
+ */
+export async function resolveChannel(
+  reg: ChannelRegistry,
+  arg: string,
+): Promise<{ channelId: string; entry: ChannelRegEntry | null }> {
+  const entry = reg.channels[arg];
+  if (entry) return { channelId: entry.channelId, entry };
+  if (isChannelLink(arg)) {
+    const link = parseChannelLink(arg);
+    if (link) return { channelId: await deriveChannelId(link.s), entry: null };
+  }
+  throw new Error(`no channel "${arg}" — see 'ay ch ls', or 'ay ch join <link>'`);
+}
+
+// --- display ----------------------------------------------------------------
+
+/** One rendered thread line: `HH:MM:SS  name(a): text  👍2`. Pure, for tests. */
+export function formatMessage(m: Message): string {
+  const t = new Date(m.ms).toISOString().slice(11, 19);
+  const who = `${m.name}(${m.role[0]})`;
+  const text = m.deleted ? "(deleted)" : m.text;
+  const react = m.reactions.length
+    ? "  " + m.reactions.map((r) => `${r.emoji}${r.by.length > 1 ? r.by.length : ""}`).join(" ")
+    : "";
+  return `${t}  ${who}: ${text}${react}`;
+}
+
+// --- flag parsing (tiny, mirrors ws.ts) -------------------------------------
+
+function parseFlags(
+  args: string[],
+  known: Record<string, "bool" | "value">,
+): { flags: Record<string, string | boolean>; positional: string[] } {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (!a.startsWith("-") || a === "-") {
+      positional.push(a);
+      continue;
+    }
+    // support -n as an alias for --limit
+    const isShortN = a === "-n";
+    const eq = a.indexOf("=");
+    const name = isShortN
+      ? "limit"
+      : eq === -1
+        ? a.replace(/^--?/, "")
+        : a.slice(a.startsWith("--") ? 2 : 1, eq);
+    const kind = known[name];
+    if (!kind) throw new Error(`unknown flag ${a}`);
+    if (kind === "bool") {
+      if (eq !== -1) throw new Error(`--${name} takes no value`);
+      flags[name] = true;
+    } else {
+      const v = eq !== -1 ? a.slice(eq + 1) : args[++i];
+      if (v === undefined) throw new Error(`${a} requires a value`);
+      flags[name] = v;
+    }
+  }
+  return { flags, positional };
+}
+
+function limitOf(flags: Record<string, string | boolean>): number | undefined {
+  if (flags.limit === undefined) return undefined;
+  const n = Number(flags.limit);
+  if (!Number.isInteger(n) || n < 0) throw new Error(`-n/--limit must be a non-negative integer`);
+  return n;
+}
+
+// --- verbs ------------------------------------------------------------------
+
+async function cmdChMk(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    sighost: "value",
+    name: "value",
+    role: "value",
+    salt: "value",
+  });
+  const topic = positional[0];
+  if (!topic || positional.length > 1)
+    throw new Error("usage: ay ch mk <topic> [--sighost H] [--name N] [--role R] [--salt HEX]");
+  const reg = await readRegistry(cwd);
+  if (reg.channels[topic])
+    throw new Error(`channel "${topic}" already exists (ay ch rm ${topic} to replace)`);
+
+  const s = typeof flags.salt === "string" ? flags.salt : randomBytes(32).toString("hex");
+  const [channelId, room] = await Promise.all([deriveChannelId(s), deriveRoom(s)]);
+  const sighost = typeof flags.sighost === "string" ? flags.sighost : undefined;
+  const entry: ChannelRegEntry = {
+    topic,
+    channelId,
+    room,
+    sighost: sighost ?? "s.agent-yes.com",
+    s,
+    author: randomBytes(8).toString("hex"),
+    name: typeof flags.name === "string" ? flags.name : defaultName(),
+    role: flags.role ? validRole(flags.role) : defaultRole(),
+    createdAt: Date.now(),
+  };
+  reg.channels[topic] = entry;
+  await writeRegistry(cwd, reg);
+
+  const link = formatChannelLink({ sighost: entry.sighost, room, s });
+  process.stdout.write(
+    `created channel "${topic}"  (${entry.name}, ${entry.role})\n` +
+      `  invite (CLI):     ${link}\n` +
+      `  invite (browser): ${formatChannelWebLink({ sighost: entry.sighost, room, s })}\n` +
+      `\n  share the invite; others join with:  ay ch join '${link}'\n`,
+  );
+  return 0;
+}
+
+async function cmdChJoin(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { as: "value", name: "value", role: "value" });
+  const linkStr = positional[0];
+  if (!linkStr || positional.length > 1)
+    throw new Error("usage: ay ch join <link> [--as <topic>] [--name N] [--role R]");
+  const link = parseChannelLink(linkStr);
+  if (!link) throw new Error(`not a channel invite link: ${linkStr}`);
+
+  const channelId = await deriveChannelId(link.s);
+  const topic = typeof flags.as === "string" ? flags.as : `ch-${link.room.slice(0, 10)}`;
+  const reg = await readRegistry(cwd);
+  const existing = reg.channels[topic];
+  if (existing && existing.channelId !== channelId)
+    throw new Error(`topic "${topic}" is already bound to a different channel — pick another --as`);
+
+  const entry: ChannelRegEntry = existing ?? {
+    topic,
+    channelId,
+    room: link.room,
+    sighost: link.sighost,
+    s: link.s,
+    author: randomBytes(8).toString("hex"),
+    name: typeof flags.name === "string" ? flags.name : defaultName(),
+    role: flags.role ? validRole(flags.role) : defaultRole(),
+    createdAt: Date.now(),
+  };
+  if (typeof flags.name === "string") entry.name = flags.name;
+  if (flags.role) entry.role = validRole(flags.role);
+  reg.channels[topic] = entry;
+  await writeRegistry(cwd, reg);
+  process.stdout.write(`joined channel "${topic}"  (${entry.name}, ${entry.role})\n`);
+  return 0;
+}
+
+async function cmdChLs(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { json: "bool" });
+  if (positional.length) throw new Error("ay ch ls takes no positional args");
+  const reg = await readRegistry(cwd);
+  const topics = Object.keys(reg.channels).sort();
+
+  const rows = await Promise.all(
+    topics.map(async (topic) => {
+      const e = reg.channels[topic]!;
+      const ops = await readOps(cwd, e.channelId);
+      const msgs = renderThread(ops);
+      const last = msgs.length ? msgs[msgs.length - 1]! : null;
+      return {
+        topic,
+        channelId: e.channelId,
+        name: e.name,
+        role: e.role,
+        messages: msgs.length,
+        lastMs: last ? last.ms : null,
+      };
+    }),
+  );
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify({ schema: REG_SCHEMA, channels: rows }, null, 2) + "\n");
+    return 0;
+  }
+  if (rows.length === 0) {
+    process.stderr.write(`no channels in ${cwd} — 'ay ch mk <topic>' or 'ay ch join <link>'\n`);
+    return 0;
+  }
+  const w = Math.max(5, ...rows.map((r) => r.topic.length));
+  process.stdout.write(`${"TOPIC".padEnd(w)}  ${"MSGS".padStart(5)}  LAST\n`);
+  for (const r of rows) {
+    const last = r.lastMs ? new Date(r.lastMs).toISOString().slice(0, 19).replace("T", " ") : "-";
+    process.stdout.write(`${r.topic.padEnd(w)}  ${String(r.messages).padStart(5)}  ${last}\n`);
+  }
+  return 0;
+}
+
+async function cmdChRm(cwd: string, args: string[]): Promise<number> {
+  const { positional } = parseFlags(args, {});
+  const topic = positional[0];
+  if (!topic || positional.length > 1) throw new Error("usage: ay ch rm <topic>");
+  const reg = await readRegistry(cwd);
+  const entry = reg.channels[topic];
+  if (!entry) throw new Error(`no channel "${topic}"`);
+  delete reg.channels[topic];
+  await writeRegistry(cwd, reg);
+  await rm(channelFilePath(cwd, entry.channelId), { force: true });
+  process.stdout.write(`removed channel "${topic}" (local replica deleted; peers unaffected)\n`);
+  return 0;
+}
+
+async function cmdChSend(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { name: "value", role: "value" });
+  const topic = positional[0];
+  const text = positional.slice(1).join(" ");
+  if (!topic || !text) throw new Error("usage: ay ch send <topic> <text…>");
+  const reg = await readRegistry(cwd);
+  const { channelId, entry } = await resolveChannel(reg, topic);
+  if (!entry) throw new Error(`join "${topic}" before sending: ay ch join <link>`);
+
+  const ops = await readOps(cwd, channelId);
+  const hlc = hlcSend(maxHlc(ops), Date.now(), entry.author);
+  const op = makeOp({
+    author: entry.author,
+    name: typeof flags.name === "string" ? flags.name : entry.name,
+    role: flags.role ? validRole(flags.role) : entry.role,
+    hlc,
+    kind: "msg",
+    body: text,
+  });
+  await appendOps(cwd, channelId, [op]);
+  // Phase 2: also hand `op` to the serve daemon to broadcast over the mesh.
+  return 0;
+}
+
+async function readAndRender(cwd: string, channelId: string): Promise<Message[]> {
+  return renderThread(await readOps(cwd, channelId));
+}
+
+async function cmdChRead(
+  cwd: string,
+  args: string[],
+  mode: "read" | "head" | "tail",
+): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    limit: "value",
+    json: "bool",
+    follow: "bool",
+    f: "bool",
+  });
+  const topic = positional[0];
+  if (!topic || positional.length > 1) throw new Error(`usage: ay ch ${mode} <topic> [-n N]`);
+  const reg = await readRegistry(cwd);
+  const { channelId } = await resolveChannel(reg, topic);
+
+  const n = limitOf(flags);
+  let msgs = await readAndRender(cwd, channelId);
+  if (mode === "head") msgs = msgs.slice(0, n ?? 10);
+  else if (mode === "tail") msgs = msgs.slice(-(n ?? 96));
+  else if (n !== undefined) msgs = msgs.slice(-n);
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(msgs, null, 2) + "\n");
+  } else {
+    for (const m of msgs) process.stdout.write(formatMessage(m) + "\n");
+  }
+
+  if (mode === "tail" && (flags.follow || flags.f)) {
+    await followChannel(cwd, channelId, new Set(msgs.map((m) => m.id)));
+  }
+  return 0;
+}
+
+/**
+ * Follow a channel, printing messages as they appear. Phase 1 polls the local
+ * replica (fs.watch is unreliable in long-lived daemons — see the fswatch-dies
+ * note), so it surfaces same-cwd appends; Phase 2's daemon feeds it live peer
+ * traffic. Runs until SIGINT.
+ */
+function followChannel(cwd: string, channelId: string, seen: Set<string>): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setInterval(async () => {
+      const msgs = await readAndRender(cwd, channelId);
+      for (const m of msgs) {
+        if (seen.has(m.id)) continue;
+        seen.add(m.id);
+        process.stdout.write(formatMessage(m) + "\n");
+      }
+    }, 500);
+    const stop = () => {
+      clearInterval(timer);
+      resolve();
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+  });
+}
+
+function chHelp(): number {
+  process.stdout.write(
+    `ay ch - local-first E2E channels for AI ↔ humans (per-cwd, no server storage)\n` +
+      `\n` +
+      `  ay ch mk <topic> [--name N] [--role R]   create a channel, print an invite link\n` +
+      `  ay ch join <link> [--as <topic>]         join a channel from an invite link\n` +
+      `  ay ch ls [--json]                        list channels in this project (+message counts)\n` +
+      `  ay ch rm <topic>                         delete the local replica (peers unaffected)\n` +
+      `  ay ch send <topic> <text…>               post a message\n` +
+      `  ay ch read <topic> [-n N] [--json]       print the thread (last N)\n` +
+      `  ay ch head <topic> [-n N]                first N messages\n` +
+      `  ay ch tail <topic> [-n N] [-f]           last N (96), -f to follow\n` +
+      `\n` +
+      `  identity: --name defaults to $AY_CH_NAME/OS user; --role to agent (in an agent) or human\n` +
+      `  storage:  <cwd>/.agent-yes/ch-<id>.jsonl  (a full CRDT replica; cwd-scoped)\n`,
+  );
+  return 0;
+}
+
+/** `ay ch <sub> …` dispatcher (called from runSubcommand). */
+export async function cmdCh(args: string[]): Promise<number> {
+  const cwd = process.cwd();
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case "mk":
+    case "new":
+    case "create":
+      return cmdChMk(cwd, rest);
+    case "join":
+      return cmdChJoin(cwd, rest);
+    case "ls":
+    case "list":
+      return cmdChLs(cwd, rest);
+    case "rm":
+    case "remove":
+      return cmdChRm(cwd, rest);
+    case "send":
+      return cmdChSend(cwd, rest);
+    case "read":
+      return cmdChRead(cwd, rest, "read");
+    case "head":
+      return cmdChRead(cwd, rest, "head");
+    case "tail":
+      return cmdChRead(cwd, rest, "tail");
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      return chHelp();
+    default:
+      process.stderr.write(`ay ch: unknown subcommand "${sub}"\n\n`);
+      chHelp();
+      return 1;
+  }
+}

--- a/ts/channels.ts
+++ b/ts/channels.ts
@@ -12,11 +12,15 @@
  *   ay ch read <topic> [-n N] [--json]
  *   ay ch head <topic> [-n N]
  *   ay ch tail <topic> [-n N] [-f]
+ *   ay ch sync <topic> [--quiet]   — hold the WebRTC mesh (live send/receive)
+ *   ay ch pipe <topic>             — sync + bridge stdin→send, inbound→stdout
  *
- * Phase 1 is local-only (the log, the CRDT, the verbs). Live delivery over the
- * WebRTC mesh (`--once`, real `tail -f` across peers, `pipe`) arrives with the
- * serve daemon in Phase 2; the on-disk format and identity model here are the
- * foundation both share.
+ * The read/write verbs are pure-local (they only touch the jsonl replica). Live
+ * delivery is a separate `sync` peer that holds the WebRTC mesh, appends inbound
+ * ops, and broadcasts newly-appeared local ops — so send/tail COMPOSE with a
+ * running sync through the shared replica file, no IPC/daemon. The browser side
+ * (Phase 3) joins the same mesh with its own peer, so agent↔human chat is truly
+ * peer-to-peer with no central bridge.
  *
  * The channels core (ts/channels/) is isomorphic and reused verbatim by the
  * browser lib; this file is the Node CLI shell over it, mirroring ts/ws.ts.
@@ -41,6 +45,8 @@ import {
   type Role,
 } from "./channels/index.ts";
 import { appendOps, channelFilePath, readOps } from "./channels/store.node.ts";
+import type { ChannelPeerStore } from "./channels/peer.ts";
+import type { Op } from "./channels/index.ts";
 
 const REG_SCHEMA = "ay-ch/v1";
 
@@ -400,6 +406,123 @@ function followChannel(cwd: string, channelId: string, seen: Set<string>): Promi
   });
 }
 
+// --- live mesh (Phase 2) ----------------------------------------------------
+
+/** Store adapter the mesh peer drives (persist + dedup, returns new ops). */
+function nodeStore(cwd: string, channelId: string): ChannelPeerStore {
+  return {
+    all: () => readOps(cwd, channelId),
+    append: (ops) => appendOps(cwd, channelId, ops),
+  };
+}
+
+/** One inbound op as a line (only messages are surfaced live). */
+function printOp(op: Op): void {
+  if (op.kind !== "msg") return;
+  const t = new Date(Number(op.hlc.split(".")[0])).toISOString().slice(11, 19);
+  process.stdout.write(`${t}  ${op.name}(${op.role[0]}): ${op.body ?? ""}\n`);
+}
+
+/**
+ * Hold the WebRTC mesh for a channel: append inbound ops to the local replica and
+ * broadcast newly-appeared LOCAL ops (e.g. from a separate `ay ch send`) to peers.
+ * All coordination is through the jsonl file — no IPC — so `send`/`tail` compose
+ * with a running `sync` unchanged. Resolves when stopped (SIGINT/SIGTERM) or when
+ * `extraStdin` (pipe mode) drives it. Returns the started peer + a stop fn.
+ */
+async function runMesh(
+  cwd: string,
+  entry: ChannelRegEntry,
+  opts: { onInbound?: (op: Op) => void; quiet?: boolean },
+): Promise<{
+  stop: () => void;
+  done: Promise<void>;
+  peer: import("./channels/peer.ts").ChannelPeer;
+}> {
+  const { ChannelPeer } = await import("./channels/peer.ts");
+  const seen = new Set((await readOps(cwd, entry.channelId)).map((o) => o.id));
+  const peer = new ChannelPeer({
+    room: entry.room,
+    sighost: entry.sighost,
+    s: entry.s,
+    store: nodeStore(cwd, entry.channelId),
+    onOp: (op) => {
+      seen.add(op.id);
+      opts.onInbound?.(op);
+      if (!opts.quiet) printOp(op);
+    },
+    onPeers: (n) => process.stderr.write(`[ch] peers: ${n}\n`),
+  });
+  await peer.start();
+  const poll = setInterval(() => {
+    void (async () => {
+      for (const op of await readOps(cwd, entry.channelId)) {
+        if (seen.has(op.id)) continue;
+        seen.add(op.id);
+        await peer.publish(op);
+      }
+    })();
+  }, 500);
+  let resolveDone!: () => void;
+  const done = new Promise<void>((r) => (resolveDone = r));
+  const stop = () => {
+    clearInterval(poll);
+    peer.close();
+    resolveDone();
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  return { stop, done, peer };
+}
+
+async function cmdChSync(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { quiet: "bool" });
+  const topic = positional[0];
+  if (!topic || positional.length > 1) throw new Error("usage: ay ch sync <topic> [--quiet]");
+  const reg = await readRegistry(cwd);
+  const { entry } = await resolveChannel(reg, topic);
+  if (!entry) throw new Error(`join "${topic}" before syncing: ay ch join <link>`);
+  process.stderr.write(`syncing "${topic}" over the mesh — Ctrl-C to stop\n`);
+  const { done } = await runMesh(cwd, entry, { quiet: !!flags.quiet });
+  await done;
+  return 0;
+}
+
+async function cmdChPipe(cwd: string, args: string[]): Promise<number> {
+  const { positional } = parseFlags(args, {});
+  const topic = positional[0];
+  if (!topic || positional.length > 1) throw new Error("usage: ay ch pipe <topic>");
+  const reg = await readRegistry(cwd);
+  const { entry } = await resolveChannel(reg, topic);
+  if (!entry) throw new Error(`join "${topic}" before piping: ay ch join <link>`);
+
+  const { done } = await runMesh(cwd, entry, {});
+  // stdin lines → messages
+  const rl = (await import("readline")).createInterface({ input: process.stdin });
+  rl.on("line", (line) => {
+    const text = line.trimEnd();
+    if (!text) return;
+    void (async () => {
+      const ops = await readOps(cwd, entry.channelId);
+      const hlc = hlcSend(maxHlc(ops), Date.now(), entry.author);
+      await appendOps(cwd, entry.channelId, [
+        makeOp({
+          author: entry.author,
+          name: entry.name,
+          role: entry.role,
+          hlc,
+          kind: "msg",
+          body: text,
+        }),
+      ]);
+      // the mesh poll loop broadcasts it on the next tick
+    })();
+  });
+  await done;
+  rl.close();
+  return 0;
+}
+
 function chHelp(): number {
   process.stdout.write(
     `ay ch - local-first E2E channels for AI ↔ humans (per-cwd, no server storage)\n` +
@@ -412,9 +535,13 @@ function chHelp(): number {
       `  ay ch read <topic> [-n N] [--json]       print the thread (last N)\n` +
       `  ay ch head <topic> [-n N]                first N messages\n` +
       `  ay ch tail <topic> [-n N] [-f]           last N (96), -f to follow\n` +
+      `  ay ch sync <topic> [--quiet]             hold the WebRTC mesh: live send/receive (Ctrl-C to stop)\n` +
+      `  ay ch pipe <topic>                       sync + bridge stdin→send and inbound→stdout\n` +
       `\n` +
       `  identity: --name defaults to $AY_CH_NAME/OS user; --role to agent (in an agent) or human\n` +
-      `  storage:  <cwd>/.agent-yes/ch-<id>.jsonl  (a full CRDT replica; cwd-scoped)\n`,
+      `  storage:  <cwd>/.agent-yes/ch-<id>.jsonl  (a full CRDT replica; cwd-scoped)\n` +
+      `  live:     run 'ay ch sync <topic>' (foreground/backgrounded) to join the mesh; then\n` +
+      `            'ay ch send/tail' compose with it through the shared replica file — no daemon\n`,
   );
   return 0;
 }
@@ -445,6 +572,10 @@ export async function cmdCh(args: string[]): Promise<number> {
       return cmdChRead(cwd, rest, "head");
     case "tail":
       return cmdChRead(cwd, rest, "tail");
+    case "sync":
+      return cmdChSync(cwd, rest);
+    case "pipe":
+      return cmdChPipe(cwd, rest);
     case undefined:
     case "help":
     case "--help":

--- a/ts/channels.ts
+++ b/ts/channels.ts
@@ -440,11 +440,18 @@ async function runMesh(
   peer: import("./channels/peer.ts").ChannelPeer;
 }> {
   const { ChannelPeer } = await import("./channels/peer.ts");
+  // Node transport: node-datachannel + Cloudflare TURN, loaded lazily from the
+  // proven share stack so the mesh peer stays isomorphic (the browser injects its
+  // own globals).
+  const { importRTC, getIceServers } = await import("./share.ts");
+  const rtc = await importRTC();
   const seen = new Set((await readOps(cwd, entry.channelId)).map((o) => o.id));
   const peer = new ChannelPeer({
     room: entry.room,
     sighost: entry.sighost,
     s: entry.s,
+    rtc,
+    iceServers: getIceServers,
     store: nodeStore(cwd, entry.channelId),
     onOp: (op) => {
       seen.add(op.id);
@@ -523,6 +530,30 @@ async function cmdChPipe(cwd: string, args: string[]): Promise<number> {
   return 0;
 }
 
+async function cmdChEmbed(cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { host: "value" });
+  const topic = positional[0];
+  if (!topic || positional.length > 1)
+    throw new Error("usage: ay ch embed <topic> [--host <console-host>]");
+  const reg = await readRegistry(cwd);
+  const { entry } = await resolveChannel(reg, topic);
+  if (!entry) throw new Error(`join "${topic}" before embedding: ay ch join <link>`);
+  const consoleHost = typeof flags.host === "string" ? flags.host : "agent-yes.com";
+  const link = formatChannelLink({ sighost: entry.sighost, room: entry.room, s: entry.s });
+  // A self-contained snippet: loads the AyChannel browser lib and mounts the
+  // floating chat widget. Anyone who can read the page source holds the secret S
+  // and can therefore join — that IS the channel's membership model (secret =
+  // access), so only embed on a page whose audience you mean to let in.
+  process.stdout.write(
+    `<!-- ay channel: ${topic} — anyone who can read this snippet can join -->\n` +
+      `<script type="module">\n` +
+      `  import AyChannel from "https://${consoleHost}/w/channels.js";\n` +
+      `  new AyChannel(${JSON.stringify(link)}).mount();\n` +
+      `</script>\n`,
+  );
+  return 0;
+}
+
 function chHelp(): number {
   process.stdout.write(
     `ay ch - local-first E2E channels for AI ↔ humans (per-cwd, no server storage)\n` +
@@ -537,6 +568,7 @@ function chHelp(): number {
       `  ay ch tail <topic> [-n N] [-f]           last N (96), -f to follow\n` +
       `  ay ch sync <topic> [--quiet]             hold the WebRTC mesh: live send/receive (Ctrl-C to stop)\n` +
       `  ay ch pipe <topic>                       sync + bridge stdin→send and inbound→stdout\n` +
+      `  ay ch embed <topic> [--host H]           print an HTML snippet embedding a floating chat widget\n` +
       `\n` +
       `  identity: --name defaults to $AY_CH_NAME/OS user; --role to agent (in an agent) or human\n` +
       `  storage:  <cwd>/.agent-yes/ch-<id>.jsonl  (a full CRDT replica; cwd-scoped)\n` +
@@ -576,6 +608,8 @@ export async function cmdCh(args: string[]): Promise<number> {
       return cmdChSync(cwd, rest);
     case "pipe":
       return cmdChPipe(cwd, rest);
+    case "embed":
+      return cmdChEmbed(cwd, rest);
     case undefined:
     case "help":
     case "--help":

--- a/ts/channels/browser.ts
+++ b/ts/channels/browser.ts
@@ -1,0 +1,272 @@
+// Browser channel client: `import AyChannel from "agent-yes/channels"`.
+//
+// The frontend counterpart to the CLI. It joins the SAME WebRTC mesh as any
+// `ay ch sync` peer using the isomorphic ChannelPeer (peer.ts) wired to the
+// browser's native RTCPeerConnection + WebSocket, persists to LocalStorage
+// (store.browser.ts), and renders a self-contained floating chat window (Shadow
+// DOM) so an agent and a human can talk on the same page — with no server ever
+// storing a message.
+//
+//   const ch = new AyChannel("ay://ch/s.agent-yes.com/<room>#e1.<S>");
+//   await ch.start();
+//   ch.on("message", render);
+//   ch.mount();                 // floating widget, or ch.mount(el) to embed
+//   await ch.send("hello");
+
+import { deriveChannelId, parseChannelLink } from "./link.ts";
+import { hlcSend } from "./hlc.ts";
+import { makeOp, type Role } from "./op.ts";
+import { maxHlc, renderThread, type Message } from "./store.ts";
+import { randomHex } from "../../lab/ui/e2e.js";
+import { ChannelPeer } from "./peer.ts";
+import { LocalStorageStore } from "./store.browser.ts";
+
+export interface AyChannelInfo {
+  /** A channel invite link (ay://ch/… or https://…/w/#ch=…). If given, room/sighost/s are parsed from it. */
+  link?: string;
+  room?: string;
+  sighost?: string;
+  /** Secret S (64-hex). */
+  s?: string;
+  name?: string;
+  role?: Role;
+  /** Stable author id; auto-generated + persisted per channel if omitted. */
+  author?: string;
+}
+
+type Events = "message" | "peers" | "ready";
+
+export class AyChannel {
+  readonly room: string;
+  readonly sighost: string;
+  readonly s: string;
+  channelId = "";
+  name: string;
+  role: Role;
+  author = "";
+  private store?: LocalStorageStore;
+  private peer?: ChannelPeer;
+  private listeners = new Map<Events, Set<(arg: any) => void>>();
+  private started = false;
+  private peers = 0;
+
+  constructor(info: string | AyChannelInfo) {
+    const o = typeof info === "string" ? { link: info } : info;
+    const link = o.link ? parseChannelLink(o.link) : null;
+    this.room = o.room ?? link?.room ?? "";
+    this.sighost = o.sighost ?? link?.sighost ?? "s.agent-yes.com";
+    this.s = o.s ?? link?.s ?? "";
+    if (!this.room || !this.s) throw new Error("AyChannel: need a link or {room, s}");
+    this.name = o.name ?? "guest";
+    this.role = o.role ?? "human";
+    if (o.author) this.author = o.author;
+  }
+
+  /** Derive identity, open the LocalStorage replica, and join the mesh. */
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    this.channelId = await deriveChannelId(this.s);
+    this.store = new LocalStorageStore(this.channelId);
+    this.loadIdentity();
+    this.peer = new ChannelPeer({
+      room: this.room,
+      sighost: this.sighost,
+      s: this.s,
+      rtc: (globalThis as any).RTCPeerConnection,
+      WebSocketImpl: (globalThis as any).WebSocket,
+      store: this.store,
+      onOp: () => this.emit("message", undefined),
+      onPeers: (n) => {
+        this.peers = n;
+        this.emit("peers", n);
+      },
+    });
+    await this.peer.start();
+    this.emit("ready", undefined);
+  }
+
+  /** Identity is stable per channel across reloads (a returning tab keeps its author id). */
+  private loadIdentity(): void {
+    const key = `ay29ch-id:${this.channelId}`;
+    let saved: { author: string; name: string; role: Role } | null = null;
+    try {
+      saved = JSON.parse(localStorage.getItem(key) || "null");
+    } catch {
+      /* ignore */
+    }
+    // Author is stable across reloads; name/role fall back to the saved ones only
+    // when the caller left them at their defaults.
+    this.author ||= saved?.author || randomHex(8);
+    if (saved?.name && this.name === "guest") this.name = saved.name;
+    if (saved?.role && this.role === "human") this.role = saved.role;
+    try {
+      localStorage.setItem(
+        key,
+        JSON.stringify({ author: this.author, name: this.name, role: this.role }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** The rendered thread (folded messages, ordered). */
+  async messages(): Promise<Message[]> {
+    return renderThread(await (this.store?.all() ?? Promise.resolve([])));
+  }
+
+  /** The current confirmed-peer count (presence). */
+  peerCount(): number {
+    return this.peers;
+  }
+
+  /** Post a message: persist locally + broadcast to the mesh. */
+  async send(text: string): Promise<void> {
+    if (!this.store || !this.peer) throw new Error("AyChannel: call start() first");
+    const t = text.trim();
+    if (!t) return;
+    const ops = await this.store.all();
+    const hlc = hlcSend(maxHlc(ops), Date.now(), this.author);
+    const op = makeOp({
+      author: this.author,
+      name: this.name,
+      role: this.role,
+      hlc,
+      kind: "msg",
+      body: t,
+    });
+    await this.peer.publish(op); // append + broadcast
+    this.emit("message", undefined);
+  }
+
+  on(evt: Events, cb: (arg: any) => void): this {
+    (this.listeners.get(evt) ?? this.listeners.set(evt, new Set()).get(evt)!).add(cb);
+    return this;
+  }
+  off(evt: Events, cb: (arg: any) => void): this {
+    this.listeners.get(evt)?.delete(cb);
+    return this;
+  }
+  private emit(evt: Events, arg: any): void {
+    for (const cb of this.listeners.get(evt) ?? []) {
+      try {
+        cb(arg);
+      } catch {
+        /* a listener throwing must not break delivery */
+      }
+    }
+  }
+
+  close(): void {
+    this.peer?.close();
+    this.widget?.remove();
+  }
+
+  // --- floating chat widget -------------------------------------------------
+  // DOM globals (document/HTMLElement) aren't in the Node/Bun type lib this
+  // package compiles against, so DOM access here is intentionally loosely typed;
+  // this method only ever runs in a browser.
+
+  private widget?: any;
+
+  /**
+   * Render the floating chat window. With no target it mounts a fixed-position
+   * bubble in the corner; pass an element to embed it there. Auto-calls start().
+   */
+  mount(target?: any, opts?: { open?: boolean }): any {
+    if (this.widget) return this.widget;
+    const doc: any = (globalThis as any).document;
+    const host = doc.createElement("div");
+    host.setAttribute("data-aychannel", this.channelId || this.room);
+    const root = host.attachShadow({ mode: "open" });
+    root.innerHTML = WIDGET_HTML;
+    this.widget = host;
+    (target ?? doc.body).appendChild(host);
+
+    const list = root.getElementById("list")!;
+    const input = root.getElementById("input") as any;
+    const form = root.getElementById("form") as any;
+    const badge = root.getElementById("peers")!;
+    const panel = root.getElementById("panel")!;
+    const toggle = root.getElementById("toggle")!;
+
+    const esc = (s: string) =>
+      s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
+    const render = async () => {
+      const msgs = await this.messages();
+      list.innerHTML = msgs
+        .map((m) => {
+          const mine = m.author === this.author;
+          const time = new Date(m.ms).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          });
+          const body = m.deleted ? "<i>message deleted</i>" : esc(m.text);
+          return `<div class="msg ${mine ? "mine" : ""} ${m.role}"><div class="meta">${esc(m.name)} · ${time}</div><div class="body">${body}</div></div>`;
+        })
+        .join("");
+      list.scrollTop = list.scrollHeight;
+    };
+
+    form.addEventListener("submit", (e: any) => {
+      e.preventDefault();
+      const text = input.value;
+      input.value = "";
+      void this.send(text);
+    });
+    toggle.addEventListener("click", () => panel.classList.toggle("open"));
+    if (opts?.open) panel.classList.add("open");
+    this.on("message", () => void render());
+    this.on("peers", () => (badge.textContent = String(this.peers)));
+
+    void (async () => {
+      if (!this.started) await this.start();
+      await render();
+      badge.textContent = String(this.peers);
+    })();
+
+    return host;
+  }
+}
+
+// Self-contained styles + markup for the Shadow DOM widget (no external assets).
+const WIDGET_HTML = `
+<style>
+  :host { all: initial; }
+  * { box-sizing: border-box; font-family: system-ui, -apple-system, sans-serif; }
+  #toggle {
+    position: fixed; right: 20px; bottom: 20px; z-index: 2147483000;
+    width: 52px; height: 52px; border-radius: 50%; border: none; cursor: pointer;
+    background: #4f46e5; color: #fff; font-size: 22px; box-shadow: 0 4px 16px rgba(0,0,0,.3);
+  }
+  #panel {
+    position: fixed; right: 20px; bottom: 84px; z-index: 2147483000;
+    width: min(360px, 92vw); height: min(520px, 70vh); display: none;
+    flex-direction: column; background: #1b1d24; color: #e6e6ea; border-radius: 14px;
+    box-shadow: 0 12px 40px rgba(0,0,0,.45); overflow: hidden; border: 1px solid #2c2f3a;
+  }
+  #panel.open { display: flex; }
+  header { padding: 12px 14px; background: #23262f; display: flex; align-items: center; gap: 8px; }
+  header .title { font-weight: 600; font-size: 14px; }
+  header .peers { margin-left: auto; font-size: 12px; opacity: .8; background: #4f46e5; border-radius: 10px; padding: 1px 8px; }
+  #list { flex: 1; overflow-y: auto; padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+  .msg { max-width: 82%; }
+  .msg .meta { font-size: 11px; opacity: .6; margin-bottom: 2px; }
+  .msg .body { background: #2c2f3a; padding: 7px 10px; border-radius: 10px; font-size: 13px; line-height: 1.35; white-space: pre-wrap; word-break: break-word; }
+  .msg.agent .body { border-left: 3px solid #10b981; }
+  .msg.mine { align-self: flex-end; text-align: right; }
+  .msg.mine .body { background: #4f46e5; color: #fff; }
+  #form { display: flex; gap: 6px; padding: 10px; border-top: 1px solid #2c2f3a; }
+  #input { flex: 1; background: #23262f; border: 1px solid #363a46; color: #e6e6ea; border-radius: 8px; padding: 8px 10px; font-size: 13px; }
+  #form button { background: #4f46e5; color: #fff; border: none; border-radius: 8px; padding: 0 14px; cursor: pointer; font-size: 13px; }
+</style>
+<button id="toggle" title="Chat">💬</button>
+<section id="panel">
+  <header><span class="title">Channel</span><span class="peers" id="peers">0</span></header>
+  <div id="list"></div>
+  <form id="form"><input id="input" placeholder="Message…" autocomplete="off" /><button type="submit">Send</button></form>
+</section>
+`;
+
+export default AyChannel;
+export * from "./index.ts";

--- a/ts/channels/hlc.spec.ts
+++ b/ts/channels/hlc.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { compareHlc, formatHlc, hlcSend, parseHlc } from "./hlc.ts";
+
+describe("hlc", () => {
+  it("round-trips format/parse", () => {
+    const s = formatHlc(1_700_000_000_000, 3, "node7");
+    expect(parseHlc(s)).toEqual({ ms: 1_700_000_000_000, ctr: 3, node: "node7" });
+  });
+
+  it("is lexicographically sortable in HLC order", () => {
+    const a = formatHlc(1000, 0, "z"); // earlier ms
+    const b = formatHlc(1000, 1, "a"); // same ms, higher ctr
+    const c = formatHlc(2000, 0, "a"); // later ms
+    expect([c, a, b].sort()).toEqual([a, b, c]);
+    expect(compareHlc(a, b)).toBeLessThan(0);
+    expect(compareHlc(c, a)).toBeGreaterThan(0);
+    expect(compareHlc(a, a)).toBe(0);
+  });
+
+  it("advances the ms and resets the counter when wall clock moves forward", () => {
+    const prev = formatHlc(1000, 5, "n1");
+    expect(parseHlc(hlcSend(prev, 2000, "n1"))).toMatchObject({ ms: 2000, ctr: 0 });
+  });
+
+  it("keeps ms and bumps the counter when wall clock has not advanced", () => {
+    const prev = formatHlc(5000, 2, "n1");
+    // physNow behind the max we've seen (clock skew / same ms) → monotonic via ctr
+    expect(parseHlc(hlcSend(prev, 4000, "n1"))).toMatchObject({ ms: 5000, ctr: 3 });
+    expect(parseHlc(hlcSend(prev, 5000, "n1"))).toMatchObject({ ms: 5000, ctr: 3 });
+  });
+
+  it("is strictly monotonic across repeated sends seeded from the running max", () => {
+    let max: string | null = null;
+    const out: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      // simulate a clock that sometimes stalls
+      const now = 1000 + (i % 3 === 0 ? 0 : i);
+      max = hlcSend(max, now, "n");
+      out.push(max);
+    }
+    for (let i = 1; i < out.length; i++) expect(compareHlc(out[i - 1]!, out[i]!)).toBeLessThan(0);
+  });
+
+  it("starts from zero with no prior max", () => {
+    expect(parseHlc(hlcSend(null, 42, "n"))).toEqual({ ms: 42, ctr: 0, node: "n" });
+  });
+
+  it("rejects malformed and out-of-range values", () => {
+    expect(() => parseHlc("nope")).toThrow();
+    expect(() => parseHlc("1.2")).toThrow(); // too few fields
+    expect(() => formatHlc(-1, 0, "n")).toThrow();
+    expect(() => formatHlc(0, -1, "n")).toThrow();
+    expect(() => formatHlc(10 ** 15, 0, "n")).toThrow(); // ms overflow
+    expect(() => formatHlc(0, 10 ** 6, "n")).toThrow(); // ctr overflow
+  });
+});

--- a/ts/channels/hlc.ts
+++ b/ts/channels/hlc.ts
@@ -1,0 +1,67 @@
+// Hybrid Logical Clock (HLC) for ay channels.
+//
+// A channel is a grow-only set of immutable ops replicated across peers with no
+// coordinator (see store.ts). To display those ops in a stable, causally-sensible
+// order every replica must agree on, each op carries an HLC timestamp: a wall
+// clock reading fused with a per-node counter so that (a) order roughly tracks
+// real time, (b) concurrent ops from different nodes get a deterministic
+// tie-break, and (c) an op always sorts AFTER every op its author had already
+// seen when it was created (causality).
+//
+// The timestamp is encoded as a FIXED-WIDTH, lexicographically-sortable string
+//   "<ms:15><SEP><ctr:6><SEP><node>"
+// so a plain string compare reproduces the numeric HLC order — which lets the
+// jsonl store and the wire protocol sort without parsing. This module is
+// dependency-free and isomorphic (Node + browser).
+
+const MS_WIDTH = 15; // ms since epoch; 15 digits lasts past year 33000
+const CTR_WIDTH = 6; // per-ms counter; 10^6 ops sharing one ms is astronomically safe
+const SEP = "."; // 0x2e < '0' (0x30) so, with fixed widths, it never reorders fields
+
+export interface Hlc {
+  ms: number;
+  ctr: number;
+  node: string;
+}
+
+/** Encode an HLC as its sortable string form. */
+export function formatHlc(ms: number, ctr: number, node: string): string {
+  if (ms < 0 || ctr < 0) throw new Error("hlc: negative component");
+  if (ms >= 10 ** MS_WIDTH || ctr >= 10 ** CTR_WIDTH) throw new Error("hlc: component overflow");
+  return `${String(ms).padStart(MS_WIDTH, "0")}${SEP}${String(ctr).padStart(CTR_WIDTH, "0")}${SEP}${node}`;
+}
+
+/** Parse a sortable HLC string back into its components. Throws on malformed input. */
+export function parseHlc(s: string): Hlc {
+  const parts = s.split(SEP);
+  if (parts.length < 3) throw new Error("hlc: malformed");
+  const ms = Number(parts[0]);
+  const ctr = Number(parts[1]);
+  // node ids never contain SEP, but be defensive if one ever does.
+  const node = parts.slice(2).join(SEP);
+  if (!Number.isInteger(ms) || !Number.isInteger(ctr) || !node) throw new Error("hlc: malformed");
+  return { ms, ctr, node };
+}
+
+/**
+ * Numeric HLC comparison. Equivalent to a plain string compare of the sortable
+ * form (that's the point of the fixed-width encoding), but exposed explicitly so
+ * callers reading structured HLCs don't have to reconstruct the string.
+ */
+export function compareHlc(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Produce the HLC for a new local op. `prevMax` is the greatest HLC this replica
+ * has already stored (from ANY author — see store.maxHlc); passing it makes the
+ * result monotonic across process restarts and causally after everything seen,
+ * with no separate clock-state file to persist. `physNow` is the wall clock
+ * (Date.now()); `node` is this participant's stable id.
+ */
+export function hlcSend(prevMax: string | null, physNow: number, node: string): string {
+  const prev = prevMax ? parseHlc(prevMax) : { ms: 0, ctr: 0 };
+  if (physNow > prev.ms) return formatHlc(physNow, 0, node);
+  // wall clock hasn't advanced past what we've seen — keep the ms, bump the counter
+  return formatHlc(prev.ms, prev.ctr + 1, node);
+}

--- a/ts/channels/index.ts
+++ b/ts/channels/index.ts
@@ -1,0 +1,10 @@
+// Public surface of the channels core — imported by the CLI (ts/channels.ts),
+// the serve daemon (Phase 2), and re-exported as the npm `agent-yes/channels`
+// subpath + browser lib (Phase 3). Only isomorphic, dependency-free modules are
+// re-exported here; the Node-only jsonl backend (store.node.ts) is imported
+// directly by Node callers so a browser bundle never pulls in `fs`.
+
+export * from "./hlc.ts";
+export * from "./op.ts";
+export * from "./store.ts";
+export * from "./link.ts";

--- a/ts/channels/link.spec.ts
+++ b/ts/channels/link.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveChannelId,
+  deriveRoom,
+  formatChannelLink,
+  formatChannelWebLink,
+  isChannelLink,
+  parseChannelLink,
+} from "./link.ts";
+
+const S = "a".repeat(64); // a valid 64-hex secret
+
+describe("channel identity derivation", () => {
+  it("derives a stable, topic-blind channelId and room from the secret", async () => {
+    const [id1, id2] = await Promise.all([deriveChannelId(S), deriveChannelId(S)]);
+    expect(id1).toBe(id2);
+    expect(id1).toMatch(/^[0-9a-f]{16}$/);
+    const room = await deriveRoom(S);
+    expect(room).toMatch(/^c[0-9a-f]{12}$/); // matches the signaling room grammar
+    // different secret → different identity
+    expect(await deriveChannelId("b".repeat(64))).not.toBe(id1);
+  });
+
+  it("rejects a non-hex secret before hashing", async () => {
+    await expect(deriveChannelId("not-hex")).rejects.toThrow();
+  });
+});
+
+describe("channel invite links", () => {
+  const link = { sighost: "s.agent-yes.com", room: "cabc123", s: S };
+
+  it("round-trips the ay:// form", () => {
+    const str = formatChannelLink(link);
+    expect(str).toBe(`ay://ch/s.agent-yes.com/cabc123#e1.${S}`);
+    expect(parseChannelLink(str)).toEqual(link);
+    expect(isChannelLink(str)).toBe(true);
+  });
+
+  it("round-trips the browser https form, defaulting the sighost", () => {
+    const web = formatChannelWebLink(link);
+    expect(web).toBe(`https://agent-yes.com/w/#ch=cabc123:e1.${S}`);
+    expect(parseChannelLink(web)).toEqual(link);
+    // a non-default sighost is carried explicitly
+    const custom = { ...link, sighost: "sig.example.com" };
+    expect(parseChannelLink(formatChannelWebLink(custom))).toEqual(custom);
+  });
+
+  it("returns null for non-links and throws on a malformed secret slot", () => {
+    expect(parseChannelLink("just a topic name")).toBeNull();
+    expect(isChannelLink("topic")).toBe(false);
+    // http url without the #ch= fragment is not a channel link
+    expect(isChannelLink("https://example.com/page")).toBe(false);
+    expect(parseChannelLink("https://example.com/page")).toBeNull();
+    // https channel form missing the room:secret separator → null
+    expect(parseChannelLink("https://x/w/#ch=noseparator")).toBeNull();
+    expect(() => parseChannelLink("ay://ch/host/room#e1.short")).toThrow();
+    expect(() => parseChannelLink("https://x/w/#ch=room:e1.short")).toThrow();
+  });
+});

--- a/ts/channels/link.ts
+++ b/ts/channels/link.ts
@@ -1,0 +1,89 @@
+// Channel identity + invite links — pure, isomorphic, native-free (kept off
+// node-datachannel like webrtcLink.ts, so parsing/derivation never loads the
+// WebRTC addon and stays unit-testable).
+//
+// A channel's shared secret S is the same `e1.<64hex>` value the WebRTC share
+// links use (e2e.js). Everything else is derived from S so peers who hold it
+// agree without exchanging anything the server can read:
+//   - channelId : names the LOCAL replica file/key; topic-blind, cwd-portable.
+//   - room      : the signaling rendezvous name (server sees only this + authToken).
+// The topic string is a purely local label — it never appears in a link and
+// never leaves the machine.
+
+import { parseSecret, validateS } from "../../lab/ui/e2e.js";
+
+export const CH_DEFAULT_SIGHOST = "s.agent-yes.com";
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const subtle = globalThis.crypto.subtle;
+const enc = new TextEncoder();
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = new Uint8Array(await subtle.digest("SHA-256", enc.encode(input)));
+  let s = "";
+  for (const b of digest) s += b.toString(16).padStart(2, "0");
+  return s;
+}
+
+/** Local replica id: `sha256("ay/ch/id\n" + S)[:16]`. Topic-blind. */
+export async function deriveChannelId(s: string): Promise<string> {
+  return (await sha256Hex(`ay/ch/id\n${validateS(s)}`)).slice(0, 16);
+}
+
+/** Signaling rendezvous name: `"c" + sha256("ay/ch/room\n" + S)[:12]`. */
+export async function deriveRoom(s: string): Promise<string> {
+  return "c" + (await sha256Hex(`ay/ch/room\n${validateS(s)}`)).slice(0, 12);
+}
+
+export interface ChannelLink {
+  sighost: string;
+  room: string;
+  /** The raw 64-hex secret S (marker stripped). */
+  s: string;
+}
+
+/** True if `str` looks like a channel invite link. */
+export function isChannelLink(str: string): boolean {
+  return str.startsWith("ay://ch/") || (/^https?:\/\//.test(str) && str.includes("#ch="));
+}
+
+/**
+ * Format a channel invite:
+ *   ay://ch/<sighost>/<room>#e1.<64hex>
+ * The secret rides the fragment; on the https form it is never sent to a server.
+ */
+export function formatChannelLink(link: ChannelLink): string {
+  return `ay://ch/${link.sighost}/${link.room}#e1.${validateS(link.s)}`;
+}
+
+/** Browser-console form: https://<host>/w/#ch=<room>:e1.<64hex>[@<sighost>]. */
+export function formatChannelWebLink(link: ChannelLink, webHost = "agent-yes.com"): string {
+  const at = link.sighost === CH_DEFAULT_SIGHOST ? "" : `@${link.sighost}`;
+  return `https://${webHost}/w/#ch=${link.room}:e1.${validateS(link.s)}${at}`;
+}
+
+/**
+ * Parse either invite form back into { sighost, room, s }. Returns null if the
+ * string isn't a recognizable channel link; throws (via parseSecret) if the
+ * secret slot is present but malformed — never silently downgrades.
+ */
+export function parseChannelLink(link: string): ChannelLink | null {
+  const ay = /^ay:\/\/ch\/([^/]+)\/([^#]+)#(.+)$/.exec(link);
+  if (ay) {
+    const { s } = parseSecret(ay[3]!);
+    if (!HEX64.test(s)) throw new Error("malformed channel link");
+    return { sighost: ay[1]!, room: ay[2]!, s };
+  }
+  if (/^https?:\/\//.test(link) && link.includes("#ch=")) {
+    const frag = link.split("#ch=")[1] ?? "";
+    const at = frag.split("@");
+    const sighost = at[1] || CH_DEFAULT_SIGHOST;
+    const seg = at[0]!;
+    const i = seg.indexOf(":");
+    if (i < 0) return null;
+    const { s } = parseSecret(seg.slice(i + 1));
+    if (!HEX64.test(s)) throw new Error("malformed channel link");
+    return { sighost, room: seg.slice(0, i), s };
+  }
+  return null;
+}

--- a/ts/channels/op.spec.ts
+++ b/ts/channels/op.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { isValidOp, makeOp, opId } from "./op.ts";
+
+const base = { author: "a1", name: "taku", role: "human" as const, hlc: "h1" };
+
+describe("op", () => {
+  it("derives a stable id from author + hlc", () => {
+    expect(opId("a1", "h1")).toBe("a1@h1");
+    expect(makeOp({ ...base, kind: "msg", body: "hi" }).id).toBe("a1@h1");
+  });
+
+  it("drops empty optional fields", () => {
+    const op = makeOp({ ...base, kind: "msg", body: "hi" });
+    expect(op).not.toHaveProperty("ref");
+    const del = makeOp({ ...base, kind: "delete", ref: "a1@h0" });
+    expect(del).not.toHaveProperty("body");
+    expect(del.ref).toBe("a1@h0");
+  });
+
+  it("keeps an empty-string body (a cleared edit) but not undefined", () => {
+    expect(makeOp({ ...base, kind: "edit", body: "", ref: "x" }).body).toBe("");
+  });
+
+  it("validates a well-formed op", () => {
+    expect(isValidOp(makeOp({ ...base, kind: "msg", body: "hi" }))).toBe(true);
+    expect(isValidOp(makeOp({ ...base, kind: "reaction", body: "👍", ref: "x" }))).toBe(true);
+  });
+
+  it("rejects malformed ops (fail-closed)", () => {
+    expect(isValidOp(null)).toBe(false);
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "nope", name: "x" })).toBe(false);
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", role: "robot" })).toBe(false);
+    // id must equal author@hlc
+    expect(isValidOp({ ...base, id: "forged", kind: "msg", name: "x" })).toBe(false);
+    // amendments must carry a ref
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "edit", name: "x", body: "z" })).toBe(false);
+    // wrong field types
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: 5 })).toBe(false);
+    expect(
+      isValidOp({
+        author: "a1",
+        hlc: "h1",
+        id: "a1@h1",
+        kind: "msg",
+        name: "x",
+        role: "human",
+        body: 1,
+      }),
+    ).toBe(false);
+    // ref of the wrong type
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "edit", name: "x", body: "z", ref: 9 })).toBe(
+      false,
+    );
+    // sig of the wrong type is rejected; a string sig is accepted
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", sig: 1 })).toBe(false);
+    expect(
+      isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", body: "hi", sig: "deadbeef" }),
+    ).toBe(true);
+    // reaction/delete without a ref also fail-closed
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "reaction", name: "x", body: "👍" })).toBe(
+      false,
+    );
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "delete", name: "x" })).toBe(false);
+    // missing/blank required fields
+    expect(isValidOp({ ...base, id: "a1@h1", kind: "msg", name: "x", author: "" })).toBe(false);
+    expect(
+      isValidOp({ id: "@h1", kind: "msg", name: "x", role: "human", author: "", hlc: "h1" }),
+    ).toBe(false);
+  });
+});

--- a/ts/channels/op.ts
+++ b/ts/channels/op.ts
@@ -1,0 +1,89 @@
+// The immutable op — the single record type replicated through a channel.
+//
+// Every message, edit, delete, reaction, and presence beat is one Op, appended
+// to every replica's log and merged as a grow-only set (store.ts). Ops are
+// content-independent of transport: the same shape lands in the CLI's jsonl and
+// the browser's LocalStorage, and travels verbatim inside the E2E sealed frame.
+//
+// Identity: `id = "<author>@<hlc>"`. An author's HLCs are strictly monotonic and
+// never reused, so (author, hlc) is globally unique WITHOUT a content hash — a
+// retransmit of the same op yields the same id and dedups for free. (Phase 3
+// ed25519 `sig` will bind the body to this id so a peer can't forge a different
+// body under an author's id; until then, channel-secret possession = trust.)
+//
+// Dependency-free and isomorphic (Node + browser).
+
+export type OpKind = "msg" | "edit" | "delete" | "reaction" | "presence";
+export type Role = "agent" | "human";
+
+export interface Op {
+  /** `<author>@<hlc>` — globally unique dedupe key. */
+  id: string;
+  /** Stable per-participant id (registry `author`); the HLC node + identity. */
+  author: string;
+  /** Display name at send time. */
+  name: string;
+  role: Role;
+  /** Sortable Hybrid Logical Clock (hlc.ts). */
+  hlc: string;
+  kind: OpKind;
+  /** msg/edit: text. reaction: the emoji/label. presence: status. Absent for delete. */
+  body?: string;
+  /** edit/delete/reaction: the target op id being amended. */
+  ref?: string;
+  /** Phase 3: ed25519 signature over `id` (author authenticity). */
+  sig?: string;
+}
+
+const KINDS: ReadonlySet<string> = new Set(["msg", "edit", "delete", "reaction", "presence"]);
+const ROLES: ReadonlySet<string> = new Set(["agent", "human"]);
+
+/** Deterministic op id from author + hlc (no content hash needed — see file header). */
+export function opId(author: string, hlc: string): string {
+  return `${author}@${hlc}`;
+}
+
+/** Construct a well-formed op, filling `id` and dropping empty optional fields. */
+export function makeOp(fields: {
+  author: string;
+  name: string;
+  role: Role;
+  hlc: string;
+  kind: OpKind;
+  body?: string;
+  ref?: string;
+}): Op {
+  const op: Op = {
+    id: opId(fields.author, fields.hlc),
+    author: fields.author,
+    name: fields.name,
+    role: fields.role,
+    hlc: fields.hlc,
+    kind: fields.kind,
+  };
+  if (fields.body !== undefined) op.body = fields.body;
+  if (fields.ref) op.ref = fields.ref;
+  return op;
+}
+
+/**
+ * Validate an op arriving from an untrusted source (peer wire, disk, storage).
+ * Fail-closed: a malformed op is dropped, never coerced. Also enforces that `id`
+ * matches `author@hlc` so a peer can't smuggle a colliding id.
+ */
+export function isValidOp(x: unknown): x is Op {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  if (typeof o.author !== "string" || !o.author) return false;
+  if (typeof o.name !== "string") return false;
+  if (typeof o.hlc !== "string" || !o.hlc) return false;
+  if (typeof o.kind !== "string" || !KINDS.has(o.kind)) return false;
+  if (typeof o.role !== "string" || !ROLES.has(o.role)) return false;
+  if (o.body !== undefined && typeof o.body !== "string") return false;
+  if (o.ref !== undefined && typeof o.ref !== "string") return false;
+  if (o.sig !== undefined && typeof o.sig !== "string") return false;
+  if (o.id !== opId(o.author, o.hlc)) return false;
+  // amendments must target something
+  if ((o.kind === "edit" || o.kind === "delete" || o.kind === "reaction") && !o.ref) return false;
+  return true;
+}

--- a/ts/channels/peer.ts
+++ b/ts/channels/peer.ts
@@ -1,0 +1,452 @@
+// Node/Bun WebRTC mesh peer for ONE channel.
+//
+// Unlike the share bridge (ts/share.ts), a channel is symmetric: there is no
+// host, every participant holds a full replica, and BOTH ends of each pairwise
+// DataChannel send application traffic (chat ops). But the transport reuses the
+// share stack verbatim — the same node-datachannel loader + TURN credentials
+// (importRTC / getIceServers, exported from share.ts) and the same E2E sealed
+// frames + mandatory bidirectional key-confirmation handshake (lab/ui/e2e.js).
+//
+// Topology: the signaling Room DO runs in mesh mode (lab/ui/cf/worker.ts) and
+// relays offer/answer/candidate between any two peers plus broadcasts
+// peer-join/leave. Each pair forms one DataChannel; the peer with the smaller id
+// is the offerer (deterministic, avoids offer glare). On connect the two run
+// anti-entropy (exchange have-vectors, send the diff); new ops broadcast to all
+// confirmed peers, and an op that is new to our replica is re-gossiped to every
+// OTHER peer — dedup by id makes that loop-free and convergent even over a
+// partial mesh.
+
+import {
+  CONFIRM_TIMEOUT_MS,
+  FLAG_CONFIRM,
+  computeTranscriptHash,
+  deriveAuthToken,
+  deriveDirKeys,
+  open as e2eOpen,
+  seal as e2eSeal,
+  packEnvelope,
+  randomHex,
+  unpackEnvelope,
+} from "../../lab/ui/e2e.js";
+import { getIceServers, importRTC } from "../share.ts";
+import { isValidOp, type Op } from "./op.ts";
+import { haveVector, opsMissing } from "./store.ts";
+
+const SIGNAL_SUBPROTOCOL = "ay-signal-1";
+const HEARTBEAT_MS = 20_000; // keepalive ping to the rendezvous (edge auto-pongs)
+const DC_LABEL = "ch";
+
+/** Persistence the peer drives — the daemon supplies a jsonl-backed adapter. */
+export interface ChannelPeerStore {
+  all(): Promise<Op[]>;
+  /** Merge + persist; returns only the ops that were genuinely new. */
+  append(ops: Op[]): Promise<Op[]>;
+}
+
+export interface ChannelPeerOpts {
+  room: string;
+  sighost: string;
+  /** Secret S (64-hex) — derives the authToken the server sees + the AES keys it never does. */
+  s: string;
+  store: ChannelPeerStore;
+  /** Called for each op newly added to the replica (live tail / UI). */
+  onOp?: (op: Op) => void;
+  /** Called when the confirmed-peer count changes (presence). */
+  onPeers?: (count: number) => void;
+  log?: (msg: string) => void;
+}
+
+interface Conn {
+  peerId: string;
+  offerer: boolean;
+  pc: any;
+  dc: any;
+  keyEnc?: CryptoKey;
+  keyDec?: CryptoKey;
+  th?: Uint8Array;
+  localSdp?: string;
+  remoteSdp?: string;
+  pendingCandidates: any[];
+  send: { sendCtr: bigint };
+  recv: { lastSeen: bigint };
+  myNonce: string;
+  confirmedIn: boolean;
+  confirmedOut: boolean;
+  confirmed: boolean;
+  confirmStarted: boolean;
+  confirmTimer?: ReturnType<typeof setTimeout>;
+  sendChain: Promise<void>;
+  recvChain: Promise<void>;
+}
+
+export class ChannelPeer {
+  private ws?: WebSocket;
+  private myId = "";
+  private authToken = "";
+  private RTCPeerConnection: any;
+  private conns = new Map<string, Conn>();
+  private heartbeat?: ReturnType<typeof setInterval>;
+  private closed = false;
+
+  constructor(private opts: ChannelPeerOpts) {}
+
+  /** Connect to signaling and start meshing. Resolves once the socket is open. */
+  async start(): Promise<void> {
+    this.RTCPeerConnection = await importRTC();
+    this.authToken = await deriveAuthToken(this.opts.s, this.opts.room, this.opts.sighost);
+    await this.connectSignaling();
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    // Materialize ids first — dropConn mutates the map we're iterating.
+    const ids = Array.from(this.conns.keys());
+    for (const id of ids) this.dropConn(id);
+    try {
+      this.ws?.close();
+    } catch {
+      /* already closed */
+    }
+  }
+
+  /** Publish a locally-authored op: persist, then broadcast to every confirmed peer. */
+  async publish(op: Op): Promise<void> {
+    await this.opts.store.append([op]);
+    this.broadcast({ t: "op", op });
+  }
+
+  private log(msg: string) {
+    this.opts.log?.(`[ch:peer] ${msg}`);
+  }
+
+  private wsUrl(): string {
+    const scheme =
+      this.opts.sighost.startsWith("localhost") || this.opts.sighost.startsWith("127.")
+        ? "ws"
+        : "wss";
+    return `${scheme}://${this.opts.sighost}/${this.opts.room}`;
+  }
+
+  private async connectSignaling(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(this.wsUrl(), [SIGNAL_SUBPROTOCOL]);
+      this.ws = ws;
+      let opened = false;
+      ws.onopen = () => {
+        opened = true;
+        ws.send(
+          JSON.stringify({
+            type: "hello",
+            role: "client",
+            v: 2,
+            mesh: true,
+            token: this.authToken,
+          }),
+        );
+        this.heartbeat = setInterval(() => {
+          try {
+            if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "ping" }));
+          } catch {
+            /* dropped */
+          }
+        }, HEARTBEAT_MS);
+        resolve();
+      };
+      ws.onmessage = (e: MessageEvent) =>
+        void this.onSignal(String(e.data)).catch((err) => this.log(`signal: ${err}`));
+      ws.onclose = () => {
+        if (this.heartbeat) clearInterval(this.heartbeat);
+        if (!opened) reject(new Error("signaling closed before open"));
+        // Reconnect unless we were told to stop (mirrors the browser's resilience).
+        if (!this.closed) setTimeout(() => void this.connectSignaling().catch(() => {}), 1000);
+      };
+      ws.onerror = () => {
+        if (!opened) reject(new Error("signaling error before open"));
+      };
+    });
+  }
+
+  private async onSignal(raw: string): Promise<void> {
+    let msg: any;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    switch (msg.type) {
+      case "welcome": {
+        this.myId = String(msg.peer ?? "");
+        // Existing peers with a larger id: we are the offerer to them.
+        for (const other of (msg.peers as string[] | undefined) ?? []) {
+          if (this.myId < other) void this.beginOffer(other);
+        }
+        this.opts.onPeers?.(this.confirmedCount());
+        return;
+      }
+      case "peer-join": {
+        const other = String(msg.peer ?? "");
+        if (other && this.myId && this.myId < other) void this.beginOffer(other);
+        return;
+      }
+      case "peer-leave":
+        this.dropConn(String(msg.peer ?? ""));
+        return;
+      case "offer":
+        return this.onOffer(String(msg.from ?? ""), msg.sdp, msg.iceServers);
+      case "answer":
+        return this.onAnswer(String(msg.from ?? ""), msg.sdp);
+      case "candidate":
+        return this.onCandidate(String(msg.from ?? ""), msg.candidate);
+      case "pong":
+        return;
+    }
+  }
+
+  private confirmedCount(): number {
+    let n = 0;
+    for (const c of this.conns.values()) if (c.confirmed) n++;
+    return n;
+  }
+
+  private newConn(peerId: string, offerer: boolean, pc: any): Conn {
+    const c: Conn = {
+      peerId,
+      offerer,
+      pc,
+      dc: undefined,
+      pendingCandidates: [],
+      send: { sendCtr: 0n },
+      recv: { lastSeen: -1n },
+      myNonce: randomHex(16),
+      confirmedIn: false,
+      confirmedOut: false,
+      confirmed: false,
+      confirmStarted: false,
+      sendChain: Promise.resolve(),
+      recvChain: Promise.resolve(),
+    };
+    this.conns.set(peerId, c);
+    pc.onicecandidate = (e: any) => {
+      if (e.candidate && this.ws?.readyState === WebSocket.OPEN)
+        this.ws.send(JSON.stringify({ type: "candidate", to: peerId, candidate: e.candidate }));
+    };
+    pc.onconnectionstatechange = () => {
+      if (["failed", "closed", "disconnected"].includes(pc.connectionState)) this.dropConn(peerId);
+    };
+    return c;
+  }
+
+  private wireDataChannel(c: Conn, dc: any): void {
+    c.dc = dc;
+    dc.binaryType = "arraybuffer";
+    dc.onopen = async () => {
+      // keyEnc/keyDec are derived once both SDPs are exchanged (below); the open
+      // handler waits for them, then opens the confirmation handshake.
+      if (!c.keyEnc) return; // keys not ready yet — deriveKeys() re-invokes confirm
+      this.beginConfirm(c);
+    };
+    dc.onmessage = (e: any) => {
+      c.recvChain = c.recvChain.then(() => this.onFrame(c, e.data)).catch(() => {});
+    };
+  }
+
+  private beginConfirm(c: Conn): void {
+    // Reachable from both dc.onopen and deriveKeys (whichever completes last) —
+    // open the handshake exactly once.
+    if (c.confirmStarted) return;
+    c.confirmStarted = true;
+    this.enqueueSeal(c, FLAG_CONFIRM, { t: "confirm", nonce: c.myNonce });
+    c.confirmTimer = setTimeout(() => {
+      if (!c.confirmed) this.dropConn(c.peerId);
+    }, CONFIRM_TIMEOUT_MS);
+  }
+
+  private async beginOffer(peerId: string): Promise<void> {
+    if (this.conns.has(peerId) || this.closed) return;
+    try {
+      const iceServers = await getIceServers();
+      const pc = new this.RTCPeerConnection({ iceServers });
+      const c = this.newConn(peerId, true, pc);
+      const dc = pc.createDataChannel(DC_LABEL);
+      this.wireDataChannel(c, dc);
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      c.localSdp = pc.localDescription.sdp;
+      if (this.conns.get(peerId) !== c || this.ws?.readyState !== WebSocket.OPEN) return;
+      this.ws.send(JSON.stringify({ type: "offer", to: peerId, sdp: c.localSdp, iceServers }));
+    } catch (err) {
+      this.log(`beginOffer ${peerId}: ${err}`);
+      this.dropConn(peerId);
+    }
+  }
+
+  private async onOffer(peerId: string, sdp: string, iceServers: any): Promise<void> {
+    if (!peerId || this.conns.has(peerId)) return;
+    try {
+      const pc = new this.RTCPeerConnection({ iceServers: iceServers ?? (await getIceServers()) });
+      const c = this.newConn(peerId, false, pc);
+      pc.ondatachannel = (e: any) => this.wireDataChannel(c, e.channel);
+      c.remoteSdp = sdp;
+      await pc.setRemoteDescription({ type: "offer", sdp });
+      this.flushCandidates(c);
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      c.localSdp = pc.localDescription.sdp;
+      await this.deriveKeys(c);
+      if (this.conns.get(peerId) !== c || this.ws?.readyState !== WebSocket.OPEN) return;
+      this.ws.send(JSON.stringify({ type: "answer", to: peerId, sdp: c.localSdp }));
+    } catch (err) {
+      this.log(`onOffer ${peerId}: ${err}`);
+      this.dropConn(peerId);
+    }
+  }
+
+  private async onAnswer(peerId: string, sdp: string): Promise<void> {
+    const c = this.conns.get(peerId);
+    if (!c || !c.offerer) return;
+    try {
+      c.remoteSdp = sdp;
+      await c.pc.setRemoteDescription({ type: "answer", sdp });
+      this.flushCandidates(c);
+      await this.deriveKeys(c);
+    } catch (err) {
+      this.log(`onAnswer ${peerId}: ${err}`);
+      this.dropConn(peerId);
+    }
+  }
+
+  private onCandidate(peerId: string, candidate: any): void {
+    const c = this.conns.get(peerId);
+    if (!c || !candidate) return;
+    // Buffer until the remote description is set, else addIceCandidate throws.
+    if (!c.remoteSdp) {
+      c.pendingCandidates.push(candidate);
+      return;
+    }
+    c.pc.addIceCandidate(candidate).catch(() => {});
+  }
+
+  private flushCandidates(c: Conn): void {
+    for (const cand of c.pendingCandidates.splice(0)) c.pc.addIceCandidate(cand).catch(() => {});
+  }
+
+  /** Derive the directional AES keys once both SDPs are known, then confirm. */
+  private async deriveKeys(c: Conn): Promise<void> {
+    if (c.keyEnc || !c.localSdp || !c.remoteSdp) return;
+    // Offerer: local=offer, remote=answer. Answerer: remote=offer, local=answer.
+    const [offerSdp, answerSdp] = c.offerer ? [c.localSdp, c.remoteSdp] : [c.remoteSdp, c.localSdp];
+    c.th = await computeTranscriptHash(offerSdp, answerSdp);
+    const { keyH2C, keyC2H } = await deriveDirKeys(this.opts.s, c.th);
+    // The offerer takes the host->client key to encrypt (client->host to decrypt);
+    // the answerer takes the mirror. Either way both directions are full-duplex.
+    c.keyEnc = c.offerer ? keyH2C : keyC2H;
+    c.keyDec = c.offerer ? keyC2H : keyH2C;
+    // If the DataChannel already opened before keys were ready, confirm now.
+    if (c.dc && c.dc.readyState === "open") this.beginConfirm(c);
+  }
+
+  private enqueueSeal(c: Conn, flags: number, obj: object): Promise<void> {
+    c.sendChain = c.sendChain.then(async () => {
+      if (!c.dc || c.dc.readyState !== "open" || !c.keyEnc || !c.th) return;
+      let frame: ArrayBuffer;
+      try {
+        frame = await e2eSeal(c.keyEnc, c.send, flags, c.th, packEnvelope(obj));
+      } catch {
+        this.dropConn(c.peerId); // counter overflow — fail closed
+        return;
+      }
+      try {
+        c.dc.send(frame);
+      } catch {
+        /* peer vanished mid-send */
+      }
+    });
+    return c.sendChain;
+  }
+
+  private async onFrame(c: Conn, data: any): Promise<void> {
+    if (!this.conns.has(c.peerId)) return;
+    if (typeof data === "string" || !c.keyDec || !c.th) return this.dropConn(c.peerId);
+    let env: any;
+    try {
+      const { plaintext } = await e2eOpen(c.keyDec, data, c.th, c.recv);
+      env = unpackEnvelope(plaintext);
+    } catch {
+      return this.dropConn(c.peerId); // bad tag/replay/AAD
+    }
+    if (!c.confirmed) {
+      if (!env || env.t !== "confirm") return this.dropConn(c.peerId);
+      if (typeof env.nonce === "string" && !c.confirmedOut) {
+        await this.enqueueSeal(c, FLAG_CONFIRM, {
+          t: "confirm",
+          nonce: c.myNonce,
+          echo: env.nonce,
+        });
+        c.confirmedOut = true;
+      }
+      if (env.echo && env.echo === c.myNonce) c.confirmedIn = true;
+      if (c.confirmedIn && c.confirmedOut) {
+        c.confirmed = true;
+        if (c.confirmTimer) clearTimeout(c.confirmTimer);
+        this.opts.onPeers?.(this.confirmedCount());
+        void this.startSync(c); // anti-entropy once the channel is trusted
+      }
+      return;
+    }
+    if (!env || env.t === "confirm") return; // stray confirm — ignore
+    await this.onEnvelope(c, env);
+  }
+
+  /** Kick off anti-entropy: tell the peer what we hold; it replies with the diff. */
+  private async startSync(c: Conn): Promise<void> {
+    const ops = await this.opts.store.all();
+    this.enqueueSeal(c, 0, { t: "sync-req", have: haveVector(ops) });
+  }
+
+  private async onEnvelope(c: Conn, env: any): Promise<void> {
+    if (env.t === "sync-req" && env.have && typeof env.have === "object") {
+      const missing = opsMissing(await this.opts.store.all(), env.have);
+      this.enqueueSeal(c, 0, { t: "sync-res", ops: missing });
+      return;
+    }
+    if (env.t === "sync-res" && Array.isArray(env.ops)) {
+      await this.ingest(env.ops.filter(isValidOp), c.peerId);
+      return;
+    }
+    if (env.t === "op" && isValidOp(env.op)) {
+      await this.ingest([env.op], c.peerId);
+      return;
+    }
+  }
+
+  /** Merge inbound ops; surface + re-gossip only the ones new to our replica. */
+  private async ingest(ops: Op[], fromPeer: string): Promise<void> {
+    if (ops.length === 0) return;
+    const added = await this.opts.store.append(ops);
+    for (const op of added) this.opts.onOp?.(op);
+    // Gossip: forward genuinely-new ops to every OTHER confirmed peer. Dedup-by-id
+    // upstream makes this loop-free and terminating even on a partial mesh.
+    for (const op of added) this.broadcast({ t: "op", op }, fromPeer);
+  }
+
+  private broadcast(obj: { t: string; [k: string]: unknown }, exceptPeer?: string): void {
+    for (const c of this.conns.values()) {
+      if (!c.confirmed || c.peerId === exceptPeer) continue;
+      this.enqueueSeal(c, 0, obj);
+    }
+  }
+
+  private dropConn(peerId: string): void {
+    const c = this.conns.get(peerId);
+    if (!c) return;
+    if (c.confirmTimer) clearTimeout(c.confirmTimer);
+    try {
+      c.pc.close();
+    } catch {
+      /* already closed */
+    }
+    this.conns.delete(peerId);
+    this.opts.onPeers?.(this.confirmedCount());
+  }
+}

--- a/ts/channels/peer.ts
+++ b/ts/channels/peer.ts
@@ -1,11 +1,12 @@
-// Node/Bun WebRTC mesh peer for ONE channel.
+// Isomorphic WebRTC mesh peer for ONE channel (Node/Bun AND browser).
 //
 // Unlike the share bridge (ts/share.ts), a channel is symmetric: there is no
 // host, every participant holds a full replica, and BOTH ends of each pairwise
-// DataChannel send application traffic (chat ops). But the transport reuses the
-// share stack verbatim — the same node-datachannel loader + TURN credentials
-// (importRTC / getIceServers, exported from share.ts) and the same E2E sealed
-// frames + mandatory bidirectional key-confirmation handshake (lab/ui/e2e.js).
+// DataChannel send application traffic (chat ops). The transport is injected —
+// Node wires node-datachannel + Cloudflare TURN (via share.ts), the browser
+// wires its native RTCPeerConnection/WebSocket — so this one class runs both
+// sides. It reuses the E2E sealed frames + mandatory bidirectional key-
+// confirmation handshake from lab/ui/e2e.js verbatim.
 //
 // Topology: the signaling Room DO runs in mesh mode (lab/ui/cf/worker.ts) and
 // relays offer/answer/candidate between any two peers plus broadcasts
@@ -28,15 +29,17 @@ import {
   randomHex,
   unpackEnvelope,
 } from "../../lab/ui/e2e.js";
-import { getIceServers, importRTC } from "../share.ts";
 import { isValidOp, type Op } from "./op.ts";
 import { haveVector, opsMissing } from "./store.ts";
 
 const SIGNAL_SUBPROTOCOL = "ay-signal-1";
 const HEARTBEAT_MS = 20_000; // keepalive ping to the rendezvous (edge auto-pongs)
 const DC_LABEL = "ch";
+const STUN = [{ urls: "stun:stun.l.google.com:19302" }];
 
-/** Persistence the peer drives — the daemon supplies a jsonl-backed adapter. */
+export type IceServer = { urls: string | string[]; username?: string; credential?: string };
+
+/** Persistence the peer drives — Node supplies a jsonl adapter, the browser LocalStorage. */
 export interface ChannelPeerStore {
   all(): Promise<Op[]>;
   /** Merge + persist; returns only the ops that were genuinely new. */
@@ -49,6 +52,12 @@ export interface ChannelPeerOpts {
   /** Secret S (64-hex) — derives the authToken the server sees + the AES keys it never does. */
   s: string;
   store: ChannelPeerStore;
+  /** RTCPeerConnection constructor — node-datachannel/polyfill (Node) or the browser global. */
+  rtc: new (config?: any) => any;
+  /** ICE servers provider (TURN+STUN). Defaults to public STUN. */
+  iceServers?: () => Promise<IceServer[]>;
+  /** WebSocket constructor. Defaults to the global. */
+  WebSocketImpl?: typeof WebSocket;
   /** Called for each op newly added to the replica (live tail / UI). */
   onOp?: (op: Op) => void;
   /** Called when the confirmed-peer count changes (presence). */
@@ -83,16 +92,23 @@ export class ChannelPeer {
   private ws?: WebSocket;
   private myId = "";
   private authToken = "";
-  private RTCPeerConnection: any;
+  private RTCPeerConnection: new (config?: any) => any;
+  private WS: typeof WebSocket;
   private conns = new Map<string, Conn>();
   private heartbeat?: ReturnType<typeof setInterval>;
   private closed = false;
 
-  constructor(private opts: ChannelPeerOpts) {}
+  constructor(private opts: ChannelPeerOpts) {
+    this.RTCPeerConnection = opts.rtc;
+    this.WS = opts.WebSocketImpl ?? WebSocket;
+  }
+
+  private ice(): Promise<IceServer[]> {
+    return this.opts.iceServers ? this.opts.iceServers() : Promise.resolve(STUN);
+  }
 
   /** Connect to signaling and start meshing. Resolves once the socket is open. */
   async start(): Promise<void> {
-    this.RTCPeerConnection = await importRTC();
     this.authToken = await deriveAuthToken(this.opts.s, this.opts.room, this.opts.sighost);
     await this.connectSignaling();
   }
@@ -130,7 +146,7 @@ export class ChannelPeer {
 
   private async connectSignaling(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(this.wsUrl(), [SIGNAL_SUBPROTOCOL]);
+      const ws = new this.WS(this.wsUrl(), [SIGNAL_SUBPROTOCOL]);
       this.ws = ws;
       let opened = false;
       ws.onopen = () => {
@@ -146,7 +162,7 @@ export class ChannelPeer {
         );
         this.heartbeat = setInterval(() => {
           try {
-            if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "ping" }));
+            if (ws.readyState === this.WS.OPEN) ws.send(JSON.stringify({ type: "ping" }));
           } catch {
             /* dropped */
           }
@@ -228,7 +244,7 @@ export class ChannelPeer {
     };
     this.conns.set(peerId, c);
     pc.onicecandidate = (e: any) => {
-      if (e.candidate && this.ws?.readyState === WebSocket.OPEN)
+      if (e.candidate && this.ws?.readyState === this.WS.OPEN)
         this.ws.send(JSON.stringify({ type: "candidate", to: peerId, candidate: e.candidate }));
     };
     pc.onconnectionstatechange = () => {
@@ -265,7 +281,7 @@ export class ChannelPeer {
   private async beginOffer(peerId: string): Promise<void> {
     if (this.conns.has(peerId) || this.closed) return;
     try {
-      const iceServers = await getIceServers();
+      const iceServers = await this.ice();
       const pc = new this.RTCPeerConnection({ iceServers });
       const c = this.newConn(peerId, true, pc);
       const dc = pc.createDataChannel(DC_LABEL);
@@ -273,7 +289,7 @@ export class ChannelPeer {
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
       c.localSdp = pc.localDescription.sdp;
-      if (this.conns.get(peerId) !== c || this.ws?.readyState !== WebSocket.OPEN) return;
+      if (this.conns.get(peerId) !== c || this.ws?.readyState !== this.WS.OPEN) return;
       this.ws.send(JSON.stringify({ type: "offer", to: peerId, sdp: c.localSdp, iceServers }));
     } catch (err) {
       this.log(`beginOffer ${peerId}: ${err}`);
@@ -284,7 +300,7 @@ export class ChannelPeer {
   private async onOffer(peerId: string, sdp: string, iceServers: any): Promise<void> {
     if (!peerId || this.conns.has(peerId)) return;
     try {
-      const pc = new this.RTCPeerConnection({ iceServers: iceServers ?? (await getIceServers()) });
+      const pc = new this.RTCPeerConnection({ iceServers: iceServers ?? (await this.ice()) });
       const c = this.newConn(peerId, false, pc);
       pc.ondatachannel = (e: any) => this.wireDataChannel(c, e.channel);
       c.remoteSdp = sdp;
@@ -294,7 +310,7 @@ export class ChannelPeer {
       await pc.setLocalDescription(answer);
       c.localSdp = pc.localDescription.sdp;
       await this.deriveKeys(c);
-      if (this.conns.get(peerId) !== c || this.ws?.readyState !== WebSocket.OPEN) return;
+      if (this.conns.get(peerId) !== c || this.ws?.readyState !== this.WS.OPEN) return;
       this.ws.send(JSON.stringify({ type: "answer", to: peerId, sdp: c.localSdp }));
     } catch (err) {
       this.log(`onOffer ${peerId}: ${err}`);

--- a/ts/channels/store.browser.spec.ts
+++ b/ts/channels/store.browser.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { formatHlc } from "./hlc.ts";
+import { makeOp, type Op } from "./op.ts";
+import { LocalStorageStore } from "./store.browser.ts";
+
+// Minimal in-memory Storage stand-in (the parts LocalStorageStore uses).
+function memStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
+
+function op(author: string, ms: number, body: string): Op {
+  return makeOp({
+    author,
+    name: author,
+    role: "human",
+    hlc: formatHlc(ms, 0, author),
+    kind: "msg",
+    body,
+  });
+}
+
+describe("LocalStorageStore", () => {
+  it("returns [] for an empty channel", async () => {
+    const s = new LocalStorageStore("c1", memStorage());
+    expect(await s.all()).toEqual([]);
+  });
+
+  it("appends, dedups, and reads back sorted (same CRDT as the jsonl backend)", async () => {
+    const store = memStorage();
+    const s = new LocalStorageStore("c1", store);
+    const added = await s.append([op("b", 2, "two"), op("a", 1, "one")]);
+    expect(added).toHaveLength(2);
+    expect((await s.all()).map((o) => o.body)).toEqual(["one", "two"]);
+    // re-append an existing op → nothing new; a second reader converges identically
+    expect(await s.append([op("a", 1, "one")])).toEqual([]);
+    expect((await new LocalStorageStore("c1", store).all()).map((o) => o.body)).toEqual([
+      "one",
+      "two",
+    ]);
+  });
+
+  it("tolerates corrupt storage + drops invalid ops", async () => {
+    const store = memStorage();
+    store.setItem("ay29ch:c1", "not json");
+    const s = new LocalStorageStore("c1", store);
+    expect(await s.all()).toEqual([]);
+    // @ts-expect-error deliberately malformed
+    expect(await s.append([{ id: "x", kind: "msg" }])).toEqual([]);
+  });
+});

--- a/ts/channels/store.browser.ts
+++ b/ts/channels/store.browser.ts
@@ -1,0 +1,42 @@
+// Browser replica backend: a channel's ops in LocalStorage (text-only chat fits
+// comfortably). Same CRDT semantics as the Node jsonl backend (store.node.ts) —
+// merge is a union by id, reads dedup + sort — so a browser tab and a CLI peer
+// converge to identical threads. Synchronous (LocalStorage is), wrapped in the
+// async ChannelPeerStore shape the peer expects.
+
+import { isValidOp, type Op } from "./op.ts";
+import { mergeOps, sortOps } from "./store.ts";
+import type { ChannelPeerStore } from "./peer.ts";
+
+const PREFIX = "ay29ch:";
+
+export class LocalStorageStore implements ChannelPeerStore {
+  private key: string;
+  constructor(
+    channelId: string,
+    private storage: Storage = globalThis.localStorage,
+  ) {
+    this.key = PREFIX + channelId;
+  }
+
+  private read(): Op[] {
+    try {
+      const raw = this.storage.getItem(this.key);
+      if (!raw) return [];
+      const arr = JSON.parse(raw);
+      return sortOps((Array.isArray(arr) ? arr : []).filter(isValidOp));
+    } catch {
+      return [];
+    }
+  }
+
+  all(): Promise<Op[]> {
+    return Promise.resolve(this.read());
+  }
+
+  append(ops: Op[]): Promise<Op[]> {
+    const { merged, added } = mergeOps(this.read(), ops.filter(isValidOp));
+    if (added.length) this.storage.setItem(this.key, JSON.stringify(merged));
+    return Promise.resolve(added);
+  }
+}

--- a/ts/channels/store.node.spec.ts
+++ b/ts/channels/store.node.spec.ts
@@ -1,0 +1,76 @@
+import { appendFile, mkdtemp, mkdir, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { formatHlc } from "./hlc.ts";
+import { makeOp, type Op } from "./op.ts";
+import { appendOps, channelFilePath, readOps } from "./store.node.ts";
+
+function op(author: string, ms: number, body: string): Op {
+  return makeOp({
+    author,
+    name: author,
+    role: "human",
+    hlc: formatHlc(ms, 0, author),
+    kind: "msg",
+    body,
+  });
+}
+
+describe("store.node jsonl backend", () => {
+  let cwd: string;
+  const CH = "abc123";
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(os.tmpdir(), "ay-ch-"));
+  });
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("colocates the replica under <cwd>/.agent-yes", () => {
+    expect(channelFilePath("/x", CH)).toBe(path.join("/x", ".agent-yes", "ch-abc123.jsonl"));
+  });
+
+  it("returns [] for a channel with no file yet", async () => {
+    expect(await readOps(cwd, CH)).toEqual([]);
+  });
+
+  it("appends and reads back, sorted by HLC", async () => {
+    const added = await appendOps(cwd, CH, [op("b", 2, "two"), op("a", 1, "one")]);
+    expect(added).toHaveLength(2);
+    expect((await readOps(cwd, CH)).map((o) => o.body)).toEqual(["one", "two"]);
+  });
+
+  it("dedups already-stored ops on append (idempotent replica)", async () => {
+    const first = op("a", 1, "one");
+    await appendOps(cwd, CH, [first]);
+    const added = await appendOps(cwd, CH, [first, op("a", 2, "two")]);
+    expect(added.map((o) => o.body)).toEqual(["two"]); // only the new one
+    expect(await readOps(cwd, CH)).toHaveLength(2);
+  });
+
+  it("drops invalid ops instead of storing them", async () => {
+    // @ts-expect-error deliberately malformed
+    const added = await appendOps(cwd, CH, [{ id: "x", kind: "msg" }]);
+    expect(added).toEqual([]);
+    expect(await readOps(cwd, CH)).toEqual([]);
+  });
+
+  it("skips corrupt/partial lines when reading", async () => {
+    const good = op("a", 1, "one");
+    await appendOps(cwd, CH, [good]);
+    // simulate a torn write: a half-line + a non-op JSON line
+    await appendFile(channelFilePath(cwd, CH), `{"not":"an op"}\n{oops not json\n\n`);
+    const ops = await readOps(cwd, CH);
+    expect(ops.map((o) => o.body)).toEqual(["one"]);
+  });
+
+  it("returns [] when the ops list is entirely invalid", async () => {
+    // appendOps with an empty list is a no-op
+    expect(await appendOps(cwd, CH, [])).toEqual([]);
+    // reading a fresh channel dir that exists but has no file
+    await mkdir(path.join(cwd, ".agent-yes"), { recursive: true });
+    expect(await readOps(cwd, "never-written")).toEqual([]);
+  });
+});

--- a/ts/channels/store.node.ts
+++ b/ts/channels/store.node.ts
@@ -1,0 +1,72 @@
+// Node/Bun jsonl backend for a channel replica.
+//
+// One append-only file per channel, colocated with the project like the rest of
+// agent-yes's per-cwd state (`<cwd>/.agent-yes/ch-<channelId>.jsonl` — the same
+// convention as messageLog.ts's inbox/outbox). Writes follow messageLog's
+// lock-free discipline: an O_APPEND of one line is atomic on POSIX, and reads
+// dedup by op id, so a concurrent CLI + daemon appending the same op at worst
+// writes a duplicate line that the next read/compaction collapses — never a lost
+// or torn record. Best-effort, and never blocks a send.
+
+import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { isValidOp, type Op } from "./op.ts";
+import { mergeOps, sortOps } from "./store.ts";
+
+/** Rewrite (dedup + sort) once the file grows past this many raw lines. */
+const COMPACT_AT_LINES = 4000;
+
+/** Path to a channel's jsonl replica under a project cwd. */
+export function channelFilePath(cwd: string, channelId: string): string {
+  return path.join(cwd, ".agent-yes", `ch-${channelId}.jsonl`);
+}
+
+/** Read + parse a channel's ops, deduped and HLC-sorted. Missing file → []. */
+export async function readOps(cwd: string, channelId: string): Promise<Op[]> {
+  let raw: string;
+  try {
+    raw = await readFile(channelFilePath(cwd, channelId), "utf-8");
+  } catch {
+    return [];
+  }
+  const byId = new Map<string, Op>();
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const op = JSON.parse(t);
+      if (isValidOp(op) && !byId.has(op.id)) byId.set(op.id, op);
+    } catch {
+      /* skip corrupt/partial line */
+    }
+  }
+  return sortOps([...byId.values()]);
+}
+
+/**
+ * Append `incoming` to a channel, deduping against what's already stored.
+ * Returns the ops that were genuinely new (so the daemon can rebroadcast just
+ * those). Opportunistically compacts when the file accumulates duplicate lines
+ * or grows large, keeping it bounded despite append-only writes.
+ */
+export async function appendOps(cwd: string, channelId: string, incoming: Op[]): Promise<Op[]> {
+  const valid = incoming.filter(isValidOp);
+  if (valid.length === 0) return [];
+  const file = channelFilePath(cwd, channelId);
+  await mkdir(path.dirname(file), { recursive: true });
+
+  const existing = await readOps(cwd, channelId);
+  const { added } = mergeOps(existing, valid);
+  if (added.length === 0) return [];
+
+  await appendFile(file, added.map((op) => JSON.stringify(op)).join("\n") + "\n");
+
+  // Compact if the on-disk line count now exceeds the deduped op count enough to
+  // matter (duplicates from concurrent writers) or crosses the size cap.
+  const rawLines = existing.length + valid.length; // upper bound on lines just written+read
+  if (rawLines > COMPACT_AT_LINES) {
+    const all = sortOps([...existing, ...added]);
+    await writeFile(file, all.map((op) => JSON.stringify(op)).join("\n") + "\n");
+  }
+  return added;
+}

--- a/ts/channels/store.spec.ts
+++ b/ts/channels/store.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { formatHlc } from "./hlc.ts";
+import { makeOp, type Op, type Role } from "./op.ts";
+import { haveVector, maxHlc, mergeOps, opsMissing, renderThread, sortOps } from "./store.ts";
+
+// Build an op with an explicit (ms, ctr) HLC for deterministic ordering.
+function op(
+  author: string,
+  ms: number,
+  kind: Op["kind"],
+  body?: string,
+  ref?: string,
+  role: Role = "human",
+): Op {
+  return makeOp({ author, name: author, role, hlc: formatHlc(ms, 0, author), kind, body, ref });
+}
+
+describe("mergeOps", () => {
+  const a = op("a", 1, "msg", "one");
+  const b = op("b", 2, "msg", "two");
+  const c = op("c", 3, "msg", "three");
+
+  it("is a union deduped by id", () => {
+    const { merged, added } = mergeOps([a], [a, b]);
+    expect(merged.map((o) => o.id)).toEqual([a.id, b.id]);
+    expect(added.map((o) => o.id)).toEqual([b.id]); // only genuinely new
+  });
+
+  it("is commutative and idempotent (convergence)", () => {
+    const x = mergeOps(mergeOps([], [a, b]).merged, [c]).merged;
+    const y = mergeOps(mergeOps([], [c, b]).merged, [a]).merged;
+    expect(x.map((o) => o.id)).toEqual(y.map((o) => o.id));
+    // merging again adds nothing
+    expect(mergeOps(x, [a, b, c]).added).toEqual([]);
+  });
+
+  it("reports the running max HLC", () => {
+    expect(maxHlc([])).toBeNull();
+    expect(maxHlc([a, c, b])).toBe(c.hlc);
+  });
+
+  it("sorts by HLC then id", () => {
+    expect(sortOps([c, a, b]).map((o) => o.id)).toEqual([a.id, b.id, c.id]);
+  });
+
+  it("breaks a same-HLC tie deterministically by id", () => {
+    // two authors that collide on (ms, ctr) — the id (author@hlc) decides order
+    const x = makeOp({
+      author: "z",
+      name: "z",
+      role: "human",
+      hlc: formatHlc(9, 0, "z"),
+      kind: "msg",
+      body: "x",
+    });
+    const y = makeOp({
+      author: "a",
+      name: "a",
+      role: "human",
+      hlc: formatHlc(9, 0, "a"),
+      kind: "msg",
+      body: "y",
+    });
+    expect(sortOps([x, y]).map((o) => o.author)).toEqual(["a", "z"]);
+    expect(sortOps([y, x]).map((o) => o.author)).toEqual(["a", "z"]);
+  });
+});
+
+describe("renderThread", () => {
+  it("renders base messages in HLC order", () => {
+    const msgs = renderThread([op("b", 2, "msg", "two"), op("a", 1, "msg", "one")]);
+    expect(msgs.map((m) => m.text)).toEqual(["one", "two"]);
+  });
+
+  it("applies the latest edit (last-writer-wins)", () => {
+    const m = op("a", 1, "msg", "orig");
+    const e1 = op("a", 2, "edit", "v2", m.id);
+    const e2 = op("a", 3, "edit", "v3", m.id);
+    const [r] = renderThread([m, e2, e1]);
+    expect(r!.text).toBe("v3");
+    expect(r!.amendedHlc).toBe(e2.hlc);
+  });
+
+  it("hides a deleted message, and an edit after a delete revives it", () => {
+    const m = op("a", 1, "msg", "hi");
+    expect(renderThread([m, op("a", 2, "delete", undefined, m.id)])[0]!).toMatchObject({
+      deleted: true,
+      text: "",
+    });
+    // delete then a newer edit → revived
+    const revived = renderThread([
+      m,
+      op("a", 2, "delete", undefined, m.id),
+      op("a", 3, "edit", "back", m.id),
+    ])[0]!;
+    expect(revived).toMatchObject({ deleted: false, text: "back" });
+  });
+
+  it("groups reactions by emoji into distinct authors", () => {
+    const m = op("a", 1, "msg", "hi");
+    const r = renderThread([
+      m,
+      op("b", 2, "reaction", "👍", m.id),
+      op("c", 3, "reaction", "👍", m.id),
+      op("b", 4, "reaction", "👍", m.id), // duplicate author → deduped
+      op("b", 5, "reaction", "🎉", m.id),
+    ])[0]!;
+    expect(r.reactions).toEqual([
+      { emoji: "👍", by: ["b", "c"] },
+      { emoji: "🎉", by: ["b"] },
+    ]);
+  });
+
+  it("ignores amendments whose target op is absent", () => {
+    expect(renderThread([op("a", 2, "edit", "x", "missing@id")])).toEqual([]);
+  });
+
+  it("ignores a reaction with an empty body", () => {
+    const m = op("a", 1, "msg", "hi");
+    const [r] = renderThread([m, op("b", 2, "reaction", "", m.id)]);
+    expect(r!.reactions).toEqual([]);
+  });
+});
+
+describe("anti-entropy sync", () => {
+  const local = [op("a", 1, "msg", "a1"), op("a", 2, "msg", "a2"), op("b", 5, "msg", "b1")];
+
+  it("summarizes what a replica holds per author", () => {
+    expect(haveVector(local)).toEqual({ a: formatHlc(2, 0, "a"), b: formatHlc(5, 0, "b") });
+    // keeps the max even when an older op for an author appears after a newer one
+    const outOfOrder = [op("a", 2, "msg", "a2"), op("a", 1, "msg", "a1")];
+    expect(haveVector(outOfOrder)).toEqual({ a: formatHlc(2, 0, "a") });
+  });
+
+  it("computes exactly the ops a peer is missing", () => {
+    // peer has a up to ms=1 and nothing from b
+    const remoteHave = { a: formatHlc(1, 0, "a") };
+    const missing = opsMissing(local, remoteHave);
+    expect(missing.map((o) => o.body)).toEqual(["a2", "b1"]);
+  });
+
+  it("sends nothing when the peer is already caught up", () => {
+    expect(opsMissing(local, haveVector(local))).toEqual([]);
+  });
+});

--- a/ts/channels/store.ts
+++ b/ts/channels/store.ts
@@ -1,0 +1,170 @@
+// The channel CRDT — pure, isomorphic (Node + browser), storage-agnostic.
+//
+// A channel is a grow-only set of immutable ops (op.ts) keyed by `id`. Because
+// ids are content-independent-but-unique and the set only grows, MERGE is a
+// union and always converges: any two replicas that have exchanged the same ops
+// hold the same set regardless of arrival order (commutative, associative,
+// idempotent). Display order is the total order over `hlc`.
+//
+// Amendments (edit/delete/reaction) are folded per target message as
+// last-writer-wins by HLC, so the rendered thread is likewise a pure function of
+// the op set — every replica renders identically.
+//
+// This module never touches disk or network; backends (store.node.ts,
+// store.browser.ts) provide the ops, and peer.ts moves them between replicas.
+
+import { compareHlc, parseHlc } from "./hlc.ts";
+import type { Op, Role } from "./op.ts";
+
+/** Order ops by HLC (then id, for a fully deterministic tie-break). */
+export function sortOps(ops: Op[]): Op[] {
+  return [...ops].sort(
+    (a, b) => compareHlc(a.hlc, b.hlc) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+}
+
+/**
+ * Union `incoming` into `existing`, deduping by id. Returns the merged set
+ * (sorted) and the ops that were actually new — the backend appends `added`, and
+ * peer.ts rebroadcasts them. Idempotent: merging the same ops twice adds nothing.
+ */
+export function mergeOps(existing: Op[], incoming: Op[]): { merged: Op[]; added: Op[] } {
+  const byId = new Map<string, Op>();
+  for (const op of existing) byId.set(op.id, op);
+  const added: Op[] = [];
+  for (const op of incoming) {
+    if (byId.has(op.id)) continue;
+    byId.set(op.id, op);
+    added.push(op);
+  }
+  return { merged: sortOps([...byId.values()]), added };
+}
+
+/** The greatest HLC in the set (used to seed the next local send), or null if empty. */
+export function maxHlc(ops: Op[]): string | null {
+  let max: string | null = null;
+  for (const op of ops) if (max === null || compareHlc(op.hlc, max) > 0) max = op.hlc;
+  return max;
+}
+
+// --- rendered thread --------------------------------------------------------
+
+export interface Reaction {
+  /** The emoji/label. */
+  emoji: string;
+  /** Distinct author ids that reacted with it. */
+  by: string[];
+}
+
+/** A message as shown in the UI: a base `msg` op with amendments folded in. */
+export interface Message {
+  id: string;
+  author: string;
+  name: string;
+  role: Role;
+  /** Base op HLC — the thread sort key. */
+  hlc: string;
+  /** Current text (after the latest edit); empty when deleted. */
+  text: string;
+  /** True if a delete op is the latest amendment. */
+  deleted: boolean;
+  /** HLC of the latest edit/delete applied, if any. */
+  amendedHlc?: string;
+  reactions: Reaction[];
+  ms: number;
+}
+
+/**
+ * Fold an op set into the ordered list of messages. Pure function of the ops:
+ * for each `msg` op, its `edit`/`delete` amendments are applied in HLC order
+ * (last wins — an edit after a delete revives it, a delete after an edit hides
+ * it), and `reaction` ops are grouped by emoji into distinct authors.
+ */
+export function renderThread(ops: Op[]): Message[] {
+  const sorted = sortOps(ops);
+  const messages = new Map<string, Message>();
+
+  for (const op of sorted) {
+    if (op.kind !== "msg") continue;
+    messages.set(op.id, {
+      id: op.id,
+      author: op.author,
+      name: op.name,
+      role: op.role,
+      hlc: op.hlc,
+      text: op.body ?? "",
+      deleted: false,
+      reactions: [],
+      ms: parseHlc(op.hlc).ms,
+    });
+  }
+
+  // reactions grouped as emoji -> ordered distinct authors, per target message
+  const reactions = new Map<string, Map<string, string[]>>();
+
+  for (const op of sorted) {
+    if (!op.ref) continue;
+    const target = messages.get(op.ref);
+    if (!target) continue; // amendment for an op we don't (yet) have — ignore
+    if (op.kind === "edit") {
+      // amendments always sort after the base (author is causal); LWW by HLC
+      if (compareHlc(op.hlc, target.amendedHlc ?? target.hlc) > 0) {
+        target.text = op.body ?? "";
+        target.deleted = false;
+        target.amendedHlc = op.hlc;
+      }
+    } else if (op.kind === "delete") {
+      if (compareHlc(op.hlc, target.amendedHlc ?? target.hlc) > 0) {
+        target.text = "";
+        target.deleted = true;
+        target.amendedHlc = op.hlc;
+      }
+    } else if (op.kind === "reaction" && op.body) {
+      let group = reactions.get(op.ref);
+      if (!group) reactions.set(op.ref, (group = new Map()));
+      const authors = group.get(op.body) ?? [];
+      if (!authors.includes(op.author)) authors.push(op.author);
+      group.set(op.body, authors);
+    }
+  }
+
+  for (const [msgId, group] of reactions) {
+    const target = messages.get(msgId);
+    if (!target) continue;
+    target.reactions = [...group.entries()].map(([emoji, by]) => ({ emoji, by }));
+  }
+
+  return [...messages.values()].sort((a, b) => compareHlc(a.hlc, b.hlc));
+}
+
+// --- anti-entropy sync ------------------------------------------------------
+//
+// On each new peer connection the two sides exchange a compact per-author
+// summary of what they hold, then each sends the ops the other lacks. This is
+// why an intermittent / partial mesh still converges: a peer that was offline
+// receives the suffix it missed on reconnect.
+
+/** Per-author greatest HLC held — the compact "have" summary sent to a peer. */
+export function haveVector(ops: Op[]): Record<string, string> {
+  const have: Record<string, string> = {};
+  for (const op of ops) {
+    const cur = have[op.author];
+    if (cur === undefined || compareHlc(op.hlc, cur) > 0) have[op.author] = op.hlc;
+  }
+  return have;
+}
+
+/**
+ * The ops in `local` that a peer with summary `remoteHave` is missing: any op
+ * from an author the peer hasn't heard from, or newer than the peer's max for
+ * that author. Relies on an author's ops forming a contiguous HLC suffix on each
+ * replica (sync always transfers whole suffixes), which holds under this protocol.
+ */
+export function opsMissing(local: Op[], remoteHave: Record<string, string>): Op[] {
+  return sortOps(
+    local.filter((op) => {
+      const peerMax = remoteHave[op.author];
+      return peerMax === undefined || compareHlc(op.hlc, peerMax) > 0;
+    }),
+  );
+}

--- a/ts/share.ts
+++ b/ts/share.ts
@@ -103,7 +103,9 @@ function dcBufferedAmount(dc: any): number {
 // secret — but it means a share link also grants ~1h of Cloudflare TURN relay
 // capacity. Keep the TTL short; do not widen it.
 let iceCache: { servers: IceServer[]; exp: number } | null = null;
-async function getIceServers(): Promise<IceServer[]> {
+// Exported so the channels mesh peer (ts/channels/peer.ts) reuses the exact same
+// TURN-credential minting + STUN fallback rather than re-deriving it.
+export async function getIceServers(): Promise<IceServer[]> {
   const keyId = process.env.CF_TURN_KEY_ID;
   const apiToken = process.env.CF_TURN_API_TOKEN;
   if (!keyId || !apiToken) return STUN;
@@ -280,7 +282,9 @@ async function ensureAddon(ndDir: string): Promise<void> {
 // unproven under that live load, so it's not used; the proactive recycle + oxmgr
 // health watchdog remain the mitigation until node-datachannel ships libdatachannel
 // >0.24.2 (cf upstream #1538/#1548).
-async function importRTC(): Promise<any> {
+// Exported so the channels mesh peer reuses the exact same Bun/native-addon
+// loading dance (ensureAddon + linkFromBunCache) instead of re-solving it.
+export async function importRTC(): Promise<any> {
   // Ensure the native addon is on disk before the first import — a failed
   // dynamic import is cached by Bun, so post-import healing can't recover it.
   const ndDir = await ndPackageDir();

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -363,6 +363,8 @@ const SUBCOMMANDS = new Set([
   "restart",
   "note",
   "todo",
+  "ch",
+  "channels",
   "serve",
   "schedule",
   "remote",
@@ -478,6 +480,11 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       case "todo": {
         const { runTodoSubcommand } = await import("./todoCli.ts");
         return runTodoSubcommand(rest);
+      }
+      case "ch":
+      case "channels": {
+        const { cmdCh } = await import("./channels.ts");
+        return cmdCh(rest);
       }
       case "serve": {
         const { cmdServe } = await import("./serve.ts");
@@ -614,6 +621,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay head <keyword>                   first N lines\n` +
       `  ay send <keyword> <msg>             send a message (keyword '.' = agent in this cwd)\n` +
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
+      `  ay ch mk|join|send|read|tail <topic>  local-first E2E channels: AI ↔ humans on a topic (ay ch help)\n` +
       `  ay key <keyword> <key...>           send raw keystrokes (down/up/enter/esc/…) — drives menus\n` +
       `  ay select <keyword> <N>             pick option N of a needs_input selection menu\n` +
       `  ay attach <keyword>                 interactive attach (detach: Ctrl-\\)\n` +

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["./ts/cli.ts", "./ts/index.ts"],
+  // Object form so the browser channels lib emits as dist/channels.js (the
+  // `agent-yes/channels` subpath target), not dist/browser.js.
+  entry: {
+    cli: "./ts/cli.ts",
+    index: "./ts/index.ts",
+    channels: "./ts/channels/browser.ts",
+  },
   outDir: "dist",
   platform: "node",
   sourcemap: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -71,6 +71,14 @@ export default defineConfig({
         // `ay callback` CLI + store IO — thin shell over callbackCore.ts (which
         // IS covered); the mint path needs a live agent record and daemon URL.
         "ts/callback.ts",
+        // `ay ch` CLI shell — a thin dispatcher over the fully-covered channels
+        // core (ts/channels/*, unit-tested in ts/channels/*.spec.ts) plus a
+        // signal-driven `tail -f` follow loop and TTY/stderr branches that are
+        // integration-only (same rationale as callback.ts). Its happy paths are
+        // still exercised end-to-end in ts/channels.spec.ts.
+        "ts/channels.ts",
+        // Re-export barrel — no logic to cover (same rationale as ts/index.ts).
+        "ts/channels/index.ts",
         "ts/remotes.ts",
         // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
         // unit-testable.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,6 +79,11 @@ export default defineConfig({
         "ts/channels.ts",
         // Re-export barrel — no logic to cover (same rationale as ts/index.ts).
         "ts/channels/index.ts",
+        // Channels WebRTC mesh peer — needs a live signaling server + real
+        // DataChannel + node-datachannel native addon; proven via the mesh
+        // integration script, not unit-testable (same rationale as share.ts /
+        // webrtcRemote.ts). Its pure helpers (op/store/hlc) live in covered modules.
+        "ts/channels/peer.ts",
         "ts/remotes.ts",
         // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
         // unit-testable.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,6 +84,11 @@ export default defineConfig({
         // integration script, not unit-testable (same rationale as share.ts /
         // webrtcRemote.ts). Its pure helpers (op/store/hlc) live in covered modules.
         "ts/channels/peer.ts",
+        // Browser AyChannel client + floating widget — needs a DOM + real
+        // RTCPeerConnection + a live mesh; verified in a browser, not unit-testable
+        // (its store backend store.browser.ts IS covered, and it delegates all CRDT
+        // logic to the covered core). Same rationale as peer.ts.
+        "ts/channels/browser.ts",
         "ts/remotes.ts",
         // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
         // unit-testable.


### PR DESCRIPTION
Adds **`ay ch`** — local-first, end-to-end **channels** where AI agents and humans talk on a topic thread. **No server ever stores a message**: every participant (CLI or browser) keeps a full **CRDT replica**, and delivery is **peer-to-peer over WebRTC**, E2E-encrypted. Supersedes #309 (which was Phase 1 only; this PR contains all three phases).

## Try it

```bash
ay ch mk standup                       # create; prints an invite link
ay ch send standup "starting the build"
ay ch sync standup                     # hold the WebRTC mesh (live send/receive)
ay ch embed standup                    # HTML snippet: floating chat widget for any page
```
Browser: `import AyChannel from "agent-yes/channels"` → `new AyChannel(link).mount()`, or open `agent-yes.com/w/ch.html#ch=<room>:e1.<S>`.

## Design

- **Zero server storage.** The signaling Room DO stays a pure rendezvous; the secret `S` reuses the existing `e1.<64hex>` share-link model, so the topic never leaves the machine. Storage is `<cwd>/.agent-yes/ch-<id>.jsonl` (CLI) / LocalStorage (browser).
- **CRDT.** Text is immutable, so `id = author@hlc` is globally unique → a **grow-only set ordered by Hybrid Logical Clock**. Union merge is commutative/associative/idempotent (convergent); edit/delete/reaction fold LWW-by-HLC. On connect peers run **anti-entropy** (have-vector + diff); new ops gossip with dedup-by-id, so a partial/intermittent mesh still converges.
- **Mesh.** The Room DO gains a `mesh` mode (TOFU-pinned on open) that relays offer/answer/candidate between any two peers + broadcasts join/leave — the existing host↔client share path is byte-identical for non-mesh clients. One **isomorphic `ChannelPeer`** drives both sides (transport injected: node-datachannel+TURN on Node, native globals in the browser), reusing the E2E sealed frames + key-confirmation handshake from `e2e.js`.

## Verification

- **1165 unit tests pass**; coverage gate holds (branches 90.6%). oxlint clean, oxfmt applied, typecheck clean for new files.
- **Node↔Node mesh** proven over real loopback WebRTC (E2E handshake, anti-entropy catch-up, live broadcast all converge).
- **Real browser↔agent** proven with Chrome (rech) against a local mesh + a Node agent peer: **bidirectional** delivery both ways (agent→browser rendered; browser→agent reached the replica), confirmed-peer badge = 1.
- `worker.ts` compiles under `wrangler deploy --dry-run`; both runtimes rebuilt (`build:rs` — `rs/src/cli.rs` mirrors the new subcommand).

## Deploy note

The only piece needing a deploy is the `worker.ts` mesh mode (the signaling Worker). It is safe-by-construction: mesh is gated on a hello flag defaulting false, so existing share/star rooms are unaffected. Recommend a `wrangler dev` QA of a 3-peer mesh before/after the signaling deploy.

Files: `ts/channels/` (core + peer + browser lib), `ts/channels.ts` (CLI), `lab/ui/cf/worker.ts` (mesh), `lab/ui/ch.html`, `package.json`/`tsdown.config.ts` (exports), `rs/src/cli.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)