### PR TITLE
feat: deprecate agent-run --cwd with a `cd <dir> && …` migration hint

### DIFF
--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -267,7 +267,7 @@ struct Args {
     #[arg(short = 'y', long = "yes", default_value = "false")]
     yes: bool,
 
-    /// Working directory for the agent (default: current directory)
+    /// Deprecated: working directory for the agent. Prefer `cd <dir> && <command>`.
     #[arg(long)]
     cwd: Option<String>,
 

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -45,6 +45,88 @@ fn detect_install_method() -> &'static str {
     "binary"
 }
 
+/// Quote one argv token for display in a copy-pasteable shell command. Leaves
+/// shell-safe tokens (including a leading `~`/`~/path`, so `cd ~/foo` still
+/// expands) bare; single-quotes anything else. Mirrors `shellDisplayQuote` in
+/// ts/cwdDeprecation.ts.
+fn shell_display_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    let safe = s.chars().all(|c| {
+        c.is_ascii_alphanumeric() || "_@%+=:,./~-".contains(c)
+    });
+    if safe {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+/// Build the `--cwd` deprecation warning from a program name and its user args
+/// (everything after argv[0]). Strips `--cwd <dir>` / `--cwd=<dir>` and rebuilds
+/// the copy-pasteable `cd <dir> && <same command>` hint. Pure so it can be unit
+/// tested. Mirrors detectCwdDeprecation in ts/cwdDeprecation.ts.
+fn build_cwd_migration(prog: &str, user_args: &[String]) -> String {
+    let mut dir: Option<String> = None;
+    let mut rest: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < user_args.len() {
+        let arg = &user_args[i];
+        if arg == "--cwd" {
+            // `--cwd DIR` — consume the value unless the next token is a flag.
+            if let Some(next) = user_args.get(i + 1) {
+                if !next.starts_with('-') {
+                    dir = Some(next.clone());
+                    i += 2;
+                    continue;
+                }
+            }
+            i += 1;
+            continue;
+        }
+        if let Some(v) = arg.strip_prefix("--cwd=") {
+            dir = Some(v.to_string());
+            i += 1;
+            continue;
+        }
+        rest.push(arg.clone());
+        i += 1;
+    }
+
+    let mut cmd = shell_display_quote(prog);
+    for a in &rest {
+        cmd.push(' ');
+        cmd.push_str(&shell_display_quote(a));
+    }
+    // `<dir>` is a placeholder shown when the flag had no value — keep it bare.
+    let dir_disp = match dir {
+        Some(ref d) => shell_display_quote(d),
+        None => "<dir>".to_string(),
+    };
+    format!(
+        "\x1b[33m⚠ --cwd is deprecated.\x1b[0m Run the command in the target directory instead:\n\n    cd {dir_disp} && {cmd}"
+    )
+}
+
+/// `--cwd <dir>` on an agent run is deprecated: `cd <dir> && <same command>`
+/// does the same thing without an agent-yes-specific flag. Print the migration
+/// hint before continuing (the flag still works). The JS launcher prints its own
+/// (more faithful, it knows the `cy`/`ay` name the user typed) copy and sets
+/// AGENT_YES_SUPPRESS_CWD_WARN so this mirror only fires on a direct
+/// `agent-yes … --cwd` invocation that bypassed the launcher.
+fn warn_cwd_deprecated() {
+    if std::env::var_os("AGENT_YES_SUPPRESS_CWD_WARN").is_some() {
+        return;
+    }
+    let raw: Vec<String> = std::env::args().collect();
+    let prog = raw
+        .first()
+        .map(|p| p.rsplit(['/', '\\']).next().unwrap_or(p.as_str()).to_string())
+        .unwrap_or_else(|| "agent-yes".to_string());
+    eprintln!("{}", build_cwd_migration(&prog, &raw[1..]));
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Delegate management subcommands (ls/send/restart/stop/serve/…) to the JS
@@ -72,6 +154,7 @@ async fn main() -> Result<()> {
     // Canonicalise to an absolute path so downstream consumers (pid_store, lock keys,
     // webhooks) see a stable identifier regardless of how the user typed it.
     let cwd = if let Some(ref requested) = args.cwd {
+        warn_cwd_deprecated();
         // Expand leading `~` / `~/` because shells (zsh, bash) do NOT expand a tilde
         // that appears after `=` (e.g. `--cwd=~/foo` arrives literally). Only the
         // user's own `~` is supported; `~user` is not.
@@ -606,4 +689,50 @@ async fn run_swarm_mode(args: CliArgs, cwd: &str) -> Result<i32> {
     }
 
     Ok(0)
+}
+
+#[cfg(test)]
+mod cwd_deprecation_tests {
+    use super::{build_cwd_migration, shell_display_quote};
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn quotes_only_when_needed() {
+        assert_eq!(shell_display_quote("/ws/app"), "/ws/app");
+        assert_eq!(shell_display_quote("~/ws/product"), "~/ws/product");
+        assert_eq!(shell_display_quote(""), "''");
+        assert_eq!(shell_display_quote("a b"), "'a b'");
+        assert_eq!(shell_display_quote("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn strips_cwd_space_form() {
+        let msg = build_cwd_migration(
+            "agent-yes",
+            &args(&["--cli", "claude", "--cwd", "/ws/app", "-p", "fix"]),
+        );
+        assert!(msg.contains("cd /ws/app && agent-yes --cli claude -p fix"), "{msg}");
+        assert!(msg.contains("--cwd is deprecated"));
+    }
+
+    #[test]
+    fn strips_cwd_equals_form() {
+        let msg = build_cwd_migration("agent-yes", &args(&["--cwd=/tmp/x", "codex"]));
+        assert!(msg.contains("cd /tmp/x && agent-yes codex"), "{msg}");
+    }
+
+    #[test]
+    fn keeps_home_relative_dir_bare() {
+        let msg = build_cwd_migration("agent-yes", &args(&["--cwd", "~/ws/product"]));
+        assert!(msg.contains("cd ~/ws/product && agent-yes"), "{msg}");
+    }
+
+    #[test]
+    fn placeholder_when_value_missing() {
+        let msg = build_cwd_migration("agent-yes", &args(&["--cli", "claude", "--cwd"]));
+        assert!(msg.contains("cd <dir> && agent-yes --cli claude"), "{msg}");
+    }
 }

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -39,6 +39,20 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   }
 }
 
+// Deprecation: `--cwd <dir>` on an agent run. Runs AFTER the subcommand fast
+// path above, so subcommand `--cwd` FILTERS (ay ls/status/spawn/schedule) are
+// untouched — only a real agent launch reaches here. Warn once, then continue
+// (the flag still works); suppress the Rust runner's mirror of this warning so
+// it isn't printed twice when we spawn the Rust binary below.
+{
+  const { detectCwdDeprecation, SUPPRESS_CWD_WARN_ENV } = await import("./cwdDeprecation.ts");
+  const dep = detectCwdDeprecation(process.argv);
+  if (dep) {
+    console.warn(dep.message);
+    process.env[SUPPRESS_CWD_WARN_ENV] = "1";
+  }
+}
+
 // Check for updates before starting — installs & re-execs if a newer version exists.
 // Fast path: cached result (no network), so this adds near-zero latency most of the time.
 await checkAndAutoUpdate();

--- a/ts/cwdDeprecation.spec.ts
+++ b/ts/cwdDeprecation.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { detectCwdDeprecation } from "./cwdDeprecation.ts";
+
+// argv shape is [exec, script, ...userArgs]; the script's basename is the
+// program name the user typed (cy/ay/claude-yes/…).
+const argv = (script: string, ...user: string[]) => ["/usr/bin/bun", script, ...user];
+
+describe("detectCwdDeprecation", () => {
+  it("returns null when --cwd is absent", () => {
+    expect(detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "-p", "hi"))).toBeNull();
+  });
+
+  it("detects `--cwd DIR` and rebuilds the command without it", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--cwd", "/ws/app", "-p", "fix"));
+    expect(dep).not.toBeNull();
+    expect(dep!.dir).toBe("/ws/app");
+    expect(dep!.suggestion).toBe("cd /ws/app && cy claude -p fix");
+  });
+
+  it("detects `--cwd=DIR` form", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/agent-yes.js", "codex", "--cwd=/tmp/x"));
+    expect(dep!.dir).toBe("/tmp/x");
+    expect(dep!.suggestion).toBe("cd /tmp/x && agent-yes codex");
+  });
+
+  it("keeps a home-relative dir bare so the shell still expands ~", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "~/ws/product"));
+    expect(dep!.suggestion).toBe("cd ~/ws/product && cy");
+  });
+
+  it("preserves the prompt after `--` and quotes tokens with spaces", () => {
+    // The shell splits `-- solve all todos` into one argv token per word.
+    const dep = detectCwdDeprecation(
+      argv("/x/dist/claude-yes.js", "--cwd", "/ws/app", "--", "solve", "all", "todos"),
+    );
+    // A single already-quoted token keeping its space is re-quoted for display.
+    const dep2 = detectCwdDeprecation(
+      argv("/x/dist/claude-yes.js", "--cwd", "/ws/app", "--", "a b"),
+    );
+    expect(dep!.suggestion).toBe("cd /ws/app && claude-yes -- solve all todos");
+    expect(dep2!.suggestion).toBe("cd /ws/app && claude-yes -- 'a b'");
+  });
+
+  it("quotes a dir containing spaces", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/my ws/app"));
+    expect(dep!.suggestion).toBe("cd '/my ws/app' && cy");
+  });
+
+  it("handles `--cwd` given as the last token with no value", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--cwd"));
+    expect(dep).not.toBeNull();
+    expect(dep!.dir).toBeUndefined();
+    expect(dep!.suggestion).toBe("cd <dir> && cy claude");
+  });
+
+  it("includes the deprecation notice in the message", () => {
+    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/ws"));
+    expect(dep!.message).toContain("--cwd is deprecated");
+    expect(dep!.message).toContain("cd /ws && cy");
+  });
+});

--- a/ts/cwdDeprecation.ts
+++ b/ts/cwdDeprecation.ts
@@ -1,0 +1,92 @@
+/**
+ * `--cwd <dir>` on an agent run is deprecated.
+ *
+ * It used to pick the directory the agent runs in. The shell already does this
+ * better: `cd <dir> && <same command>` puts the agent AND every relative path in
+ * the command in the same place, with no agent-yes-specific flag to remember.
+ * This module detects the flag on a raw argv and builds the copy-pasteable
+ * migration hint we print before continuing (the flag still works for now).
+ *
+ * Scope: the agent-run path only (ts/cli.ts). Management subcommands that take a
+ * `--cwd` FILTER (`ay ls/status/spawn/schedule …`) are a different flag and are
+ * not deprecated — they never reach this code because subcommands are dispatched
+ * earlier. The Rust runner mirrors this warning in rs/src/main.rs for direct
+ * `agent-yes` invocations that bypass this launcher.
+ */
+
+/** Env var the JS launcher sets on the spawned Rust child so the warning, once
+ * printed here, is not printed a second time by the Rust runner. Mirrored in
+ * rs/src/main.rs. */
+export const SUPPRESS_CWD_WARN_ENV = "AGENT_YES_SUPPRESS_CWD_WARN";
+
+export interface CwdDeprecation {
+  /** The directory value the user passed to --cwd (undefined if the flag had no value). */
+  dir: string | undefined;
+  /** The suggested replacement command line, e.g. `cd ~/foo && cy claude -- fix`. */
+  suggestion: string;
+  /** Colorized, multi-line warning ready to write to stderr (no trailing newline). */
+  message: string;
+}
+
+/**
+ * Quote a single argv token for display in a copy-pasteable shell command.
+ * Leaves shell-safe tokens (including a leading `~`/`~/path`, so `cd ~/foo`
+ * still expands) bare; single-quotes anything else.
+ */
+function shellDisplayQuote(s: string): string {
+  if (s === "") return "''";
+  // Safe unquoted: word chars and the handful of path/opt punctuation that carry
+  // no shell meaning here. `~` included so a home-relative dir keeps expanding.
+  if (/^[A-Za-z0-9_@%+=:,./~-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Program name as the user typed it, derived from argv[1] (the launched script). */
+function programName(scriptPath: string | undefined): string {
+  if (!scriptPath) return "agent-yes";
+  const base = scriptPath.split(/[\\/]/).pop() || scriptPath;
+  return base.replace(/\.(js|ts|mjs|cjs)$/, "");
+}
+
+/**
+ * Detect a deprecated `--cwd <dir>` / `--cwd=<dir>` flag on a full process.argv
+ * (`[exec, script, ...userArgs]`). Returns the migration hint, or null when no
+ * `--cwd` flag is present.
+ */
+export function detectCwdDeprecation(argv: string[]): CwdDeprecation | null {
+  const prog = programName(argv[1]);
+  const userArgs = argv.slice(2);
+
+  let sawCwd = false;
+  let dir: string | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < userArgs.length; i++) {
+    const arg = userArgs[i]!;
+    if (arg === "--cwd") {
+      sawCwd = true;
+      const next = userArgs[i + 1];
+      // `--cwd DIR` — consume the value; a following flag means the value is missing.
+      if (next !== undefined && !next.startsWith("-")) {
+        dir = next;
+        i++;
+      }
+      continue;
+    }
+    if (arg.startsWith("--cwd=")) {
+      sawCwd = true;
+      dir = arg.slice("--cwd=".length);
+      continue;
+    }
+    rest.push(arg);
+  }
+  if (!sawCwd) return null;
+
+  const cmd = [prog, ...rest].map(shellDisplayQuote).join(" ");
+  // `<dir>` is a placeholder shown when the flag had no value — keep it bare.
+  const dirDisplay = dir === undefined ? "<dir>" : shellDisplayQuote(dir);
+  const suggestion = `cd ${dirDisplay} && ${cmd}`;
+  const message =
+    `\x1b[33m⚠ --cwd is deprecated.\x1b[0m Run the command in the target directory instead:\n\n` +
+    `    ${suggestion}`;
+  return { dir, suggestion, message };
+}


### PR DESCRIPTION
Deprecates the **agent-run** `--cwd <dir>` flag. It still works, but prints a copy-pasteable migration hint before continuing:

```
⚠ --cwd is deprecated. Run the command in the target directory instead:

    cd <dir> && <same command you typed, without --cwd>
```

Clean re-cut of #299 onto current `main` (that PR had accidentally carried the unrelated `ay todo Milestone 1` base commit). Contents identical.

## How (both runtimes — Rust default, TS fallback)
- **`ts/cwdDeprecation.ts`** (new): pure `detectCwdDeprecation(argv)` strips `--cwd <dir>`/`--cwd=<dir>` and rebuilds the command from the real program name (`cy`/`ay`/`claude-yes`) with shell-safe quoting that keeps `~/foo` bare.
- **`ts/cli.ts`**: warns once on the agent-run path (after subcommand dispatch, so filter `--cwd` on `ls/status/spawn/schedule` is untouched) and sets `AGENT_YES_SUPPRESS_CWD_WARN` so the spawned Rust child doesn't double-print.
- **`rs/src/main.rs`**: mirrored `warn_cwd_deprecated()` for direct `agent-yes` invocations; honours the suppress env.
- **`rs/src/cli.rs`**: clap `--help` marks `--cwd` deprecated.

## Scope
Only the agent-run `--cwd` is deprecated; the subcommand filter `--cwd` and oxmgr's `--cwd` in `ay schedule` are unaffected.

## Tests
8 new TS specs + 5 new Rust unit tests; existing `--cwd` integration tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)