### PR TITLE
fix(ay widget): discover unmanaged/portless daemon (align with --base-free UX)

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -988,6 +988,26 @@ export async function resolveLocalServeUrl(): Promise<string | null> {
   return port ? `http://127.0.0.1:${port}` : null;
 }
 
+/**
+ * Best-effort HTTP base URL of the LOCAL running daemon, for CLI→daemon calls
+ * (`ay widget`). More robust than resolveLocalServeUrl for UNMANAGED daemons: it
+ * also reads the portless proxy backend port (~/.portless/routes.json) and the
+ * PORT env, so a daemon started outside oxmgr (e.g. a portless wrapper that injects
+ * PORT) is still found without the caller having to pass --base. Null if nothing
+ * local is discoverable.
+ */
+export async function resolveDaemonHttpBase(): Promise<string | null> {
+  const managed = await resolveLocalServeUrl();
+  if (managed) return managed;
+  // Unmanaged portless run: the real loopback backend is in the portless routes.
+  const pport = await portlessAppPort();
+  if (pport) return `http://127.0.0.1:${pport}`;
+  // Last resort: an explicit port in the environment.
+  const envPort = process.env.AGENT_YES_SERVE_PORT || process.env.PORT;
+  if (envPort && /^\d+$/.test(envPort)) return `http://127.0.0.1:${envPort}`;
+  return null;
+}
+
 async function warnStrayServeProcesses(): Promise<void> {
   const stray = await listStrayServeProcesses();
   if (stray.length === 0) return;

--- a/ts/widget.ts
+++ b/ts/widget.ts
@@ -42,8 +42,8 @@ function parseFlags(
 async function daemonTarget(
   flags: Record<string, string | boolean>,
 ): Promise<{ base: string; token: string }> {
-  const { resolveLocalServeUrl, loadTokenReadOnly } = await import("./serve.ts");
-  const base = typeof flags.base === "string" ? flags.base : await resolveLocalServeUrl();
+  const { resolveDaemonHttpBase, loadTokenReadOnly } = await import("./serve.ts");
+  const base = typeof flags.base === "string" ? flags.base : await resolveDaemonHttpBase();
   if (!base)
     throw new Error(
       "no running ay serve daemon found — start `ay serve` or pass --base <url> (e.g. http://127.0.0.1:PORT)",


### PR DESCRIPTION
## Problem
`ay widget ls/read` used `resolveLocalServeUrl`, which only resolves an **oxmgr-managed** daemon. A daemon started outside oxmgr — e.g. a portless wrapper that injects `PORT` into the env (grocy's kitchen-rack setup, on `127.0.0.1:4443`) — wasn't found, so the CLI errored "no running ay serve daemon" and required a manual `--base http://127.0.0.1:4443`.

## Fix
Add `resolveDaemonHttpBase()` with a fallback chain: managed config → **portless proxy backend** (`~/.portless/routes.json` via `portlessAppPort()`) → `PORT`/`AGENT_YES_SERVE_PORT` env. `ay widget` uses it; `--base` still overrides. Bundle unchanged (CLI/daemon-side only).

Reported by grocy after a clean 3.0–3.2 production acceptance (ls / read selection / read dom / --json all green); this removes the last manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)