### PR TITLE
feat(serve): trace PTY resize across all channels (presence-nego + ay attach), not just /api/resize

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2159,6 +2159,20 @@ export async function cmdServe(rest: string[]): Promise<number> {
         if (prev && Math.abs(prev.cols - eff.cols) <= 1 && Math.abs(prev.rows - eff.rows) <= 1)
           return;
         const content = `${eff.cols} ${eff.rows} ${Date.now()}\n`;
+        // Log this presence-negotiated resize (mirrors the POST /api/resize log) so
+        // resize-fights are traceable across ALL channels, not just direct HTTP — a
+        // remote console reporting a big viewport cap resizes the shared PTY THROUGH
+        // HERE, which otherwise leaves no trace and looks like "nobody pushed".
+        const srcViewers = [...presence.values()]
+          .filter(
+            (v) => Date.now() - v.ts <= PRESENCE_TTL_MS && String(v.agent) === String(pid) && v.cap,
+          )
+          .map((v) => v.viewer)
+          .join(",");
+        process.stderr.write(
+          `[api/resize] pid=${pid} ${eff.cols}x${eff.rows} src=presence-nego ` +
+            `caps=${liveCapsFor(pid).length} viewers=${srcViewers || "-"}\n`,
+        );
         await mkdir(path.dirname(file), { recursive: true });
         await writeFile(file, content);
         negoApplied.set(pid, { ...eff, content });
@@ -3488,7 +3502,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         // clobber the agent's terminal (last-writer-wins), and without this it's
         // impossible to tell who did it. Logs auth kind + origin/referer/UA.
         process.stderr.write(
-          `[api/resize] pid=${record.pid} ${cols}x${rows} auth=${authResult.kind} ` +
+          `[api/resize] pid=${record.pid} ${cols}x${rows} src=api-resize auth=${authResult.kind} ` +
             `origin=${req.headers.get("origin") ?? "-"} ref=${req.headers.get("referer") ?? "-"} ` +
             `ua=${(req.headers.get("user-agent") ?? "-").slice(0, 80)}\n`,
         );

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4054,6 +4054,10 @@ async function cmdAttach(rest: string[]): Promise<number> {
     const rows = process.stdout.rows ?? 24;
     try {
       await writeFile(winsizePath, `${cols} ${rows} ${Date.now()}\n`);
+      // Trace the source (mirrors the daemon's /api/resize log) — `ay attach` also
+      // resizes the shared PTY to its terminal, so it must be visible when hunting
+      // a resize-fight. Goes to this attach process's stderr (not the daemon log).
+      process.stderr.write(`[api/resize] pid=${record.pid} ${cols}x${rows} src=ay-attach\n`);
       try {
         process.kill(record.pid, "SIGWINCH");
       } catch {


### PR DESCRIPTION
grocy's fishing test found #327's log caught only their own curl — the console re-pushing taku's PTY doesn't go through `POST /api/resize`. The shared PTY is resized (winsize + SIGWINCH) from **three** paths; #327 logged one. Now all three tag `src=`:

- `POST /api/resize` → `src=api-resize` (+ auth/origin/UA)
- **presence/sizeNego** → `src=presence-nego` (+ the viewer ids whose caps drove it) — **the one that bit taku**: a remote console reporting its viewport as a presence `cap` resizes the shared PTY through `applyNego`, invisibly.
- `ay attach` → `src=ay-attach` (to the attach process's stderr)

`grep '[api/resize]'` now shows every resize with source + who caused it. Verified: `… src=presence-nego caps=1 viewers=<viewer>`. Suite 1205 pass.

The principled fix (taku's local terminal not joining sizeNego, so a remote console's cap wins) is the v1.2 console-sizeNego slice; this makes it diagnosable now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)