### PR TITLE
fix(ay term): heal foreign winsize drift in nego + fix attach cap discovery/guards (3d)

### DIFF
--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -2213,30 +2213,40 @@ export async function cmdServe(rest: string[]): Promise<number> {
     try {
       if (eff) {
         negoCapsGoneAt.delete(pid); // caps are back — cancel any pending withdraw
-        // ±1-cell dead band: a viewer's reported capacity jitters by a row/col
-        // between visits (open-time layout vs steady state), and a 1-cell
-        // SIGWINCH reflow on every re-visit is exactly the churn users notice.
-        if (prev && Math.abs(prev.cols - eff.cols) <= 1 && Math.abs(prev.rows - eff.rows) <= 1)
-          return;
-        // Cross-daemon convergence: if the winsize file ALREADY holds this size (a
-        // sibling daemon negotiated the same min), do NOT rewrite/re-SIGWINCH — else
-        // two daemons thrash the PTY with same-size, different-timestamp writes.
+        // RECONCILE the winsize to the negotiated min. Compare against the ACTUAL
+        // winsize on disk — NOT the last value we ourselves negotiated (`prev`) — so
+        // that a drift introduced by a FOREIGN writer gets healed: `ay attach`'s
+        // direct fallback, a `force:true` resize, or an old console can pin the file
+        // to some other size, and with no subsequent cap change the old prev-only dead
+        // band never corrected it → a stale size (e.g. 80×24) lingered forever
+        // (grocy's design gap). The ±1-cell band still absorbs a viewer's open-time
+        // capacity jitter AND makes a sibling daemon's identical write a no-op (no
+        // cross-daemon same-size thrash). The 5s grow-back sweep re-runs this, so a
+        // foreign write is reconciled within ~5s even without a cap change.
+        let curr: { cols: number; rows: number } | null = null;
         try {
-          const curr = (await readFile(file, "utf-8")).trim().split(/\s+/);
-          if (Number(curr[0]) === eff.cols && Number(curr[1]) === eff.rows) {
-            negoApplied.set(pid, { cols: eff.cols, rows: eff.rows, content: "" });
-            return;
-          }
+          const parts = (await readFile(file, "utf-8")).trim().split(/\s+/);
+          const c = Number(parts[0]);
+          const r = Number(parts[1]);
+          if (Number.isFinite(c) && Number.isFinite(r)) curr = { cols: c, rows: r };
         } catch {
-          /* no winsize file yet — fall through and write it */
+          /* no winsize file yet — treat as drift and write it */
+        }
+        if (curr && Math.abs(curr.cols - eff.cols) <= 1 && Math.abs(curr.rows - eff.rows) <= 1) {
+          // Already at (≈) the negotiated size — nothing to correct.
+          negoApplied.set(pid, { cols: eff.cols, rows: eff.rows, content: "" });
+          return;
         }
         const content = `${eff.cols} ${eff.rows} ${Date.now()}\n`;
         // Trace the negotiated resize + this daemon's identity (multi-daemon topology:
         // the HTTP daemon and each --webrtc share daemon each negotiate off the shared
         // store; the trace shows which one wrote, so a resize-fight is diagnosable).
+        // `correct=` shows the drifted size we healed (a foreign write), if any.
         process.stderr.write(
           `[api/resize] pid=${pid} ${eff.cols}x${eff.rows} src=presence-nego ` +
-            `daemon=${daemonTag} caps=${caps.length}\n`,
+            `daemon=${daemonTag} caps=${caps.length}` +
+            (curr ? ` correct=${curr.cols}x${curr.rows}` : ``) +
+            `\n`,
         );
         await mkdir(path.dirname(file), { recursive: true });
         await writeFile(file, content);

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -4056,9 +4056,13 @@ async function cmdAttach(rest: string[]): Promise<number> {
   // no daemon is running — then this attach is the sole authority and drives it itself.
   const { resolveDaemonHttpBase, loadTokenReadOnly } = await import("./serve.ts");
   const daemonBase = await resolveDaemonHttpBase().catch(() => null);
-  const daemonToken = daemonBase ? await loadTokenReadOnly().catch(() => null) : null;
+  // The token may legitimately be "" — a localhost daemon started without a
+  // .serve-token accepts an empty token as master. Gate cap mode on the BASE alone,
+  // exactly like `ay widget ls` (which discovers the same daemon and works with ""):
+  // requiring a non-null token here is what wrongly dropped attach to the direct path.
+  const daemonToken = daemonBase ? ((await loadTokenReadOnly().catch(() => null)) ?? "") : "";
   const capViewer = `attach:${process.pid}`;
-  let capMode = !!(daemonBase && daemonToken);
+  let capMode = !!daemonBase;
 
   const writeWinsizeDirect = async (cols: number, rows: number) => {
     try {
@@ -4074,8 +4078,12 @@ async function cmdAttach(rest: string[]): Promise<number> {
     }
   };
   const sendResize = async () => {
-    const cols = process.stdout.columns ?? 80;
-    const rows = process.stdout.rows ?? 24;
+    const cols = process.stdout.columns ?? 0;
+    const rows = process.stdout.rows ?? 0;
+    // Size not ready yet (a freshly-allocated pty — e.g. under script(1) — reports
+    // 0×0 for a beat): skip rather than drive the agent to 0×0. The stdout "resize"
+    // listener fires sendResize again once the real size lands.
+    if (cols < 1 || rows < 1) return;
     // Cap path: POST /api/resize (cap-report; the daemon publishCap+scheduleNego's it).
     if (capMode && daemonBase && daemonToken) {
       try {
@@ -4194,6 +4202,8 @@ async function cmdAttach(rest: string[]): Promise<number> {
     detached = true;
     if (pollTimer) clearInterval(pollTimer);
     if (aliveCheck) clearInterval(aliveCheck);
+    process.off("SIGTERM", onSignalExit);
+    process.off("SIGHUP", onSignalExit);
     void withdrawAttachCap(); // release our size cap so the PTY re-negotiates without us
     watcher.close();
     process.stdout.removeListener("resize", onResize);
@@ -4239,6 +4249,20 @@ async function cmdAttach(rest: string[]): Promise<number> {
     triggerDetach();
   };
   process.stdin.on("data", onStdinData);
+
+  // `kill`/SIGHUP (e.g. the controlling terminal closing) must run the same cleanup
+  // as a manual detach — restore cooked mode AND withdraw our size cap — else the
+  // agent's PTY is left pinned at this attach's size (grocy: kill -TERM left 80×24).
+  // In raw mode Ctrl-C arrives as a stdin byte, not SIGINT, so SIGINT isn't handled
+  // here (it'd double-fire); SIGTERM/SIGHUP are the `kill` paths that need it.
+  const onSignalExit = () => {
+    triggerDetach(); // restores the terminal (sync) + fires the async cap withdraw
+    // give withdrawAttachCap's fetch a beat to reach the daemon before we exit; the
+    // daemon's TTL + nego reconciliation heal it even if the process dies first.
+    setTimeout(() => process.exit(0), 200);
+  };
+  process.on("SIGTERM", onSignalExit);
+  process.on("SIGHUP", onSignalExit);
 
   // 7. Detach automatically if the agent exits.
   aliveCheck = setInterval(() => {


### PR DESCRIPTION
grocy #336 real-machine verify surfaced 4 issues, incl. a design gap:

- **① attach cap mode never activated** — attach required a non-null daemon token, but a localhost daemon without a `.serve-token` accepts `""` as master (why `ay widget ls` — same discovery — worked). Gate cap mode on the daemon **base** alone, pass `token ?? ""`, mirroring widget ls.
- **② direct-wrote 0×0** — `process.stdout.columns` is `0` (not undefined) for a beat on a fresh pty under `script(1)`; `??` doesn't catch `0`. Skip until `cols/rows>0`; the resize listener re-fires.
- **③ kill -TERM left the PTY pinned** — no signal cleanup. Add SIGTERM/SIGHUP handlers → `triggerDetach` (restore cooked mode + withdraw cap) then exit.
- **④ DESIGN GAP: nego didn't heal a foreign winsize write.** `applyNego`'s dead band compared `eff` to the value **we** last negotiated (`prev`), so a foreign write (attach `--direct`, a `force` resize, an old console) with no later cap change was never corrected → a stale 80×24 lingered forever. Now **reconcile against the actual on-disk winsize**: if it differs from the negotiated min by >±1, correct it (trace `correct=CxR`). The 5s sweep re-runs this, healing drift within ~5s without a cap change — also cures the historical 'console 316 lingers after its cap disappears'.

Suite 1205 pass; no new typecheck errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)