### PR TITLE
feat(serve): log the source of POST /api/resize (auth + origin/UA)

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -3483,6 +3483,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
       if (!cols || !rows) return new Response("missing cols/rows", { status: 400 });
       try {
         const record = await resolveOne(keyword, defaultOpts());
+        // Trace the SOURCE of every PTY resize: a secondary/observer view (a console
+        // tab, a widget) that force-resizes the shared PTY to its own window can
+        // clobber the agent's terminal (last-writer-wins), and without this it's
+        // impossible to tell who did it. Logs auth kind + origin/referer/UA.
+        process.stderr.write(
+          `[api/resize] pid=${record.pid} ${cols}x${rows} auth=${authResult.kind} ` +
+            `origin=${req.headers.get("origin") ?? "-"} ref=${req.headers.get("referer") ?? "-"} ` +
+            `ua=${(req.headers.get("user-agent") ?? "-").slice(0, 80)}\n`,
+        );
         const ayHome = process.env.AGENT_YES_HOME ?? path.join(homedir(), ".agent-yes");
         const winsizeDir = path.join(ayHome, "winsize");
         await mkdir(winsizeDir, { recursive: true });


### PR DESCRIPTION
grocy: a console tab was force-resizing taku's shared PTY via raw `/api/resize` (last-writer-wins) and it was impossible to tell who. Log the source (auth kind + Origin/Referer/User-Agent) so resize fights are traceable — this round was blind guessing. Small, additive, daemon-side.

Verified: `[api/resize] pid=3583 80x24 auth=master origin=https://console.example ref=- ua=TestConsole/1.0`. Suite passes.

The principled fix (secondary views — console, widgets — joining sizeNego smallest-client-wins instead of raw last-writer-wins) is tracked as a v1.2 slice; the widget half already shipped in #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)