### PR TITLE
feat(rs): publish the operator terminal as a size-nego cap (3b)

### DIFF
--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -646,6 +646,12 @@ impl AgentContext {
             initial_size.0,
             initial_size.1,
         );
+        // Publish the operator terminal's real size as the `local` cap so `ay serve`
+        // negotiation can't let a remote viewer grow the PTY past it (3b). Heartbeated
+        // + updated on SIGWINCH below; a headless agent (no console) publishes nothing.
+        if let Some((c, r)) = crate::pty_spawner::console_size() {
+            crate::pty_spawner::write_local_cap(std::process::id(), c, r);
+        }
         // Keep vterm in sync with the same initial size, otherwise vterm
         // could remain stuck at AgentContext::new() dimensions until the
         // first SIGWINCH fires.
@@ -680,8 +686,32 @@ impl AgentContext {
                     // workflow working.
                     let size = crate::pty_spawner::read_external_winsize(my_pid)
                         .unwrap_or_else(|| crate::pty_spawner::console_size().unwrap_or((80, 24)));
+                    // Refresh the `local` cap from the REAL console size (independent
+                    // of any external winsize applied to the child) so a window resize
+                    // updates negotiation immediately.
+                    if let Some((c, r)) = crate::pty_spawner::console_size() {
+                        crate::pty_spawner::write_local_cap(my_pid, c, r);
+                    }
                     if resize_tx.send(size).is_err() {
                         break;
+                    }
+                }
+            })
+        };
+
+        // Local-cap heartbeat: keep the operator terminal's size fresh in the shared
+        // cap store (short TTL) so negotiation includes it, and it EXPIRES cleanly if
+        // the terminal goes away (console_size() → None → remove). Best-effort.
+        #[cfg(unix)]
+        let _local_cap_handle = {
+            let my_pid = std::process::id();
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(Duration::from_secs(5));
+                loop {
+                    tick.tick().await;
+                    match crate::pty_spawner::console_size() {
+                        Some((c, r)) => crate::pty_spawner::write_local_cap(my_pid, c, r),
+                        None => crate::pty_spawner::remove_local_cap(my_pid),
                     }
                 }
             })

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -136,6 +136,37 @@ pub fn write_current_ptysize(pid: u32, cols: u16, rows: u16) {
     }
 }
 
+/// Publish this agent's REAL controlling-terminal size as the `local` size cap in
+/// the shared cap store (`$AGENT_YES_HOME/caps/<pid>/local`, format
+/// `<cols> <rows> <ts_ms> local`). `ay serve`'s size negotiation reads every cap
+/// (all viewers + this one) and drives the agent's PTY to the elementwise minimum
+/// — so a remote web viewer can no longer GROW the PTY past the operator's own
+/// terminal (a smaller viewer still shrinks it, tmux-style). Heartbeated (see
+/// context.rs) so it expires by TTL when the operator's terminal goes away.
+/// Best-effort; never panics.
+pub fn write_local_cap(pid: u32, cols: u16, rows: u16) {
+    if cols == 0 || rows == 0 {
+        return;
+    }
+    if let Some(dir) = crate::log_files::global_dir() {
+        let d = dir.join("caps").join(pid.to_string());
+        let _ = std::fs::create_dir_all(&d);
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|x| x.as_millis())
+            .unwrap_or(0);
+        let _ = std::fs::write(d.join("local"), format!("{} {} {} local\n", cols, rows, ts));
+    }
+}
+
+/// Remove this agent's `local` size cap (operator terminal gone / agent exiting),
+/// so negotiation stops counting it immediately instead of waiting for the TTL.
+pub fn remove_local_cap(pid: u32) {
+    if let Some(dir) = crate::log_files::global_dir() {
+        let _ = std::fs::remove_file(dir.join("caps").join(pid.to_string()).join("local"));
+    }
+}
+
 /// Parse a single `"cols rows timestamp_ms"` line. Extracted for unit tests.
 pub fn parse_winsize_line(line: &str) -> Option<(u16, u16)> {
     let mut parts = line.split_ascii_whitespace();


### PR DESCRIPTION
Second slice of negotiated PTY resize (v1.2 #13). Depends on 3a (#329) for the read side.

**Problem:** 3a negotiates the PTY size as the min over viewers' caps, but the operator's own terminal wasn't a participant (only a fallback), so a remote viewer's bigger viewport grew the PTY past the operator's window (taku's 316 vs his real 172).

**Fix:** the Rust wrapper publishes its real controlling-terminal size as the `local` cap (`~/.agent-yes/caps/<pid>/local`) — on init, on SIGWINCH, and via a 5s heartbeat so it refreshes and expires by TTL if the terminal goes away. Negotiation already reads it (3a), so the min now includes the operator: a viewer can't grow the PTY past the local terminal; a smaller viewer still shrinks it (tmux semantics). Headless agents publish nothing.

**Verify:** `caps/<pid>/local=172×69` + viewer cap 316×102 → negotiation **172×69** (local wins); the Rust write matches the store format 3a reads. build:rs green.

Next: 3c widget caps, 3d ay attach/console unify + force escape-hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)