### PR TITLE
feat: ay ch embed hardening — keep channel secrets out of deploy-bound files

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -125,15 +125,37 @@ ch.mount();          // floating chat window (Shadow DOM); or ch.mount(el) to em
 
 The browser client joins the **same mesh** as any `ay ch sync` peer, persists to
 LocalStorage, and renders a self-contained floating widget — so an agent and a human
-can talk on the same page. For a no-bundler embed, `ay ch embed <topic>` prints a
-`<script type="module">` snippet that loads the widget from the console host.
+can talk on the same page.
+
+### Embedding on a page (safely)
+
+`ay ch embed <topic>` prints a `<script type="module">` snippet (NOT an iframe, so a
+`frame-ancestors` CSP doesn't apply). It has three modes that trade off **where the
+channel secret lives** — this matters because a channel's invite link contains the
+secret, and the secret *is* read+write access:
+
+- **`--from-url`** (safest for a static/public page): the snippet derives the channel
+  from the page URL (`AyChannel.fromTopic(location.href)`) — **no secret is ever written
+  into the file**, so it can't leak through a committed or deployed file. Anyone who
+  opens the same URL joins (public-by-design page chat).
+- **`--placeholder`**: the snippet reads `window.AY_CH_LINK`, which you set at runtime
+  (server-rendered / env) — no secret in the file. Needs a runtime; **does not work on a
+  purely static host** (e.g. Cloudflare Pages) — use `--from-url` there.
+- **default** (live secret baked in): convenient for a private, non-committed page, but
+  **never** commit or deploy it — the secret is exposed to anyone who can read the source.
+
+Notes: `channels.js` must be reachable at `https://<host>/w/channels.js`; if it isn't
+deployed to the CDN yet, **self-host** the bundle (built at
+`lab/ui/cf/public/w/channels.js`), pass `--host <your-origin>`, and pin a version.
 
 ### Security
 
 The channel secret (carried in the invite link) **is** the membership credential:
 anyone who holds it can read and post. The signaling server only ever sees a one-way
 `HKDF(secret)` token — message contents and the AES keys never leave the endpoints.
-Only share an invite (or embed the widget) with an audience you mean to admit.
+Only share an invite (or embed the widget) with an audience you mean to admit, and
+**never put a live invite into a committed or deploy-bound file** — use `ay ch embed
+--from-url` (no secret in the file) or a random-secret channel you can abandon.
 
 ## Configuration Options
 

--- a/ts/channels.spec.ts
+++ b/ts/channels.spec.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildBookmarklet,
+  buildEmbedSnippet,
   cmdCh,
   defaultName,
   defaultRole,
@@ -65,7 +66,9 @@ describe("formatMessage", () => {
   });
   it("shows (deleted) and reaction counts", () => {
     expect(formatMessage({ ...base, deleted: true, text: "" })).toContain("(deleted)");
-    expect(formatMessage({ ...base, reactions: [{ emoji: "👍", by: ["a", "b"] }] })).toContain("👍2");
+    expect(formatMessage({ ...base, reactions: [{ emoji: "👍", by: ["a", "b"] }] })).toContain(
+      "👍2",
+    );
     expect(formatMessage({ ...base, reactions: [{ emoji: "🎉", by: ["a"] }] })).toContain("🎉");
   });
 });
@@ -166,6 +169,39 @@ describe("ay ch CLI (local-only)", () => {
     expect(bm).toContain("beta.example.dev/w/channels.js");
     expect(bm).toContain("sig.example.dev");
     expect(bm).toContain("location.href"); // default topic = full page URL
+  });
+
+  it("embed modes trade off where the secret lives", async () => {
+    await capture(() => cmdCh(["mk", "pub"]));
+    // default (live): the secret IS in the file
+    expect((await capture(() => cmdCh(["embed", "pub"]))).out).toContain("e1.");
+    // --placeholder: no secret; runtime-injected global
+    const ph = (await capture(() => cmdCh(["embed", "pub", "--placeholder"]))).out;
+    expect(ph).not.toContain("e1.");
+    expect(ph).toContain("window.AY_CH_LINK");
+    // --from-url: no secret; derived from the page URL (safe for static pages)
+    const fu = (await capture(() => cmdCh(["embed", "pub", "--from-url"]))).out;
+    expect(fu).not.toContain("e1.");
+    expect(fu).toContain("AyChannel.fromTopic(location.href)");
+    // the two secret-less modes are mutually exclusive
+    await expect(cmdCh(["embed", "pub", "--from-url", "--placeholder"])).rejects.toThrow(
+      /mutually/,
+    );
+  });
+
+  it("buildEmbedSnippet: always a <script> (never an iframe), across modes", () => {
+    const live = buildEmbedSnippet("agent-yes.com", "t", {
+      kind: "live",
+      link: "ay://ch/h/r#e1.dead",
+    });
+    expect(live).toContain("<script");
+    expect(live).not.toContain("<iframe");
+    expect(live).toContain("ay://ch/h/r#e1.dead");
+    const fu = buildEmbedSnippet("self.example", "t", { kind: "from-url" });
+    expect(fu).toContain("self.example/w/channels.js");
+    expect(fu).toContain("fromTopic(location.href)");
+    expect(fu).not.toContain("e1.");
+    expect(buildEmbedSnippet("h", "t", { kind: "placeholder" })).toContain("window.AY_CH_LINK");
   });
 
   it("prints help for no subcommand and rejects unknown ones", async () => {

--- a/ts/channels.ts
+++ b/ts/channels.ts
@@ -541,26 +541,94 @@ async function cmdChPipe(cwd: string, args: string[]): Promise<number> {
   return 0;
 }
 
+export type EmbedMode =
+  | { kind: "live"; link: string } // the invite (with secret) is baked into the file
+  | { kind: "placeholder" } // page injects window.AY_CH_LINK at runtime (server-rendered)
+  | { kind: "from-url" }; // channel derived from the page URL — NO secret in the file
+
+/**
+ * The embed `<script>` snippet — a script (NOT an iframe) that loads the AyChannel
+ * browser lib and mounts the floating widget in the page, so the console's
+ * `frame-ancestors` CSP is irrelevant. Three modes trade off where the secret lives:
+ * baked in (`live`), injected at runtime (`placeholder`), or never present because
+ * the channel is derived from the (public) page URL (`from-url`) — the last is the
+ * safe default for a STATIC public page, since no token ever lands in the file.
+ */
+export function buildEmbedSnippet(host: string, topic: string, mode: EmbedMode): string {
+  const imp = `  import AyChannel from "https://${host}/w/channels.js";\n`;
+  if (mode.kind === "from-url") {
+    return (
+      `<!-- ay channel: ${topic} — channel derived from the page URL; no secret in this file -->\n` +
+      `<script type="module">\n${imp}` +
+      `  AyChannel.fromTopic(location.href).then((c) => c.mount());\n` +
+      `</script>\n`
+    );
+  }
+  if (mode.kind === "placeholder") {
+    return (
+      `<!-- ay channel: ${topic} — set window.AY_CH_LINK to the invite at runtime; do NOT commit the secret -->\n` +
+      `<script type="module">\n${imp}` +
+      `  new AyChannel(window.AY_CH_LINK).mount();\n` +
+      `</script>\n`
+    );
+  }
+  return (
+    `<!-- ay channel: ${topic} — this snippet contains a LIVE secret; anyone who reads it can join -->\n` +
+    `<script type="module">\n${imp}` +
+    `  new AyChannel(${JSON.stringify(mode.link)}).mount();\n` +
+    `</script>\n`
+  );
+}
+
 async function cmdChEmbed(cwd: string, args: string[]): Promise<number> {
-  const { flags, positional } = parseFlags(args, { host: "value" });
+  const { flags, positional } = parseFlags(args, {
+    host: "value",
+    placeholder: "bool",
+    "from-url": "bool",
+  });
   const topic = positional[0];
   if (!topic || positional.length > 1)
-    throw new Error("usage: ay ch embed <topic> [--host <console-host>]");
+    throw new Error("usage: ay ch embed <topic> [--host H] [--placeholder | --from-url]");
+  if (flags.placeholder && flags["from-url"])
+    throw new Error("--placeholder and --from-url are mutually exclusive");
   const reg = await readRegistry(cwd);
   const { entry } = await resolveChannel(reg, topic);
   if (!entry) throw new Error(`join "${topic}" before embedding: ay ch join <link>`);
-  const consoleHost = typeof flags.host === "string" ? flags.host : "agent-yes.com";
-  const link = formatChannelLink({ sighost: entry.sighost, room: entry.room, s: entry.s });
-  // A self-contained snippet: loads the AyChannel browser lib and mounts the
-  // floating chat widget. Anyone who can read the page source holds the secret S
-  // and can therefore join — that IS the channel's membership model (secret =
-  // access), so only embed on a page whose audience you mean to let in.
-  process.stdout.write(
-    `<!-- ay channel: ${topic} — anyone who can read this snippet can join -->\n` +
-      `<script type="module">\n` +
-      `  import AyChannel from "https://${consoleHost}/w/channels.js";\n` +
-      `  new AyChannel(${JSON.stringify(link)}).mount();\n` +
-      `</script>\n`,
+  const host = typeof flags.host === "string" ? flags.host : "agent-yes.com";
+  const invite = formatChannelLink({ sighost: entry.sighost, room: entry.room, s: entry.s });
+  const mode: EmbedMode = flags["from-url"]
+    ? { kind: "from-url" }
+    : flags.placeholder
+      ? { kind: "placeholder" }
+      : { kind: "live", link: invite };
+
+  // stdout: only the snippet (safe to pipe/paste). stderr: the guidance.
+  process.stdout.write(buildEmbedSnippet(host, topic, mode));
+
+  if (mode.kind === "from-url") {
+    process.stderr.write(
+      `\n  URL-derived: no secret in the snippet — the channel is computed from the page URL,\n` +
+        `  so a committed/static file carries no token (ideal for static public pages like\n` +
+        `  Cloudflare Pages). Anyone who opens the same URL joins — that IS the membership.\n`,
+    );
+  } else if (mode.kind === "placeholder") {
+    process.stderr.write(
+      `\n  Placeholder: the invite is NOT in the snippet — set window.AY_CH_LINK at runtime\n` +
+        `  (server-rendered / env), so a committed file carries no secret. This needs a\n` +
+        `  runtime; on a STATIC host use --from-url instead. Invite to inject: ${invite}\n`,
+    );
+  } else {
+    process.stderr.write(
+      `\n  ⚠ This snippet embeds a LIVE channel secret (read+write). Anyone who can read the\n` +
+        `    page source can join. Do NOT commit it to a public or deploy-bound file. For a\n` +
+        `    static public page use --from-url (no secret in the file); for a server-rendered\n` +
+        `    page use --placeholder. Prefer a dedicated random-secret channel you can abandon.\n`,
+    );
+  }
+  process.stderr.write(
+    `  channels.js must load from https://${host}/w/channels.js — if it 404s (not yet on the\n` +
+      `  CDN), self-host the bundle (lab/ui/cf/public/w/channels.js) and pass --host <origin>,\n` +
+      `  pinning a version. The embed is a <script>, not an iframe.\n`,
   );
   return 0;
 }
@@ -611,7 +679,8 @@ function chHelp(): number {
       `  ay ch tail <topic> [-n N] [-f]           last N (96), -f to follow\n` +
       `  ay ch sync <topic> [--quiet]             hold the WebRTC mesh: live send/receive (Ctrl-C to stop)\n` +
       `  ay ch pipe <topic>                       sync + bridge stdin→send and inbound→stdout\n` +
-      `  ay ch embed <topic> [--host H]           print an HTML snippet embedding a floating chat widget\n` +
+      `  ay ch embed <topic> [--host H] [--from-url|--placeholder]  HTML snippet for a chat widget\n` +
+      `                                           (--from-url keeps NO secret in the file — best for static pages)\n` +
       `  ay ch bookmarklet [--host H]             print a bookmarklet: any page joins a channel by its URL\n` +
       `\n` +
       `  URL-topic: 'ay ch mk <name> --topic <string>' derives the SAME channel a\n` +


### PR DESCRIPTION
Prompted by real cross-repo feedback: a live `ay ch` channel invite got embedded in a static report page that deploys the working tree, exposing the secret on a semi-public URL. A channel invite contains the secret, and the secret **is** read+write access — so `ay ch embed` handing one out by default is a footgun for committed/deployed files.

## `ay ch embed` now has three modes
- **`--from-url`** — snippet derives the channel from the page URL (`AyChannel.fromTopic(location.href)`); **no secret ever written into the file**. Safe default for a static/public page (e.g. Cloudflare Pages) — can't leak via a committed/deployed file. Anyone on the same URL joins (public-by-design chat).
- **`--placeholder`** — snippet reads `window.AY_CH_LINK` injected at runtime (server-rendered/env); no secret in the file, but needs a runtime (**not** a purely static host — use `--from-url` there).
- **default** — live secret baked in; convenient for a private non-committed page, with a loud stderr warning to never commit/deploy it.

All guidance goes to **stderr**; stdout is only the snippet (safe to pipe). The embed is a `<script>` (not an iframe), so the console's `frame-ancestors` CSP is irrelevant; stderr also notes the self-host + version-pin path when `channels.js` isn't on the CDN. `SKILL.md` gains an "Embedding on a page (safely)" section.

## Verification
`buildEmbedSnippet` unit-tested across modes (live carries the secret; placeholder + from-url do not; mutual-exclusion enforced), plus a CLI mode test. All 1170 tests pass; coverage gate holds. oxlint/oxfmt/typecheck clean.

Follow-up context: the exposed channel is rotated on the owner side (abandon + fresh `ay ch mk`), and the widget is re-enabled with `--from-url` (no token in the file) — the general safe pattern for a public page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
