### PR TITLE
fix(cli): error on unknown manager first-word instead of spawning (footgun)

### DIFF
--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -28,7 +28,9 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   const managerCommands = !invokedCliName(process.argv);
   // Intercept bare -h/--help so we show TS subcommands, not just Rust agent-runner options.
   const isHelpFlag = rawArg === "-h" || rawArg === "--help";
-  const { isSubcommand, runSubcommand, cmdHelp } = await import("./subcommands.ts");
+  const { isSubcommand, runSubcommand, cmdHelp, isUnknownManagerToken } = await import(
+    "./subcommands.ts"
+  );
   if (isHelpFlag && process.argv.length === 3) {
     await cmdHelp(managerCommands);
     process.exit(0);
@@ -36,6 +38,21 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   if (isSubcommand(rawArg, managerCommands)) {
     const code = await runSubcommand(process.argv);
     process.exit(code ?? 0);
+  }
+  // Footgun guard: on the manager entry, a bare first word that is neither a
+  // subcommand nor a known CLI is a typo or a newer subcommand on an older build
+  // — error instead of silently spawning an agent with it as the prompt (taku
+  // 2026-07-26). A spawn must name a CLI: `ay <cli> …` or `ay --cli <cli> …`.
+  {
+    const { SUPPORTED_CLIS } = await import("./SUPPORTED_CLIS.ts");
+    if (isUnknownManagerToken(rawArg, managerCommands, SUPPORTED_CLIS)) {
+      process.stderr.write(
+        `ay: unknown subcommand or CLI '${rawArg}'.\n` +
+          `    See 'ay help' for subcommands. To run an agent, name a CLI:\n` +
+          `    'ay <cli> …' (e.g. 'ay claude …') or 'ay --cli <cli> …'.\n`,
+      );
+      process.exit(1);
+    }
   }
 }
 

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -113,6 +113,29 @@ describe("subcommands.isSubcommand", () => {
   });
 });
 
+describe("subcommands.isUnknownManagerToken (footgun guard)", () => {
+  const CLIS = ["claude", "codex", "gemini"];
+  it("flags a bare non-cli non-subcommand word on the manager entry", async () => {
+    const { isUnknownManagerToken } = await loadModule();
+    // `ay frobnicate` / a newer subcommand on an older build — neither a
+    // subcommand nor a CLI here → error (rather than spawn it as a prompt).
+    expect(isUnknownManagerToken("frobnicate", true, CLIS)).toBe(true);
+    expect(isUnknownManagerToken("xyzzy", true, CLIS)).toBe(true);
+  });
+  it("allows a known CLI, a subcommand, a flag, and empty", async () => {
+    const { isUnknownManagerToken } = await loadModule();
+    expect(isUnknownManagerToken("claude", true, CLIS)).toBe(false); // `ay claude …`
+    expect(isUnknownManagerToken("ls", true, CLIS)).toBe(false); // subcommand
+    expect(isUnknownManagerToken("--cli", true, CLIS)).toBe(false); // flag → explicit spawn
+    expect(isUnknownManagerToken(undefined, true, CLIS)).toBe(false); // bare `ay`
+  });
+  it("never fires for a cli-bound alias (first word is the prompt)", async () => {
+    const { isUnknownManagerToken } = await loadModule();
+    // `cy widget ls` → managerCommands=false → "widget ls" is a prompt to claude.
+    expect(isUnknownManagerToken("widget", false, CLIS)).toBe(false);
+  });
+});
+
 describe("subcommands.cmdHelp", () => {
   const capture = async (managerCommands?: boolean) => {
     const { cmdHelp } = await loadModule();

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -426,6 +426,25 @@ export function isSubcommand(name: string | undefined, managerCommands = true): 
 }
 
 /**
+ * Footgun guard for the MANAGER entry (`ay`/`agent-yes`): true when the first arg
+ * is a bare word (not a flag) that is neither a subcommand nor a known CLI — a
+ * typo, or a newer subcommand run on an older build. The caller should error
+ * rather than silently spawn an agent with the word as a prompt (taku 2026-07-26:
+ * bare `ay <prompt>` is too dangerous; a spawn must name a CLI — `ay <cli> …` or
+ * `--cli`). Never fires for cli-bound aliases (cy/claude-yes/…), where the first
+ * word is legitimately the prompt, nor for flags or an empty invocation.
+ */
+export function isUnknownManagerToken(
+  rawArg: string | undefined,
+  managerCommands: boolean,
+  supportedClis: readonly string[],
+): boolean {
+  if (!managerCommands || !rawArg || rawArg.startsWith("-")) return false;
+  if (isSubcommand(rawArg, managerCommands)) return false;
+  return !supportedClis.includes(rawArg);
+}
+
+/**
  * Top-level entry. Returns the desired process exit code, or null if argv
  * is not a subcommand invocation.
  */


### PR DESCRIPTION
## Problem
`ay <word>` where `<word>` is neither a subcommand nor a known CLI fell through to the agent-spawn path and treated the word as a prompt for the default CLI. So a typo — or a **newer subcommand run on an older build** (grocy hit `ay widget` / `ay mint` on a pre-widget `v1.236.0` dist) — silently tried to launch an agent (printed version + a cwd-conflict warning) instead of erroring. **taku 2026-07-26:** bare `ay <prompt>` spawn is too dangerous; a spawn must name a CLI.

## Fix
`isUnknownManagerToken` (subcommands.ts): true only for the **manager entry** (`ay`/`agent-yes`) when the first arg is a bare word (not a flag) that is neither a subcommand nor in `SUPPORTED_CLIS`. `cli.ts` errors + `exit 1` with a pointer to `ay help` and the explicit-CLI forms (`ay <cli> …` / `ay --cli <cli> …`). It sits **before** the `--rust` dispatch, so it covers both runtimes via the `ay` launcher.

Never fires for: cli-bound aliases (`cy …`, where the first word is legitimately the prompt), flags, bare `ay`, or a real CLI/subcommand.

## Verify
`ay frobnicate` → exit 1 with the guidance; `ay claude …`, `ay widget …`, `ay --help`, bare `ay` all unaffected. Unit tests for the predicate (known CLI / subcommand / flag / empty / alias); full suite **1205 pass**.

## Note
Covers every `ay`/`agent-yes` JS-launcher invocation (the standard install). Invoking the cargo-native `agent-yes` Rust binary *directly* (bypassing the JS launcher) is a rare edge not guarded here — a small `rs/src/cli.rs` follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)