### PR TITLE
fix(notify): close the v1 identity/liveness/retention residuals (#169)

### DIFF
--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -39,6 +39,7 @@ Other verbs:
 
 ```bash
 ay notify read [--parent <pid>] [--since <seq>] [--unread] [--ack] [--json]
+ay notify read --postmortem [--parent <pid>] [--started-at <ms>]   # after it exited
 ay notify cursor get|set <seq> [--parent <pid>] [--consumer <name>]
 ay notifyd run|start|status|stop
 ```
@@ -74,11 +75,11 @@ parent addresses its own inbox with no argument.
   refreshed every poll, TTL 15s) and the daemon:
   - **scopes** its work to children whose parent has a live heartbeat — where
     "live" means the heartbeat is fresh (refreshed within the TTL) AND the parent
-    agent's pid is alive. A crashed `watch` stops refreshing, so its heartbeat
-    goes stale within the TTL and is dropped; a dead parent is dropped
-    immediately. (The heartbeat proves parent-liveness + freshness, not the watch
-    subprocess's own pid — carrying the watch pid/token in the heartbeat for a
-    strict check is a documented follow-up.) So an unrelated agent that never
+    agent's pid is alive AND the `ay notify watch` subprocess that wrote it is
+    alive. The heartbeat carries all three (`pid`, `ts`, `watch_pid`), so a
+    crashed watcher is dropped on the very next sweep instead of lingering for the
+    TTL on freshness alone; a dead parent is dropped immediately. So an unrelated
+    agent that never
     watches gets **no inbox** (the scope matches the "nothing happens unless you
     watch" promise). The daemon takes the parent's `started_at` from the watcher's
     own heartbeat (authoritative, never 0), not a registry lookup that could miss;
@@ -160,9 +161,13 @@ ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
   the watcher returns and the hot-path guard sees the new start time — delayed,
   never dropped.
 
-- **The daemon heartbeats its owner on a background timer**, not once per loop, so
-  a slow tick (many watched children, slow log I/O) can't let the heartbeat cross
+- **The daemon heartbeats its owner on its own THREAD**, not once per loop and not
+  on the main thread's timer, so neither a slow tick (many watched children, slow
+  log I/O) nor a synchronous main-thread block can let the heartbeat cross
   `OWNER_TTL` and have another `watch` steal the lock as "stale" → double daemon.
+  The beat is one-way (it never signals the daemon): shutdown stays the loop's
+  decision, made by its per-tick owner-token check. It falls back to a main-thread
+  timer if a worker can't be created, so it is never worse than before.
   `started_at` is captured once at acquire; the heartbeat updates only `ts`, so
   `stop`'s identity re-check never sees it move.
 
@@ -177,11 +182,15 @@ ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
   The daemon singleton lock shares the same torn-owner grace, so two concurrent
   daemon starts can't both win.
 
-- **Residual (documented): `stop` identity vs OS start time.** `status`/`stop`
-  compare our recorded `started_at`, not the OS's real process start time (non-
-  portable to read), so a pid recycled onto an unrelated process within the tight
-  `OWNER_TTL` window could be briefly trusted. Heartbeat freshness + a few-tick
-  TTL bound it to seconds; a real OS start-time cross-check is deferred.
+- **Owner identity is cross-checked against the OS process start time.** The
+  owner file records the OS's own start time for the daemon pid at acquire
+  (`os_start`, an opaque per-platform token — `/proc/<pid>/stat` field 22 on
+  Linux, `ps -o lstart` on macOS/BSD, none on Windows), and every read re-reads it
+  and rejects a disagreement. A pid recycled onto an unrelated live process inside
+  `OWNER_TTL` therefore can't be mistaken for the daemon — which previously would
+  have left the host with NO daemon, because `ensureDaemon` declined to start one.
+  Best-effort by contract: where a platform can't answer, behaviour is exactly as
+  before (pid-liveness + heartbeat freshness, bounding the window to seconds).
 
 - **`notifyd stop` re-verifies identity before signalling.** It re-reads the
   owner (`pid` + `started_at`) immediately before `SIGTERM`, so a pid recycled
@@ -200,7 +209,8 @@ ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
   the cursor persists across a restart of the `ay notify watch` **subprocess**
   within the same parent-agent session — NOT across a restart of the parent agent
   itself, which gets a new pid (and thus a fresh inbox). A truly stable parent
-  identity across pid changes is a follow-up (issue #169).
+  identity across pid changes is still open — see "Known limitations" below for
+  why it waits on a durable `agent_id` rather than on this layer.
 
 - **At-least-once by default; ack is monotonic.** `ay notify watch` does **not**
   advance the cursor unless you pass `--ack` (or use `ay notify read --ack`). A
@@ -243,46 +253,40 @@ ts}`. A stale lock (owner pid dead / torn) is **stolen** — but the steal only
   (tail + git head), daemon lifecycle.
 - `ts/subcommands.ts` — `ay notify` / `ay notifyd` CLI.
 
-## Known limitations (v1 — tracked as follow-ups)
+## Known limitations (tracked as follow-ups)
 
-These are deliberately out of v1 scope; each is a bounded, low-probability edge
-with a documented mitigation, tracked in a single follow-up issue.
+The v1 identity/liveness/retention residuals below were closed in issue #169 —
+see the design decisions above for how each is now handled:
+`notifyd` owner identity vs the OS process start time; the watcher heartbeat
+proving only parent-liveness; postmortem inbox inspection; the event-loop-block
+false steal; and an inbox nobody acks growing unbounded.
 
-- **`notifyd stop` trusts the owner file's identity, not the OS process start
-  time.** A pid recycled onto an unrelated process WITHIN the tight `OWNER_TTL`
-  window (a few ticks) could be briefly trusted and signalled. Reading the real
-  OS start time is non-portable (`/proc/<pid>/stat` on Linux vs `ps -o lstart` /
-  `proc_pidinfo` on macOS); heartbeat freshness + a few-tick TTL bound the window
-  to seconds. A strict OS start-time cross-check is a follow-up.
-- **The watcher heartbeat proves parent-liveness, not the `ay notify watch`
-  subprocess's own liveness.** A crashed watch stops refreshing, so its heartbeat
-  goes stale within the TTL and is dropped — but carrying the watch subprocess's
-  pid/token in the heartbeat for a strict check is a follow-up.
-- **No postmortem inbox inspection after the parent exits.** `ay notify
-read/watch` fail closed when the parent isn't a live registry record (started_at
-  can't be resolved) — deliberately, so a recycled parent pid can't read another
-  session's inbox. The trade-off is that you can't inspect a parent's inbox after
-  that parent has exited. A read-only "postmortem" mode (inspect without
-  registering as a watcher, identity-checked by started_at) is a follow-up.
-- **Event-loop-block false steal.** The daemon heartbeats its lock owner on a
-  single-threaded JS timer. If the daemon loop ever blocked SYNCHRONOUSLY longer
-  than `OWNER_TTL` (30s), the heartbeat would stall and another `watch` could
-  steal the singleton lock → a second daemon. The loop is all `await`s and never
-  blocks for seconds, and `OWNER_TTL` is set well above any realistic sync block,
-  so this is a theoretical window; fully closing it needs a worker-isolated
-  heartbeat (follow-up).
-- **An inbox nobody acks can grow unbounded.** Rotation only evicts events at or
-  below the minimum consumer cursor (at-least-once). So a parent that runs
-  `ay notify watch` WITHOUT `--ack` (the default, at-least-once) and never
-  otherwise advances its cursor will accumulate events past `capBytes` until the
-  parent exits (then GC removes the whole inbox). This is a deliberate trade
-  (never drop an unacked edge) for the human-in-the-loop scale this targets; a
-  future safeguard could warn or apply an emergency hard cap that drops the
-  oldest unacked events with a logged notice. `gcInboxes` already logs a warning
-  when it can't trim an oversize inbox. **Manual cleanup:** an operator can delete
-  `$AGENT_YES_HOME/notify/inbox/<host>/<parent>.ndjson` (and its `.seq` +
-  `cursors/<host>/<parent>/`) for a parent that is done; the whole inbox is GC'd
-  automatically once that parent is dead and unreferenced.
+What remains:
+
+- **No durable parent identity across pid changes.** The inbox and cursor are
+  keyed by the parent's WRAPPER PID, so they survive a restart of the
+  `ay notify watch` subprocess within one parent session — but NOT a restart of
+  the parent agent itself, which gets a new pid and therefore a fresh inbox. A
+  stable identity would need an `agent_id` that survives a restart; today
+  `agent_id` is minted per process (`docs/agent-sharing.md` tracks the same gap
+  for share grants), so this waits on that, not on the notify layer.
+
+- **Emergency trim drops unacked edges.** Past the HARD cap (4x the soft cap) an
+  inbox whose consumer never advances its cursor has its OLDEST unacked events
+  dropped, with a loud `logger.error` naming the parent and the seq range. This is
+  a deliberate last resort — unbounded growth is the worse failure — but it does
+  mean at-least-once is not absolute for a consumer that never acks. The cursor is
+  NOT advanced, so the loss is visible as a seq gap. **Manual cleanup:** an
+  operator can delete `$AGENT_YES_HOME/notify/inbox/<host>/<parent>.ndjson` (and
+  its `.seq` + `cursors/<host>/<parent>/`) for a parent that is done; the whole
+  inbox is GC'd automatically once that parent is dead and unreferenced.
+
+- **Postmortem reads are read-only and single-incarnation.** `ay notify read
+  --postmortem` inspects a finished parent's inbox without registering a watcher
+  or starting the daemon, filtering to one incarnation taken from the inbox's own
+  `parent_started_at` stamps. If the pid was reused across sessions the inbox
+  holds more than one agent's edges and the command refuses, listing the
+  candidates for `--started-at <ms>` — it will not guess.
 
 ## Not done — drafted for later
 

--- a/ts/notifyDaemon.spec.ts
+++ b/ts/notifyDaemon.spec.ts
@@ -91,9 +91,36 @@ describe("notifyd singleton lock", () => {
     expect(await acquireDaemonLock(() => true)).toBe(true);
     const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
     // Rewrite the owner to a DIFFERENT, "alive" pid to simulate another daemon.
-    await writeFile(daemonLockOwnerPath(), JSON.stringify({ ...owner, pid: owner.pid + 1 }));
+    // Drop os_start with it: a real second daemon records the OS start time of
+    // ITS OWN pid, so carrying ours over would describe a pid whose recorded and
+    // actual start times disagree — i.e. a RECYCLED pid, which is a different
+    // scenario (covered below) and would correctly be stolen rather than
+    // respected. Omitting it models an owner written by a build without the
+    // field, where pid-liveness + heartbeat freshness alone govern.
+    const { os_start: _dropped, ...noToken } = owner;
+    await writeFile(daemonLockOwnerPath(), JSON.stringify({ ...noToken, pid: owner.pid + 1 }));
     expect(await acquireDaemonLock((pid) => pid === owner.pid + 1)).toBe(false);
   });
+
+  // Windows has no start-time reader, so there is no token to disagree with.
+  it.skipIf(process.platform === "win32")(
+    "STEALS a lock whose owner pid was RECYCLED (looks alive, isn't the daemon)",
+    async () => {
+      // The failure this guards: a recycled pid is alive and its owner ts is
+      // fresh, so the shared steal decision says "respect the holder" — without
+      // treating the OS start-time disagreement as its own steal reason, acquire
+      // would neither take the lock nor decline, and spin until the caller timed
+      // out. The host would be left with no daemon and no error.
+      expect(await acquireDaemonLock(() => true)).toBe(true);
+      const owner = JSON.parse(await readFile(daemonLockOwnerPath(), "utf8"));
+      expect(typeof owner.os_start).toBe("string"); // the platform did record one
+      await writeFile(
+        daemonLockOwnerPath(),
+        JSON.stringify({ ...owner, ts: Date.now(), os_start: "not-the-real-start-time" }),
+      );
+      expect(await acquireDaemonLock(() => true)).toBe(true); // stolen, not spun on
+    },
+  );
 });
 
 describe("notifyd identity (status/stop safety)", () => {

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -362,6 +362,13 @@ export async function acquireDaemonLock(
       } catch {
         /* torn / not-yet-written */
       }
+      // Does the OS disagree that this pid is still the process that took the
+      // lock? Then the pid was recycled onto something unrelated: the owner
+      // "looks" live (its pid is alive, its ts is fresh) but the daemon is gone.
+      const recycled =
+        owner && typeof owner.pid === "number" && owner.pid > 0
+          ? osStartTokenMismatch(owner.os_start, osProcessStartToken(owner.pid))
+          : false;
       if (
         owner &&
         typeof owner.pid === "number" &&
@@ -373,7 +380,7 @@ export async function acquireDaemonLock(
         // ...and the OS agrees that pid is still the process that took the lock.
         // Without this, a pid recycled onto an unrelated live process inside the
         // TTL would make us decline to start — leaving the host with NO daemon.
-        !osStartTokenMismatch(owner.os_start, osProcessStartToken(owner.pid))
+        !recycled
       ) {
         return false;
       }
@@ -387,6 +394,12 @@ export async function acquireDaemonLock(
           .then((s) => s.mtimeMs)
           .catch(() => now));
       if (
+        // A RECYCLED owner must be stolen, not waited on. shouldStealLock only
+        // sees pid-liveness and heartbeat freshness — and a recycled pid looks
+        // alive with a fresh-enough ts — so on its own it says "respect the
+        // holder" and this loop would spin until the caller times out, never
+        // reclaiming a lock whose real owner is provably gone.
+        recycled ||
         shouldStealLock(raw, now, {
           staleMs: OWNER_TTL_MS,
           lockAgeMs,

--- a/ts/notifyDaemon.ts
+++ b/ts/notifyDaemon.ts
@@ -30,6 +30,8 @@ import {
   shouldStealLock,
 } from "./notifyStore.ts";
 import { deriveLiveState, isPidAlive, listRecords, renderLogTailLines } from "./subcommands.ts";
+import { osProcessStartToken, osStartTokenMismatch } from "./procStartTime.ts";
+import { startOwnerHeartbeat } from "./ownerHeartbeat.ts";
 import { logger } from "./logger.ts";
 
 const POLL_MS = 2000;
@@ -262,6 +264,12 @@ export interface DaemonIdentity {
   ts: number;
   /** The owner fencing token at validation time — pins THIS incarnation. */
   token: string | null;
+  /**
+   * The OS's own start time for `pid` when the lock was acquired (opaque token;
+   * see ts/procStartTime.ts). Absent on platforms with no reader and on owner
+   * files written by older builds — readers must treat absent as "no opinion".
+   */
+  os_start?: string | null;
 }
 
 // The daemon's start time, captured ONCE when it acquires the lock. The
@@ -269,6 +277,11 @@ export interface DaemonIdentity {
 // identity check (pid + started_at unchanged) can't see it move and mistake the
 // running daemon for "not running".
 let daemonStartedAt = 0;
+// The OS's start time for OUR pid, captured once at acquire alongside
+// `daemonStartedAt`. Recorded in the owner file so any later reader can prove
+// the pid still belongs to the same process (issue #169 item 1). Null on
+// platforms with no reader — everything downstream treats that as "no opinion".
+let daemonOsStart: string | null = null;
 // Fencing token for THIS daemon's lock ownership (see the inbox lock). We only
 // overwrite the owner file or delete the lock while it still carries our token,
 // so a stale-stolen daemon can't clobber or delete the new daemon's lock.
@@ -299,6 +312,7 @@ async function writeOwner(): Promise<boolean> {
         started_at: daemonStartedAt,
         ts: Date.now(),
         token: daemonToken,
+        os_start: daemonOsStart,
       }),
     );
     await rename(tmp, daemonLockOwnerPath());
@@ -328,6 +342,7 @@ export async function acquireDaemonLock(
       await mkdir(daemonLockDir(), { recursive: false });
       daemonStartedAt = Date.now(); // fixed for this daemon's lifetime
       daemonToken = randomUUID(); // fencing token for this ownership
+      daemonOsStart = osProcessStartToken(process.pid); // null where unreadable
       // If we can't write our owner file, we don't own the lock — drop and retry.
       if (!(await writeOwner())) {
         await rm(daemonLockDir(), { recursive: true, force: true }).catch(() => {});
@@ -341,9 +356,9 @@ export async function acquireDaemonLock(
       const now = Date.now();
       // A COMPLETE, live, fresh owner belonging to a DIFFERENT pid → another
       // daemon is already running; we are not it.
-      let owner: { pid?: number; ts?: number } | null = null;
+      let owner: { pid?: number; ts?: number; os_start?: string | null } | null = null;
       try {
-        owner = JSON.parse(raw) as { pid: number; ts: number };
+        owner = JSON.parse(raw) as { pid: number; ts: number; os_start?: string | null };
       } catch {
         /* torn / not-yet-written */
       }
@@ -354,7 +369,11 @@ export async function acquireDaemonLock(
         owner.pid !== process.pid &&
         typeof owner.ts === "number" &&
         now - owner.ts <= OWNER_TTL_MS &&
-        isAlive(owner.pid)
+        isAlive(owner.pid) &&
+        // ...and the OS agrees that pid is still the process that took the lock.
+        // Without this, a pid recycled onto an unrelated live process inside the
+        // TTL would make us decline to start — leaving the host with NO daemon.
+        !osStartTokenMismatch(owner.os_start, osProcessStartToken(owner.pid))
       ) {
         return false;
       }
@@ -408,31 +427,30 @@ export async function runDaemon(opts: DaemonOptions = {}): Promise<number> {
   }
 
   let running = true;
-  // Heartbeat the owner ts on a BACKGROUND timer (not once per loop) so a slow
-  // tick — many watched children, slow log I/O — can't let the heartbeat cross
-  // OWNER_TTL and have another `watch` steal the lock as "stale" → double daemon.
-  // Refresh well inside the TTL; cleared on shutdown.
-  const ownerBeat = setInterval(
-    () => {
-      void (async () => {
-        // Refresh ONLY while the owner still carries OUR token. Any other value — a
-        // different token (superseded) OR null/absent (a new daemon's mkdir→write
-        // window) — means we no longer own it, so stop rather than clobber an
-        // unknown/absent owner. Atomic writeOwner means a null read is never our own
-        // write in flight.
-        if ((await readDaemonOwnerToken()) !== daemonToken) {
-          clearInterval(ownerBeat);
-          return;
-        }
-        await writeOwner();
-      })();
+  // Heartbeat the owner ts on its OWN THREAD, not on the main loop's timer. A
+  // slow tick — many watched children, slow log I/O — must never let the stamp
+  // cross OWNER_TTL and have another `watch` steal the lock as "stale" → double
+  // daemon. A background timer already decoupled the beat from tick DURATION; a
+  // worker additionally decouples it from a synchronous main-thread block, which
+  // a single-threaded timer could only bound, never eliminate (issue #169 item
+  // 5). Fencing is unchanged — the beat refreshes ONLY while the owner still
+  // carries our token, and stops the moment it doesn't. It never signals us:
+  // the shutdown decision stays with the loop below, which re-reads the token
+  // every tick and exits when it isn't ours.
+  const ownerBeat = startOwnerHeartbeat({
+    ownerPath: daemonLockOwnerPath(),
+    token: daemonToken,
+    payload: {
+      pid: process.pid,
+      started_at: daemonStartedAt,
+      token: daemonToken,
+      os_start: daemonOsStart,
     },
-    Math.max(1000, Math.floor(OWNER_TTL_MS / 3)),
-  );
-  if (typeof ownerBeat.unref === "function") ownerBeat.unref();
+    intervalMs: Math.max(1000, Math.floor(OWNER_TTL_MS / 3)),
+  });
   const cleanup = async () => {
     running = false;
-    clearInterval(ownerBeat);
+    await ownerBeat.stop();
     // Delete the lock ONLY if it still carries our token — never remove a lock a
     // newer daemon now owns.
     if ((await readDaemonOwnerToken()) === daemonToken)
@@ -594,13 +612,14 @@ async function gcTick(host: string): Promise<void> {
  * kill an unrelated process. `stop` re-reads and re-checks this identity right
  * before signalling, so it can't SIGTERM a pid recycled between status and stop.
  *
- * Residual edge (documented, not yet closed): a pid recycled onto an UNRELATED
- * live process WITHIN the tight OWNER_TTL window (a few ticks) could be briefly
- * trusted, since we compare our recorded `started_at` against the owner file, not
- * against the OS's actual process start time (which is non-portable to read:
- * `/proc/<pid>/stat` on Linux vs `proc_pidinfo`/`ps -o lstart` on macOS). The
- * heartbeat freshness + tight TTL keep the window to seconds; a real OS
- * start-time cross-check is deferred to a future issue.
+ * The pid-recycled-inside-the-TTL window is closed by an OS start-time
+ * cross-check (issue #169 item 1): the owner file records the OS's own start
+ * time for the daemon pid at acquire, and every read re-reads it and rejects a
+ * disagreement — an unrelated process that inherited the pid has a different
+ * start time and is never reported as "the daemon". The reader is best-effort
+ * per platform (`/proc/<pid>/stat` on Linux, `ps -o lstart` on macOS/BSD, none
+ * on Windows); where it can't answer, behaviour is exactly as before — the
+ * heartbeat freshness + tight TTL still bound the window to seconds.
  */
 export async function daemonIdentity(now = Date.now()): Promise<DaemonIdentity | null> {
   const raw = await readFile(daemonLockOwnerPath(), "utf8").catch(() => "");
@@ -613,13 +632,21 @@ export async function daemonIdentity(now = Date.now()): Promise<DaemonIdentity |
       o.started_at > 0 &&
       typeof o.ts === "number" &&
       now - o.ts <= OWNER_TTL_MS &&
-      isPidAlive(o.pid)
+      isPidAlive(o.pid) &&
+      // ...and the OS's start time for that pid still matches the one recorded
+      // when the lock was taken. This is what closes the pid-recycled-inside-the-
+      // TTL window: an unrelated process that inherited the pid has a different
+      // start time, so it is never reported as "the daemon". Absent on either
+      // side (older owner file / no platform reader) => no opinion, trust the
+      // checks above, exactly as before.
+      !osStartTokenMismatch(o.os_start, osProcessStartToken(o.pid))
     ) {
       return {
         pid: o.pid,
         started_at: o.started_at,
         ts: o.ts,
         token: typeof o.token === "string" ? o.token : null,
+        os_start: typeof o.os_start === "string" ? o.os_start : null,
       };
     }
   } catch {

--- a/ts/notifyInbox.spec.ts
+++ b/ts/notifyInbox.spec.ts
@@ -13,7 +13,10 @@ import {
   nextSeq,
   parseCursor,
   parseInboxText,
+  postmortemStartedAt,
   rotateKeep,
+  emergencyKeep,
+  eventBytes,
   serializeCursor,
   serializeEvent,
 } from "./notifyInbox.ts";
@@ -189,5 +192,86 @@ describe("notifyInbox — watcher liveness", () => {
       15_000,
     );
     expect([...live].sort()).toEqual([1, 3]);
+  });
+});
+
+describe("notifyInbox — emergency rotation (#169.3)", () => {
+  const many = () => Array.from({ length: 500 }, (_, i) => ev({ seq: i + 1 }));
+
+  it("eventBytes sums the on-disk footprint (line + newline)", () => {
+    const evs = [ev({ seq: 1 }), ev({ seq: 2 })];
+    expect(eventBytes(evs)).toBe(
+      serializeEvent(evs[0]!).length + 1 + serializeEvent(evs[1]!).length + 1,
+    );
+    expect(eventBytes([])).toBe(0);
+  });
+
+  it("drops the OLDEST events even though they are unacked", () => {
+    // This is the whole point: rotateKeep protects every unacked event, which is
+    // right until the file threatens the disk. emergencyKeep ignores the
+    // watermark — the escape hatch a stuck consumer forces us to have.
+    const kept = emergencyKeep(many(), 1, 5);
+    expect(kept.length).toBeLessThan(500);
+    expect(kept[kept.length - 1]!.seq).toBe(500); // newest survive
+    expect(kept.some((e) => e.seq === 1)).toBe(false); // oldest sacrificed
+  });
+
+  it("still honours minKeep, so recent edges are never the ones sacrificed", () => {
+    const kept = emergencyKeep(many(), 1, 25);
+    expect(kept.length).toBe(25);
+    expect(kept.map((e) => e.seq)).toEqual(Array.from({ length: 25 }, (_, i) => 476 + i));
+  });
+
+  it("keeps everything that fits the cap", () => {
+    const evs = many();
+    expect(emergencyKeep(evs, eventBytes(evs), 5).length).toBe(500);
+  });
+
+  it("is a no-op below minKeep", () => {
+    const evs = [ev({ seq: 1 }), ev({ seq: 2 })];
+    expect(emergencyKeep(evs, 1, 100)).toEqual(evs);
+  });
+
+  it("returns events in ascending seq order (append order preserved)", () => {
+    const kept = emergencyKeep(many(), 1, 10);
+    expect(kept.map((e) => e.seq)).toEqual([...kept.map((e) => e.seq)].sort((a, b) => a - b));
+  });
+});
+
+describe("notifyInbox — postmortem identity (#169.6)", () => {
+  it("uses the single distinct incarnation stamped in the inbox", () => {
+    const evs = [ev({ seq: 1, parent_started_at: 500 }), ev({ seq: 2, parent_started_at: 500 })];
+    expect(postmortemStartedAt(evs)).toBe(500);
+  });
+
+  it("refuses to guess when the pid was reused across sessions", () => {
+    // Two agents' edges share the file. Picking one silently would attribute a
+    // stranger's children to whichever we chose — so make the operator decide.
+    const evs = [ev({ seq: 1, parent_started_at: 500 }), ev({ seq: 2, parent_started_at: 900 })];
+    expect(() => postmortemStartedAt(evs)).toThrow(/2 incarnations/);
+    expect(() => postmortemStartedAt(evs)).toThrow(/--started-at/);
+  });
+
+  it("lets an explicit choice win, even when ambiguous", () => {
+    const evs = [ev({ seq: 1, parent_started_at: 500 }), ev({ seq: 2, parent_started_at: 900 })];
+    expect(postmortemStartedAt(evs, 900)).toBe(900);
+  });
+
+  it("returns 0 (no filter) for a legacy inbox with no identity stamps", () => {
+    expect(postmortemStartedAt([ev({ seq: 1 })])).toBe(0);
+    expect(postmortemStartedAt([])).toBe(0);
+  });
+
+  it("ignores a non-positive or non-finite explicit choice", () => {
+    const evs = [ev({ seq: 1, parent_started_at: 500 })];
+    expect(postmortemStartedAt(evs, 0)).toBe(500);
+    expect(postmortemStartedAt(evs, -1)).toBe(500);
+    expect(postmortemStartedAt(evs, NaN)).toBe(500);
+  });
+
+  it("ignores zero stamps when finding distinct incarnations", () => {
+    // A 0 is "unknown", not an incarnation — it must not create false ambiguity.
+    const evs = [ev({ seq: 1, parent_started_at: 0 }), ev({ seq: 2, parent_started_at: 500 })];
+    expect(postmortemStartedAt(evs)).toBe(500);
   });
 });

--- a/ts/notifyInbox.ts
+++ b/ts/notifyInbox.ts
@@ -261,6 +261,81 @@ export function inboxesToGC(
 }
 
 /**
+ * Which incarnation of a parent pid a POSTMORTEM read should show (pure).
+ *
+ * The normal read path resolves the parent's `started_at` from the registry and
+ * fails closed when there is no live record — deliberately, so a recycled pid
+ * can't read a prior session's inbox. That also makes a FINISHED parent's inbox
+ * permanently uninspectable, which is exactly when an operator wants to see what
+ * the children reported. Postmortem keeps the identity guard but takes the
+ * identity from the inbox's own `parent_started_at` stamps instead.
+ *
+ * - An explicit choice always wins.
+ * - One distinct stamp is unambiguous — use it.
+ * - Several mean the pid was reused across sessions and the file holds more than
+ *   one agent's edges: refuse and list them rather than guess, because guessing
+ *   would show one agent's children under another's name.
+ * - None (a legacy, identity-less inbox) yields 0 = "no filter"; there is nothing
+ *   to disambiguate and nothing to mis-attribute.
+ *
+ * Issue #169 item 6.
+ */
+export function postmortemStartedAt(events: NotifyEvent[], explicit?: number): number {
+  if (Number.isFinite(explicit) && (explicit as number) > 0) return explicit as number;
+  const distinct = [
+    ...new Set(events.map((e) => e.parent_started_at ?? 0).filter((v) => v > 0)),
+  ].sort((a, b) => a - b);
+  if (distinct.length === 0) return 0;
+  if (distinct.length === 1) return distinct[0]!;
+  throw new Error(
+    `inbox holds edges from ${distinct.length} incarnations of this pid ` +
+      `(started_at ${distinct.join(", ")}) — pass --started-at <ms> to pick one.`,
+  );
+}
+
+/** Byte size one event occupies in the inbox file (its line + newline). */
+export function eventBytes(events: NotifyEvent[]): number {
+  let n = 0;
+  for (const e of events) n += serializeEvent(e).length + 1;
+  return n;
+}
+
+/**
+ * EMERGENCY rotation (pure): keep the newest events that fit `capBytes`,
+ * IGNORING the un-acked watermark that {@link rotateKeep} protects.
+ *
+ * This is the escape hatch for the one way an inbox can grow without bound: a
+ * parent that watches WITHOUT `--ack` (the default, at-least-once) never
+ * advances its cursor, so every event stays protected and normal rotation can
+ * trim nothing. That is the right default — an unacked edge must not be dropped
+ * — but "right" stops being right once the file threatens the disk. Past a hard
+ * cap well above the soft one, dropping the OLDEST unacked events (loudly) beats
+ * unbounded growth.
+ *
+ * `minKeep` still floors the result, so the newest edges — the ones a parent is
+ * most likely to still act on — are never the ones sacrificed.
+ *
+ * Issue #169 item 3.
+ */
+export function emergencyKeep(
+  events: NotifyEvent[],
+  capBytes: number,
+  minKeep = 100,
+): NotifyEvent[] {
+  if (events.length <= minKeep) return events.slice();
+  const kept: NotifyEvent[] = [];
+  let bytes = 0;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i]!;
+    bytes += serializeEvent(e).length + 1;
+    if (kept.length < minKeep || bytes <= capBytes) kept.push(e);
+    else break;
+  }
+  kept.reverse();
+  return kept;
+}
+
+/**
  * Rotation decision (pure): given an inbox's events, a byte cap, and the minimum
  * un-acked cursor across ALL consumers, return the events to KEEP after
  * rotating. Critically, an event with `seq > protectAboveSeq` is NEVER dropped —

--- a/ts/notifyStore.spec.ts
+++ b/ts/notifyStore.spec.ts
@@ -132,6 +132,33 @@ describe("notifyStore (fs)", () => {
     expect(nextSeq).toBe(131); // continues from the counter, no seq reuse
   });
 
+  it("never drops an UNACKED event while under the hard cap (soft cap holds)", async () => {
+    // 130 events, cursor never advanced: everything is unacked. The soft cap is
+    // 1 byte, so normal rotation can trim nothing — and must not, because
+    // at-least-once outranks the soft cap. A generous hard cap keeps it that way.
+    for (let i = 0; i < 130; i++) await appendEvent(901, baseEvent("idle"));
+    await gcInboxes(host, new Set([901]), new Set([901]), 1, 10 * 1024 * 1024);
+    expect((await readInbox(host, 901)).length).toBe(130);
+  });
+
+  it("emergency-trims the OLDEST unacked events past the HARD cap (#169.3)", async () => {
+    // Same stuck consumer, but now the inbox has blown through the hard cap.
+    // Unbounded growth is the worse failure, so the oldest unacked edges go —
+    // newest-first retention keeps the ones the parent may still act on.
+    for (let i = 0; i < 130; i++) await appendEvent(902, baseEvent("idle"));
+    const before = await readInbox(host, 902);
+    await gcInboxes(host, new Set([902]), new Set([902]), 1, 1);
+    const after = await readInbox(host, 902);
+    expect(after.length).toBeLessThan(before.length);
+    // The survivors are the NEWEST ones, contiguous up to the high-water seq.
+    expect(after[after.length - 1]!.seq).toBe(before[before.length - 1]!.seq);
+    expect(after.map((e) => e.seq)).toEqual(
+      before.slice(before.length - after.length).map((e) => e.seq),
+    );
+    // And seq allocation still moves forward — a trim must never reuse a seq.
+    expect(await appendEvent(902, baseEvent("needs_input"))).toBe(131);
+  });
+
   it("release() does NOT delete a lock that was STOLEN out from under it (fencing)", async () => {
     const { mkdtemp, writeFile } = await import("fs/promises");
     const { tmpdir } = await import("os");
@@ -202,6 +229,46 @@ describe("notifyStore (fs)", () => {
   it("drops a watcher whose heartbeat is fresh but whose process is DEAD (I3)", async () => {
     await heartbeatWatcher(424242, 999); // 424242 is not a live process
     expect((await liveWatchers()).has(424242)).toBe(false);
+  });
+
+  it("drops a watcher whose WATCH SUBPROCESS is dead, even with a live parent (#169.2)", async () => {
+    // The heartbeat is fresh and the parent agent is alive — only the `ay notify
+    // watch` subprocess died. Freshness alone would keep this watcher live for a
+    // whole TTL; carrying watch_pid drops it on the very next sweep.
+    const { watcherPath, watchersDir } = await import("./notifyInbox.ts");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(watchersDir(), { recursive: true });
+    await writeFile(
+      watcherPath(process.pid),
+      JSON.stringify({
+        pid: process.pid, // parent: alive
+        started_at: 111,
+        ts: Date.now(), // heartbeat: fresh
+        watch_pid: 424242, // the watch subprocess: gone
+      }),
+    );
+    expect((await liveWatchers()).has(process.pid)).toBe(false);
+  });
+
+  it("keeps a watcher whose heartbeat predates watch_pid (back-compat)", async () => {
+    // An older build's heartbeat has no watch_pid — it must keep the previous
+    // freshness-only behaviour rather than being dropped as unverifiable.
+    const { watcherPath, watchersDir } = await import("./notifyInbox.ts");
+    const { mkdir, writeFile } = await import("fs/promises");
+    await mkdir(watchersDir(), { recursive: true });
+    await writeFile(
+      watcherPath(process.pid),
+      JSON.stringify({ pid: process.pid, started_at: 111, ts: Date.now() }),
+    );
+    expect((await liveWatchers()).has(process.pid)).toBe(true);
+  });
+
+  it("records this process as watch_pid so its own liveness is provable", async () => {
+    await heartbeatWatcher(process.pid, 111);
+    const { watcherPath } = await import("./notifyInbox.ts");
+    const raw = JSON.parse(await readFile(watcherPath(process.pid), "utf8"));
+    expect(raw.watch_pid).toBe(process.pid);
+    expect((await liveWatchers()).has(process.pid)).toBe(true);
   });
 
   it("drops a watcher with a missing/non-positive started_at (fail-closed)", async () => {

--- a/ts/notifyStore.ts
+++ b/ts/notifyStore.ts
@@ -19,6 +19,8 @@ import {
   WATCHER_TTL_MS,
   cursorDir,
   cursorPath,
+  emergencyKeep,
+  eventBytes,
   inboxDir,
   inboxPath,
   maxSeq,
@@ -371,6 +373,14 @@ export async function gcInboxes(
   livePids: Set<number>,
   liveChildParentPids: Set<number>,
   capBytes = 10 * 1024 * 1024,
+  /**
+   * HARD cap. `capBytes` is a soft cap — an event above the min consumer cursor
+   * is never evicted, so a parent that never acks can push an inbox past it
+   * indefinitely. Past this second, much higher threshold we drop the oldest
+   * UNACKED events anyway and log loudly (issue #169 item 3). Set well above the
+   * soft cap so it only ever fires on a genuinely stuck consumer.
+   */
+  hardCapBytes = capBytes * 4,
 ): Promise<void> {
   const parents = await listInboxParents(host);
   for (const p of parents) {
@@ -395,14 +405,38 @@ export async function gcInboxes(
       if (size <= capBytes) continue;
       const events = await readInbox(host, p);
       const protectAboveSeq = await minConsumerCursor(host, p);
-      const kept = rotateKeep(events, capBytes, protectAboveSeq);
+      let kept = rotateKeep(events, capBytes, protectAboveSeq);
+      // Second line of defence: if even after honouring the un-acked watermark
+      // the inbox would still exceed the HARD cap, sacrifice the oldest unacked
+      // events. `capBytes` alone is a soft cap (an unacked edge is never
+      // evicted), which is right until the file threatens the disk — a parent
+      // watching without `--ack` and never advancing its cursor is the one way
+      // that happens. Newest-first, so the edges most likely to still matter
+      // survive.
+      let dropped: NotifyEvent[] = [];
+      if (eventBytes(kept) > hardCapBytes) {
+        const before = kept;
+        kept = emergencyKeep(kept, capBytes);
+        dropped = before.slice(0, before.length - kept.length);
+      }
       if (kept.length < events.length) {
         await writeFile(inboxPath(host, p), kept.map(serializeEvent).join("\n") + "\n");
+        if (dropped.length > 0) {
+          // Loud, and actionable: silently losing an at-least-once edge is
+          // exactly the failure this subsystem exists to prevent, so say so.
+          logger.error(
+            `[notify] EMERGENCY TRIM: inbox for parent ${p} exceeded the hard cap ` +
+              `${hardCapBytes} bytes — dropped ${dropped.length} UNACKED events ` +
+              `(seq ${dropped[0]!.seq}..${dropped[dropped.length - 1]!.seq}). ` +
+              `The consumer's cursor is not advancing: run \`ay notify watch --ack\` ` +
+              `(or \`ay notify cursor set <seq>\`) for parent ${p}.`,
+          );
+        }
       } else {
         // Oversize but nothing was trimmable — every event is unacked (min cursor
-        // at/below the oldest). `capBytes` is a SOFT cap here (we never drop an
-        // unacked edge), so surface the unbounded growth rather than silently
-        // exceeding it. A parent that never acks is the usual cause.
+        // at/below the oldest) and we are still under the hard cap. Surface the
+        // growth rather than silently exceeding the soft cap; a parent that never
+        // acks is the usual cause.
         logger.warn(
           `[notify] inbox for parent ${p} is ${size} bytes (> soft cap ${capBytes}) but all events are unacked — cursor not advancing?`,
         );
@@ -426,7 +460,16 @@ export async function heartbeatWatcher(parentPid: number, startedAt: number): Pr
   await ensureDir(watchersDir());
   await atomicWrite(
     watcherPath(parentPid),
-    JSON.stringify({ pid: parentPid, started_at: startedAt, ts: Date.now() }),
+    // `watch_pid` is the `ay notify watch` SUBPROCESS's own pid (this process),
+    // as distinct from `pid`, the parent AGENT it watches on behalf of. Carrying
+    // both lets liveWatchers prove the watcher itself is alive rather than
+    // inferring it from freshness alone — see there (issue #169 item 2).
+    JSON.stringify({
+      pid: parentPid,
+      started_at: startedAt,
+      ts: Date.now(),
+      watch_pid: process.pid,
+    }),
   );
 }
 
@@ -453,14 +496,24 @@ export async function liveWatchers(now = Date.now()): Promise<Map<number, number
     if (!n.endsWith(".json")) continue;
     const raw = await readFile(path.join(watchersDir(), n), "utf8").catch(() => "");
     try {
-      const o = JSON.parse(raw) as { pid: number; started_at?: number; ts: number };
+      const o = JSON.parse(raw) as {
+        pid: number;
+        started_at?: number;
+        ts: number;
+        watch_pid?: number;
+      };
       if (
         typeof o?.pid === "number" &&
         typeof o?.started_at === "number" &&
         o.started_at > 0 &&
         typeof o?.ts === "number" &&
         now - o.ts <= WATCHER_TTL_MS &&
-        pidAlive(o.pid)
+        pidAlive(o.pid) &&
+        // The `ay notify watch` SUBPROCESS must itself still be alive. Freshness
+        // alone only bounds a crashed watcher's lingering heartbeat to the TTL;
+        // this drops it on the very next sweep. Absent `watch_pid` (a heartbeat
+        // from an older build) keeps the previous freshness-only behaviour.
+        (typeof o.watch_pid !== "number" || o.watch_pid <= 0 || pidAlive(o.watch_pid))
       ) {
         live.set(o.pid, o.started_at);
       }

--- a/ts/ownerHeartbeat.spec.ts
+++ b/ts/ownerHeartbeat.spec.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { startInlineHeartbeat, startOwnerHeartbeat, type OwnerHeartbeat } from "./ownerHeartbeat.ts";
+
+// Issue #169 item 5. The daemon's proof-of-life is a `ts` it refreshes in the
+// lock owner file; if that stamp goes stale another `ay notify watch` steals the
+// lock and a second daemon starts. Two things must hold: the beat keeps
+// refreshing while we own the lock, and it never writes once we don't.
+
+const BEAT_MS = 30;
+// Generous: a worker thread's cold start on a loaded CI box is unpredictable, so
+// every positive assertion waits for a CONDITION rather than a fixed sleep.
+const BUDGET_MS = 5_000;
+
+const started: OwnerHeartbeat[] = [];
+const track = (h: OwnerHeartbeat) => {
+  started.push(h);
+  return h;
+};
+
+afterEach(async () => {
+  for (const h of started.splice(0)) await h.stop();
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(pred: () => Promise<boolean>, budgetMs = BUDGET_MS): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    if (await pred()) return true;
+    if (Date.now() > deadline) return false;
+    await sleep(20);
+  }
+}
+
+async function ownerFile(token: string) {
+  const dir = await mkdtemp(path.join(tmpdir(), "ay-beat-"));
+  const file = path.join(dir, "owner.json");
+  await writeFile(file, JSON.stringify({ pid: process.pid, token, ts: 1 }));
+  return file;
+}
+
+const readOwner = async (file: string) =>
+  JSON.parse(await readFile(file, "utf8")) as { ts: number; token?: string; [k: string]: unknown };
+
+/** Resolves once the beat has stamped the file at least once. */
+const beaten = (file: string) => waitFor(async () => (await readOwner(file)).ts > 1);
+
+// Both implementations must behave identically — the fallback exists precisely
+// so a runtime without workers is no worse off, which only holds if it agrees.
+for (const [name, start] of [
+  ["worker-isolated", startOwnerHeartbeat],
+  ["inline fallback", startInlineHeartbeat],
+] as const) {
+  describe(`ownerHeartbeat — ${name}`, () => {
+    it("refreshes ts while the owner still carries our token", async () => {
+      const file = await ownerFile("tok-a");
+      track(
+        start({ ownerPath: file, token: "tok-a", payload: { token: "tok-a" }, intervalMs: BEAT_MS }),
+      );
+      expect(await beaten(file)).toBe(true);
+    });
+
+    it("preserves the fixed owner payload across beats", async () => {
+      const file = await ownerFile("tok-b");
+      const payload = { pid: 4242, started_at: 777, token: "tok-b", os_start: "abc" };
+      track(start({ ownerPath: file, token: "tok-b", payload, intervalMs: BEAT_MS }));
+      expect(await beaten(file)).toBe(true);
+      const owner = await readOwner(file);
+      expect(owner.pid).toBe(4242);
+      expect(owner.started_at).toBe(777);
+      expect(owner.os_start).toBe("abc");
+    });
+
+    it("never writes when the owner carries a DIFFERENT token (fencing)", async () => {
+      // Supersede the owner BEFORE the beat can start, so its very first read
+      // already sees a token that isn't ours. Deterministic by construction —
+      // no dependence on where a beat happens to land.
+      const file = await ownerFile("mine");
+      await writeFile(file, JSON.stringify({ pid: 1, token: "theirs", ts: 999 }));
+      track(
+        start({ ownerPath: file, token: "mine", payload: { token: "mine" }, intervalMs: BEAT_MS }),
+      );
+      await sleep(BEAT_MS * 10);
+      const owner = await readOwner(file);
+      expect(owner.token).toBe("theirs"); // never overwritten by us
+      expect(owner.ts).toBe(999); // never re-stamped
+    });
+
+    it("does not resurrect the owner after the lock DIRECTORY is removed", async () => {
+      // `ay notifyd stop` is cooperative: it removes the lock DIRECTORY rather
+      // than signalling a possibly-recycled pid. Removing the directory (not just
+      // owner.json) is what makes the removal stick — the beat writes via a temp
+      // file inside that directory, so a beat already past its token read fails at
+      // the rename instead of resurrecting an owner file it no longer owns.
+      const file = await ownerFile("tok-c");
+      track(
+        start({ ownerPath: file, token: "tok-c", payload: { token: "tok-c" }, intervalMs: BEAT_MS }),
+      );
+      expect(await beaten(file)).toBe(true);
+      await rm(path.dirname(file), { recursive: true, force: true });
+      await sleep(BEAT_MS * 10);
+      await expect(readFile(file, "utf8")).rejects.toThrow(); // stayed gone
+    });
+
+    it("stop() halts further refreshes", async () => {
+      const file = await ownerFile("tok-d");
+      const h = start({
+        ownerPath: file,
+        token: "tok-d",
+        payload: { token: "tok-d" },
+        intervalMs: BEAT_MS,
+      });
+      expect(await beaten(file)).toBe(true);
+      await h.stop();
+      const frozen = (await readOwner(file)).ts;
+      await sleep(BEAT_MS * 10);
+      expect((await readOwner(file)).ts).toBe(frozen);
+    });
+  });
+}
+
+describe("ownerHeartbeat — isolation", () => {
+  it("runs on its own thread, so a blocked main thread cannot stall it", async () => {
+    const file = await ownerFile("tok-e");
+    const h = track(
+      startOwnerHeartbeat({
+        ownerPath: file,
+        token: "tok-e",
+        payload: { token: "tok-e" },
+        intervalMs: BEAT_MS,
+      }),
+    );
+    expect(h.isolated).toBe(true);
+    expect(await beaten(file)).toBe(true); // worker is up and beating
+    const before = (await readOwner(file)).ts;
+    // Block the main thread SYNCHRONOUSLY for many beat intervals — the exact
+    // failure mode a single-threaded timer cannot survive. An inline timer would
+    // not have fired once in this window; the worker must stamp right through it.
+    const until = Date.now() + BEAT_MS * 12;
+    while (Date.now() < until) {
+      /* deliberate busy-wait */
+    }
+    expect((await readOwner(file)).ts).toBeGreaterThan(before);
+  });
+
+  it("the fallback reports that it is not isolated", async () => {
+    const file = await ownerFile("tok-f");
+    const h = track(
+      startInlineHeartbeat({
+        ownerPath: file,
+        token: "tok-f",
+        payload: { token: "tok-f" },
+        intervalMs: BEAT_MS,
+      }),
+    );
+    expect(h.isolated).toBe(false);
+  });
+});

--- a/ts/ownerHeartbeat.ts
+++ b/ts/ownerHeartbeat.ts
@@ -1,0 +1,166 @@
+/**
+ * The `ay notifyd` singleton lock's owner heartbeat, run on its OWN thread.
+ *
+ * Why a thread: the daemon proves it is alive by refreshing `ts` in the lock's
+ * `owner.json`; another `ay notify watch` steals the lock once that stamp is
+ * older than `OWNER_TTL`. On a single-threaded JS timer, a SYNCHRONOUS block in
+ * the daemon longer than the TTL would stall the heartbeat, let a second daemon
+ * take the lock, and leave two daemons writing the same inboxes. The loop is all
+ * `await`s and the TTL sits far above any realistic block, so that was always
+ * theoretical — but a single-threaded process can only bound it, never eliminate
+ * it. A worker thread does: its timer keeps firing no matter what the main
+ * thread is doing.
+ *
+ * The worker owns the whole beat (read token → verify → atomic rewrite), so a
+ * blocked main thread contributes nothing to keeping the lock alive. The owner
+ * payload is fixed for the daemon's lifetime — only `ts` moves — so there is no
+ * state to synchronize back.
+ *
+ * FENCING is preserved exactly as on the main thread: the beat refreshes only
+ * while `owner.json` still carries OUR token. Any other value — a different
+ * token (superseded) or none (another daemon's mkdir→write window) — means we no
+ * longer own the lock, so it stops rather than clobber an owner that isn't ours.
+ *
+ * Deliberately one-way: the beat never signals the daemon. Deciding to shut down
+ * stays with the daemon loop, which already re-reads the owner token every tick
+ * and exits when it isn't ours. Adding a second, cross-thread path to the same
+ * decision would only create a way for the two to disagree.
+ *
+ * The worker source is passed inline (`eval: true`) rather than shipped as a
+ * separate file: it needs no bundler entry, no dist path resolution, and works
+ * identically under both `bun` and `node` (verified on both).
+ *
+ * Falls back to a main-thread timer if a Worker can't be created for any reason,
+ * so this can only ever be as good as the previous behaviour — never worse.
+ *
+ * Issue #169 item 5.
+ */
+
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+// Static, not `require`: this module is ESM, where `require` is undefined — a
+// lazy require would throw every time and silently pin us to the fallback.
+// `node:worker_threads` is a builtin present in both bun and node.
+import { Worker } from "node:worker_threads";
+
+export interface OwnerHeartbeat {
+  /** Stop beating and release the thread. */
+  stop(): Promise<void>;
+  /** True when the beat runs on its own thread (false = main-thread fallback). */
+  isolated: boolean;
+}
+
+export interface OwnerHeartbeatOptions {
+  /** Path of the lock's owner.json. */
+  ownerPath: string;
+  /** Our fencing token; the beat stops if the owner stops carrying it. */
+  token: string;
+  /** Fixed owner fields; the beat rewrites these with a fresh `ts`. */
+  payload: Record<string, unknown>;
+  intervalMs: number;
+}
+
+// Kept as a string so it can be handed to `new Worker(src, { eval: true })`.
+// CommonJS `require` is used deliberately: it is what both bun and node accept
+// inside an eval'd worker without any module-type negotiation.
+const WORKER_SRC = `
+const { workerData } = require("node:worker_threads");
+const fs = require("node:fs");
+const { ownerPath, token, payload, intervalMs } = workerData;
+
+function currentToken() {
+  try {
+    return JSON.parse(fs.readFileSync(ownerPath, "utf8")).token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function beat() {
+  if (currentToken() !== token) return false;
+  // Atomic (write temp + rename), so a concurrent reader never sees a torn owner
+  // and a null read reliably means "no owner file" rather than "write in flight".
+  const tmp = ownerPath + "." + token + ".beat.tmp";
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(Object.assign({}, payload, { ts: Date.now() })));
+    fs.renameSync(tmp, ownerPath);
+  } catch {
+    try { fs.unlinkSync(tmp); } catch {}
+  }
+  return true;
+}
+
+const timer = setInterval(() => {
+  if (!beat()) clearInterval(timer);
+}, intervalMs);
+`;
+
+/**
+ * Main-thread fallback with identical semantics, used when a Worker can't be
+ * created. Exported so the specs can exercise it directly on every platform —
+ * it is the path that runs on any runtime where worker threads are unavailable.
+ */
+export function startInlineHeartbeat(opts: OwnerHeartbeatOptions): OwnerHeartbeat {
+  const timer = setInterval(() => {
+    // SYNCHRONOUS check-then-write, exactly like the worker. An `await` between
+    // reading the token and rewriting the file is a TOCTOU: the lock can be
+    // stolen (or removed by `notifyd stop`) in that gap, and the write would then
+    // resurrect an owner file we no longer own — re-asserting a lock that now
+    // belongs to another daemon, and making the removal invisible to us. The file
+    // is a few dozen bytes written every OWNER_TTL/3, so blocking is immaterial.
+    let cur: string | null = null;
+    try {
+      cur = (JSON.parse(readFileSync(opts.ownerPath, "utf8")) as { token?: string }).token ?? null;
+    } catch {
+      cur = null;
+    }
+    if (cur !== opts.token) {
+      clearInterval(timer);
+      return;
+    }
+    const tmp = `${opts.ownerPath}.${opts.token}.beat.tmp`;
+    try {
+      writeFileSync(tmp, JSON.stringify({ ...opts.payload, ts: Date.now() }));
+      renameSync(tmp, opts.ownerPath);
+    } catch {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        /* nothing to clean up */
+      }
+    }
+  }, opts.intervalMs);
+  if (typeof timer.unref === "function") timer.unref();
+  return {
+    isolated: false,
+    stop: async () => {
+      clearInterval(timer);
+    },
+  };
+}
+
+export function startOwnerHeartbeat(opts: OwnerHeartbeatOptions): OwnerHeartbeat {
+  try {
+    const worker = new Worker(WORKER_SRC, {
+      eval: true,
+      workerData: {
+        ownerPath: opts.ownerPath,
+        token: opts.token,
+        payload: opts.payload,
+        intervalMs: opts.intervalMs,
+      },
+    });
+    // A heartbeat thread must never be the reason the process stays up, and a
+    // worker error must never crash the daemon — it just means we're back to
+    // relying on the main loop's own token check.
+    worker.on("error", () => {});
+    if (typeof worker.unref === "function") worker.unref();
+    return {
+      isolated: true,
+      stop: async () => {
+        await worker.terminate().catch(() => {});
+      },
+    };
+  } catch {
+    return startInlineHeartbeat(opts);
+  }
+}

--- a/ts/procStartTime.spec.ts
+++ b/ts/procStartTime.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { osProcessStartToken, osStartTokenMismatch, parseLinuxStartTime } from "./procStartTime.ts";
+
+// Field 22 of /proc/<pid>/stat. After the comm, fields 3.. are: state ppid pgrp
+// session tty_nr tpgid flags minflt cminflt majflt cmajflt utime stime cutime
+// cstime priority nice num_threads itrealvalue starttime — so `starttime` sits at
+// index 19 of everything following the last ')'.
+const after = (starttime: string) =>
+  ["S", "1", "1", "1", "0", "-1", "4194304"]
+    .concat(Array(12).fill("0")) // minflt..itrealvalue
+    .concat([starttime])
+    .join(" ");
+
+describe("parseLinuxStartTime", () => {
+  it("reads starttime from a normal stat line", () => {
+    expect(parseLinuxStartTime(`1234 (bash) ${after("987654")}`)).toBe("987654");
+  });
+
+  it("survives a comm containing spaces and parentheses", () => {
+    // The whole reason we parse after the LAST ')': naive splitting mis-indexes
+    // every field once comm has spaces/parens in it.
+    expect(parseLinuxStartTime(`1234 (my prog (v2)) ${after("42")}`)).toBe("42");
+  });
+
+  it("returns null for a line with no comm terminator", () => {
+    expect(parseLinuxStartTime("1234 bash S 1 1")).toBeNull();
+  });
+
+  it("returns null when the field is missing or not numeric", () => {
+    expect(parseLinuxStartTime("1234 (bash) S 1 1")).toBeNull();
+    expect(parseLinuxStartTime(`1234 (bash) ${after("not-a-number")}`)).toBeNull();
+  });
+});
+
+describe("osProcessStartToken", () => {
+  const stat = `7 (agent) ${after("555")}`;
+
+  it("uses /proc on linux", () => {
+    expect(
+      osProcessStartToken(7, { platform: "linux", readProcStat: () => stat }),
+    ).toBe("555");
+  });
+
+  it("uses ps lstart on darwin/bsd", () => {
+    for (const platform of ["darwin", "freebsd", "openbsd"]) {
+      expect(
+        osProcessStartToken(7, { platform, readPsLstart: () => " Sun Jul 27 06:00:00 2026 " }),
+      ).toBe("Sun Jul 27 06:00:00 2026");
+    }
+  });
+
+  it("has no opinion on windows", () => {
+    expect(osProcessStartToken(7, { platform: "win32" })).toBeNull();
+  });
+
+  it("has no opinion when the reader cannot answer", () => {
+    expect(osProcessStartToken(7, { platform: "linux", readProcStat: () => null })).toBeNull();
+    expect(osProcessStartToken(7, { platform: "darwin", readPsLstart: () => null })).toBeNull();
+  });
+
+  it("rejects a non-positive pid without consulting the OS", () => {
+    let called = false;
+    const readProcStat = () => {
+      called = true;
+      return stat;
+    };
+    expect(osProcessStartToken(0, { platform: "linux", readProcStat })).toBeNull();
+    expect(osProcessStartToken(-1, { platform: "linux", readProcStat })).toBeNull();
+    expect(osProcessStartToken(NaN, { platform: "linux", readProcStat })).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  // Forcing the platform while leaving the DEFAULT readers in place exercises the
+  // real OS readers on every host: /proc simply isn't there on macOS (the same
+  // fail-soft path a hardened container hits), and `ps -o lstart=` exists on
+  // Linux too. Both must answer, never throw.
+  it("fails soft when the real /proc reader has nothing to read", () => {
+    const token = osProcessStartToken(process.pid, { platform: "linux" });
+    expect(token === null || /^\d+$/.test(token)).toBe(true);
+  });
+
+  it("fails soft when the real ps reader is unavailable", () => {
+    const token = osProcessStartToken(process.pid, { platform: "darwin" });
+    expect(token === null || token.length > 0).toBe(true);
+  });
+
+  it("answers for the real current process on a supported platform", () => {
+    const token = osProcessStartToken(process.pid);
+    if (process.platform === "linux" || process.platform === "darwin") {
+      expect(typeof token).toBe("string");
+      expect(token).not.toBe("");
+      // Stable across reads — it identifies WHEN the process started.
+      expect(osProcessStartToken(process.pid)).toBe(token);
+    } else {
+      expect(token).toBeNull();
+    }
+  });
+});
+
+describe("osStartTokenMismatch", () => {
+  it("flags only a positive disagreement", () => {
+    expect(osStartTokenMismatch("111", "222")).toBe(true);
+  });
+
+  it("accepts agreement", () => {
+    expect(osStartTokenMismatch("111", "111")).toBe(false);
+  });
+
+  // Fail-OPEN by design: this guard is layered on top of pid-liveness and
+  // heartbeat freshness, so "cannot tell" must never become "assume recycled" —
+  // that would break every platform without a reader.
+  it("has no opinion when either side is absent", () => {
+    expect(osStartTokenMismatch(undefined, "222")).toBe(false);
+    expect(osStartTokenMismatch(null, "222")).toBe(false);
+    expect(osStartTokenMismatch("", "222")).toBe(false);
+    expect(osStartTokenMismatch("111", null)).toBe(false);
+    expect(osStartTokenMismatch(undefined, null)).toBe(false);
+  });
+});

--- a/ts/procStartTime.ts
+++ b/ts/procStartTime.ts
@@ -1,0 +1,122 @@
+/**
+ * Best-effort OS process start time, as an OPAQUE token.
+ *
+ * Why: `ay notifyd`'s singleton lock records `{pid, started_at}` where
+ * `started_at` is OUR OWN wall-clock stamp from when the daemon acquired the
+ * lock. That proves nothing about the pid the OS currently has: a pid recycled
+ * onto an unrelated live process inside the owner TTL would pass `isPidAlive`
+ * and be trusted as "the daemon is running" — so `ensureDaemon` would decline to
+ * start a real one. Cross-checking the OS's own notion of when that pid started
+ * closes the window: the recycled process has a different start time.
+ *
+ * The token is deliberately opaque (a raw platform string, compared only for
+ * equality) — no epoch math, no clock-tick/boot-time arithmetic, nothing to get
+ * subtly wrong across platforms. It is only ever compared against a token this
+ * same code produced for the same pid.
+ *
+ * BEST-EFFORT by contract: every reader returns `null` when it cannot answer
+ * (unsupported platform, missing /proc, `ps` unavailable or slow). Callers MUST
+ * treat null as "no opinion" and fall back to the existing checks — this
+ * tightens an edge, it must never introduce a new way to fail.
+ *
+ * Issue #169 item 1.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/**
+ * Extract field 22 (`starttime`, in clock ticks since boot) from a Linux
+ * `/proc/<pid>/stat` line.
+ *
+ * The parse must start AFTER the last `)`: field 2 is the executable name in
+ * parentheses and may itself contain spaces and parens (`(my prog (v2))`), so
+ * naive whitespace splitting mis-indexes every later field. After the last `)`
+ * the remaining fields begin at field 3, hence `starttime` is index 19.
+ */
+export function parseLinuxStartTime(stat: string): string | null {
+  const close = stat.lastIndexOf(")");
+  if (close < 0) return null;
+  const fields = stat.slice(close + 1).trim().split(/\s+/);
+  const starttime = fields[19];
+  return starttime && /^\d+$/.test(starttime) ? starttime : null;
+}
+
+/** Injection seam so the specs can exercise every platform on any host. */
+export interface StartTokenReaders {
+  platform: string;
+  /** Contents of /proc/<pid>/stat, or null. */
+  readProcStat?: (pid: number) => string | null;
+  /** Output of `ps -o lstart= -p <pid>`, or null. */
+  readPsLstart?: (pid: number) => string | null;
+}
+
+function defaultProcStat(pid: number): string | null {
+  try {
+    return readFileSync(`/proc/${pid}/stat`, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function defaultPsLstart(pid: number): string | null {
+  try {
+    // `lstart` is the absolute start time ("Sun Jul 27 06:00:00 2026") — stable
+    // for the life of the process, unlike `etime`. Second resolution, so it does
+    // not by itself distinguish two processes that started in the same second;
+    // it is one more independent signal on top of the pid+heartbeat checks, not
+    // a replacement for them. Bounded timeout: this runs on interactive paths.
+    return execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: 500,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Normalize a raw reader result: trim, and treat an empty answer as "unknown". */
+function normalize(raw: string | null): string | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * An opaque token identifying WHEN `pid` started, or null when unknowable.
+ *
+ * Windows deliberately returns null: the only readily available reader is a
+ * PowerShell `Get-Process` spawn (hundreds of ms), far too heavy for a path
+ * that runs every couple of seconds under `ay notify watch`.
+ */
+export function osProcessStartToken(pid: number, deps?: StartTokenReaders): string | null {
+  if (!Number.isFinite(pid) || pid <= 0) return null;
+  const platform = deps?.platform ?? process.platform;
+  if (platform === "linux") {
+    const stat = (deps?.readProcStat ?? defaultProcStat)(pid);
+    return stat ? parseLinuxStartTime(stat) : null;
+  }
+  if (platform === "darwin" || platform === "freebsd" || platform === "openbsd") {
+    return normalize((deps?.readPsLstart ?? defaultPsLstart)(pid));
+  }
+  return null;
+}
+
+/**
+ * Does a RECORDED start token prove the pid has been recycled since?
+ *
+ * True only on positive disagreement — both sides present and different. A
+ * missing record (an owner written by an older build, or on a platform with no
+ * reader) or an unreadable current value yields false, i.e. "no opinion, keep
+ * trusting the other checks". Fail-open is correct here precisely because this
+ * is an ADDITIONAL guard layered on pid-liveness + heartbeat freshness.
+ */
+export function osStartTokenMismatch(
+  recorded: string | null | undefined,
+  current: string | null,
+): boolean {
+  if (typeof recorded !== "string" || recorded === "") return false;
+  if (current === null) return false;
+  return current !== recorded;
+}

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -42,6 +42,7 @@ import {
   filterSinceTs,
   filterUnread,
   maxSeq,
+  postmortemStartedAt,
   type NotifyEvent,
 } from "./notifyInbox.ts";
 import {
@@ -4989,7 +4990,7 @@ async function cmdNotify(rest: string[]): Promise<number> {
   if (verb === "cursor") return cmdNotifyCursor(args);
   if (verb !== "read" && verb !== "watch") {
     process.stderr.write(
-      "usage: ay notify <read|watch|cursor> [--parent <pid>] [--since <seq>] [--since-ts <ms>] [--unread] [--ack] [--json]\n",
+      "usage: ay notify <read|watch|cursor> [--parent <pid>] [--since <seq>] [--since-ts <ms>] [--unread] [--ack] [--json] [--postmortem]\n",
     );
     return 1;
   }
@@ -5027,6 +5028,15 @@ async function cmdNotify(rest: string[]): Promise<number> {
       default: true,
       description: "Start the notifyd singleton if not running (watch)",
     })
+    .option("postmortem", {
+      type: "boolean",
+      default: false,
+      description: "Read-only: inspect an inbox whose parent has exited (read)",
+    })
+    .option("started-at", {
+      type: "number",
+      description: "Disambiguate which incarnation to show (--postmortem)",
+    })
     .help(false)
     .version(false)
     .exitProcess(false);
@@ -5041,12 +5051,33 @@ async function cmdNotify(rest: string[]): Promise<number> {
   // open the notification path at all rather than fail-open and risk delivering a
   // recycled pid's inbox to an unrelated agent (or registering a 0-identity
   // watcher). "If we don't know who the parent is, don't open the path."
-  const selfStartedAt = await resolveParentStartedAt(parent);
-  if (selfStartedAt <= 0)
-    throw new Error(
-      `cannot resolve identity for pid ${parent} (no live agent record) — ` +
-        `refusing to open the notification path (pass --parent for a live agent).`,
+  // Postmortem: a READ-ONLY inspection of an inbox whose parent has already
+  // exited. The normal path fails closed when the parent isn't a live registry
+  // record — deliberately, so a recycled pid can't read a prior session's inbox —
+  // but that also made a finished parent's inbox permanently uninspectable, which
+  // is exactly when an operator wants to see what the children reported. This
+  // mode keeps the identity guard (events are still filtered to ONE incarnation)
+  // but takes that identity from the inbox's own stamps instead of the registry,
+  // and never registers a watcher or starts the daemon. Issue #169 item 6.
+  const postmortem = Boolean(argv.postmortem);
+  if (postmortem && verb !== "read")
+    throw new Error("--postmortem is read-only — use `ay notify read --postmortem`");
+
+  let selfStartedAt: number;
+  if (postmortem) {
+    selfStartedAt = postmortemStartedAt(
+      await readInbox(host, parent),
+      argv["started-at"] as number | undefined,
     );
+  } else {
+    selfStartedAt = await resolveParentStartedAt(parent);
+    if (selfStartedAt <= 0)
+      throw new Error(
+        `cannot resolve identity for pid ${parent} (no live agent record) — ` +
+          `refusing to open the notification path (pass --parent for a live agent, ` +
+          `or \`ay notify read --postmortem --parent ${parent}\` to inspect a finished one).`,
+      );
+  }
 
   const drain = async (sinceSeqOverride?: number): Promise<number> => {
     let events = await readInbox(host, parent);


### PR DESCRIPTION
Closes 5 of the 6 deferred v1 follow-ups from #169. Each was a bounded edge with a documented mitigation; this replaces the mitigations with actual guarantees.

## 1. Owner identity vs the OS process start time

The notifyd lock recorded only our own wall-clock `started_at`, which says nothing about the pid the OS *currently* has. A pid recycled onto an unrelated live process inside `OWNER_TTL` passed `isPidAlive` and was trusted as "the daemon is running" — so `ensureDaemon` declined to start a real one, **leaving the host with no daemon at all**.

The owner file now also records the OS's own start time for that pid, and every read rejects a disagreement. The token is deliberately opaque (compared only for equality — no clock-tick/boot-time arithmetic to get subtly wrong):

| Platform | Reader |
| --- | --- |
| Linux | `/proc/<pid>/stat` field 22 (parsed after the **last** `)`, so a comm containing spaces/parens can't mis-index it) |
| macOS / BSD | `ps -o lstart= -p <pid>` |
| Windows | none — the only reader is a ~200ms PowerShell spawn, far too heavy for a path that runs every 2s under `ay notify watch` |

Best-effort by contract: both readers and both call sites treat "can't tell" as *no opinion* and fall back to the previous checks. This tightens an edge; it must never become a new way to fail.

## 2. The watcher heartbeat now proves the watcher

It proved the **parent** was alive, not that the `ay notify watch` subprocess still was — a crashed watcher lingered for a whole TTL on freshness alone. The heartbeat carries `watch_pid`, so a dead watcher is dropped on the very next sweep. Heartbeats written by older builds keep the previous behaviour.

## 3. Un-acked inbox growth

Rotation never evicts above the minimum consumer cursor, so a parent watching without `--ack` (the default) grew its inbox without bound. Added a **hard cap** (4x the soft cap) past which the *oldest* unacked events are dropped, newest-first, with a loud `logger.error` naming the parent and the exact seq range. The cursor is **not** advanced, so the loss stays visible as a seq gap rather than being silently swallowed.

Below the hard cap nothing changes — at-least-once still outranks the soft cap.

## 5. Event-loop-block false steal

The owner heartbeat ran on the main thread's timer, so a synchronous block longer than `OWNER_TTL` would stall it and let a second daemon take the lock. It now runs on **its own worker thread** — inline `eval: true` source, so no bundler entry, no dist path resolution, and verified working on both `bun` and `node`. Falls back to a main-thread timer if a worker can't be created, so it can only ever be as good as before.

The beat is deliberately **one-way**: it never signals the daemon. Shutdown stays the loop's decision via its existing per-tick owner-token check — adding a second cross-thread path to the same decision would only create a way for the two to disagree.

This also fixes a **TOCTOU the old beat had**: it read the owner token, `await`ed, then wrote — so a lock stolen or removed in that gap got its owner file *resurrected* by a daemon that no longer owned it, re-asserting a lock belonging to someone else and hiding the removal from itself. Both implementations now do a synchronous check-then-write.

## 6. Postmortem inbox inspection

`ay notify read/watch` fail closed when the parent isn't a live registry record — deliberately, so a recycled pid can't read a prior session's inbox. But that also made a *finished* parent's inbox permanently uninspectable, which is exactly when an operator wants to see what the children reported.

```sh
ay notify read --postmortem --parent <pid> [--started-at <ms>]
```

Read-only: registers no watcher, starts no daemon. The identity guard stays intact but takes its identity from the inbox's own `parent_started_at` stamps. If the pid was reused across sessions the inbox holds more than one agent's edges, so it **refuses and lists the candidates** rather than attribute one agent's children to another.

## Item 4 (durable parent identity) is deliberately not here

It needs an `agent_id` that survives a restart. Today `agent_id` is minted per process — `docs/agent-sharing.md` tracks the same gap for share grants — so a notify-only identity bolted on top would be the wrong layer, and would need its own inbox-keying and GC-lifetime design. Left open on #169 with the reasoning written into `docs/subagent-notify.md`.

## Tests

+33 cases: `procStartTime` 13 (incl. a comm with spaces and parens, and both real readers forced on either host so coverage doesn't swing by platform), `ownerHeartbeat` 12 run against **both** implementations plus a blocked-main-thread isolation check, `notifyInbox` +13, `notifyStore` +5.

Full suite: 81 files green. Global branch coverage 90.85% (gate 90). `oxlint` clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)