### PR TITLE
fix(ay widget): screenshot on modern-CSS pages (html2canvas-pro) + surface errors (v1.1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "codehost": "^0.32.0",
-        "html2canvas": "^1.4.1",
+        "html2canvas-pro": "^2.3.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "node-pty": "^1.1.0",
@@ -966,7 +966,7 @@
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
-    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
+    "html2canvas-pro": ["html2canvas-pro@2.3.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-w7CCWi0B0kCy/joy5cPN2GIDGW0iwbqBppxxc2Vc5UyqYDQ1K13ZVr+MyGR/34Mq03emCTxVbBTpG299/prACw=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "codehost": "^0.32.0",
-    "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^2.3.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "node-pty": "^1.1.0",

--- a/ts/widget.ts
+++ b/ts/widget.ts
@@ -126,8 +126,21 @@ async function cmdWidgetRead(args: string[]): Promise<number> {
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ viewer, kind, args: cmdArgs }),
   });
-  const body = (await res.json().catch(() => ({}))) as any;
-  if (!res.ok) throw new Error(`widget read failed: ${res.status} ${JSON.stringify(body)}`);
+  // Read the body as text first: a daemon error (403/404/409) is a plain-text
+  // reason (e.g. "scoped token lacks 'screenshot'"), not JSON — parsing it as JSON
+  // would swallow the reason. Success bodies ARE JSON (the envelope).
+  const raw = await res.text();
+  let body: any = {};
+  try {
+    body = raw ? JSON.parse(raw) : {};
+  } catch {
+    body = { error: raw }; // non-JSON error text → surface it verbatim
+  }
+  if (!res.ok) {
+    // Surface the daemon's plain-text reason cleanly (e.g. a scoped-token 403), not a stack.
+    process.stderr.write(`read ${kind} @ ${viewer}: ${res.status} ${raw || "request failed"}\n`);
+    return 1;
+  }
   if (body.error) {
     process.stderr.write(`read ${kind} @ ${body.viewer ?? viewer}: ${body.error}\n`);
     return 1;

--- a/ts/widget/browser.ts
+++ b/ts/widget/browser.ts
@@ -210,7 +210,9 @@ export class AyWidget {
 
   private async h2c(el: any, viewport: boolean, rect?: any): Promise<any> {
     const g = globalThis as any;
-    const mod: any = await import("html2canvas"); // deferred: only loaded on first screenshot
+    // html2canvas-pro (fork) supports color-mix()/oklch()/lab() — the modern CSS
+    // the original html2canvas silently fails on. Deferred: only loaded on a screenshot.
+    const mod: any = await import("html2canvas-pro");
     const html2canvas = mod.default ?? mod;
     const opts: any = {
       backgroundColor: viewport ? "#ffffff" : null,
@@ -225,7 +227,21 @@ export class AyWidget {
       opts.width = Math.max(1, rect.width);
       opts.height = Math.max(1, rect.height);
     }
-    return html2canvas(el, opts);
+    let canvas: any;
+    try {
+      canvas = await html2canvas(el, opts);
+    } catch (e: any) {
+      throw new Error(`screenshot render failed: ${String(e?.message ?? e)}`);
+    }
+    // A 0×0 result means the renderer choked (unsupported CSS, tainted canvas, …).
+    // Surface it as an error rather than returning a fake-success empty image.
+    if (!canvas?.width || !canvas?.height) {
+      throw new Error(
+        "screenshot render produced an empty image — the target may use CSS the renderer " +
+          "can't handle; for a WebGL/<canvas> element register a snapshots hook for an exact capture",
+      );
+    }
+    return canvas;
   }
 
   /** In the doc html2canvas clones, replace each registered WebGL canvas with the hook's <img>. */


### PR DESCRIPTION
## Problem (grocy 3.3 acceptance)
The snapshot-hook path was pixel-perfect (1916×1540 exact 3D), but html2canvas 1.4.1 rendered a **0×0 empty image** — silently, written as a fake-success 0-byte file — for a subtree using `color-mix()`/`oklch()` (modern CSS it can't parse). Also, a scoped-token 403 came back with an empty `{}` body (reason swallowed).

## Fix
- **html2canvas → html2canvas-pro** (same API; supports `color-mix()`/`oklch()`/`lab()`). The reported `#panel` now renders instead of coming back empty.
- **Render failure is an ERROR, not a fake success**: `h2c` throws if html2canvas throws OR returns a 0×0 canvas → `read screenshot` exits 1 with a message and writes no file (instead of a 0-byte "success").
- **CLI surfaces the daemon's plain-text reason**: a non-2xx (e.g. a scoped-token 403 `lacks 'screenshot'`) is read as text and printed cleanly + exit 1, instead of being JSON-parsed into `{}` (dropping the reason) or thrown as a stack.

## Verify
- `color-mix()`/`oklch()` `#panel` → 400×200 PNG (was empty) ✅
- missing selector / render failure → clean error, **no** 0-byte file ✅
- `--token <read-only>` screenshot → `read screenshot @ panel-test: 403 scoped token lacks 'screenshot'`, exit 1 ✅
- Full suite **1205 pass**; typecheck delta 0.

Follow-up to #324. Hook path (the core exact-capture scenario) was already full marks; this makes the html2canvas fallback robust on modern-CSS pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)