### PR TITLE
feat(ay widget): in-page agent sensors — ls + read selection/dom (phase 3.0–3.2)

### DIFF
--- a/lab/ui/cf/_headers
+++ b/lab/ui/cf/_headers
@@ -24,3 +24,6 @@
 /w/terminal.js
   Access-Control-Allow-Origin: *
   Cross-Origin-Resource-Policy: cross-origin
+/w/widget.js
+  Access-Control-Allow-Origin: *
+  Cross-Origin-Resource-Policy: cross-origin

--- a/lab/ui/cf/build-assets.sh
+++ b/lab/ui/cf/build-assets.sh
@@ -54,6 +54,9 @@ bun build ../../../ts/channels/browser.ts --outfile ./public/w/channels.js --for
 # loads to render a live read-only agent terminal (ay term embed). Same browser
 # target + independence from the npm dist build as channels.js above.
 bun build ../../../ts/terminal/browser.ts --outfile ./public/w/terminal.js --format esm --target browser --minify
+# Widget sensor lib (`import { AyWidget } from "agent-yes/widgets"` / agent-yes/widget):
+# an in-page agent sensor (selection/dom/screenshot) an agent reads via `ay widget`.
+bun build ../../../ts/widget/browser.ts --outfile ./public/w/widget.js --format esm --target browser --minify
 
 cp _headers ./public/_headers
 bun ../../../scripts/build-rgui.ts ./public/r

--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
       "types": "./ts/terminal/browser.ts",
       "import": "./dist/terminal.js"
     },
+    "./widget": {
+      "types": "./ts/widget/browser.ts",
+      "import": "./dist/widget.js"
+    },
     "./widgets": {
       "types": "./ts/widgets.ts",
       "import": "./dist/widgets.js"

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -22,7 +22,7 @@ use std::env;
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
     "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
-    "term", "serve", "schedule", "remote", "expose", "callback", "reap", "help",
+    "term", "widget", "mint", "serve", "schedule", "remote", "expose", "callback", "reap", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -184,7 +184,7 @@ async function loadOrCreateToken(tokenFlag?: string): Promise<string> {
 
 // Read the serve token WITHOUT creating one — `ay serve status` must be a pure
 // read (creating a token as a side effect of asking "is it running?" is wrong).
-async function loadTokenReadOnly(): Promise<string | null> {
+export async function loadTokenReadOnly(): Promise<string | null> {
   try {
     return (await readFile(tokenPath(), "utf-8")).trim();
   } catch {
@@ -241,7 +241,12 @@ function authorizeRequest(req: Request, expectedToken: string): AuthResult | nul
 // a cross-origin report page can reach the daemon — the token is still required to
 // get a 200, and no cookies are involved, so `*` leaks nothing.
 function isTermCorsPath(p: string): boolean {
-  return /^\/api\/(tail|size)\/.+$/.test(p) || p === "/api/send";
+  return (
+    /^\/api\/(tail|size)\/.+$/.test(p) ||
+    p === "/api/send" ||
+    /^\/api\/resize\/.+$/.test(p) ||
+    p.startsWith("/api/widget/")
+  );
 }
 
 function withTermCors(req: Request, res: Response | undefined): Response | undefined {
@@ -291,24 +296,34 @@ async function scopedGate(
   p: string,
 ): Promise<Response | null> {
   const forbid = (m: string) => new Response(m, { status: 403 });
+  const needs = (cap: string) => (scope.caps.includes(cap) ? null : forbid(`scoped token lacks '${cap}'`));
   const m = /^\/api\/(?:tail|size)\/(.+)$/.exec(p);
   if (method === "GET" && m) {
-    return (await scopedKeywordOk(decodeURIComponent(m[1]!), scope))
-      ? null
-      : forbid("scoped token: not bound to this agent");
+    return (
+      needs("tail") ??
+      ((await scopedKeywordOk(decodeURIComponent(m[1]!), scope))
+        ? null
+        : forbid("scoped token: not bound to this agent"))
+    );
   }
   if (method === "POST" && p === "/api/send") {
-    if (!scope.canSend) return forbid("scoped token is read-only");
-    return null; // pid binding enforced in the /api/send handler (it has the body)
+    return needs("send"); // pid binding enforced in the /api/send handler (it has the body)
   }
   // Interactive viewers may renegotiate the agent's PTY size (drag-to-resize) —
-  // send-capable scope only, bound pid. The keyword is in the path, so bind here.
+  // needs the resize cap, bound pid. The keyword is in the path, so bind here.
   const rz = /^\/api\/resize\/(.+)$/.exec(p);
   if (method === "POST" && rz) {
-    if (!scope.canSend) return forbid("scoped token is read-only");
-    return (await scopedKeywordOk(decodeURIComponent(rz[1]!), scope))
-      ? null
-      : forbid("scoped token: not bound to this agent");
+    return (
+      needs("resize") ??
+      ((await scopedKeywordOk(decodeURIComponent(rz[1]!), scope))
+        ? null
+        : forbid("scoped token: not bound to this agent"))
+    );
+  }
+  // Widget sensor routes: require the 'read' cap; the widget-route handlers do the
+  // fine-grained viewer-binding (and the 'screenshot' cap check for that kind).
+  if (p.startsWith("/api/widget/")) {
+    return needs("read");
   }
   return forbid("scoped token: route not permitted");
 }
@@ -318,20 +333,65 @@ async function scopedGate(
  * master token file, resolve the keyword to a concrete pid, and sign. Used by
  * `ay term mint`. Throws if there's no serve token or the agent can't be resolved.
  */
+const TERMINAL_CAPS = new Set(["tail", "size", "send", "resize"]);
+
 export async function mintScopedTermToken(
-  keyword: string,
-  opts: { ttlSec: number; canSend: boolean },
-): Promise<{ token: string; pid: string; exp: number; canSend: boolean }> {
+  target: string,
+  opts: { ttlSec: number; caps?: string[]; canSend?: boolean },
+): Promise<{ token: string; sub: string; pid: string; exp: number; caps: string[] }> {
   const master = await loadTokenReadOnly();
   if (!master)
     throw new Error(
       "no serve token at ~/.agent-yes/.serve-token — run `ay serve` once on this host to create it",
     );
-  const rec = await resolveOne(keyword, defaultOpts({ all: true }));
-  const pid = String(rec.pid);
+  const caps = opts.caps ?? (opts.canSend ? ["tail", "size", "send", "resize"] : ["tail", "size"]);
+  // A terminal-cap token binds to a concrete pid (resolve it); a widget-only token
+  // (read/screenshot) binds to the target verbatim (a viewer id, or "*" for any).
+  let sub = target;
+  if (target !== "*" && caps.some((c) => TERMINAL_CAPS.has(c))) {
+    const rec = await resolveOne(target, defaultOpts({ all: true }));
+    sub = String(rec.pid);
+  }
   const exp = Math.floor(Date.now() / 1000) + Math.max(1, Math.floor(opts.ttlSec));
-  const token = mintTermToken(master, { pid, canSend: opts.canSend, exp });
-  return { token, pid, exp, canSend: opts.canSend };
+  const token = mintTermToken(master, { pid: sub, caps, exp });
+  return { token, sub, pid: sub, exp, caps };
+}
+
+// ── Widget sensor broker (`ay widget`) ──────────────────────────────────────
+// The daemon is a STATELESS broker between the CLI (`ay widget read …`) and an
+// in-page AyWidget: it correlates a command with its result and forwards the
+// payload, but stores no page data. A widget registers on mount, holds an SSE
+// poll for commands, and POSTs results; a CLI read enqueues a command and awaits
+// the matching result. All in-memory — one daemon per process.
+interface WidgetViewer {
+  id: string;
+  url: string;
+  title: string;
+  caps: string[]; // what the page author opted into (selection/dom/screenshot)
+  lastSeen: number;
+}
+const widgetViewers = new Map<string, WidgetViewer>();
+const widgetPushers = new Map<string, (cmd: unknown) => void>(); // viewerId → active poll push
+const widgetWaiters = new Map<string, (r: { ok: boolean; data?: unknown; error?: string }) => void>();
+let widgetCmdSeq = 0;
+const WIDGET_TTL_MS = 30_000; // a viewer with no poll heartbeat this long is offline
+
+function widgetNewId(): string {
+  return "v_" + randomBytes(4).toString("hex");
+}
+function widgetLive(): WidgetViewer[] {
+  const now = Date.now();
+  for (const [id, v] of widgetViewers) if (now - v.lastSeen >= WIDGET_TTL_MS) widgetViewers.delete(id);
+  return [...widgetViewers.values()];
+}
+/** Resolve a `<viewer>` selector: exact id, then id-prefix / url / title substring. */
+function widgetResolve(sel: string): string | null {
+  if (widgetViewers.has(sel) && Date.now() - widgetViewers.get(sel)!.lastSeen < WIDGET_TTL_MS)
+    return sel;
+  const hit = widgetLive().find(
+    (v) => v.id.startsWith(sel) || v.url.includes(sel) || v.title.includes(sel),
+  );
+  return hit?.id ?? null;
 }
 
 const defaultOpts = (overrides: Partial<CommonOpts> = {}): CommonOpts => ({
@@ -2867,6 +2927,161 @@ export async function cmdServe(rest: string[]): Promise<number> {
       } catch (e) {
         return new Response((e as Error).message, { status: 404 });
       }
+    }
+
+    // ── Widget sensor broker routes (`ay widget`) ───────────────────────────
+    // A scoped token binds to one viewer id (scope.pid); "*" means any. Enforce
+    // that binding on the per-viewer routes (scopedGate already required 'read').
+    const scopedSub = authResult.kind === "scoped" ? authResult.scope.pid : null;
+    const boundOk = (vid: string) => !scopedSub || scopedSub === "*" || scopedSub === vid;
+
+    // POST /api/widget/register {id?, url, title, caps} → { viewerId }
+    if (req.method === "POST" && p === "/api/widget/register") {
+      let b: { id?: string; url?: string; title?: string; caps?: string[] };
+      try {
+        b = (await req.json()) as typeof b;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      // A scoped token pins the id to its subject (so a page can't register as
+      // another viewer); "*"/master lets the widget pick (its provided id or a new one).
+      const id =
+        scopedSub && scopedSub !== "*"
+          ? scopedSub
+          : typeof b.id === "string" && b.id
+            ? b.id
+            : widgetNewId();
+      widgetViewers.set(id, {
+        id,
+        url: String(b.url ?? ""),
+        title: String(b.title ?? ""),
+        caps: Array.isArray(b.caps) ? b.caps.filter((c) => typeof c === "string") : [],
+        lastSeen: Date.now(),
+      });
+      return Response.json({ viewerId: id });
+    }
+
+    // GET /api/widget/list → live viewers (id, url, title, caps, age)
+    if (req.method === "GET" && p === "/api/widget/list") {
+      const now = Date.now();
+      return Response.json(
+        widgetLive().map((v) => ({
+          id: v.id,
+          url: v.url,
+          title: v.title,
+          caps: v.caps,
+          age: Math.round((now - v.lastSeen) / 1000),
+        })),
+      );
+    }
+
+    // GET /api/widget/poll/:viewerId  (SSE) — the widget's command channel + heartbeat
+    const pollM = /^\/api\/widget\/poll\/(.+)$/.exec(p);
+    if (req.method === "GET" && pollM) {
+      const vid = decodeURIComponent(pollM[1]!);
+      if (!boundOk(vid)) return new Response("token not bound to this viewer", { status: 403 });
+      const enc = new TextEncoder();
+      let hb: ReturnType<typeof setInterval> | null = null;
+      const stream = new ReadableStream({
+        start(controller) {
+          const push = (obj: unknown) => {
+            try {
+              controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+            } catch {
+              /* stream closed */
+            }
+          };
+          widgetPushers.set(vid, push);
+          const touch = () => {
+            const v = widgetViewers.get(vid);
+            if (v) v.lastSeen = Date.now();
+          };
+          touch();
+          hb = setInterval(() => {
+            try {
+              controller.enqueue(enc.encode(": ping\n\n"));
+              touch();
+            } catch {
+              /* closed */
+            }
+          }, 15_000);
+          const cleanup = () => {
+            if (hb) clearInterval(hb);
+            if (widgetPushers.get(vid) === push) widgetPushers.delete(vid);
+          };
+          req.signal.addEventListener("abort", cleanup);
+        },
+        cancel() {
+          if (hb) clearInterval(hb);
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+
+    // POST /api/widget/result {cmdId, ok, data?, error?} — widget → CLI result
+    if (req.method === "POST" && p === "/api/widget/result") {
+      let b: { cmdId?: string; ok?: boolean; data?: unknown; error?: string };
+      try {
+        b = (await req.json()) as typeof b;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      const resolve = b.cmdId ? widgetWaiters.get(b.cmdId) : undefined;
+      if (resolve) {
+        widgetWaiters.delete(b.cmdId!);
+        resolve({ ok: b.ok === true, data: b.data, error: b.error });
+      }
+      return Response.json({ ok: true });
+    }
+
+    // POST /api/widget/read {viewer, kind, args?} — CLI issues a read to a viewer
+    if (req.method === "POST" && p === "/api/widget/read") {
+      let b: { viewer?: string; kind?: string; args?: unknown };
+      try {
+        b = (await req.json()) as typeof b;
+      } catch {
+        return new Response("invalid JSON body", { status: 400 });
+      }
+      if (!b.viewer || !b.kind) return new Response("missing viewer/kind", { status: 400 });
+      // A scoped token needs the 'screenshot' cap for that kind (scopedGate already
+      // required 'read'); the master token is unrestricted.
+      if (
+        authResult.kind === "scoped" &&
+        b.kind === "screenshot" &&
+        !authResult.scope.caps.includes("screenshot")
+      )
+        return new Response("scoped token lacks 'screenshot'", { status: 403 });
+      const vid = widgetResolve(b.viewer);
+      if (!vid) return new Response(`no online viewer matching "${b.viewer}"`, { status: 404 });
+      if (!boundOk(vid)) return new Response("token not bound to this viewer", { status: 403 });
+      const push = widgetPushers.get(vid);
+      if (!push) return new Response("viewer offline", { status: 409 });
+      const cmdId = `c${++widgetCmdSeq}_${Date.now()}`;
+      const result = await new Promise<{ ok: boolean; data?: unknown; error?: string }>((resolve) => {
+        const timer = setTimeout(() => {
+          widgetWaiters.delete(cmdId);
+          resolve({ ok: false, error: "timeout" });
+        }, 10_000);
+        widgetWaiters.set(cmdId, (r) => {
+          clearTimeout(timer);
+          resolve(r);
+        });
+        push({ cmdId, kind: b.kind, args: b.args ?? {} });
+      });
+      const v = widgetViewers.get(vid);
+      return Response.json({
+        viewer: vid,
+        url: v?.url ?? "",
+        ts: Math.floor(Date.now() / 1000),
+        kind: b.kind,
+        ...(result.ok ? { data: result.data } : { error: result.error ?? "failed" }),
+      });
     }
 
     // GET /api/tail/:keyword  — SSE streaming

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -366,6 +366,8 @@ const SUBCOMMANDS = new Set([
   "ch",
   "channels",
   "term",
+  "widget",
+  "mint",
   "serve",
   "schedule",
   "remote",
@@ -490,6 +492,14 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
       case "term": {
         const { cmdTerm } = await import("./terminal.ts");
         return cmdTerm(rest);
+      }
+      case "widget": {
+        const { cmdWidget } = await import("./widget.ts");
+        return cmdWidget(rest);
+      }
+      case "mint": {
+        const { cmdMint } = await import("./widget.ts");
+        return cmdMint(rest);
       }
       case "serve": {
         const { cmdServe } = await import("./serve.ts");
@@ -628,6 +638,8 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
       `  ay ch mk|join|send|read|tail <topic>  local-first E2E channels: AI ↔ humans on a topic (ay ch help)\n` +
       `  ay term embed <pid>                 <script> to embed a live read-only agent terminal in a page (ay term help)\n` +
+      `  ay widget ls | read selection|dom   read an opted-in page widget's context (selection/DOM) (ay widget help)\n` +
+      `  ay mint <target> --caps ...         mint a scoped, short-TTL capability token (embeddable in a page)\n` +
       `  ay key <keyword> <key...>           send raw keystrokes (down/up/enter/esc/…) — drives menus\n` +
       `  ay select <keyword> <N>             pick option N of a needs_input selection menu\n` +
       `  ay attach <keyword>                 interactive attach (detach: Ctrl-\\)\n` +

--- a/ts/termToken.spec.ts
+++ b/ts/termToken.spec.ts
@@ -9,12 +9,34 @@ describe("termToken", () => {
     const tok = mintTermToken(MASTER, { pid: "4242", canSend: false, exp: now + 900 });
     expect(isTermToken(tok)).toBe(true);
     const scope = verifyTermToken(MASTER, tok, now);
-    expect(scope).toEqual({ pid: "4242", canSend: false, exp: now + 900 });
+    expect(scope).toEqual({ pid: "4242", canSend: false, caps: ["tail", "size"], exp: now + 900 });
   });
 
-  it("round-trips an interactive token (canSend true)", () => {
+  it("round-trips an interactive token (canSend true → send/resize caps)", () => {
     const tok = mintTermToken(MASTER, { pid: "7", canSend: true, exp: now + 60 });
-    expect(verifyTermToken(MASTER, tok, now)?.canSend).toBe(true);
+    const scope = verifyTermToken(MASTER, tok, now);
+    expect(scope?.canSend).toBe(true);
+    expect(scope?.caps).toEqual(["tail", "size", "send", "resize"]);
+  });
+
+  it("carries an explicit caps array (widget read/screenshot)", () => {
+    const tok = mintTermToken(MASTER, { pid: "v_ab12", caps: ["read", "screenshot"], exp: now + 60 });
+    const scope = verifyTermToken(MASTER, tok, now);
+    expect(scope?.caps).toEqual(["read", "screenshot"]);
+    expect(scope?.canSend).toBe(false); // no "send" cap
+    expect(scope?.pid).toBe("v_ab12");
+  });
+
+  it("verifies a legacy {p,w,x} token (pre-caps format) into derived caps", () => {
+    // hand-build a legacy payload to prove backward-compat with live phase-2 tokens
+    const legacy = Buffer.from(JSON.stringify({ p: "9", w: 1, x: now + 60 })).toString("base64url");
+    const body = `ayt1.${legacy}`;
+    const { createHmac, createHash } = require("crypto");
+    const key = createHash("sha256").update("ay/term/token/v1\n" + MASTER).digest();
+    const sig = createHmac("sha256", key).update(body).digest().toString("base64url");
+    const scope = verifyTermToken(MASTER, `${body}.${sig}`, now);
+    expect(scope?.pid).toBe("9");
+    expect(scope?.caps).toEqual(["tail", "size", "send", "resize"]);
   });
 
   it("rejects a token signed with a different master (forgery)", () => {

--- a/ts/termToken.ts
+++ b/ts/termToken.ts
@@ -17,16 +17,28 @@
 // delivers short-TTL + read-only + single-session, which is what embeds need.)
 import { createHash, createHmac, timingSafeEqual } from "crypto";
 
+/** Capability vocabulary a scoped token can carry (see scopedGate in serve.ts). */
+export type Cap = "tail" | "size" | "send" | "resize" | "read" | "screenshot";
+
 export interface TermScope {
-  /** The agent pid this token is bound to (resolved to a concrete pid at mint time). */
+  /** Subject the token is bound to: an agent pid (terminal) or a viewer id (widget). */
   pid: string;
-  /** Interactive: may also write to this pid's stdin (/api/send). Read-only when false. */
+  /** Convenience mirror of caps.includes("send") — interactive terminal write. */
   canSend: boolean;
+  /** Full capability list this token grants for its subject. */
+  caps: string[];
   /** Expiry, epoch seconds. */
   exp: number;
 }
 
 const PREFIX = "ayt1";
+
+const CAPS_READONLY: Cap[] = ["tail", "size"];
+const CAPS_INTERACTIVE: Cap[] = ["tail", "size", "send", "resize"];
+/** Derive caps for a legacy `{w}` token (pre-caps format): w=1 ⇒ interactive. */
+function legacyCaps(w: unknown): string[] {
+  return w === 1 ? [...CAPS_INTERACTIVE] : [...CAPS_READONLY];
+}
 
 /** Dedicated HMAC key derived from the master token (so the token isn't signed with the raw master). */
 function keyFor(masterToken: string): Buffer {
@@ -40,10 +52,19 @@ export function isTermToken(tok: unknown): tok is string {
   return typeof tok === "string" && tok.startsWith(PREFIX + ".");
 }
 
-/** Mint a scoped token bound to `scope.pid`, signed with the master token. */
-export function mintTermToken(masterToken: string, scope: TermScope): string {
+/**
+ * Mint a scoped token bound to `scope.pid` (the subject), signed with the master
+ * token. `caps` is authoritative; if omitted it derives from `canSend` (terminal
+ * back-compat). Emits the caps-format payload `{s, c, x}` (verified alongside the
+ * legacy `{p, w, x}`).
+ */
+export function mintTermToken(
+  masterToken: string,
+  scope: { pid: string; exp: number; caps?: string[]; canSend?: boolean },
+): string {
+  const caps = scope.caps ?? (scope.canSend ? [...CAPS_INTERACTIVE] : [...CAPS_READONLY]);
   const payload = Buffer.from(
-    JSON.stringify({ p: scope.pid, w: scope.canSend ? 1 : 0, x: Math.floor(scope.exp) }),
+    JSON.stringify({ s: scope.pid, c: caps, x: Math.floor(scope.exp) }),
   ).toString("base64url");
   const body = `${PREFIX}.${payload}`;
   const sig = createHmac("sha256", keyFor(masterToken)).update(body).digest().toString("base64url");
@@ -73,13 +94,19 @@ export function verifyTermToken(
   }
   // constant-time compare; length check first (timingSafeEqual throws on mismatch)
   if (got.length !== expected.length || !timingSafeEqual(got, expected)) return null;
-  let obj: { p?: unknown; w?: unknown; x?: unknown };
+  let obj: { s?: unknown; p?: unknown; w?: unknown; c?: unknown; x?: unknown };
   try {
     obj = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf-8"));
   } catch {
     return null;
   }
-  if (typeof obj.p !== "string" || !obj.p) return null;
+  // subject: new tokens use `s`, legacy tokens use `p`
+  const sub = typeof obj.s === "string" && obj.s ? obj.s : obj.p;
+  if (typeof sub !== "string" || !sub) return null;
   if (typeof obj.x !== "number" || !Number.isFinite(obj.x) || obj.x <= nowSec) return null; // expired
-  return { pid: obj.p, canSend: obj.w === 1, exp: obj.x };
+  // caps: new tokens carry `c`; legacy tokens derive from `w`
+  const caps = Array.isArray(obj.c)
+    ? (obj.c.filter((x) => typeof x === "string") as string[])
+    : legacyCaps(obj.w);
+  return { pid: sub, canSend: caps.includes("send"), caps, exp: obj.x };
 }

--- a/ts/widget.ts
+++ b/ts/widget.ts
@@ -1,0 +1,207 @@
+// `ay widget` — read what a viewer is looking at, through an opted-in page widget.
+//
+// Agent-side CLI over the daemon's widget broker (serve.ts /api/widget/*). The
+// page embeds `new AyWidget({sensors:[…]})` (widget/browser.ts); this reads it:
+//   ay widget ls                         # online viewers
+//   ay widget read selection <viewer>    # what the viewer has selected
+//   ay widget read dom <viewer> --selector <css>
+// Complements rechrome (rech drives any page; this reads an author-opted-in page,
+// cross-origin / WebRTC-remote, no extension). Verb `read` matches `ay read`/`tail`.
+
+type FlagSpec = Record<string, "bool" | "value">;
+
+function parseFlags(
+  args: string[],
+  known: FlagSpec,
+): { flags: Record<string, string | boolean>; positional: string[] } {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (!a.startsWith("-") || a === "-") {
+      positional.push(a);
+      continue;
+    }
+    const eq = a.indexOf("=");
+    const name = eq === -1 ? a.replace(/^--?/, "") : a.slice(a.startsWith("--") ? 2 : 1, eq);
+    const kind = known[name];
+    if (!kind) throw new Error(`unknown flag ${a}`);
+    if (kind === "bool") {
+      if (eq !== -1) throw new Error(`--${name} takes no value`);
+      flags[name] = true;
+    } else {
+      const v = eq !== -1 ? a.slice(eq + 1) : args[++i];
+      if (v === undefined) throw new Error(`${a} requires a value`);
+      flags[name] = v;
+    }
+  }
+  return { flags, positional };
+}
+
+/** Resolve the local daemon base URL + token (flags override discovery). */
+async function daemonTarget(
+  flags: Record<string, string | boolean>,
+): Promise<{ base: string; token: string }> {
+  const { resolveLocalServeUrl, loadTokenReadOnly } = await import("./serve.ts");
+  const base = typeof flags.base === "string" ? flags.base : await resolveLocalServeUrl();
+  if (!base)
+    throw new Error(
+      "no running ay serve daemon found — start `ay serve` or pass --base <url> (e.g. http://127.0.0.1:PORT)",
+    );
+  const token = typeof flags.token === "string" ? flags.token : ((await loadTokenReadOnly()) ?? "");
+  if (!token) throw new Error("no serve token — pass --token or run `ay serve` once");
+  return { base: base.replace(/\/+$/, ""), token };
+}
+
+function withTok(url: string, token: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}token=${encodeURIComponent(token)}`;
+}
+
+async function cmdWidgetLs(args: string[]): Promise<number> {
+  const { flags } = parseFlags(args, { json: "bool", base: "value", token: "value" });
+  const { base, token } = await daemonTarget(flags);
+  const res = await fetch(withTok(`${base}/api/widget/list`, token), {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`widget list failed: ${res.status} ${await res.text()}`);
+  const list = (await res.json()) as Array<{
+    id: string;
+    url: string;
+    title: string;
+    caps: string[];
+    age: number;
+  }>;
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(list, null, 2) + "\n");
+    return 0;
+  }
+  if (!list.length) {
+    process.stderr.write("no online widgets (a page must embed AyWidget and start() it)\n");
+    return 0;
+  }
+  for (const v of list) {
+    process.stdout.write(
+      `${v.id.padEnd(12)}  ${(v.title || "(untitled)").slice(0, 28).padEnd(28)}  ` +
+        `caps:${v.caps.join(",") || "-"}  ${v.age}s  ${v.url}\n`,
+    );
+  }
+  return 0;
+}
+
+async function cmdWidgetRead(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    selector: "value",
+    all: "bool",
+    text: "bool",
+    html: "bool",
+    json: "bool",
+    base: "value",
+    token: "value",
+  });
+  const kind = positional[0];
+  const viewer = positional[1];
+  if (!kind || !viewer)
+    throw new Error("usage: ay widget read <selection|dom> <viewer> [--selector <css>] [--all] [--text|--html]");
+  const cmdArgs: Record<string, unknown> = {};
+  if (kind === "dom") {
+    if (typeof flags.selector !== "string") throw new Error("dom read needs --selector <css>");
+    cmdArgs.selector = flags.selector;
+    cmdArgs.all = flags.all === true;
+  }
+  const { base, token } = await daemonTarget(flags);
+  const res = await fetch(withTok(`${base}/api/widget/read`, token), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ viewer, kind, args: cmdArgs }),
+  });
+  const body = (await res.json().catch(() => ({}))) as any;
+  if (!res.ok) throw new Error(`widget read failed: ${res.status} ${JSON.stringify(body)}`);
+  if (body.error) {
+    process.stderr.write(`read ${kind} @ ${body.viewer ?? viewer}: ${body.error}\n`);
+    return 1;
+  }
+  // Plain-text shortcut for selection unless --json/--html asked for the envelope.
+  if (kind === "selection" && !flags.json) {
+    process.stdout.write((flags.html ? body.data?.html : body.data?.text) ?? "");
+    process.stdout.write("\n");
+    return 0;
+  }
+  process.stdout.write(JSON.stringify(flags.json ? body : body.data, null, 2) + "\n");
+  return 0;
+}
+
+function widgetHelp(): number {
+  process.stdout.write(
+    `ay widget — read an opted-in page widget's context (selection / DOM)\n\n` +
+      `Usage:\n` +
+      `  ay widget ls [--json]\n` +
+      `  ay widget read selection <viewer> [--text|--html|--json]\n` +
+      `  ay widget read dom <viewer> --selector <css> [--all] [--json]\n\n` +
+      `  <viewer> = an id, or a url/title substring (see \`ay widget ls\`).\n` +
+      `  Common flags: --base <daemon-url>  --token <tok>  (default: the local daemon).\n` +
+      `  The page must embed \`new AyWidget({sensors:[...]}).start()\` and the token must\n` +
+      `  carry the 'read' cap (ay mint <viewer> --caps read) — or use the master token.\n`,
+  );
+  return 0;
+}
+
+export async function cmdWidget(args: string[]): Promise<number> {
+  const sub = args[0];
+  const rest = args.slice(1);
+  switch (sub) {
+    case "ls":
+    case "list":
+      return cmdWidgetLs(rest);
+    case "read":
+      return cmdWidgetRead(rest);
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      return widgetHelp();
+    default:
+      process.stderr.write(`ay widget: unknown subcommand "${sub}"\n\n`);
+      widgetHelp();
+      return 1;
+  }
+}
+
+// ── `ay mint` — the general scoped-token minter (ay term mint is an alias) ────
+function parseTtlSec(s: string): number {
+  const m = /^(\d+)(s|m|h)?$/.exec(s.trim());
+  if (!m) throw new Error(`bad --ttl "${s}" (use e.g. 900, 30s, 15m, 2h)`);
+  const mult = m[2] === "h" ? 3600 : m[2] === "m" ? 60 : 1;
+  return Number(m[1]) * mult;
+}
+
+const KNOWN_CAPS = new Set(["tail", "size", "send", "resize", "read", "screenshot"]);
+
+export async function cmdMint(args: string[]): Promise<number> {
+  const { flags, positional } = parseFlags(args, {
+    caps: "value",
+    ttl: "value",
+    json: "bool",
+  });
+  const target = positional[0];
+  if (!target || positional.length > 1)
+    throw new Error("usage: ay mint <pid|viewer|url|*> --caps tail,send,read,screenshot [--ttl 15m] [--json]");
+  if (typeof flags.caps !== "string")
+    throw new Error("--caps is required, e.g. --caps read  or  --caps tail,send");
+  const caps = flags.caps.split(",").map((c) => c.trim()).filter(Boolean);
+  const bad = caps.filter((c) => !KNOWN_CAPS.has(c));
+  if (bad.length) throw new Error(`unknown cap(s): ${bad.join(", ")} (valid: ${[...KNOWN_CAPS].join(", ")})`);
+  const ttlSec = parseTtlSec(typeof flags.ttl === "string" ? flags.ttl : "15m");
+  const { mintScopedTermToken } = await import("./serve.ts");
+  const r = await mintScopedTermToken(target, { ttlSec, caps });
+  if (flags.json === true) {
+    process.stdout.write(JSON.stringify(r) + "\n");
+    return 0;
+  }
+  process.stdout.write(r.token + "\n");
+  process.stderr.write(
+    `\n  Scoped token for ${r.sub === "*" ? "ANY subject" : r.sub}, caps [${r.caps.join(", ")}], ` +
+      `expires ${new Date(r.exp * 1000).toISOString()}.\n` +
+      `  It grants ONLY those caps for that subject — safe to embed in a page (not the master token).\n`,
+  );
+  return 0;
+}

--- a/ts/widget/browser.ts
+++ b/ts/widget/browser.ts
@@ -1,0 +1,217 @@
+// In-page agent sensor: `import { AyWidget } from "agent-yes/widgets"`.
+//
+// The page-side counterpart of `ay widget`. It registers with a serving `ay serve`
+// daemon, holds an SSE command channel, and answers read requests an agent issues
+// (`ay widget read selection|dom … <viewer>`) — turning a page the author embedded
+// it into a high-quality context source for the page's owning agent. Complements
+// rechrome (rech drives any page; this reads a page the author OPTED IN, and works
+// cross-origin / for WebRTC-remote viewers with no extension).
+//
+//   new AyWidget({ id: "report-A", sensors: ["selection", "dom"] }).start();
+//
+// SECURITY — dual consent: a read runs only if BOTH (a) the daemon authorized the
+// caller (scoped-token 'read'/'screenshot' cap, or master token) AND (b) the page
+// author enabled that kind here (`sensors`). Every read flashes a visible indicator
+// so the viewer sees collection happen. Nothing is stored on the daemon — it only
+// brokers the request/response. Screenshot is a later slice (needs the html2canvas
+// bundle + the WebGL snapshot hook); this build ships selection + dom.
+//
+// DOM is accessed as `any` (the Node tsconfig has no DOM lib); it only runs in a browser.
+
+export interface AyWidgetInfo {
+  /** Stable author-assigned id for deterministic addressing (`ay widget read … report-A`). Optional. */
+  id?: string;
+  /** Daemon origin, e.g. "https://box.local:8787". Default "" = same-origin. */
+  origin?: string;
+  /** Token: default discovered from window.AY_TERM_TOKEN / #k= / localStorage. */
+  token?: string;
+  /** Kinds the author allows an agent to read: "selection" | "dom" | "screenshot". Default none. */
+  sensors?: string[];
+  /**
+   * Author opt-in exact-capture hooks, keyed by CSS selector → a function returning
+   * a data: URL. Lets `read screenshot` capture a WebGL/`<canvas>` (three.js) view that
+   * html2canvas can't — the widget calls the hook when a screenshot targets that element.
+   * (Consumed by the screenshot slice; declared here so the API is stable.)
+   */
+  snapshots?: Record<string, () => string>;
+}
+
+type Handler = (args: any) => Promise<unknown>;
+
+export class AyWidget {
+  readonly origin: string;
+  private token: string;
+  private wantId?: string;
+  private viewerId = "";
+  private sensors: Set<string>;
+  private snapshots: Record<string, () => string>;
+  private es?: any;
+  private started = false;
+  private handlers = new Map<string, Handler>();
+  private indicator?: any;
+
+  constructor(info: AyWidgetInfo = {}) {
+    this.origin = (info.origin ?? "").replace(/\/+$/, "");
+    this.token = info.token ?? discoverToken();
+    this.wantId = info.id;
+    this.sensors = new Set(info.sensors ?? []);
+    this.snapshots = info.snapshots ?? {};
+    // Built-in, always-allowed liveness probe (used by `ay widget ls`/addressing).
+    this.handlers.set("ping", async () => ({ caps: [...this.sensors], id: this.viewerId }));
+    this.handlers.set("selection", readSelection);
+    this.handlers.set("dom", readDom);
+  }
+
+  private url(path: string): string {
+    const p = this.token
+      ? `${path}${path.includes("?") ? "&" : "?"}token=${encodeURIComponent(this.token)}`
+      : path;
+    return this.origin + p;
+  }
+
+  /** Register with the daemon and open the command channel. Idempotent. */
+  async start(): Promise<string> {
+    if (this.started) return this.viewerId;
+    this.started = true;
+    const g = globalThis as any;
+    const doc = g.document;
+    const res = await g.fetch(this.url("/api/widget/register"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: this.wantId,
+        url: g.location?.href ?? "",
+        title: doc?.title ?? "",
+        caps: [...this.sensors],
+      }),
+    });
+    if (!res.ok) throw new Error(`widget register failed: ${res.status}`);
+    this.viewerId = ((await res.json()) as { viewerId: string }).viewerId;
+    this.openPoll();
+    return this.viewerId;
+  }
+
+  private openPoll(): void {
+    const g = globalThis as any;
+    const es = new g.EventSource(this.url(`/api/widget/poll/${encodeURIComponent(this.viewerId)}`));
+    es.onmessage = (e: any) => {
+      let cmd: { cmdId?: string; kind?: string; args?: unknown };
+      try {
+        cmd = JSON.parse(e.data);
+      } catch {
+        return; // keepalive
+      }
+      if (cmd.cmdId && cmd.kind) void this.dispatch(cmd.cmdId, cmd.kind, cmd.args ?? {});
+    };
+    // EventSource auto-reconnects; nothing else to wire.
+    this.es = es;
+  }
+
+  private async dispatch(cmdId: string, kind: string, args: any): Promise<void> {
+    this.flash();
+    const handler = this.handlers.get(kind);
+    // Author allowlist: only "ping" is implicit; sensor kinds must be opted in.
+    if (!handler || (kind !== "ping" && !this.sensors.has(kind))) {
+      return this.postResult(cmdId, { ok: false, error: `kind '${kind}' not enabled on this widget` });
+    }
+    try {
+      const data = await handler(args);
+      await this.postResult(cmdId, { ok: true, data });
+    } catch (e: any) {
+      await this.postResult(cmdId, { ok: false, error: String(e?.message ?? e) });
+    }
+  }
+
+  private async postResult(cmdId: string, r: { ok: boolean; data?: unknown; error?: string }): Promise<void> {
+    const g = globalThis as any;
+    try {
+      await g.fetch(this.url("/api/widget/result"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cmdId, ...r }),
+      });
+    } catch {
+      /* best-effort; the CLI read times out if this never lands */
+    }
+  }
+
+  /** A brief visible pulse so the viewer always sees a collection happen. */
+  private flash(): void {
+    const g = globalThis as any;
+    const doc = g.document;
+    if (!doc) return;
+    if (!this.indicator) {
+      const el = doc.createElement("div");
+      el.setAttribute("data-aywidget-indicator", this.viewerId || "1");
+      el.style.cssText =
+        "position:fixed;right:14px;bottom:14px;width:12px;height:12px;border-radius:50%;" +
+        "background:#1f6feb;box-shadow:0 0 0 0 rgba(31,111,235,.6);z-index:2147483000;" +
+        "opacity:0;transition:opacity .15s;pointer-events:none";
+      (doc.body ?? doc.documentElement).appendChild(el);
+      this.indicator = el;
+    }
+    const el = this.indicator;
+    el.style.opacity = "1";
+    el.animate?.(
+      [
+        { boxShadow: "0 0 0 0 rgba(31,111,235,.6)" },
+        { boxShadow: "0 0 0 10px rgba(31,111,235,0)" },
+      ],
+      { duration: 600 },
+    );
+    clearTimeout(el._t);
+    el._t = setTimeout(() => (el.style.opacity = "0"), 500);
+  }
+
+  stop(): void {
+    this.es?.close?.();
+    this.es = undefined;
+    this.indicator?.remove?.();
+    this.indicator = undefined;
+    this.started = false;
+  }
+}
+
+async function readSelection(): Promise<{ text: string; html: string }> {
+  const g = globalThis as any;
+  const sel = g.getSelection?.();
+  const text = sel ? String(sel) : "";
+  let html = "";
+  if (sel && sel.rangeCount) {
+    const div = g.document.createElement("div");
+    for (let i = 0; i < sel.rangeCount; i++) div.appendChild(sel.getRangeAt(i).cloneContents());
+    html = div.innerHTML;
+  }
+  return { text, html };
+}
+
+async function readDom(args: { selector?: string; all?: boolean }): Promise<{
+  matches: number;
+  outerHTML: string[];
+}> {
+  const g = globalThis as any;
+  const selector = args?.selector;
+  if (!selector) throw new Error("dom read needs a --selector");
+  const nodes: any[] = args?.all
+    ? [...g.document.querySelectorAll(selector)]
+    : [g.document.querySelector(selector)].filter(Boolean);
+  return { matches: nodes.length, outerHTML: nodes.map((n) => String(n.outerHTML ?? "")) };
+}
+
+/** window.AY_TERM_TOKEN → page `#k=` hash → localStorage["ay.localToken"]. */
+function discoverToken(): string {
+  const g = globalThis as any;
+  if (g.AY_TERM_TOKEN) return String(g.AY_TERM_TOKEN);
+  try {
+    const parts: string[] = (g.location?.hash ?? "").slice(1).split("&");
+    const k = parts.find((s) => s.startsWith("k="));
+    if (k) return decodeURIComponent(k.slice(2));
+    const stored = g.localStorage?.getItem("ay.localToken");
+    if (stored) return stored;
+  } catch {
+    /* no DOM */
+  }
+  return "";
+}
+
+export default AyWidget;

--- a/ts/widgets.ts
+++ b/ts/widgets.ts
@@ -12,3 +12,5 @@ export { AyTerminal } from "./terminal/browser.ts";
 export type { AyTerminalInfo } from "./terminal/browser.ts";
 export { AyChannel } from "./channels/browser.ts";
 export type { AyChannelInfo } from "./channels/browser.ts";
+export { AyWidget } from "./widget/browser.ts";
+export type { AyWidgetInfo } from "./widget/browser.ts";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     index: "./ts/index.ts",
     channels: "./ts/channels/browser.ts",
     terminal: "./ts/terminal/browser.ts",
+    widget: "./ts/widget/browser.ts",
     widgets: "./ts/widgets.ts",
   },
   outDir: "dist",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -97,6 +97,13 @@ export default defineConfig({
         // daemon SSE stream; verified in a browser, not unit-testable. Same
         // rationale as ts/channels/browser.ts.
         "ts/terminal/browser.ts",
+        // `ay widget`/`ay mint` CLI shell — thin dispatcher over the daemon broker;
+        // integration-only (needs a live daemon + a browser widget). Same rationale
+        // as ts/terminal.ts / ts/channels.ts.
+        "ts/widget.ts",
+        // Browser AyWidget sensor — needs a DOM + live daemon SSE; verified in a
+        // browser, not unit-testable (same rationale as ts/terminal/browser.ts).
+        "ts/widget/browser.ts",
         // Aggregate widget re-export barrel — no logic (same rationale as ts/index.ts).
         "ts/widgets.ts",
         "ts/remotes.ts",


### PR DESCRIPTION
## What
`ay widget` lets an agent read what a viewer is looking at, through a page widget the author opted in. Complements rechrome: rech drives any page; this reads an **opted-in** page (cross-origin / WebRTC-remote, no extension, no local Chrome). Requested by taku (grocy) as the next slice after the terminal widget.

## How
- **`ts/widget/browser.ts`** `AyWidget` (`import { AyWidget } from "agent-yes/widgets"` or `"agent-yes/widget"`). Registers with the daemon, holds an SSE command channel, and answers reads it's authorized + opted-in for. Ships `selection` (getSelection) + `dom` (querySelector → outerHTML); a visible indicator pulses on every read. `sensors:[…]` author allowlist; the `snapshots` WebGL hook is declared (screenshot is the next slice).
- **`ts/serve.ts`** stateless broker: `/api/widget/{register,list,poll(SSE),result,read}`. A CLI read enqueues a command for a viewer and awaits the matching result; the daemon correlates `cmdId` and forwards — storing no page data. CORS-open.
- **`ts/widget.ts`** `ay widget ls | read selection|dom <viewer>` + `ay mint <target> --caps …` (general scoped-token minter; `ay term mint` stays an alias). `<viewer>` resolves by id / url / title substring.
- **`ts/termToken.ts`** generalized scope `{pid,canSend}` → `{sub,caps[]}` (caps: tail/size/send/resize/read/screenshot), **backward compatible** with live phase-2 `{p,w,x}` tokens. `scopedGate` is caps-driven and gates `/api/widget/*` on the `read` cap (+ `screenshot` for that kind).
- exports `./widget` + widgets aggregate re-exports `AyWidget`; CDN `/w/widget.js`; `widget`/`mint` in subcommands.ts + rs/src/cli.rs.

## Security — dual consent
A read runs only if BOTH the daemon authorized the caller (scoped `read`/`screenshot` cap, or master token) AND the page author enabled that kind (`sensors`) — else fail-closed. Every read flashes a visible indicator. Nothing stored on the daemon.

## Verify
End-to-end in a **real browser, cross-origin with a scoped read token**: register → `ay widget ls` lists it → `read selection` returns the live `getSelection()` → `read dom --selector` returns real `outerHTML` → `read screenshot` **fail-closed** ("not enabled") → visible indicator present. Full suite 1202 pass; token unit tests cover caps + legacy back-compat; typecheck delta 0.

## Next
Phase 3.3 `read screenshot` — html2canvas (bundled) + the author `snapshots` hook for WebGL/three.js (html2canvas can't capture a 3D canvas) → later getDisplayMedia for pixel-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)