### PR TITLE
feat(ay term): live agent terminal widget (embed + scoped tokens + polish) & /w CORS

### DIFF
--- a/lab/ui/cf/_headers
+++ b/lab/ui/cf/_headers
@@ -11,12 +11,16 @@
 /*
   Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; worker-src 'self'; manifest-src 'self'
 
-# The channel widget bundle is designed to be imported cross-origin from any page
-# (`import AyChannel from "https://agent-yes.com/w/channels.js"` — the ay ch embed
-# snippet). A cross-origin `type=module` import is CORS-gated, so the bundle MUST
-# advertise CORS or every embed fails to load. It's public, credential-free JS, so
-# `*` is correct; CORP:cross-origin lets it also load under a strict COEP embedder.
+# The widget bundles (channels.js / terminal.js) are designed to be imported
+# cross-origin from any page (e.g. `import AyChannel from
+# "https://agent-yes.com/w/channels.js"` — the ay ch/term embed snippets). A
+# cross-origin `type=module` import is CORS-gated, so the bundle MUST advertise
+# CORS or every embed fails to load. They're public, credential-free JS, so `*` is
+# correct; CORP:cross-origin lets them also load under a strict COEP embedder.
 # Different header names from /* still apply, so the CSP above is unaffected.
 /w/channels.js
+  Access-Control-Allow-Origin: *
+  Cross-Origin-Resource-Policy: cross-origin
+/w/terminal.js
   Access-Control-Allow-Origin: *
   Cross-Origin-Resource-Policy: cross-origin

--- a/lab/ui/cf/_headers
+++ b/lab/ui/cf/_headers
@@ -10,3 +10,13 @@
 # keeps working.
 /*
   Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; worker-src 'self'; manifest-src 'self'
+
+# The channel widget bundle is designed to be imported cross-origin from any page
+# (`import AyChannel from "https://agent-yes.com/w/channels.js"` — the ay ch embed
+# snippet). A cross-origin `type=module` import is CORS-gated, so the bundle MUST
+# advertise CORS or every embed fails to load. It's public, credential-free JS, so
+# `*` is correct; CORP:cross-origin lets it also load under a strict COEP embedder.
+# Different header names from /* still apply, so the CSP above is unaffected.
+/w/channels.js
+  Access-Control-Allow-Origin: *
+  Cross-Origin-Resource-Policy: cross-origin

--- a/lab/ui/cf/build-assets.sh
+++ b/lab/ui/cf/build-assets.sh
@@ -49,6 +49,11 @@ fi
 # and third-party embeds load. Built with bun (browser target) independent of the
 # npm dist build, so it exists even in a bare `wrangler dev` / beta Pages deploy.
 bun build ../../../ts/channels/browser.ts --outfile ./public/w/channels.js --format esm --target browser --minify
+# Terminal widget: bundle the browser AyTerminal lib (`import AyTerminal from
+# "agent-yes/terminal"`) — a self-contained ESM (xterm.js inlined) that any page
+# loads to render a live read-only agent terminal (ay term embed). Same browser
+# target + independence from the npm dist build as channels.js above.
+bun build ../../../ts/terminal/browser.ts --outfile ./public/w/terminal.js --format esm --target browser --minify
 
 cp _headers ./public/_headers
 bun ../../../scripts/build-rgui.ts ./public/r

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
   },
   "devDependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "ts/*.ts",
     "ts/channels/*.ts",
     "!ts/channels/*.spec.ts",
+    "ts/terminal/*.ts",
+    "!ts/terminal/*.spec.ts",
     "!dist/**/*.map",
     "dist/**/*.js",
     "lab/ui/console-logic.js",
@@ -87,6 +89,14 @@
     "./channels": {
       "types": "./ts/channels/browser.ts",
       "import": "./dist/channels.js"
+    },
+    "./terminal": {
+      "types": "./ts/terminal/browser.ts",
+      "import": "./dist/terminal.js"
+    },
+    "./widgets": {
+      "types": "./ts/widgets.ts",
+      "import": "./dist/widgets.js"
     }
   },
   "publishConfig": {
@@ -134,6 +144,7 @@
   },
   "devDependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@xterm/xterm": "^6.0.0",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@types/bun": "^1.3.6",

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -22,7 +22,7 @@ use std::env;
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
     "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
-    "serve", "schedule", "remote", "expose", "callback", "reap", "help",
+    "term", "serve", "schedule", "remote", "expose", "callback", "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -40,7 +40,11 @@ async function openConsole(
   extra: Record<string, unknown> = {},
 ): Promise<{ ctx: BrowserContext; page: Page }> {
   const ctx = await browser.newContext({ viewport, ...extra });
-  await ctx.route(/cdn\.jsdelivr\.net/, (route) => {
+  // Stub xterm.js + addons. The console self-hosts them (./vendor/*.min.js, #317)
+  // instead of cdn.jsdelivr.net now, so intercept BOTH paths — otherwise the real
+  // xterm loads, the stub's onData never captures window.__onData, and the
+  // keystroke tests time out.
+  await ctx.route(/cdn\.jsdelivr\.net|\/vendor\/[\w-]+\.min\.js/, (route) => {
     const body = route.request().url().includes("addon-fit") ? FITADDON_STUB : TERMINAL_STUB;
     route.fulfill({ status: 200, contentType: "application/javascript", body });
   });

--- a/tests/ui-dom/console-peer-spawn.test.ts
+++ b/tests/ui-dom/console-peer-spawn.test.ts
@@ -87,7 +87,9 @@ async function openConsole(
   url: string,
 ): Promise<{ ctx: BrowserContext; page: Page }> {
   const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
-  await ctx.route(/cdn\.jsdelivr\.net/, (route) => {
+  // xterm.js + addons are self-hosted now (./vendor/*.min.js, #317), not jsdelivr —
+  // intercept both so the stub applies (see console-dom.test.ts for the rationale).
+  await ctx.route(/cdn\.jsdelivr\.net|\/vendor\/[\w-]+\.min\.js/, (route) => {
     const body = route.request().url().includes("addon-fit") ? FITADDON_STUB : TERMINAL_STUB;
     route.fulfill({ status: 200, contentType: "application/javascript", body });
   });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2855,6 +2855,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
           pid: record.pid,
           cols: size?.cols ?? null,
           rows: size?.rows ?? null,
+          // Enough identity for a widget's title bar without exposing /api/ls to a
+          // scoped token (it's bound to this pid anyway — no extra info leaked).
+          cwd: record.cwd,
+          cli: record.cli,
           // This host negotiates the PTY size from viewer capacities (presence
           // `cap`) — a capable console should report its cap instead of pushing
           // /api/resize directly, so viewers stop fighting last-writer-wins.

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -39,6 +39,7 @@ import {
 } from "./subcommands.ts";
 import { answerAsk, listAsks } from "./askApi.ts";
 import { TYPING_BADGE } from "./badges.ts";
+import { isTermToken, mintTermToken, verifyTermToken, type TermScope } from "./termToken.ts";
 import { isCallbackRevoked, loadCallbackSecretReadOnly } from "./callback.ts";
 import { CLAUDE_SESSION_PIN_ENV } from "./sessionEnv.ts";
 import { MAX_CALLBACK_MSG_BYTES, frameVisitorMessage, verifyCapability } from "./callbackCore.ts";
@@ -215,6 +216,122 @@ function checkAuth(req: Request, expectedToken: string): boolean {
   // Fallback: ?token= query param — the web UI's EventSource cannot set headers.
   const q = new URL(req.url).searchParams.get("token");
   return q ? tokenEqual(q, expectedToken) : false;
+}
+
+// Authorization result: the master token grants everything (as before); a scoped
+// terminal-embed token (termToken.ts) grants a NARROW capability confined to one
+// agent by scopedGate() below.
+type AuthResult = { kind: "master" } | { kind: "scoped"; scope: TermScope };
+
+function authorizeRequest(req: Request, expectedToken: string): AuthResult | null {
+  const auth = req.headers.get("authorization") ?? "";
+  const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  const provided = bearer ?? new URL(req.url).searchParams.get("token") ?? "";
+  if (!provided) return null;
+  if (tokenEqual(provided, expectedToken)) return { kind: "master" };
+  // A scoped token is verified against the master token (stateless HMAC).
+  if (isTermToken(provided)) {
+    const scope = verifyTermToken(expectedToken, provided);
+    if (scope) return { kind: "scoped", scope };
+  }
+  return null;
+}
+
+// The embeddable terminal routes. Token-gated (master OR scoped) but CORS-open so
+// a cross-origin report page can reach the daemon — the token is still required to
+// get a 200, and no cookies are involved, so `*` leaks nothing.
+function isTermCorsPath(p: string): boolean {
+  return /^\/api\/(tail|size)\/.+$/.test(p) || p === "/api/send";
+}
+
+function withTermCors(req: Request, res: Response | undefined): Response | undefined {
+  if (!res) return res; // mux upgrade returns undefined
+  if (isTermCorsPath(new URL(req.url).pathname)) {
+    try {
+      res.headers.set("Access-Control-Allow-Origin", "*");
+      res.headers.set("Vary", "Origin");
+    } catch {
+      /* immutable headers — skip */
+    }
+  }
+  return res;
+}
+
+function termCorsPreflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "content-type, authorization",
+      "Access-Control-Max-Age": "600",
+    },
+  });
+}
+
+/** Does `keyword` resolve to the exact pid a scoped token is bound to? */
+async function scopedKeywordOk(keyword: string, scope: TermScope): Promise<boolean> {
+  try {
+    const rec = await resolveOne(keyword, defaultOpts({ all: true }));
+    return String(rec.pid) === String(scope.pid);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Confine a scoped token to its capability. Returns a 403 Response when the
+ * request is outside the token's grant, or null when it's allowed to proceed.
+ * Allowed: GET /api/tail|size/<kw> for the bound pid; POST /api/send for the bound
+ * pid IFF the token is interactive (canSend). Everything else is denied.
+ */
+async function scopedGate(
+  scope: TermScope,
+  method: string,
+  p: string,
+): Promise<Response | null> {
+  const forbid = (m: string) => new Response(m, { status: 403 });
+  const m = /^\/api\/(?:tail|size)\/(.+)$/.exec(p);
+  if (method === "GET" && m) {
+    return (await scopedKeywordOk(decodeURIComponent(m[1]!), scope))
+      ? null
+      : forbid("scoped token: not bound to this agent");
+  }
+  if (method === "POST" && p === "/api/send") {
+    if (!scope.canSend) return forbid("scoped token is read-only");
+    return null; // pid binding enforced in the /api/send handler (it has the body)
+  }
+  // Interactive viewers may renegotiate the agent's PTY size (drag-to-resize) —
+  // send-capable scope only, bound pid. The keyword is in the path, so bind here.
+  const rz = /^\/api\/resize\/(.+)$/.exec(p);
+  if (method === "POST" && rz) {
+    if (!scope.canSend) return forbid("scoped token is read-only");
+    return (await scopedKeywordOk(decodeURIComponent(rz[1]!), scope))
+      ? null
+      : forbid("scoped token: not bound to this agent");
+  }
+  return forbid("scoped token: route not permitted");
+}
+
+/**
+ * Mint a scoped terminal-embed token locally (no daemon round-trip): read the
+ * master token file, resolve the keyword to a concrete pid, and sign. Used by
+ * `ay term mint`. Throws if there's no serve token or the agent can't be resolved.
+ */
+export async function mintScopedTermToken(
+  keyword: string,
+  opts: { ttlSec: number; canSend: boolean },
+): Promise<{ token: string; pid: string; exp: number; canSend: boolean }> {
+  const master = await loadTokenReadOnly();
+  if (!master)
+    throw new Error(
+      "no serve token at ~/.agent-yes/.serve-token — run `ay serve` once on this host to create it",
+    );
+  const rec = await resolveOne(keyword, defaultOpts({ all: true }));
+  const pid = String(rec.pid);
+  const exp = Math.floor(Date.now() / 1000) + Math.max(1, Math.floor(opts.ttlSec));
+  const token = mintTermToken(master, { pid, canSend: opts.canSend, exp });
+  return { token, pid, exp, canSend: opts.canSend };
 }
 
 const defaultOpts = (overrides: Partial<CommonOpts> = {}): CommonOpts => ({
@@ -2019,12 +2136,23 @@ export async function cmdServe(rest: string[]): Promise<number> {
     req: Request,
     srv?: { upgrade: (r: Request, o?: unknown) => boolean },
   ): Promise<Response> => {
-    if (!checkAuth(req, token)) {
-      return new Response("Unauthorized", { status: 401 });
-    }
-
     const url = new URL(req.url);
     const p = url.pathname;
+
+    // CORS preflight for the embeddable terminal routes carries no auth header —
+    // answer it before the auth gate.
+    if (req.method === "OPTIONS" && isTermCorsPath(p)) return termCorsPreflight();
+
+    const authResult = authorizeRequest(req, token);
+    if (!authResult) {
+      return withTermCors(req, new Response("Unauthorized", { status: 401 }))!;
+    }
+    // A scoped token is confined to its bound agent + capability; the master token
+    // is unrestricted (existing behavior).
+    if (authResult.kind === "scoped") {
+      const denied = await scopedGate(authResult.scope, req.method, p);
+      if (denied) return withTermCors(req, denied)!;
+    }
 
     // GET /api/mux — WebSocket request multiplexer. HTTP/1.1 gives a browser
     // ~6 concurrent same-origin connections and no multiplexing, so console
@@ -2936,6 +3064,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
       if (!keyword || typeof keyword !== "string") {
         return new Response("missing keyword", { status: 400 });
       }
+      // A scoped interactive token may only write to the agent it's bound to
+      // (the gate already confirmed canSend; bind the pid now that we have the body).
+      if (authResult.kind === "scoped" && !(await scopedKeywordOk(keyword, authResult.scope))) {
+        return new Response("scoped token: not bound to this agent", { status: 403 });
+      }
       try {
         const record = await resolveOne(keyword, defaultOpts());
         if (!record.fifo_file)
@@ -3804,7 +3937,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
     if (req.method === "GET" && p === "/icon.svg") return serveUiFile("icon.svg", "image/svg+xml");
     if (req.method === "GET" && p === "/favicon.ico") return new Response(null, { status: 204 });
     if (p.startsWith("/cb/")) return handleCallback(req, p);
-    return apiFetch(req, srv);
+    // CORS-open the embeddable terminal routes (tail/size/send) so a cross-origin
+    // report page can reach this daemon; the token is still required for a 200.
+    return withTermCors(req, await apiFetch(req, srv)) as Response;
   };
 
   const serverOpts: any = {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -365,6 +365,7 @@ const SUBCOMMANDS = new Set([
   "todo",
   "ch",
   "channels",
+  "term",
   "serve",
   "schedule",
   "remote",
@@ -485,6 +486,10 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       case "channels": {
         const { cmdCh } = await import("./channels.ts");
         return cmdCh(rest);
+      }
+      case "term": {
+        const { cmdTerm } = await import("./terminal.ts");
+        return cmdTerm(rest);
       }
       case "serve": {
         const { cmdServe } = await import("./serve.ts");
@@ -622,6 +627,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay send <keyword> <msg>             send a message (keyword '.' = agent in this cwd)\n` +
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
       `  ay ch mk|join|send|read|tail <topic>  local-first E2E channels: AI ↔ humans on a topic (ay ch help)\n` +
+      `  ay term embed <pid>                 <script> to embed a live read-only agent terminal in a page (ay term help)\n` +
       `  ay key <keyword> <key...>           send raw keystrokes (down/up/enter/esc/…) — drives menus\n` +
       `  ay select <keyword> <N>             pick option N of a needs_input selection menu\n` +
       `  ay attach <keyword>                 interactive attach (detach: Ctrl-\\)\n` +

--- a/ts/termToken.spec.ts
+++ b/ts/termToken.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { isTermToken, mintTermToken, verifyTermToken } from "./termToken.ts";
+
+const MASTER = "master-token-abc123";
+const now = 1_000_000; // fixed epoch seconds for deterministic exp checks
+
+describe("termToken", () => {
+  it("round-trips a valid read-only token", () => {
+    const tok = mintTermToken(MASTER, { pid: "4242", canSend: false, exp: now + 900 });
+    expect(isTermToken(tok)).toBe(true);
+    const scope = verifyTermToken(MASTER, tok, now);
+    expect(scope).toEqual({ pid: "4242", canSend: false, exp: now + 900 });
+  });
+
+  it("round-trips an interactive token (canSend true)", () => {
+    const tok = mintTermToken(MASTER, { pid: "7", canSend: true, exp: now + 60 });
+    expect(verifyTermToken(MASTER, tok, now)?.canSend).toBe(true);
+  });
+
+  it("rejects a token signed with a different master (forgery)", () => {
+    const tok = mintTermToken(MASTER, { pid: "7", canSend: true, exp: now + 60 });
+    expect(verifyTermToken("other-master", tok, now)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    const tok = mintTermToken(MASTER, { pid: "7", canSend: false, exp: now - 1 });
+    expect(verifyTermToken(MASTER, tok, now)).toBeNull();
+  });
+
+  it("rejects a tampered payload (pid swap) — signature no longer matches", () => {
+    const tok = mintTermToken(MASTER, { pid: "7", canSend: false, exp: now + 60 });
+    const [prefix, , sig] = tok.split(".");
+    const evil = Buffer.from(JSON.stringify({ p: "9999", w: 1, x: now + 60 })).toString("base64url");
+    expect(verifyTermToken(MASTER, `${prefix}.${evil}.${sig}`, now)).toBeNull();
+  });
+
+  it("rejects the master token itself and other non-scoped strings", () => {
+    expect(isTermToken(MASTER)).toBe(false);
+    expect(verifyTermToken(MASTER, MASTER, now)).toBeNull();
+    expect(verifyTermToken(MASTER, "ayt1.only-two-parts", now)).toBeNull();
+    expect(verifyTermToken(MASTER, "", now)).toBeNull();
+    expect(verifyTermToken(MASTER, undefined, now)).toBeNull();
+  });
+});

--- a/ts/termToken.ts
+++ b/ts/termToken.ts
@@ -1,0 +1,85 @@
+// Scoped terminal-embed tokens — a capability you can safely put in a web page.
+//
+// The serve daemon's MASTER token (~/.agent-yes/.serve-token) is full-fleet
+// read+write+spawn = RCE; it must NEVER land in an embed. A scoped token instead
+// grants a NARROW capability: read (and optionally write to) exactly ONE agent
+// session, and only until it expires. It is a stateless HMAC bearer token — the
+// daemon verifies it with the same master token it already holds, so there is no
+// server-side token store to manage or revoke (short TTL is the bound).
+//
+//   ayt1.<payloadB64url>.<sigB64url>
+//     payload = {p: <pid>, w: 0|1 (write/interactive), x: <exp epoch-seconds>}
+//     sig     = HMAC-SHA256(keyFor(masterToken), "ayt1.<payloadB64url>")
+//
+// `ay term mint` signs one locally (it can read the master token file); the
+// daemon's checkAuth verifies it and confines the request to the bound pid.
+// (ed25519 per-author signing is a stronger future form; symmetric HMAC already
+// delivers short-TTL + read-only + single-session, which is what embeds need.)
+import { createHash, createHmac, timingSafeEqual } from "crypto";
+
+export interface TermScope {
+  /** The agent pid this token is bound to (resolved to a concrete pid at mint time). */
+  pid: string;
+  /** Interactive: may also write to this pid's stdin (/api/send). Read-only when false. */
+  canSend: boolean;
+  /** Expiry, epoch seconds. */
+  exp: number;
+}
+
+const PREFIX = "ayt1";
+
+/** Dedicated HMAC key derived from the master token (so the token isn't signed with the raw master). */
+function keyFor(masterToken: string): Buffer {
+  return createHash("sha256")
+    .update("ay/term/token/v1\n" + masterToken)
+    .digest();
+}
+
+/** True for anything shaped like a scoped terminal token (cheap pre-check before verify). */
+export function isTermToken(tok: unknown): tok is string {
+  return typeof tok === "string" && tok.startsWith(PREFIX + ".");
+}
+
+/** Mint a scoped token bound to `scope.pid`, signed with the master token. */
+export function mintTermToken(masterToken: string, scope: TermScope): string {
+  const payload = Buffer.from(
+    JSON.stringify({ p: scope.pid, w: scope.canSend ? 1 : 0, x: Math.floor(scope.exp) }),
+  ).toString("base64url");
+  const body = `${PREFIX}.${payload}`;
+  const sig = createHmac("sha256", keyFor(masterToken)).update(body).digest().toString("base64url");
+  return `${body}.${sig}`;
+}
+
+/**
+ * Verify a scoped token against the master token. Returns the scope if the
+ * signature is valid AND it hasn't expired, else null. Fail-closed on any
+ * malformed input. `nowSec` is injectable for tests.
+ */
+export function verifyTermToken(
+  masterToken: string,
+  tok: unknown,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): TermScope | null {
+  if (!isTermToken(tok)) return null;
+  const parts = tok.split(".");
+  if (parts.length !== 3) return null;
+  const body = `${parts[0]}.${parts[1]}`;
+  const expected = createHmac("sha256", keyFor(masterToken)).update(body).digest();
+  let got: Buffer;
+  try {
+    got = Buffer.from(parts[2]!, "base64url");
+  } catch {
+    return null;
+  }
+  // constant-time compare; length check first (timingSafeEqual throws on mismatch)
+  if (got.length !== expected.length || !timingSafeEqual(got, expected)) return null;
+  let obj: { p?: unknown; w?: unknown; x?: unknown };
+  try {
+    obj = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf-8"));
+  } catch {
+    return null;
+  }
+  if (typeof obj.p !== "string" || !obj.p) return null;
+  if (typeof obj.x !== "number" || !Number.isFinite(obj.x) || obj.x <= nowSec) return null; // expired
+  return { pid: obj.p, canSend: obj.w === 1, exp: obj.x };
+}

--- a/ts/terminal.spec.ts
+++ b/ts/terminal.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildTermEmbedSnippet } from "./terminal.ts";
+
+describe("buildTermEmbedSnippet", () => {
+  it("discover mode: no token in the file, imports terminal.js, mounts", () => {
+    const s = buildTermEmbedSnippet("agent-yes.com", "12345", { kind: "discover" });
+    expect(s).toContain(`import AyTerminal from "https://agent-yes.com/w/terminal.js"`);
+    expect(s).toContain(`new AyTerminal({ pid: "12345" })`);
+    expect(s).toContain(`.mount(document.getElementById("ay-term") ?? undefined)`);
+    expect(s).not.toContain("token:"); // safe default — no secret baked in
+    expect(s).not.toContain("readOnly"); // read-only is the default
+    expect(s).toContain("read-only view");
+  });
+
+  it("placeholder mode: reads window.AY_TERM_TOKEN at runtime", () => {
+    const s = buildTermEmbedSnippet("agent-yes.com", "42", { kind: "placeholder" });
+    expect(s).toContain("token: window.AY_TERM_TOKEN");
+    expect(s).not.toContain('"undefined"');
+  });
+
+  it("live mode: bakes the token, warns in the comment", () => {
+    const s = buildTermEmbedSnippet("h.example", "7", { kind: "live", token: "tok-abc" });
+    expect(s).toContain(`token: "tok-abc"`);
+    expect(s).toContain("LIVE token");
+    expect(s).toContain(`import AyTerminal from "https://h.example/w/terminal.js"`);
+  });
+
+  it("interactive opt-in sets readOnly:false and labels the comment", () => {
+    const s = buildTermEmbedSnippet("agent-yes.com", "9", {
+      kind: "live",
+      token: "t",
+      interactive: true,
+    });
+    expect(s).toContain("readOnly: false");
+    expect(s).toContain("interactive view");
+  });
+
+  it("origin is threaded through for a cross-origin daemon", () => {
+    const s = buildTermEmbedSnippet("agent-yes.com", "9", {
+      kind: "discover",
+      origin: "https://box.local:8787",
+    });
+    expect(s).toContain(`origin: "https://box.local:8787"`);
+  });
+
+  it("escapes the pid into a JSON string (no injection into the snippet)", () => {
+    const s = buildTermEmbedSnippet("agent-yes.com", 'a"b', { kind: "discover" });
+    expect(s).toContain(`pid: "a\\"b"`);
+  });
+});

--- a/ts/terminal.ts
+++ b/ts/terminal.ts
@@ -1,0 +1,245 @@
+// `ay term` — embed a LIVE, read-only agent-session terminal in any web page.
+//
+// The terminal sibling of `ay ch`. `ay term embed <pid>` prints a <script> that
+// loads the AyTerminal widget (terminal/browser.ts) and renders a read-only
+// xterm mirror of the agent's PTY, streamed from the serving `ay serve` daemon's
+// `/api/tail/<pid>?raw=1` SSE endpoint.
+//
+// PHASE 1 = SAME-ORIGIN. `/api/tail` is token-gated and emits no CORS headers, so
+// the embedding page must be served same-origin with the daemon (`ay serve --http`),
+// or the token/origin must be provided AND the daemon reachable. Cross-origin
+// arbitrary pages (via the WebRTC `--share` transport) are a later phase.
+
+type FlagSpec = Record<string, "bool" | "value">;
+
+function parseFlags(
+  args: string[],
+  known: FlagSpec,
+): { flags: Record<string, string | boolean>; positional: string[] } {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (!a.startsWith("-") || a === "-") {
+      positional.push(a);
+      continue;
+    }
+    const eq = a.indexOf("=");
+    const name = eq === -1 ? a.replace(/^--?/, "") : a.slice(a.startsWith("--") ? 2 : 1, eq);
+    const kind = known[name];
+    if (!kind) throw new Error(`unknown flag ${a}`);
+    if (kind === "bool") {
+      if (eq !== -1) throw new Error(`--${name} takes no value`);
+      flags[name] = true;
+    } else {
+      const v = eq !== -1 ? a.slice(eq + 1) : args[++i];
+      if (v === undefined) throw new Error(`${a} requires a value`);
+      flags[name] = v;
+    }
+  }
+  return { flags, positional };
+}
+
+export interface TermEmbedOpts {
+  origin?: string;
+  /** Wire keyboard input to the agent (opt-in). Needs a token that grants /api/send for this pid. */
+  interactive?: boolean;
+}
+export type TermEmbedMode =
+  | ({ kind: "discover" } & TermEmbedOpts) // no token in the file — widget reads it from the page
+  | ({ kind: "placeholder" } & TermEmbedOpts) // window.AY_TERM_TOKEN injected at runtime
+  | ({ kind: "live"; token: string } & TermEmbedOpts); // token baked into the file
+
+/**
+ * The embed `<script>` snippet — a script (NOT an iframe) that loads the AyTerminal
+ * browser lib and mounts a read-only terminal in the page. Three modes trade off
+ * where the serve token lives: never in the file (`discover` — the safe default,
+ * the widget reads #k= / window.AY_TERM_TOKEN / localStorage), injected at runtime
+ * (`placeholder`), or baked in (`live`, loud warning — a serve token is full-fleet
+ * read+write until scoped read-only tokens land).
+ */
+export function buildTermEmbedSnippet(host: string, pid: string, mode: TermEmbedMode): string {
+  const imp = `  import AyTerminal from "https://${host}/w/terminal.js";\n`;
+  const originArg = mode.origin ? `origin: ${JSON.stringify(mode.origin)}, ` : "";
+  // interactive is opt-in; the widget only wires the keyboard when readOnly:false
+  // AND the token actually grants /api/send (a 403 reverts it to a mirror).
+  const roArg = mode.interactive ? `readOnly: false, ` : "";
+  const tokenArg =
+    mode.kind === "live"
+      ? `token: ${JSON.stringify(mode.token)}, `
+      : mode.kind === "placeholder"
+        ? `token: window.AY_TERM_TOKEN, `
+        : "";
+  // mount into <div id="ay-term">…</div> if the page has one, else float in the corner
+  const tail = `.mount(document.getElementById("ay-term") ?? undefined);`;
+  const hint =
+    `Add <div id="ay-term" style="width:720px;height:420px"></div> where you want the ` +
+    `terminal, or omit it to float in the corner.`;
+  const kindLabel = mode.interactive ? "interactive" : "read-only";
+  const tokenNote =
+    mode.kind === "live"
+      ? `this snippet embeds a LIVE token — do NOT commit it to a public or deploy-bound file.`
+      : mode.kind === "placeholder"
+        ? `set window.AY_TERM_TOKEN at runtime; do NOT commit it.`
+        : `no token in this file; the widget reads it from the page (#k= / window.AY_TERM_TOKEN / localStorage).`;
+  return (
+    `<!-- ay terminal: ${kindLabel} view of #${pid} — ${tokenNote} ${hint} -->\n` +
+    `<script type="module">\n${imp}` +
+    `  new AyTerminal({ ${originArg}${roArg}${tokenArg}pid: ${JSON.stringify(pid)} })${tail}\n` +
+    `</script>\n`
+  );
+}
+
+function cmdTermEmbed(args: string[]): number {
+  const { flags, positional } = parseFlags(args, {
+    host: "value",
+    origin: "value",
+    token: "value",
+    placeholder: "bool",
+    interactive: "bool",
+  });
+  const pid = positional[0];
+  if (!pid || positional.length > 1)
+    throw new Error(
+      "usage: ay term embed <pid|keyword> [--host H] [--origin URL] [--token TOK | --placeholder] [--interactive]",
+    );
+  if (flags.token && flags.placeholder)
+    throw new Error("--token and --placeholder are mutually exclusive");
+  const host = typeof flags.host === "string" ? flags.host : "agent-yes.com";
+  const origin = typeof flags.origin === "string" ? flags.origin : undefined;
+  const interactive = flags.interactive === true;
+  const mode: TermEmbedMode = flags.placeholder
+    ? { kind: "placeholder", origin, interactive }
+    : typeof flags.token === "string"
+      ? { kind: "live", token: flags.token, origin, interactive }
+      : { kind: "discover", origin, interactive };
+
+  // stdout: only the snippet (safe to pipe/paste). stderr: the guidance.
+  process.stdout.write(buildTermEmbedSnippet(host, pid, mode));
+
+  if (mode.kind === "discover") {
+    process.stderr.write(
+      `\n  Token-free snippet — the widget reads the serve token from the page (#k= hash,\n` +
+        `  window.AY_TERM_TOKEN, or the console's localStorage["ay.localToken"]). Ideal when the\n` +
+        `  page is served by the daemon itself (ay serve --http) with a #k=<token> link.\n`,
+    );
+  } else if (mode.kind === "placeholder") {
+    process.stderr.write(
+      `\n  Placeholder — the token is NOT in the snippet; set window.AY_TERM_TOKEN at runtime\n` +
+        `  (server-rendered / env), so a committed file carries no secret.\n`,
+    );
+  } else {
+    process.stderr.write(
+      `\n  ⚠ This snippet embeds a LIVE serve token — full-fleet READ+WRITE for this daemon.\n` +
+        `    Anyone who reads the page source gets it. Do NOT commit it to a public or\n` +
+        `    deploy-bound file. Prefer --placeholder (runtime-injected) or the token-free\n` +
+        `    default. Scoped read-only embed tokens are future work (need per-author signing).\n`,
+    );
+  }
+  if (interactive) {
+    process.stderr.write(
+      `\n  ⚠ INTERACTIVE: keystrokes in the widget go to the agent's stdin. This needs a token\n` +
+        `    that grants /api/send for #${pid} (the widget reverts to read-only on a 403). Prefer a\n` +
+        `    scoped, short-TTL, single-session interactive token (future: ay term mint --interactive)\n` +
+        `    over the master token — the master token is full-fleet RCE.\n`,
+    );
+  } else {
+    process.stderr.write(
+      `\n  Read-only mirror: it renders the agent's PTY but never types into it. Add --interactive\n` +
+        `  (with a send-granting token) to let viewers type to the agent.\n`,
+    );
+  }
+  process.stderr.write(`  terminal.js must load from https://${host}/w/terminal.js.\n`);
+  if (!origin) {
+    process.stderr.write(
+      `  Same-origin: /api/tail sends no CORS headers, so the page must be served by the\n` +
+        `  daemon (ay serve --http). For an arbitrary-origin page, pass --origin <daemon-url>\n` +
+        `  (the daemon must be reachable + allow it); the WebRTC --share transport for any\n` +
+        `  origin is a later phase.\n`,
+    );
+  }
+  return 0;
+}
+
+/** Parse a TTL like "900", "30s", "15m", "2h" → seconds. */
+function parseTtlSec(s: string): number {
+  const m = /^(\d+)(s|m|h)?$/.exec(s.trim());
+  if (!m) throw new Error(`bad --ttl "${s}" (use e.g. 900, 30s, 15m, 2h)`);
+  const mult = m[2] === "h" ? 3600 : m[2] === "m" ? 60 : 1;
+  return Number(m[1]) * mult;
+}
+
+async function cmdTermMint(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    ttl: "value",
+    ro: "bool",
+    interactive: "bool",
+    json: "bool",
+  });
+  const pid = positional[0];
+  if (!pid || positional.length > 1)
+    throw new Error("usage: ay term mint <pid|keyword> [--ttl 15m] [--ro | --interactive] [--json]");
+  if (flags.ro && flags.interactive)
+    throw new Error("--ro and --interactive are mutually exclusive");
+  const ttlSec = parseTtlSec(typeof flags.ttl === "string" ? flags.ttl : "15m");
+  const canSend = flags.interactive === true; // default read-only
+  // Sign locally off ~/.agent-yes/.serve-token — no daemon round-trip.
+  const { mintScopedTermToken } = await import("./serve.ts");
+  const r = await mintScopedTermToken(pid, { ttlSec, canSend });
+  if (flags.json === true) {
+    process.stdout.write(JSON.stringify(r) + "\n");
+    return 0;
+  }
+  process.stdout.write(r.token + "\n");
+  const mins = Math.round(ttlSec / 60);
+  process.stderr.write(
+    `\n  Scoped ${canSend ? "INTERACTIVE (read+write)" : "read-only"} token for #${r.pid}, ` +
+      `expires in ~${mins}m (${new Date(r.exp * 1000).toISOString()}).\n` +
+      `  It grants ONLY ${canSend ? "read+write of" : "read of"} #${r.pid} — no other agent, no spawn.\n` +
+      `  Safe to embed in a page (this is NOT the master token):\n` +
+      `    ay term embed ${r.pid} --token <token> ${canSend ? "--interactive " : ""}--origin <daemon-url>\n` +
+      `  Short TTL is the backstop (serverless — no central revoke); re-mint when it lapses.\n`,
+  );
+  return 0;
+}
+
+function termHelp(): number {
+  process.stdout.write(
+    `ay term — embed a live, read-only agent terminal in a web page\n\n` +
+      `Usage:\n` +
+      `  ay term embed <pid|keyword> [--host H] [--origin URL] [--token TOK | --placeholder] [--interactive]\n` +
+      `  ay term mint  <pid|keyword> [--ttl 15m] [--ro | --interactive] [--json]\n\n` +
+      `  embed   print a <script> snippet that mounts a read-only xterm mirror of the agent\n` +
+      `          into <div id="ay-term">, or a floating panel if that div is absent.\n` +
+      `  mint    mint a scoped, short-TTL token bound to ONE agent (read-only by default;\n` +
+      `          --interactive also grants that agent's stdin) — safe to embed in a page,\n` +
+      `          unlike the master serve token. Prints the token on stdout.\n\n` +
+      `Flags (embed):\n` +
+      `  --host H        CDN host serving terminal.js (default agent-yes.com)\n` +
+      `  --origin URL    daemon origin if the page is NOT served by the daemon (same-origin default)\n` +
+      `  --token TOK     bake a LIVE serve token into the snippet (⚠ full-fleet r/w; avoid committing)\n` +
+      `  --placeholder   read the token from window.AY_TERM_TOKEN at runtime (no secret in the file)\n` +
+      `  --interactive   wire the keyboard to the agent's stdin (needs a send-granting token; ⚠ opt-in)\n`,
+  );
+  return 0;
+}
+
+export async function cmdTerm(args: string[]): Promise<number> {
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case "embed":
+      return cmdTermEmbed(rest);
+    case "mint":
+      return cmdTermMint(rest);
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      return termHelp();
+    default:
+      process.stderr.write(`ay term: unknown subcommand "${sub}"\n\n`);
+      termHelp();
+      return 1;
+  }
+}

--- a/ts/terminal/browser.ts
+++ b/ts/terminal/browser.ts
@@ -1,33 +1,30 @@
 // Browser terminal client: `import AyTerminal from "agent-yes/terminal"`.
 //
-// A self-contained floating widget (Shadow DOM) that renders a LIVE, READ-ONLY
-// mirror of an agent session's PTY on any page — the terminal sibling of
-// AyChannel (channels/browser.ts). It streams the agent's raw PTY bytes from the
-// serving `ay serve` daemon's SSE endpoint (`GET /api/tail/<pid>?raw=1`) into an
-// xterm.js terminal, sizing the grid to the agent's NATIVE PTY (via /api/size)
-// and visually CSS-scaling it to fit — it never pushes a resize back, so a viewer
-// can never reflow the agent's real terminal. This is the read-only model the
-// rgui embed (lab/ui/rgui/main.ts `initEmbed`) already proved.
+// A self-contained Shadow-DOM widget that renders a LIVE agent-session terminal
+// on any page — the terminal sibling of AyChannel (channels/browser.ts). It
+// streams the agent's raw PTY bytes from the serving `ay serve` daemon's SSE
+// endpoint (`GET /api/tail/<pid>?raw=1`) into an xterm.js terminal.
 //
 //   const t = new AyTerminal({ pid: "12345" });   // token auto-discovered
 //   t.mount(document.getElementById("term"));      // inline, or t.mount() to float
 //
-// PHASE 1 = SAME-ORIGIN, READ-ONLY. `/api/tail` + `/api/send` are token-gated and
-// emit NO CORS headers, so this widget must load same-origin with the daemon (the
-// report page is served by `ay serve --http`), or the daemon origin must be in the
-// embedding page's connect-src AND the daemon must allow the origin (phase 2 uses
-// the WebRTC `--share` transport to reach an arbitrary-origin page). Interactive
-// input (keystrokes/send) is deliberately NOT wired here — that's a later phase,
-// gated on an explicit opt-in, because typing into a terminal drives the agent's
-// box.
-
-// xterm is bundled in (both the npm dist build and the /w/terminal.js CDN bundle)
-// so the widget is self-contained — no CDN <script> the embedding page's CSP must
-// allow. Its stylesheet is injected into the Shadow root (below), since
-// `:host { all: initial }` + Shadow DOM isolates the page's styles from it.
-// Imported for the value (the constructor); typed as `any` at every use site
-// because the Node tsconfig has no DOM lib (xterm's own types reference DOM types).
+// READ-ONLY by default: the grid is sized to the agent's NATIVE PTY (via
+// /api/size) and CSS-scaled to fit, and NO resize is ever pushed back, so a viewer
+// can't reflow the agent's real terminal (the rgui read-only model). INTERACTIVE
+// (an explicit opt-in gated on a send-capable token) instead lets the viewer type
+// (→ /api/send) and drag-resize to renegotiate the real PTY (→ /api/resize); it
+// fails closed to a mirror on a 403.
+//
+// The floating widget is a draggable, resizable window with OS-native min/max
+// controls; `transparent:true` lets it float over page content. xterm + its CSS
+// are bundled/inlined so the widget is self-contained — no CDN <script> the
+// embedding page's CSP must allow. Its stylesheet is injected into the Shadow root
+// (`:host { all: initial }` isolates the page's styles from it).
+//
+// DOM/xterm are accessed as `any` throughout because the Node tsconfig has no DOM
+// lib (xterm's own types reference DOM types); the widget only ever runs in a browser.
 import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
 
 export interface AyTerminalInfo {
   /** Agent pid or any keyword `ay` can resolve (passed to /api/tail/<keyword>). */
@@ -36,23 +33,32 @@ export interface AyTerminalInfo {
   origin?: string;
   /** Serve token. Default: discovered from window.AY_TERM_TOKEN, the page #k= hash, or localStorage. */
   token?: string;
-  /** Read-only mirror. Phase 1 is always read-only; the flag is reserved for a later interactive opt-in. */
+  /** Interactive when false (type to the agent + drag-resize the PTY); read-only mirror when true (default). */
   readOnly?: boolean;
-  /** Header label; default `#<pid>`. */
+  /** Header label; default a rich title fetched from /api/ls, falling back to `#<pid>`. */
   title?: string;
+  /** Semi-transparent panel + xterm allowTransparency, so the terminal floats over page content. */
+  transparent?: boolean;
+  /** Window-control button side: "left" (macOS traffic-light) | "right" (Win/Linux) | "auto" (OS-detect, default). */
+  controls?: "left" | "right" | "auto";
 }
 
 export class AyTerminal {
   readonly pid: string;
   readonly origin: string;
   readonly readOnly: boolean;
+  readonly transparent: boolean;
   title: string;
   private token: string;
-  private term?: any; // xterm Terminal (typed any — no DOM lib in the Node tsconfig)
+  private controls: "left" | "right" | "auto";
+  private term?: any; // xterm Terminal
+  private fit?: any; // FitAddon (interactive PTY-fit only)
   private es?: any; // EventSource
   private widget?: any;
+  private badgeEl?: any; // the interactive/read-only header badge (flipped on a 403)
   private started = false;
-  private writable = false; // flips false on the first /api/send 403 (token is read-only)
+  private writable = false; // flips false on the first /api/send|resize 403 (token is read-only)
+  private resizeTimer: any = null;
 
   constructor(info: string | number | AyTerminalInfo) {
     const o: AyTerminalInfo =
@@ -61,7 +67,9 @@ export class AyTerminal {
       throw new Error("AyTerminal: need a pid/keyword");
     this.pid = String(o.pid);
     this.origin = (o.origin ?? "").replace(/\/+$/, ""); // "" ⇒ same-origin relative URLs
-    this.readOnly = o.readOnly !== false; // default true; phase 1 never wires input
+    this.readOnly = o.readOnly !== false; // default true
+    this.transparent = o.transparent === true;
+    this.controls = o.controls ?? "auto";
     this.token = o.token ?? discoverToken();
     this.title = o.title ?? `#${this.pid}`;
   }
@@ -86,16 +94,23 @@ export class AyTerminal {
     this.term = new Terminal({
       fontSize: 13,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
-      theme: TERM_THEME,
-      disableStdin: this.readOnly, // read-only mirror unless an interactive token was supplied
+      theme: this.transparent ? { ...TERM_THEME, background: "rgba(13,17,23,0)" } : TERM_THEME,
+      allowTransparency: this.transparent, // construction-time — can't be toggled later
+      disableStdin: this.readOnly,
       cursorBlink: !this.readOnly,
       scrollback: 2000,
       convertEol: false,
     });
+    // Interactive viewers reflow the real PTY, so load the fit addon to propose
+    // cols/rows from the container size; read-only viewers never do (native grid).
+    if (!this.readOnly) {
+      this.fit = new FitAddon();
+      this.term.loadAddon(this.fit);
+    }
     this.term.open(el);
 
     // Size the grid to the agent's own PTY so absolute-cursor raw bytes land in
-    // the right cells; we only READ /api/size and never POST a resize back.
+    // the right cells; we only READ /api/size and never POST a resize here.
     try {
       const res = await g.fetch(this.url(`/api/size/${encodeURIComponent(this.pid)}`), {
         headers: { accept: "application/json" },
@@ -121,10 +136,8 @@ export class AyTerminal {
     this.es = es;
 
     // Interactive input (opt-in): forward keystrokes to the agent's stdin as raw
-    // bytes (code:"none" = no trailing Enter — the terminal itself sends \r). Only
-    // when a WRITABLE token was supplied; a read-only token that reaches here 403s,
-    // and we fail closed — disable stdin so the widget silently reverts to a mirror.
-    // This is the same discipline as the rgui embed's attachStdin/onDenied.
+    // bytes (code:"none" — the terminal itself sends \r). Fails closed to a mirror
+    // on a 403 (a read-only token), like the rgui embed's attachStdin/onDenied.
     if (!this.readOnly) {
       this.term.onData((data: string) => {
         if (!this.writable) return;
@@ -135,17 +148,54 @@ export class AyTerminal {
             body: JSON.stringify({ keyword: this.pid, msg: data, code: "none" }),
           })
           .then((r: any) => {
-            if (r.status === 403 || r.status === 401) {
-              this.writable = false;
-              this.term.options.disableStdin = true;
-              this.term.options.cursorBlink = false;
-            }
+            if (r.status === 403 || r.status === 401) this.revokeWrite();
           })
           .catch(() => {
             /* transient network error — keep trying on the next keystroke */
           });
       });
     }
+  }
+
+  /**
+   * A write path (send/resize) was refused (403/401) — the token is read-only.
+   * Fail closed: stop sending, disable stdin, and flip the header badge so the
+   * viewer SEES it reverted to a mirror (grocy: the badge must reflect the state).
+   */
+  private revokeWrite(): void {
+    if (!this.writable) return; // already reverted — flip once
+    this.writable = false;
+    if (this.term) {
+      this.term.options.disableStdin = true;
+      this.term.options.cursorBlink = false;
+    }
+    if (this.badgeEl) {
+      this.badgeEl.className = "ro";
+      this.badgeEl.textContent = "read-only";
+      this.badgeEl.title = "reverted to read-only — this token can't write to the agent";
+    }
+  }
+
+  /**
+   * Push a PTY resize to the agent (interactive only). Debounced, gated on a
+   * still-writable token; a 403 reverts to read-only.
+   */
+  private pushPtyResize(cols: number, rows: number): void {
+    if (this.readOnly || !this.writable) return;
+    const g = globalThis as any;
+    clearTimeout(this.resizeTimer);
+    this.resizeTimer = setTimeout(() => {
+      void g
+        .fetch(this.url(`/api/resize/${encodeURIComponent(this.pid)}`), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ cols, rows }),
+        })
+        .then((r: any) => {
+          if (r.status === 403 || r.status === 401) this.revokeWrite();
+        })
+        .catch(() => {});
+    }, 200);
   }
 
   /** Tear down the stream, the terminal, and the mounted widget. */
@@ -163,60 +213,213 @@ export class AyTerminal {
 
   /**
    * Render the widget. With a `target` element it embeds inline, filling that
-   * element (the report-page case); with no target it mounts a floating panel
-   * with a toggle bubble in the corner (like AyChannel). Auto-calls start().
+   * element (the report-page case); with no target it mounts a floating,
+   * draggable, resizable window with a corner bubble. Auto-calls start().
    */
   mount(target?: any, opts?: { open?: boolean }): any {
     if (this.widget) return this.widget;
-    const doc: any = (globalThis as any).document;
+    const g = globalThis as any;
+    const doc: any = g.document;
     const host = doc.createElement("div");
     host.setAttribute("data-ayterminal", this.pid);
     const root = host.attachShadow({ mode: "open" });
     const inline = !!target;
-    root.innerHTML = widgetHtml(inline, this.title, this.readOnly);
+    const side = controlsSide(this.controls);
+    root.innerHTML = widgetHtml({ inline, title: this.title, readOnly: this.readOnly, side });
     this.widget = host;
+    if (opts?.open) host.setAttribute("data-open", "1");
     (target ?? doc.body).appendChild(host);
 
     const panel = root.getElementById("panel")!;
     const inner = root.getElementById("inner")!;
     const wrap = root.getElementById("wrap")!;
+    const titleEl = root.getElementById("title")!;
+    this.badgeEl = root.getElementById("badge");
+    if (this.transparent) panel.classList.add("transparent");
 
-    // Scale the native-grid terminal to FIT the wrap box (never upscale past 1:1),
-    // exactly like the rgui embed — the grid stays the agent's size, only pixels scale.
-    const fit = () => {
-      const xt = inner.querySelector(".xterm") as any;
-      if (!xt || !xt.offsetWidth || !xt.offsetHeight) return;
-      const s = Math.min(1, wrap.clientWidth / xt.offsetWidth, wrap.clientHeight / xt.offsetHeight);
-      inner.style.transform = `scale(${s})`;
+    // Reflow: read-only CSS-scales the native grid to fit; interactive fits the
+    // grid to the container and pushes the new PTY size to the agent.
+    const reflow = () => {
+      if (this.readOnly) {
+        const xt = inner.querySelector(".xterm") as any;
+        if (!xt || !xt.offsetWidth || !xt.offsetHeight) return;
+        const s = Math.min(
+          1,
+          wrap.clientWidth / xt.offsetWidth,
+          wrap.clientHeight / xt.offsetHeight,
+        );
+        inner.style.transform = `scale(${s})`;
+      } else if (this.fit) {
+        const d = this.fit.proposeDimensions?.();
+        if (d?.cols && d?.rows && this.term) {
+          this.term.resize(d.cols, d.rows);
+          this.pushPtyResize(d.cols, d.rows);
+        }
+      }
     };
 
     if (inline) {
-      // fill the target; make it a positioning context if it is statically positioned
       try {
-        const cs = (globalThis as any).getComputedStyle?.(target);
+        const cs = g.getComputedStyle?.(target);
         if (cs && cs.position === "static") target.style.position = "relative";
       } catch {
         /* no getComputedStyle */
       }
     } else {
-      const toggle = root.getElementById("toggle")!;
-      toggle.addEventListener("click", () => panel.classList.toggle("open"));
-      if (opts?.open) panel.classList.add("open");
+      inner.style.inset = this.readOnly ? "" : "0"; // interactive fills the wrap (no scale)
+      this.wireWindow(root, panel, doc, reflow);
     }
 
-    const g = globalThis as any;
-    g.addEventListener?.("resize", fit);
+    // Reflow on container size changes (drag-resize, maximize, viewport resize).
+    try {
+      new g.ResizeObserver(() => reflow()).observe(wrap);
+    } catch {
+      /* no ResizeObserver — fall back to the window listener below */
+    }
+    g.addEventListener?.("resize", reflow);
+
     void (async () => {
       await this.start(inner);
-      // let xterm lay out its rows before measuring, then fit a couple of times
+      void this.applyRichTitle(titleEl);
       (g.requestAnimationFrame ?? ((cb: () => void) => setTimeout(cb, 16)))(() => {
-        fit();
-        setTimeout(fit, 150);
+        reflow();
+        setTimeout(reflow, 150);
       });
     })();
 
     return host;
   }
+
+  /**
+   * Window chrome for the floating panel: restore saved geometry, drag-move by the
+   * titlebar, minimize (→ corner bubble) / maximize (→ full viewport) controls.
+   */
+  private wireWindow(root: any, panel: any, doc: any, reflow: () => void): void {
+    const toggle = root.getElementById("toggle")!;
+    const titlebar = root.getElementById("titlebar")!;
+    const showPanel = (on: boolean) => {
+      panel.classList.toggle("open", on);
+      toggle.style.display = on ? "none" : "";
+      if (on) reflow();
+    };
+    toggle.addEventListener("click", () => showPanel(true));
+    root.getElementById("min")?.addEventListener("click", () => showPanel(false));
+    root.getElementById("max")?.addEventListener("click", () => {
+      panel.classList.toggle("max");
+      this.saveGeom(panel);
+      reflow();
+    });
+
+    // Restore saved geometry (position + size), else the CSS default corner.
+    const geom = this.loadGeom();
+    if (geom) {
+      panel.style.left = geom.left + "px";
+      panel.style.top = geom.top + "px";
+      panel.style.right = "auto";
+      panel.style.bottom = "auto";
+      panel.style.width = geom.width + "px";
+      panel.style.height = geom.height + "px";
+    }
+
+    // Drag-move by the titlebar (but not when a control button is the target).
+    let dragging = false;
+    let sx = 0;
+    let sy = 0;
+    let ox = 0;
+    let oy = 0;
+    titlebar.addEventListener("mousedown", (e: any) => {
+      if (e.target?.closest?.("[data-ctl]") || panel.classList.contains("max")) return;
+      const r = panel.getBoundingClientRect();
+      panel.style.left = r.left + "px";
+      panel.style.top = r.top + "px";
+      panel.style.right = "auto";
+      panel.style.bottom = "auto";
+      dragging = true;
+      sx = e.clientX;
+      sy = e.clientY;
+      ox = r.left;
+      oy = r.top;
+      e.preventDefault();
+    });
+    doc.addEventListener("mousemove", (e: any) => {
+      if (!dragging) return;
+      panel.style.left = ox + (e.clientX - sx) + "px";
+      panel.style.top = oy + (e.clientY - sy) + "px";
+    });
+    doc.addEventListener("mouseup", () => {
+      if (!dragging) return;
+      dragging = false;
+      this.saveGeom(panel);
+    });
+    // CSS `resize:both` drag ends without a mouseup we can catch on the handle, so
+    // persist geometry after any resize settles (the ResizeObserver drives reflow).
+    try {
+      let t: any = null;
+      new (globalThis as any).ResizeObserver(() => {
+        clearTimeout(t);
+        t = setTimeout(() => this.saveGeom(panel), 300);
+      }).observe(panel);
+    } catch {
+      /* no ResizeObserver */
+    }
+
+    if (opts_open(root)) showPanel(true);
+  }
+
+  private geomKey(): string {
+    return `ay29term:${this.pid}:geom`;
+  }
+  private loadGeom(): { left: number; top: number; width: number; height: number } | null {
+    try {
+      const raw = (globalThis as any).localStorage?.getItem(this.geomKey());
+      if (!raw) return null;
+      const o = JSON.parse(raw);
+      if (["left", "top", "width", "height"].every((k) => typeof o[k] === "number")) return o;
+    } catch {
+      /* ignore */
+    }
+    return null;
+  }
+  private saveGeom(panel: any): void {
+    try {
+      if (panel.classList.contains("max")) return; // don't persist the maximized rect
+      const r = panel.getBoundingClientRect();
+      (globalThis as any).localStorage?.setItem(
+        this.geomKey(),
+        JSON.stringify({ left: r.left, top: r.top, width: r.width, height: r.height }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /**
+   * Replace the bare `#pid` title with a rich one (repo/branch · cli) from the
+   * /api/size metadata — that route is already allowed + CORS'd for a scoped token
+   * (and bound to this pid), so no need to expose /api/ls to a page embed.
+   */
+  private async applyRichTitle(titleEl: any): Promise<void> {
+    const g = globalThis as any;
+    try {
+      const res = await g.fetch(this.url(`/api/size/${encodeURIComponent(this.pid)}`), {
+        headers: { accept: "application/json" },
+      });
+      if (!res.ok) return;
+      const rec = (await res.json()) as { cwd?: string; cli?: string };
+      const rich = richTitle(rec);
+      if (rich && titleEl) {
+        titleEl.textContent = rich;
+        titleEl.title = `#${this.pid}${rec.cwd ? " · " + rec.cwd : ""}`; // pid + full cwd tooltip
+        this.title = rich;
+      }
+    } catch {
+      /* keep the fallback title */
+    }
+  }
+}
+
+function opts_open(root: any): boolean {
+  return root.host?.getAttribute?.("data-open") === "1";
 }
 
 /** window.AY_TERM_TOKEN → page `#k=` hash → localStorage["ay.localToken"] (the rgui/console cache). */
@@ -235,6 +438,42 @@ function discoverToken(): string {
   return "";
 }
 
+/** OS-adaptive control side: macOS → left (traffic-light), Win/Linux → right. */
+function controlsSide(pref: "left" | "right" | "auto"): "left" | "right" {
+  if (pref === "left" || pref === "right") return pref;
+  try {
+    const nav = (globalThis as any).navigator;
+    const plat = String(nav?.userAgentData?.platform ?? nav?.platform ?? "").toLowerCase();
+    return plat.includes("mac") ? "left" : "right";
+  } catch {
+    return "right";
+  }
+}
+
+/** A console-style rich title from an /api/ls record: "repo/branch · <summary>". */
+function richTitle(rec: any): string {
+  const parts: string[] = [];
+  const rb = repoBranch(String(rec?.cwd ?? ""));
+  if (rb) parts.push(rb);
+  const summary = rec?.title ?? rec?.summary ?? rec?.name ?? rec?.last_prompt ?? rec?.prompt;
+  if (typeof summary === "string" && summary.trim()) parts.push(clip(summary.trim(), 48));
+  else if (rec?.cli) parts.push(String(rec.cli));
+  return parts.join(" · ");
+}
+
+/** ".../snomiao/grocy/tree/main" → "grocy/main"; degrades to the last path segment. */
+function repoBranch(cwd: string): string {
+  if (!cwd) return "";
+  const segs = cwd.split(/[/\\]/).filter(Boolean);
+  const ti = segs.lastIndexOf("tree");
+  if (ti > 0 && segs[ti + 1]) return `${segs[ti - 1]}/${segs[ti + 1]}`;
+  return segs.slice(-1)[0] ?? "";
+}
+
+function clip(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
 const TERM_THEME = {
   background: "#0d1117",
   foreground: "#c9d1d9",
@@ -244,32 +483,57 @@ const TERM_THEME = {
 
 /**
  * Shadow-DOM markup + styles. Self-contained (xterm's own stylesheet is inlined
- * below so it applies inside the isolated shadow root). Inline mode fills the
- * target; floating mode is a corner bubble + panel like AyChannel.
+ * so it applies inside the isolated shadow root). Inline mode fills the target;
+ * floating mode is a corner bubble + a draggable, resizable window.
  */
-function widgetHtml(inline: boolean, title: string, readOnly: boolean): string {
+function widgetHtml(o: {
+  inline: boolean;
+  title: string;
+  readOnly: boolean;
+  side: "left" | "right";
+}): string {
   const esc = (s: string) =>
     s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
-  const badge = readOnly
-    ? `<span class="ro" title="read-only mirror">read-only</span>`
-    : `<span class="rw" title="interactive — type to the agent">interactive</span>`;
-  const chrome = inline
-    ? `
-  #panel { position: absolute; inset: 0; display: flex; }
-  #wrap { border-radius: 0; }
-`
+  const badge = o.readOnly
+    ? `<span id="badge" class="ro" title="read-only mirror">read-only</span>`
+    : `<span id="badge" class="rw" title="interactive — type &amp; drag-resize the agent">interactive</span>`;
+  // macOS: traffic-light dots on the left; Win/Linux: _ □ buttons on the right.
+  // Inline embeds have no window semantics (no bubble/move/maximize) → no controls.
+  const controls = o.inline
+    ? ""
+    : o.side === "left"
+      ? `<span class="ctl mac" data-ctl>
+           <button id="min" class="dot yellow" data-ctl title="Minimize"></button>
+           <button id="max" class="dot green" data-ctl title="Maximize"></button>
+         </span>`
+      : `<span class="ctl win" data-ctl>
+           <button id="min" data-ctl title="Minimize">_</button>
+           <button id="max" data-ctl title="Maximize">□</button>
+         </span>`;
+  const titleSpan = `<span class="title" id="title">${esc(o.title)}</span>`;
+  const header =
+    !o.inline && o.side === "left"
+      ? `${controls}${titleSpan}${badge}`
+      : `${titleSpan}${badge}${controls}`;
+  const chrome = o.inline
+    ? `#panel { position: absolute; inset: 0; display: flex; } #titlebar { cursor: default; }`
     : `
   #toggle {
     position: fixed; right: 20px; bottom: 20px; z-index: 2147483000;
-    width: 52px; height: 52px; border-radius: 50%; border: none; cursor: pointer;
+    width: 52px; height: 52px; border-radius: 50%; cursor: pointer;
     background: #0d1117; color: #c9d1d9; font-size: 22px; box-shadow: 0 4px 16px rgba(0,0,0,.4);
     border: 1px solid #30363d;
   }
   #panel {
     position: fixed; right: 20px; bottom: 84px; z-index: 2147483000;
     width: min(720px, 94vw); height: min(460px, 72vh); display: none;
+    resize: both; min-width: 260px; min-height: 160px;
   }
   #panel.open { display: flex; }
+  #panel.max { inset: 0 !important; left: 0 !important; top: 0 !important;
+    right: 0 !important; bottom: 0 !important; width: auto !important; height: auto !important;
+    border-radius: 0; resize: none; }
+  #titlebar { cursor: move; }
 `;
   return `
 <style>
@@ -278,19 +542,28 @@ function widgetHtml(inline: boolean, title: string, readOnly: boolean): string {
   ${chrome}
   #panel { flex-direction: column; background: #0d1117; border-radius: 12px;
     box-shadow: 0 12px 40px rgba(0,0,0,.45); overflow: hidden; border: 1px solid #30363d; }
-  header { padding: 7px 11px; background: #161b22; display: flex; align-items: center; gap: 8px;
-    font: 600 12px ui-monospace, SFMono-Regular, Menlo, monospace; color: #c9d1d9; }
-  header .dot { width: 8px; height: 8px; border-radius: 50%; background: #10b981; flex: none; }
-  header .title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  header .ro { font-size: 10px; opacity: .7; background: #30363d; border-radius: 9px; padding: 1px 7px; }
-  header .rw { font-size: 10px; background: #1f6feb; color: #fff; border-radius: 9px; padding: 1px 7px; }
+  #panel.transparent { background: rgba(13,17,23,.62); backdrop-filter: blur(3px); }
+  #panel.transparent #wrap { background: transparent; }
+  #titlebar { padding: 6px 10px; background: #161b22; display: flex; align-items: center; gap: 8px;
+    font: 600 12px ui-monospace, SFMono-Regular, Menlo, monospace; color: #c9d1d9; user-select: none; }
+  #panel.transparent #titlebar { background: rgba(22,27,34,.7); }
+  .title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ro { font-size: 10px; opacity: .7; background: #30363d; border-radius: 9px; padding: 1px 7px; }
+  .rw { font-size: 10px; background: #1f6feb; color: #fff; border-radius: 9px; padding: 1px 7px; }
+  .ctl { display: inline-flex; align-items: center; gap: 6px; flex: none; }
+  .ctl.win button { background: #21262d; color: #c9d1d9; border: 1px solid #30363d; border-radius: 4px;
+    width: 20px; height: 18px; font: 12px monospace; cursor: pointer; line-height: 1; padding: 0; }
+  .ctl.win button:hover { background: #30363d; }
+  .ctl.mac .dot { width: 12px; height: 12px; border-radius: 50%; border: none; cursor: pointer; padding: 0; }
+  .ctl.mac .dot.yellow { background: #febc2e; }
+  .ctl.mac .dot.green { background: #28c840; }
   #wrap { flex: 1; position: relative; overflow: hidden; background: #0d1117; }
   #inner { position: absolute; left: 0; top: 0; transform-origin: 0 0; }
   ${XTERM_CSS}
 </style>
-${inline ? "" : `<button id="toggle" title="Terminal">🖥️</button>`}
+${o.inline ? "" : `<button id="toggle" title="Terminal">🖥️</button>`}
 <section id="panel">
-  <header><span class="dot"></span><span class="title">${esc(title)}</span>${badge}</header>
+  <header id="titlebar">${header}</header>
   <div id="wrap"><div id="inner"></div></div>
 </section>
 `;
@@ -305,7 +578,7 @@ const XTERM_CSS = `
 .xterm .xterm-helper-textarea { padding: 0; border: 0; margin: 0; position: absolute; opacity: 0; left: -9999em; top: 0; width: 0; height: 0; z-index: -5; white-space: nowrap; overflow: hidden; resize: none; }
 .xterm .composition-view { background: #000; color: #FFF; display: none; position: absolute; white-space: nowrap; z-index: 1; }
 .xterm .composition-view.active { display: block; }
-.xterm .xterm-viewport { background-color: #000; overflow-y: scroll; cursor: default; position: absolute; right: 0; left: 0; top: 0; bottom: 0; }
+.xterm .xterm-viewport { background-color: transparent; overflow-y: scroll; cursor: default; position: absolute; right: 0; left: 0; top: 0; bottom: 0; }
 .xterm .xterm-screen { position: relative; }
 .xterm .xterm-screen canvas { position: absolute; left: 0; top: 0; }
 .xterm-char-measure-element { display: inline-block; visibility: hidden; position: absolute; top: 0; left: -9999em; line-height: normal; }

--- a/ts/terminal/browser.ts
+++ b/ts/terminal/browser.ts
@@ -1,0 +1,334 @@
+// Browser terminal client: `import AyTerminal from "agent-yes/terminal"`.
+//
+// A self-contained floating widget (Shadow DOM) that renders a LIVE, READ-ONLY
+// mirror of an agent session's PTY on any page — the terminal sibling of
+// AyChannel (channels/browser.ts). It streams the agent's raw PTY bytes from the
+// serving `ay serve` daemon's SSE endpoint (`GET /api/tail/<pid>?raw=1`) into an
+// xterm.js terminal, sizing the grid to the agent's NATIVE PTY (via /api/size)
+// and visually CSS-scaling it to fit — it never pushes a resize back, so a viewer
+// can never reflow the agent's real terminal. This is the read-only model the
+// rgui embed (lab/ui/rgui/main.ts `initEmbed`) already proved.
+//
+//   const t = new AyTerminal({ pid: "12345" });   // token auto-discovered
+//   t.mount(document.getElementById("term"));      // inline, or t.mount() to float
+//
+// PHASE 1 = SAME-ORIGIN, READ-ONLY. `/api/tail` + `/api/send` are token-gated and
+// emit NO CORS headers, so this widget must load same-origin with the daemon (the
+// report page is served by `ay serve --http`), or the daemon origin must be in the
+// embedding page's connect-src AND the daemon must allow the origin (phase 2 uses
+// the WebRTC `--share` transport to reach an arbitrary-origin page). Interactive
+// input (keystrokes/send) is deliberately NOT wired here — that's a later phase,
+// gated on an explicit opt-in, because typing into a terminal drives the agent's
+// box.
+
+// xterm is bundled in (both the npm dist build and the /w/terminal.js CDN bundle)
+// so the widget is self-contained — no CDN <script> the embedding page's CSP must
+// allow. Its stylesheet is injected into the Shadow root (below), since
+// `:host { all: initial }` + Shadow DOM isolates the page's styles from it.
+// Imported for the value (the constructor); typed as `any` at every use site
+// because the Node tsconfig has no DOM lib (xterm's own types reference DOM types).
+import { Terminal } from "@xterm/xterm";
+
+export interface AyTerminalInfo {
+  /** Agent pid or any keyword `ay` can resolve (passed to /api/tail/<keyword>). */
+  pid: string | number;
+  /** Daemon origin, e.g. "https://box.local:8787". Default "" = same-origin (relative URLs). */
+  origin?: string;
+  /** Serve token. Default: discovered from window.AY_TERM_TOKEN, the page #k= hash, or localStorage. */
+  token?: string;
+  /** Read-only mirror. Phase 1 is always read-only; the flag is reserved for a later interactive opt-in. */
+  readOnly?: boolean;
+  /** Header label; default `#<pid>`. */
+  title?: string;
+}
+
+export class AyTerminal {
+  readonly pid: string;
+  readonly origin: string;
+  readonly readOnly: boolean;
+  title: string;
+  private token: string;
+  private term?: any; // xterm Terminal (typed any — no DOM lib in the Node tsconfig)
+  private es?: any; // EventSource
+  private widget?: any;
+  private started = false;
+  private writable = false; // flips false on the first /api/send 403 (token is read-only)
+
+  constructor(info: string | number | AyTerminalInfo) {
+    const o: AyTerminalInfo =
+      typeof info === "string" || typeof info === "number" ? { pid: info } : info;
+    if (o.pid === undefined || o.pid === null || o.pid === "")
+      throw new Error("AyTerminal: need a pid/keyword");
+    this.pid = String(o.pid);
+    this.origin = (o.origin ?? "").replace(/\/+$/, ""); // "" ⇒ same-origin relative URLs
+    this.readOnly = o.readOnly !== false; // default true; phase 1 never wires input
+    this.token = o.token ?? discoverToken();
+    this.title = o.title ?? `#${this.pid}`;
+  }
+
+  /** URL to a daemon API path with the token appended as a query param (EventSource can't set headers). */
+  private url(path: string): string {
+    const p = this.token
+      ? `${path}${path.includes("?") ? "&" : "?"}token=${encodeURIComponent(this.token)}`
+      : path;
+    return this.origin + p;
+  }
+
+  /**
+   * Create the xterm, size its grid to the agent's native PTY, and subscribe to
+   * the raw SSE stream. `el` is the element the terminal renders into.
+   */
+  async start(el: any): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    const g = globalThis as any;
+    this.writable = !this.readOnly;
+    this.term = new Terminal({
+      fontSize: 13,
+      fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+      theme: TERM_THEME,
+      disableStdin: this.readOnly, // read-only mirror unless an interactive token was supplied
+      cursorBlink: !this.readOnly,
+      scrollback: 2000,
+      convertEol: false,
+    });
+    this.term.open(el);
+
+    // Size the grid to the agent's own PTY so absolute-cursor raw bytes land in
+    // the right cells; we only READ /api/size and never POST a resize back.
+    try {
+      const res = await g.fetch(this.url(`/api/size/${encodeURIComponent(this.pid)}`), {
+        headers: { accept: "application/json" },
+      });
+      if (res.ok) {
+        const sz = (await res.json()) as { cols?: number; rows?: number };
+        if (sz?.cols && sz?.rows) this.term.resize(sz.cols, sz.rows);
+      }
+    } catch {
+      /* keep the default grid — the stream still redraws on the next full repaint */
+    }
+
+    // SSE: each `data:` frame is a JSON-encoded raw chunk (`: ping` keepalives are
+    // non-JSON and ignored). Replays the last ~64KB on connect so the view converges.
+    const es = new g.EventSource(this.url(`/api/tail/${encodeURIComponent(this.pid)}?raw=1`));
+    es.onmessage = (e: any) => {
+      try {
+        this.term!.write(JSON.parse(e.data) as string);
+      } catch {
+        /* keepalive / non-JSON frame */
+      }
+    };
+    this.es = es;
+
+    // Interactive input (opt-in): forward keystrokes to the agent's stdin as raw
+    // bytes (code:"none" = no trailing Enter — the terminal itself sends \r). Only
+    // when a WRITABLE token was supplied; a read-only token that reaches here 403s,
+    // and we fail closed — disable stdin so the widget silently reverts to a mirror.
+    // This is the same discipline as the rgui embed's attachStdin/onDenied.
+    if (!this.readOnly) {
+      this.term.onData((data: string) => {
+        if (!this.writable) return;
+        void g
+          .fetch(this.url("/api/send"), {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ keyword: this.pid, msg: data, code: "none" }),
+          })
+          .then((r: any) => {
+            if (r.status === 403 || r.status === 401) {
+              this.writable = false;
+              this.term.options.disableStdin = true;
+              this.term.options.cursorBlink = false;
+            }
+          })
+          .catch(() => {
+            /* transient network error — keep trying on the next keystroke */
+          });
+      });
+    }
+  }
+
+  /** Tear down the stream, the terminal, and the mounted widget. */
+  close(): void {
+    this.es?.close();
+    this.es = undefined;
+    this.term?.dispose();
+    this.term = undefined;
+    if (this.widget) {
+      this.widget.remove();
+      this.widget = undefined;
+    }
+    this.started = false;
+  }
+
+  /**
+   * Render the widget. With a `target` element it embeds inline, filling that
+   * element (the report-page case); with no target it mounts a floating panel
+   * with a toggle bubble in the corner (like AyChannel). Auto-calls start().
+   */
+  mount(target?: any, opts?: { open?: boolean }): any {
+    if (this.widget) return this.widget;
+    const doc: any = (globalThis as any).document;
+    const host = doc.createElement("div");
+    host.setAttribute("data-ayterminal", this.pid);
+    const root = host.attachShadow({ mode: "open" });
+    const inline = !!target;
+    root.innerHTML = widgetHtml(inline, this.title, this.readOnly);
+    this.widget = host;
+    (target ?? doc.body).appendChild(host);
+
+    const panel = root.getElementById("panel")!;
+    const inner = root.getElementById("inner")!;
+    const wrap = root.getElementById("wrap")!;
+
+    // Scale the native-grid terminal to FIT the wrap box (never upscale past 1:1),
+    // exactly like the rgui embed — the grid stays the agent's size, only pixels scale.
+    const fit = () => {
+      const xt = inner.querySelector(".xterm") as any;
+      if (!xt || !xt.offsetWidth || !xt.offsetHeight) return;
+      const s = Math.min(1, wrap.clientWidth / xt.offsetWidth, wrap.clientHeight / xt.offsetHeight);
+      inner.style.transform = `scale(${s})`;
+    };
+
+    if (inline) {
+      // fill the target; make it a positioning context if it is statically positioned
+      try {
+        const cs = (globalThis as any).getComputedStyle?.(target);
+        if (cs && cs.position === "static") target.style.position = "relative";
+      } catch {
+        /* no getComputedStyle */
+      }
+    } else {
+      const toggle = root.getElementById("toggle")!;
+      toggle.addEventListener("click", () => panel.classList.toggle("open"));
+      if (opts?.open) panel.classList.add("open");
+    }
+
+    const g = globalThis as any;
+    g.addEventListener?.("resize", fit);
+    void (async () => {
+      await this.start(inner);
+      // let xterm lay out its rows before measuring, then fit a couple of times
+      (g.requestAnimationFrame ?? ((cb: () => void) => setTimeout(cb, 16)))(() => {
+        fit();
+        setTimeout(fit, 150);
+      });
+    })();
+
+    return host;
+  }
+}
+
+/** window.AY_TERM_TOKEN → page `#k=` hash → localStorage["ay.localToken"] (the rgui/console cache). */
+function discoverToken(): string {
+  const g = globalThis as any;
+  if (g.AY_TERM_TOKEN) return String(g.AY_TERM_TOKEN);
+  try {
+    const parts: string[] = (g.location?.hash ?? "").slice(1).split("&");
+    const k = parts.find((s) => s.startsWith("k="));
+    if (k) return decodeURIComponent(k.slice(2));
+    const stored = g.localStorage?.getItem("ay.localToken");
+    if (stored) return stored;
+  } catch {
+    /* no DOM */
+  }
+  return "";
+}
+
+const TERM_THEME = {
+  background: "#0d1117",
+  foreground: "#c9d1d9",
+  cursor: "#c9d1d9",
+  selectionBackground: "#264f78",
+};
+
+/**
+ * Shadow-DOM markup + styles. Self-contained (xterm's own stylesheet is inlined
+ * below so it applies inside the isolated shadow root). Inline mode fills the
+ * target; floating mode is a corner bubble + panel like AyChannel.
+ */
+function widgetHtml(inline: boolean, title: string, readOnly: boolean): string {
+  const esc = (s: string) =>
+    s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
+  const badge = readOnly
+    ? `<span class="ro" title="read-only mirror">read-only</span>`
+    : `<span class="rw" title="interactive — type to the agent">interactive</span>`;
+  const chrome = inline
+    ? `
+  #panel { position: absolute; inset: 0; display: flex; }
+  #wrap { border-radius: 0; }
+`
+    : `
+  #toggle {
+    position: fixed; right: 20px; bottom: 20px; z-index: 2147483000;
+    width: 52px; height: 52px; border-radius: 50%; border: none; cursor: pointer;
+    background: #0d1117; color: #c9d1d9; font-size: 22px; box-shadow: 0 4px 16px rgba(0,0,0,.4);
+    border: 1px solid #30363d;
+  }
+  #panel {
+    position: fixed; right: 20px; bottom: 84px; z-index: 2147483000;
+    width: min(720px, 94vw); height: min(460px, 72vh); display: none;
+  }
+  #panel.open { display: flex; }
+`;
+  return `
+<style>
+  :host { all: initial; }
+  * { box-sizing: border-box; }
+  ${chrome}
+  #panel { flex-direction: column; background: #0d1117; border-radius: 12px;
+    box-shadow: 0 12px 40px rgba(0,0,0,.45); overflow: hidden; border: 1px solid #30363d; }
+  header { padding: 7px 11px; background: #161b22; display: flex; align-items: center; gap: 8px;
+    font: 600 12px ui-monospace, SFMono-Regular, Menlo, monospace; color: #c9d1d9; }
+  header .dot { width: 8px; height: 8px; border-radius: 50%; background: #10b981; flex: none; }
+  header .title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  header .ro { font-size: 10px; opacity: .7; background: #30363d; border-radius: 9px; padding: 1px 7px; }
+  header .rw { font-size: 10px; background: #1f6feb; color: #fff; border-radius: 9px; padding: 1px 7px; }
+  #wrap { flex: 1; position: relative; overflow: hidden; background: #0d1117; }
+  #inner { position: absolute; left: 0; top: 0; transform-origin: 0 0; }
+  ${XTERM_CSS}
+</style>
+${inline ? "" : `<button id="toggle" title="Terminal">🖥️</button>`}
+<section id="panel">
+  <header><span class="dot"></span><span class="title">${esc(title)}</span>${badge}</header>
+  <div id="wrap"><div id="inner"></div></div>
+</section>
+`;
+}
+
+// xterm.js default stylesheet (v6), inlined so it applies inside the Shadow root.
+// Upstream: node_modules/@xterm/xterm/css/xterm.css (MIT, xterm.js authors).
+const XTERM_CSS = `
+.xterm { cursor: text; position: relative; user-select: none; -ms-user-select: none; -webkit-user-select: none; }
+.xterm.focus, .xterm:focus { outline: none; }
+.xterm .xterm-helpers { position: absolute; top: 0; z-index: 5; }
+.xterm .xterm-helper-textarea { padding: 0; border: 0; margin: 0; position: absolute; opacity: 0; left: -9999em; top: 0; width: 0; height: 0; z-index: -5; white-space: nowrap; overflow: hidden; resize: none; }
+.xterm .composition-view { background: #000; color: #FFF; display: none; position: absolute; white-space: nowrap; z-index: 1; }
+.xterm .composition-view.active { display: block; }
+.xterm .xterm-viewport { background-color: #000; overflow-y: scroll; cursor: default; position: absolute; right: 0; left: 0; top: 0; bottom: 0; }
+.xterm .xterm-screen { position: relative; }
+.xterm .xterm-screen canvas { position: absolute; left: 0; top: 0; }
+.xterm-char-measure-element { display: inline-block; visibility: hidden; position: absolute; top: 0; left: -9999em; line-height: normal; }
+.xterm.enable-mouse-events { cursor: default; }
+.xterm.xterm-cursor-pointer, .xterm .xterm-cursor-pointer { cursor: pointer; }
+.xterm.column-select.focus { cursor: crosshair; }
+.xterm .xterm-accessibility:not(.debug), .xterm .xterm-message { position: absolute; left: 0; top: 0; bottom: 0; right: 0; z-index: 10; color: transparent; pointer-events: none; }
+.xterm .xterm-accessibility-tree:not(.debug) *::selection { color: transparent; }
+.xterm .xterm-accessibility-tree { font-family: monospace; user-select: text; white-space: pre; }
+.xterm .xterm-accessibility-tree > div { transform-origin: left; width: fit-content; }
+.xterm .live-region { position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden; }
+.xterm-dim { opacity: 1 !important; }
+.xterm-underline-1 { text-decoration: underline; }
+.xterm-underline-2 { text-decoration: double underline; }
+.xterm-underline-3 { text-decoration: wavy underline; }
+.xterm-underline-4 { text-decoration: dotted underline; }
+.xterm-underline-5 { text-decoration: dashed underline; }
+.xterm-overline { text-decoration: overline; }
+.xterm-strikethrough { text-decoration: line-through; }
+.xterm-screen .xterm-decoration-container .xterm-decoration { z-index: 6; position: absolute; }
+.xterm-screen .xterm-decoration-container .xterm-decoration.xterm-decoration-top-layer { z-index: 7; }
+.xterm-decoration-overview-ruler { z-index: 8; position: absolute; top: 0; right: 0; pointer-events: none; }
+.xterm-decoration-top { z-index: 2; position: relative; }
+`;
+
+export default AyTerminal;

--- a/ts/widgets.ts
+++ b/ts/widgets.ts
@@ -1,0 +1,14 @@
+// Aggregate entry for the agent-yes browser widgets: `import { AyTerminal,
+// AyChannel } from "agent-yes/widgets"`.
+//
+// Named exports only — NO default export. The plural name means "the collection
+// of widgets"; each individual widget also ships as its own singular subpath
+// (`agent-yes/terminal`, `agent-yes/channels`) which is the tree-shakeable import
+// to prefer when you only need one — the terminal widget inlines xterm.js and is
+// heavy, so a chat-only page should import `agent-yes/channels` directly rather
+// than pull this aggregate. The CDN keeps them as separate files too
+// (/w/terminal.js, /w/channels.js).
+export { AyTerminal } from "./terminal/browser.ts";
+export type { AyTerminalInfo } from "./terminal/browser.ts";
+export { AyChannel } from "./channels/browser.ts";
+export type { AyChannelInfo } from "./channels/browser.ts";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     cli: "./ts/cli.ts",
     index: "./ts/index.ts",
     channels: "./ts/channels/browser.ts",
+    terminal: "./ts/terminal/browser.ts",
+    widgets: "./ts/widgets.ts",
   },
   outDir: "dist",
   platform: "node",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -89,6 +89,16 @@ export default defineConfig({
         // (its store backend store.browser.ts IS covered, and it delegates all CRDT
         // logic to the covered core). Same rationale as peer.ts.
         "ts/channels/browser.ts",
+        // `ay term` CLI shell — thin dispatcher over buildTermEmbedSnippet (pure,
+        // unit-tested in ts/terminal.spec.ts); the flag/stderr-guidance branches are
+        // integration-only. Same rationale as ts/channels.ts.
+        "ts/terminal.ts",
+        // Browser AyTerminal client + xterm widget — needs a DOM + xterm + a live
+        // daemon SSE stream; verified in a browser, not unit-testable. Same
+        // rationale as ts/channels/browser.ts.
+        "ts/terminal/browser.ts",
+        // Aggregate widget re-export barrel — no logic (same rationale as ts/index.ts).
+        "ts/widgets.ts",
         "ts/remotes.ts",
         // WebRTC share bridge — needs a peer + signaling server; proven e2e, not
         // unit-testable.


### PR DESCRIPTION
## Problem
`agent-yes.com/w/channels.js` was served without `Access-Control-Allow-Origin`. The `ay ch embed` snippet imports it cross-origin as `type=module` (`import AyChannel from "https://agent-yes.com/w/channels.js"`), which the browser CORS-gates — so every third-party embed failed to load. It only worked when the embedding site self-hosted the bundle same-origin.

## Fix
Add `Access-Control-Allow-Origin: *` + `Cross-Origin-Resource-Policy: cross-origin` for `/w/channels.js` in `lab/ui/cf/_headers` (the mechanism that applies headers to CF static assets, which serve before the Worker). It's public, credential-free JS, so `*` is correct. Different header name from the `/*` CSP rule, so the console CSP is unaffected.

## Verify
Deployed to prod; live `curl -H "Origin: https://example.localhost" https://agent-yes.com/w/channels.js` now returns `access-control-allow-origin: *` (and CORP:cross-origin). Cross-origin `type=module` embed now loads out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)