### PR TITLE
docs: add channels (ay ch / AyChannel) to the agent-yes skill + ship its types

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -80,6 +80,61 @@ await cliYes({
 });
 ```
 
+## Channels — AI ↔ Human Chat (`ay ch` / `AyChannel`)
+
+`agent-yes` includes **channels**: local-first, end-to-end encrypted threads where
+AI agents and humans talk on a topic, **peer-to-peer over WebRTC**. No server ever
+stores a message — every participant (CLI or browser) keeps a full CRDT replica, so
+concurrent messages merge automatically and offline peers catch up on reconnect.
+
+### When to use
+
+- Let a human talk to a running agent (or a fleet of agents) from a web page or another machine
+- Agent-to-agent coordination on a shared topic
+- A drop-in chat widget for any site, backed by your agents
+
+### CLI
+
+```bash
+ay ch mk standup                 # create a channel; prints an invite link
+ay ch join <invite-link>         # join from someone else's invite
+ay ch send standup "build is green"
+ay ch read standup               # print the thread (from the local replica)
+ay ch tail standup -f            # follow
+ay ch sync standup               # hold the WebRTC mesh: live send/receive (run backgrounded)
+ay ch pipe standup               # bridge stdin→send and inbound→stdout (script an agent into a channel)
+ay ch embed standup              # print an HTML snippet embedding a floating chat widget
+```
+
+Messages persist per project at `<cwd>/.agent-yes/ch-<id>.jsonl`. `send`/`read`/`tail`
+are pure-local; run `ay ch sync` (foreground or backgrounded) to actually deliver over
+the mesh — it coordinates through the replica file, so no daemon or IPC is needed.
+
+### Browser library
+
+```ts
+import AyChannel from "agent-yes/channels";
+
+const ch = new AyChannel("ay://ch/s.agent-yes.com/<room>#e1.<secret>");
+await ch.start();
+ch.on("message", async () => render(await ch.messages()));
+await ch.send("hi from the browser");
+
+ch.mount();          // floating chat window (Shadow DOM); or ch.mount(el) to embed in an element
+```
+
+The browser client joins the **same mesh** as any `ay ch sync` peer, persists to
+LocalStorage, and renders a self-contained floating widget — so an agent and a human
+can talk on the same page. For a no-bundler embed, `ay ch embed <topic>` prints a
+`<script type="module">` snippet that loads the widget from the console host.
+
+### Security
+
+The channel secret (carried in the invite link) **is** the membership credential:
+anyone who holds it can read and post. The signaling server only ever sees a one-way
+`HKDF(secret)` token — message contents and the AES keys never leave the endpoints.
+Only share an invite (or embed the widget) with an audience you mean to admit.
+
 ## Configuration Options
 
 - `--cli=<tool>`: Specify AI CLI tool (claude, gemini, codex, copilot, cursor, grok, qwen)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "examples",
     "scripts",
     "ts/*.ts",
+    "ts/channels/*.ts",
+    "!ts/channels/*.spec.ts",
     "!dist/**/*.map",
     "dist/**/*.js",
     "lab/ui/console-logic.js",


### PR DESCRIPTION
Follow-up to #310 (channels).

## What
- **SKILL.md**: adds a *Channels — AI ↔ Human Chat* section so agents/Claude discover the feature — the `ay ch` CLI (`mk/join/send/sync/pipe/embed/read/tail`) and the browser lib `import AyChannel from "agent-yes/channels"`, with a usage example and the secret=membership security note.
- **package.json `files`**: ships the `agent-yes/channels` type sources. The subpath's `types` entry (`ts/channels/browser.ts`) and its source dependency graph weren't shipped (the glob was `ts/*.ts` = top-level only), so consumers got the runtime (`dist/channels.js`) but **no types**. Adds `ts/channels/*.ts` (specs excluded), consistent with how the root export ships `ts/index.ts` as its types.

## Why
So the documented `import AyChannel from "agent-yes/channels"` actually resolves — types *and* runtime — for anyone who installs the package. Otherwise the skill would promise an import that gives TS users a "no declaration file" error.

## Verification
`npm pack --dry-run` confirms `dist/channels.js` + the `ts/channels/*.ts` type sources ship, and `*.spec.ts` under `ts/channels/` are excluded. Docs + packaging only — no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)