### PR TITLE
perf(console): kill the dead-saved-room reconnect storm on /w/

### DIFF
--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -204,8 +204,18 @@ export class Room {
       // to everyone else, so both sides can open a direct DataChannel. Who sends
       // the offer (initiator = lower peer id) is decided client-side to avoid glare.
       const roster = mesh ? this.peers(ws) : undefined;
+      // hostPresent lets a client FAST-FAIL a previously-opened star room whose
+      // host has since left: the room's token is still stored (so we don't close
+      // it as "room not open" above), but no live host socket remains to answer
+      // with an offer — without this the client waits the full 8s connect timeout
+      // (rtc.js) for an offer that never comes, and a viewer with N dead saved
+      // rooms pays N×8s of reconnect churn on every open. Only meaningful for a
+      // non-mesh client; omitted (undefined → dropped by JSON) for host/mesh.
+      const hostPresent = mesh || role === "host" ? undefined : this.hasHost();
       ws.serializeAttachment({ authed: true, role, peer, mesh } satisfies Attach);
-      ws.send(JSON.stringify({ type: "welcome", peer, role, v: proto, mesh, peers: roster }));
+      ws.send(
+        JSON.stringify({ type: "welcome", peer, role, v: proto, mesh, peers: roster, hostPresent }),
+      );
       if (mesh) this.broadcast(ws, { type: "peer-join", peer });
       else if (role === "client") this.toHost({ type: "peer-join", peer });
       return;
@@ -238,6 +248,19 @@ export class Room {
     if (!self.authed) return;
     if (self.mesh) this.broadcast(ws, { type: "peer-leave", peer: self.peer });
     else if (self.role === "client") this.toHost({ type: "peer-leave", peer: self.peer });
+  }
+
+  // Is a live host peer currently attached? (star rooms only.) Used to tell a
+  // joining client to fast-fail a room whose host has left, instead of waiting
+  // for an offer that will never arrive. A dead host that dropped uncleanly may
+  // linger briefly until the runtime reaps its socket — a transient false
+  // "present" just means one more 8s wait + backoff, never a wrong connection.
+  private hasHost(): boolean {
+    for (const s of this.state.getWebSockets()) {
+      const a = s.deserializeAttachment() as Attach | null;
+      if (a?.authed && a.role === "host") return true;
+    }
+    return false;
   }
 
   // Role isn't a hibernation tag (it's only known after the hello), so route by

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -7209,6 +7209,12 @@ my.translate = async (text, lang) => {
       // ---- rooms: localStorage cache + a manager you open by clicking the badge ----
       const ROOMS_KEY = "ay.rooms";
       const ROOM_TTL_MS = 90 * 24 * 60 * 60 * 1000; // evict stale rooms to bound how long a secret lingers in localStorage
+      // Cap the saved-room set so the boot fan-out (and the localStorage secret
+      // footprint) stays bounded no matter how many share links get opened over
+      // time. When over the cap we keep the most-recently-saved rooms and drop the
+      // oldest — a room silently forgotten this way is trivially re-added by
+      // re-opening its share link.
+      const MAX_ROOMS = 16;
       const loadRooms = () => {
         try {
           const r = JSON.parse(localStorage.getItem(ROOMS_KEY) || "{}");
@@ -7216,6 +7222,14 @@ my.translate = async (text, lang) => {
           let changed = false;
           for (const k of Object.keys(r)) {
             if (r[k]?.ts && now - r[k].ts > ROOM_TTL_MS) {
+              delete r[k];
+              changed = true;
+            }
+          }
+          const keys = Object.keys(r);
+          if (keys.length > MAX_ROOMS) {
+            keys.sort((a, b) => (r[b]?.ts || 0) - (r[a]?.ts || 0)); // newest first
+            for (const k of keys.slice(MAX_ROOMS)) {
               delete r[k];
               changed = true;
             }
@@ -7229,6 +7243,14 @@ my.translate = async (text, lang) => {
       const saveRoom = (room, token, host) => {
         const r = loadRooms();
         r[room] = { token, host: host || SIG_DEFAULT, ts: Date.now() };
+        // Bound at write time too: loadRooms() trims on read, but a fresh add can
+        // push to MAX_ROOMS+1 until the next read. The just-added room has the
+        // newest ts, so the trim drops the oldest OTHER room, never this one.
+        const keys = Object.keys(r);
+        if (keys.length > MAX_ROOMS) {
+          keys.sort((a, b) => (r[b]?.ts || 0) - (r[a]?.ts || 0)); // newest first
+          for (const k of keys.slice(MAX_ROOMS)) delete r[k];
+        }
         localStorage.setItem(ROOMS_KEY, JSON.stringify(r));
       };
       const dropRoom = (room) => {
@@ -7461,14 +7483,26 @@ my.translate = async (text, lang) => {
         loadList();
       }
 
-      // Connect to every saved room at once (called on boot). A room already
-      // started from the URL/hash can be skipped so it gets a brief uncontended
-      // head start before the rest of the fleet performs crypto + ICE setup.
+      // Connect the saved rooms on boot. A room already started from the URL/hash
+      // is skipped (exceptRoom) so it gets an uncontended head start. The rest are
+      // STAGGERED rather than fired in one tick: opening N WebSockets + doing N
+      // crypto/ICE setups simultaneously janks the foreground room's open and
+      // spikes the browser's connection pool. Combined with the host-presence
+      // fast-fail (welcome.hostPresent), a dead saved room now costs ~one round
+      // trip instead of an 8s timeout, so the whole fleet settles quickly.
+      const RTC_FANOUT_STAGGER_MS = 120;
       function connectAllRooms(exceptRoom = null) {
         const r = loadRooms();
-        for (const name of Object.keys(r)) {
-          if (name !== exceptRoom) addRoomSource(name, r[name].token, r[name].host);
-        }
+        const names = Object.keys(r).filter((n) => n !== exceptRoom);
+        names.forEach((name, i) => {
+          setTimeout(() => {
+            // Re-read at fire time: during the stagger delay the user may have
+            // forgotten this room (removeRoom + dropRoom) — don't let a stale
+            // closure resurrect and re-persist it.
+            const cur = loadRooms()[name];
+            if (cur) addRoomSource(name, cur.token, cur.host);
+          }, i * RTC_FANOUT_STAGGER_MS);
+        });
       }
 
       // Back-compat alias: a freshly pasted/linked room is added like any other.

--- a/lab/ui/rtc.js
+++ b/lab/ui/rtc.js
@@ -176,7 +176,12 @@ export class RTCClient {
       ws.onmessage = async (ev) => {
         const m = JSON.parse(ev.data);
         if (m.type === "welcome") {
-          mark("signal.welcome", { v: m.v });
+          mark("signal.welcome", { v: m.v, hostPresent: m.hostPresent });
+          // No live host in this (previously-opened) room → fail NOW instead of
+          // waiting out the 8s connect-timeout for an offer that never comes.
+          // Distinct error so telemetry separates "dead room" from a real
+          // timeout, and so the reconnect layer can evict it fast (see below).
+          if (m.hostPresent === false) return fail(new Error("no host in room"));
           if (this._v2 && m.v !== 2)
             return fail(new Error("host is running an old agent-yes — ask it to upgrade"));
           // pc is created on the offer below so it can use the host-supplied


### PR DESCRIPTION
## Problem (measured with rechrome + perf-beacon log)
Opening `/w/#room` fans out a reconnect to **every** saved room at once. The target room opens in **~500 ms**, but each **dead** saved room (host long gone) then sits in the fixed **8 s** connect timeout waiting for an offer that never comes, then retries — so N dead rooms = N×8 s of overlapping signaling+ICE churn that janks the open. Real data: 9 saved rooms, 3+ dead, each burning 8 s.

## #1 — Host-presence fast-fail (the big win)
- **`worker.ts` Room DO**: a non-mesh client's `welcome` now carries `hostPresent` (`hasHost()` walks the room's sockets for an authed `role:host`). A previously-opened room whose host has left keeps its stored token (so it isn't closed as "room not open"), but no host remains to answer — `hostPresent:false` tells the client immediately.
- **`rtc.js`**: on `welcome.hostPresent === false`, fail **now** (`"no host in room"`) instead of arming the 8 s timeout. **Backward-compatible**: an old signaling server omits the field → client behaves exactly as before; mesh/host welcomes omit it.

Result: a dead saved room costs ~one round-trip instead of 8 s → the ~24 s open storm collapses.

## #2 — Dead-room hygiene (client)
- **Cap** `ay.rooms` at `MAX_ROOMS=16` (evict oldest by `ts`), enforced on **read and write** — bounds the fan-out + the localStorage secret footprint.
- **Stagger** `connectAllRooms` by 120 ms/room instead of one tick, so N rooms don't open N sockets + do N crypto/ICE setups simultaneously. The staggered timer **re-reads `loadRooms()` at fire time** so a room forgotten mid-stagger isn't resurrected.

## Verification
- worker.ts transpiles clean; rtc.js + index.html inline JS parse; changes present in `public/w/` build output.
- Codex-reviewed — 2 findings fixed: stagger-resurrect race (re-read at fire time) and MAX_ROOMS not enforced at write (trim in `saveRoom`).
- Will confirm on beta with rechrome (fast-fail timeline) before the 1 h soak → prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)