### PR TITLE
fix(ay widget): un-clip selector-capture so flex/overflow #panel renders full, not empty

### DIFF
--- a/ts/widget/browser.ts
+++ b/ts/widget/browser.ts
@@ -189,7 +189,11 @@ export class AyWidget {
       // Hook hit by ELEMENT IDENTITY (not string equality) → exact capture.
       const hook = this.snapshotFor(el);
       if (hook) return dataUrlResult(hook, el.width, el.height);
-      return canvasResult(await this.h2c(el, false));
+      // Pass the selector so onclone can un-clip the target's ancestor chain: a
+      // flex-item / overflow scroll container (e.g. a side panel inside a
+      // display:flex + overflow:hidden body) otherwise renders EMPTY or clipped
+      // because html2canvas recomputes the flex/clip context in its cloned doc.
+      return canvasResult(await this.h2c(el, false, undefined, args.selector));
     }
     if (mode === "selection") {
       const sel = g.getSelection?.();
@@ -214,7 +218,12 @@ export class AyWidget {
     return null;
   }
 
-  private async h2c(el: any, viewport: boolean, rect?: any): Promise<any> {
+  private async h2c(
+    el: any,
+    viewport: boolean,
+    rect?: any,
+    unclipSelector?: string,
+  ): Promise<any> {
     const g = globalThis as any;
     // html2canvas-pro (fork) supports color-mix()/oklch()/lab() — the modern CSS
     // the original html2canvas silently fails on. Deferred: only loaded on a screenshot.
@@ -225,7 +234,10 @@ export class AyWidget {
       logging: false,
       useCORS: true,
       scale: g.devicePixelRatio || 1,
-      onclone: (d: any) => this.swapSnapshots(d),
+      onclone: (d: any) => {
+        this.swapSnapshots(d);
+        if (unclipSelector) this.unclipForCapture(d, unclipSelector);
+      },
     };
     if (rect) {
       opts.x = rect.left + (g.scrollX || 0);
@@ -248,6 +260,44 @@ export class AyWidget {
       );
     }
     return canvas;
+  }
+
+  /**
+   * In the cloned doc, neutralise the clipping/flex context around a selector-capture
+   * target so its FULL subtree lays out and renders. Without this, a target that is a
+   * flex item and/or an `overflow:auto|hidden|scroll` box (very common: a fixed-width
+   * side panel inside `body{display:flex;overflow:hidden}`) renders EMPTY or clipped —
+   * html2canvas recomputes the flex/clip box in its clone and the content falls outside it.
+   * Only applied for `--selector` captures; viewport/selection keep the natural layout.
+   */
+  private unclipForCapture(clonedDoc: any, selector: string): void {
+    let target: any;
+    try {
+      target = clonedDoc.querySelector(selector);
+    } catch {
+      return; // bad selector
+    }
+    if (!target) return;
+    // Walk ancestors: drop overflow clipping + flex + fixed heights so nothing crops
+    // the target subtree in the clone.
+    for (let n = target.parentElement; n && n !== clonedDoc.documentElement; n = n.parentElement) {
+      try {
+        n.style.setProperty("overflow", "visible", "important");
+        n.style.setProperty("display", "block", "important");
+        n.style.setProperty("height", "auto", "important");
+        n.style.setProperty("max-height", "none", "important");
+      } catch {
+        /* frozen style — skip */
+      }
+    }
+    // The target itself: reveal its full (scrolled-out) content.
+    try {
+      target.style.setProperty("overflow", "visible", "important");
+      target.style.setProperty("max-height", "none", "important");
+      target.style.setProperty("height", "auto", "important");
+    } catch {
+      /* skip */
+    }
   }
 
   /** In the doc html2canvas clones, replace each registered WebGL canvas with the hook's <img>. */


### PR DESCRIPTION
## Problem

`ay widget` `screenshot --selector "#panel"` rendered the target **empty / clipped** when the target is a flex item and/or an `overflow:auto|hidden|scroll` scroll container — the classic case being a fixed-width side panel inside `body{display:flex; height:100vh; overflow:hidden}`. html2canvas-pro recomputes the flex/clip context in its cloned document, so the target's subtree falls outside the recomputed clip box and renders as an empty (or partial) image.

Found during grocy's v1.2 real-machine testing of the `kitchen-rack-3d` page (`#panel` = flex child + `overflow-y:auto`; `#scene{flex:1}`). The 3D snapshot-hook path was already full marks; only the DOM `#panel` capture was empty. Non-blocking tail of v1.2 #13.

## Fix

Add `unclipForCapture(clonedDoc, selector)`, invoked from `h2c`'s `onclone` **only for selector-mode captures**:
- walks the target's ancestor chain in the CLONE and neutralises clipping/flex/fixed heights (`overflow:visible`, `display:block`, `height:auto`, `max-height:none`, all `!important`),
- reveals the target's own scrolled-out content.

Viewport / selection captures are untouched — they keep the natural page layout.

## Verification

- Isolated repro (same `body{display:flex;overflow:hidden}` + `#panel{overflow-y:auto}` structure) driven with rech + html2canvas-pro 2.3.1: the target now captures its **full content (360×2304)**, crisp and complete, vs the clipped visible slice before. Visually eyeballed — title, subtitle, all rows present, not garbled.
- `bun run build` ✓, typecheck ✓ (no new widget errors), full suite **1205 passed / 1 skipped**.
- Widget CDN bundle rebuilt via `build-assets.sh`; compiled fix present (`h2c(el,false,undefined,selector)` → `unclipForCapture`).

TS-only change (`ts/widget/browser.ts`). To be verified against `kitchen-rack.localhost` on grocy's real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)