### PR TITLE
feat: ay ch bookmarklet — any page joins a channel by its URL

### DIFF
--- a/ts/channels.spec.ts
+++ b/ts/channels.spec.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildBookmarklet,
   cmdCh,
   defaultName,
   defaultRole,
@@ -143,6 +144,28 @@ describe("ay ch CLI (local-only)", () => {
     expect(resolved.entry).toBeTruthy();
     const linkResolved = await resolveChannel(await readRegistry(cwd), link);
     expect(linkResolved.entry).toBeNull();
+  });
+
+  it("mk --topic derives the same channel for the same topic string", async () => {
+    await capture(() => cmdCh(["mk", "a", "--topic", "https://example.com/p"]));
+    await capture(() => cmdCh(["mk", "b", "--topic", "https://example.com/p"]));
+    await capture(() => cmdCh(["mk", "c", "--topic", "https://example.com/other"]));
+    const reg = await readRegistry(cwd);
+    // same topic → same underlying channel; different topic → different channel
+    expect(reg.channels.a!.channelId).toBe(reg.channels.b!.channelId);
+    expect(reg.channels.c!.channelId).not.toBe(reg.channels.a!.channelId);
+  });
+
+  it("bookmarklet prints a javascript: URL that loads the widget by page topic", async () => {
+    const out = (await capture(() => cmdCh(["bookmarklet"]))).out;
+    expect(out).toMatch(/^javascript:/);
+    expect(out).toContain("AyChannel.fromTopic");
+    expect(out).toContain("agent-yes.com/w/channels.js");
+    // custom host/sighost flow through
+    const bm = buildBookmarklet("beta.example.dev", "sig.example.dev");
+    expect(bm).toContain("beta.example.dev/w/channels.js");
+    expect(bm).toContain("sig.example.dev");
+    expect(bm).toContain("location.href"); // default topic = full page URL
   });
 
   it("prints help for no subcommand and rejects unknown ones", async () => {

--- a/ts/channels.ts
+++ b/ts/channels.ts
@@ -41,6 +41,7 @@ import {
   maxHlc,
   parseChannelLink,
   renderThread,
+  secretFromTopic,
   type Message,
   type Role,
 } from "./channels/index.ts";
@@ -196,15 +197,25 @@ async function cmdChMk(cwd: string, args: string[]): Promise<number> {
     name: "value",
     role: "value",
     salt: "value",
+    topic: "value",
   });
   const topic = positional[0];
   if (!topic || positional.length > 1)
-    throw new Error("usage: ay ch mk <topic> [--sighost H] [--name N] [--role R] [--salt HEX]");
+    throw new Error(
+      "usage: ay ch mk <name> [--topic <string>] [--sighost H] [--name N] [--role R] [--salt HEX]",
+    );
   const reg = await readRegistry(cwd);
   if (reg.channels[topic])
     throw new Error(`channel "${topic}" already exists (ay ch rm ${topic} to replace)`);
 
-  const s = typeof flags.salt === "string" ? flags.salt : randomBytes(32).toString("hex");
+  // --topic derives a deterministic secret from a public string (e.g. a page URL)
+  // so this peer lands in the SAME channel a bookmarklet on that URL joins.
+  const s =
+    typeof flags.topic === "string"
+      ? await secretFromTopic(flags.topic)
+      : typeof flags.salt === "string"
+        ? flags.salt
+        : randomBytes(32).toString("hex");
   const [channelId, room] = await Promise.all([deriveChannelId(s), deriveRoom(s)]);
   const sighost = typeof flags.sighost === "string" ? flags.sighost : undefined;
   const entry: ChannelRegEntry = {
@@ -554,6 +565,38 @@ async function cmdChEmbed(cwd: string, args: string[]): Promise<number> {
   return 0;
 }
 
+/** The page bookmarklet: derive a channel from the page URL and mount the widget. */
+export function buildBookmarklet(host: string, sighost: string): string {
+  // One line, minimal, defensive: prompt for the topic (default = full URL incl.
+  // hash), remember the name, load the widget, and alert clearly if the page CSP
+  // blocks the cross-origin import (the expected failure on hardened sites).
+  return (
+    `javascript:(async()=>{try{` +
+    `const{AyChannel}=await import('https://${host}/w/channels.js');` +
+    `const t=prompt('ay channel — topic (same topic = same room):',location.href);if(!t)return;` +
+    `let n=localStorage.getItem('ay29ch-name');if(!n){n=prompt('Your name:','guest')||'guest';localStorage.setItem('ay29ch-name',n);}` +
+    `const ch=await AyChannel.fromTopic(t,{sighost:'${sighost}',name:n});` +
+    `ch.mount(document.body,{open:true});` +
+    `}catch(e){alert('ay channel could not load — this page\\'s CSP may block it (works on your own apps, localhost, blogs, docs).\\n'+(e&&e.message||e));}})()`
+  );
+}
+
+async function cmdChBookmarklet(_cwd: string, args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, { host: "value", sighost: "value" });
+  if (positional.length) throw new Error("usage: ay ch bookmarklet [--host H] [--sighost H]");
+  const host = typeof flags.host === "string" ? flags.host : "agent-yes.com";
+  const sighost = typeof flags.sighost === "string" ? flags.sighost : "s.agent-yes.com";
+  process.stdout.write(buildBookmarklet(host, sighost) + "\n");
+  process.stderr.write(
+    `\n  Make a new bookmark and paste the line above as its URL. Click it on any\n` +
+      `  page to drop an ay-channel chat window joined to that page's URL (edit the\n` +
+      `  prompt to change the topic). Same topic = same room, no invite needed.\n` +
+      `  Heads-up: strict site CSP (GitHub/Google/…) blocks it; it works on your own\n` +
+      `  apps, localhost, blogs, and docs.\n`,
+  );
+  return 0;
+}
+
 function chHelp(): number {
   process.stdout.write(
     `ay ch - local-first E2E channels for AI ↔ humans (per-cwd, no server storage)\n` +
@@ -569,7 +612,10 @@ function chHelp(): number {
       `  ay ch sync <topic> [--quiet]             hold the WebRTC mesh: live send/receive (Ctrl-C to stop)\n` +
       `  ay ch pipe <topic>                       sync + bridge stdin→send and inbound→stdout\n` +
       `  ay ch embed <topic> [--host H]           print an HTML snippet embedding a floating chat widget\n` +
+      `  ay ch bookmarklet [--host H]             print a bookmarklet: any page joins a channel by its URL\n` +
       `\n` +
+      `  URL-topic: 'ay ch mk <name> --topic <string>' derives the SAME channel a\n` +
+      `             bookmarklet on that URL joins (topic = public membership)\n` +
       `  identity: --name defaults to $AY_CH_NAME/OS user; --role to agent (in an agent) or human\n` +
       `  storage:  <cwd>/.agent-yes/ch-<id>.jsonl  (a full CRDT replica; cwd-scoped)\n` +
       `  live:     run 'ay ch sync <topic>' (foreground/backgrounded) to join the mesh; then\n` +
@@ -610,6 +656,8 @@ export async function cmdCh(args: string[]): Promise<number> {
       return cmdChPipe(cwd, rest);
     case "embed":
       return cmdChEmbed(cwd, rest);
+    case "bookmarklet":
+      return cmdChBookmarklet(cwd, rest);
     case undefined:
     case "help":
     case "--help":

--- a/ts/channels/browser.ts
+++ b/ts/channels/browser.ts
@@ -13,7 +13,7 @@
 //   ch.mount();                 // floating widget, or ch.mount(el) to embed
 //   await ch.send("hello");
 
-import { deriveChannelId, parseChannelLink } from "./link.ts";
+import { deriveChannelId, deriveRoom, parseChannelLink, secretFromTopic } from "./link.ts";
 import { hlcSend } from "./hlc.ts";
 import { makeOp, type Role } from "./op.ts";
 import { maxHlc, renderThread, type Message } from "./store.ts";
@@ -49,6 +49,21 @@ export class AyChannel {
   private listeners = new Map<Events, Set<(arg: any) => void>>();
   private started = false;
   private peers = 0;
+
+  /**
+   * Build a channel whose identity is DERIVED from a topic string (e.g. the page
+   * URL) — same topic ⇒ same room, no invite needed. Public to anyone with the
+   * topic (see secretFromTopic). This is what the page bookmarklet uses.
+   */
+  static async fromTopic(
+    topic: string,
+    opts?: { sighost?: string; name?: string; role?: Role },
+  ): Promise<AyChannel> {
+    const s = await secretFromTopic(topic);
+    const sighost = opts?.sighost ?? "s.agent-yes.com";
+    const room = await deriveRoom(s);
+    return new AyChannel({ room, sighost, s, name: opts?.name, role: opts?.role });
+  }
 
   constructor(info: string | AyChannelInfo) {
     const o = typeof info === "string" ? { link: info } : info;

--- a/ts/channels/link.spec.ts
+++ b/ts/channels/link.spec.ts
@@ -6,6 +6,7 @@ import {
   formatChannelWebLink,
   isChannelLink,
   parseChannelLink,
+  secretFromTopic,
 } from "./link.ts";
 
 const S = "a".repeat(64); // a valid 64-hex secret
@@ -23,6 +24,18 @@ describe("channel identity derivation", () => {
 
   it("rejects a non-hex secret before hashing", async () => {
     await expect(deriveChannelId("not-hex")).rejects.toThrow();
+  });
+
+  it("derives a deterministic, valid secret from a topic (same URL → same channel)", async () => {
+    const url = "https://example.com/docs/page";
+    const [a, b] = await Promise.all([secretFromTopic(url), secretFromTopic(url)]);
+    expect(a).toBe(b); // deterministic
+    expect(a).toMatch(/^[0-9a-f]{64}$/); // a valid S
+    // usable as a real secret end-to-end
+    await expect(deriveChannelId(a)).resolves.toMatch(/^[0-9a-f]{16}$/);
+    // distinct topics (incl. a differing hash) yield distinct channels
+    expect(await secretFromTopic(url + "#section")).not.toBe(a);
+    expect(await secretFromTopic("https://example.com/other")).not.toBe(a);
   });
 });
 

--- a/ts/channels/link.ts
+++ b/ts/channels/link.ts
@@ -35,6 +35,20 @@ export async function deriveRoom(s: string): Promise<string> {
   return "c" + (await sha256Hex(`ay/ch/room\n${validateS(s)}`)).slice(0, 12);
 }
 
+/**
+ * Deterministic channel secret from a public topic string (e.g. a page URL) —
+ * `sha256("ay/ch/topic/v1\n" + topic)`, a full 64-hex S. Everyone who derives
+ * from the SAME topic gets the SAME channel, so a page can "join by its URL" with
+ * no invite exchange (the bookmarklet + `ay ch mk --topic`).
+ *
+ * SECURITY: this makes the channel PUBLIC to anyone who knows the topic (topic =
+ * membership). Message contents still stay E2E from the signaling server, but it
+ * is NOT a private channel — use a random secret (the default) for those.
+ */
+export async function secretFromTopic(topic: string): Promise<string> {
+  return sha256Hex(`ay/ch/topic/v1\n${topic}`);
+}
+
 export interface ChannelLink {
   sighost: string;
   room: string;


### PR DESCRIPTION
Builds on the channels feature (#310). A page becomes a chat room keyed by its own URL.

## What
Run the bookmarklet on any page → it drops the AyChannel floating widget, joined to a channel **derived from the page URL**. Everyone who runs it on the same URL lands in the same room — no invite exchange.

- **`secretFromTopic(topic)`** (link.ts): deterministic `S = sha256("ay/ch/topic/v1\n"+topic)`. Same topic ⇒ same channel.
- **`AyChannel.fromTopic(topic, opts)`** (browser.ts): build a channel from a topic string.
- **`ay ch bookmarklet [--host H] [--sighost H]`**: prints the one-line `javascript:` URL. Prompts for the topic (default = full page URL incl. hash, editable), remembers the name, mounts the widget, alerts if the page CSP blocks it.
- **`ay ch mk <name> --topic <string>`**: derive the SAME channel a bookmarklet on that URL joins, so an agent can `ay ch sync` into a page's room.

## The CSP caveat (documented in the command output)
A bookmarklet runs in the **page's origin**, so a strict site CSP (GitHub, Google, most SaaS) blocks the cross-origin widget import + `wss` signaling. It works great on **your own apps, `localhost`, blogs, and docs**. Universal "any page" coverage would need a **browser extension** (content script in an isolated world, exempt from page CSP) — noted as future work.

Security: a URL-derived channel is **public to anyone who runs the bookmarklet on that URL** (topic = membership). Message contents still stay E2E from the signaling server — it's a public page-chat by design, not a private room.

## Verification
Real Chrome (rech): a page calling `AyChannel.fromTopic(url)` and a Node agent deriving the same channel via `secretFromTopic(url)` connect over the mesh and exchange messages (peer badge = 1, message received). `secretFromTopic` unit-tested (determinism + valid S); `buildBookmarklet` + `mk --topic` determinism covered. All 1168 tests pass; coverage gate holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)