### PR TITLE
feat(env-nodes): stamp each agent's permission posture + enforce it on spawn (#236)

### DIFF
--- a/rs/src/agent_permissions.rs
+++ b/rs/src/agent_permissions.rs
@@ -1,0 +1,136 @@
+//! The permission posture an agent was actually spawned with — derived once at
+//! registration and stamped into the pid record so it can be audited later.
+//!
+//! Why record it rather than re-derive on read: the global index carries no
+//! argv, and the wrapper's own flags (`--robust`, auto-continue) never appear in
+//! the CLI's args at all. Without stamping this, "was this agent running with
+//! permission checks disabled?" is unanswerable after the fact — which is
+//! exactly the question an operator looking at a fleet of agents needs answered.
+//!
+//! MIRRORS `ts/agentPermissions.ts` — keep the two in sync (field names are the
+//! serialized wire format shared through `~/.agent-yes/pids.jsonl`).
+//!
+//! Issue #236.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentPermissions {
+    /// The wrapped CLI got its "yolo" flag — the per-CLI `yes_args` appended by
+    /// `-y`/`--yes`, or the same flag passed through directly. This is the one
+    /// that matters for audit: it disables the CLI's own confirmation gate, so
+    /// the agent edits files and runs commands with no human in the loop.
+    pub skip_permissions: bool,
+    /// agent-yes `--robust`: restart the CLI automatically when it crashes.
+    pub robust: bool,
+    /// agent-yes auto-continue: resume the prior session on restart.
+    pub auto_continue: bool,
+}
+
+/// Flags that disable a CLI's confirmation gate, recognised regardless of what
+/// `yes_args` the config declares.
+///
+/// The configured `yes_args` are the flags `-y` APPENDS; a user is free to pass
+/// the same flag directly, and a config that omits `yes_args` entirely (some
+/// CLIs deliberately have none) must not make a genuinely dangerous flag
+/// invisible. So the check is the union: configured flags OR any of these.
+const DANGEROUS_FLAGS: &[&str] = &[
+    "--dangerously-skip-permissions",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--yolo",
+    "--full-auto",
+];
+
+/// `--flag=value` and `--flag value` must compare equal — match on the flag part.
+fn flag_name(arg: &str) -> &str {
+    match arg.find('=') {
+        Some(i) => &arg[..i],
+        None => arg,
+    }
+}
+
+pub fn derive_permissions(
+    cli_args: &[String],
+    yes_args: &[String],
+    robust: bool,
+    auto_continue: bool,
+) -> AgentPermissions {
+    let skip_permissions = cli_args.iter().any(|a| {
+        let name = flag_name(a);
+        DANGEROUS_FLAGS.contains(&name) || yes_args.iter().any(|y| flag_name(y) == name)
+    });
+    AgentPermissions {
+        skip_permissions,
+        robust,
+        auto_continue,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_detects_the_configured_yolo_flag() {
+        let p = derive_permissions(
+            &v(&["--print", "--dangerously-skip-permissions"]),
+            &v(&["--dangerously-skip-permissions"]),
+            false,
+            false,
+        );
+        assert!(p.skip_permissions);
+    }
+
+    #[test]
+    fn test_detects_a_dangerous_flag_the_config_never_declared() {
+        // A CLI with no yes_args must still not hide a flag that disables its gate.
+        let p = derive_permissions(&v(&["--yolo"]), &[], false, false);
+        assert!(p.skip_permissions);
+    }
+
+    #[test]
+    fn test_matches_the_flag_part_of_an_equals_form() {
+        let p = derive_permissions(&v(&["--full-auto=true"]), &[], false, false);
+        assert!(p.skip_permissions);
+    }
+
+    #[test]
+    fn test_plain_args_are_not_skip() {
+        let p = derive_permissions(
+            &v(&["--model", "opus", "--continue"]),
+            &v(&["--dangerously-skip-permissions"]),
+            false,
+            false,
+        );
+        assert!(!p.skip_permissions);
+    }
+
+    #[test]
+    fn test_a_value_that_merely_looks_like_a_flag_is_not_a_flag_match() {
+        // The flag lives in the args as a VALUE here, so it is still present in
+        // argv — we deliberately flag it: an audit must be conservative.
+        let p = derive_permissions(&v(&["--note", "--yolo"]), &[], false, false);
+        assert!(p.skip_permissions);
+    }
+
+    #[test]
+    fn test_wrapper_flags_are_recorded_independently() {
+        let p = derive_permissions(&[], &[], true, true);
+        assert!(!p.skip_permissions);
+        assert!(p.robust);
+        assert!(p.auto_continue);
+    }
+
+    #[test]
+    fn test_serializes_with_the_shared_wire_names() {
+        // The TS runtime reads these exact keys out of pids.jsonl.
+        let json = serde_json::to_string(&derive_permissions(&[], &[], true, false)).unwrap();
+        assert!(json.contains("\"skip_permissions\":false"));
+        assert!(json.contains("\"robust\":true"));
+        assert!(json.contains("\"auto_continue\":false"));
+    }
+}

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_permissions;
 mod cli;
 mod codex_sessions;
 mod config;
@@ -377,13 +378,23 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
 
         // Register in PID store and send RUNNING webhook
         let log_file = agent_ctx.raw_log_path();
-        pid_store.register_with_fifo(
+        // Stamp the permission posture alongside the record: `auto_continue` is
+        // robust AND a CLI that declares restore_args — robust alone only
+        // restarts, it resumes nothing. Mirrors ts/index.ts.
+        let permissions = agent_permissions::derive_permissions(
+            &cmd_args,
+            &cli_config.yes_args,
+            args.robust,
+            args.robust && !cli_config.restore_args.is_empty(),
+        );
+        pid_store.register_full(
             pid,
             &args.cli,
             args.prompt.as_deref(),
             cwd,
             log_file.as_deref(),
             fifo_str.as_deref(),
+            Some(permissions),
         );
         webhook::notify("RUNNING", args.prompt.as_deref().unwrap_or(""), cwd);
 

--- a/rs/src/pid_store.rs
+++ b/rs/src/pid_store.rs
@@ -1,5 +1,6 @@
 //! JSONL-based process registry — tracks running agent-yes processes
 
+use crate::agent_permissions::AgentPermissions;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -57,6 +58,12 @@ pub struct PidRecord {
     /// follow-up (see docs/agent-sharing.md). Mirrors the TS `agent_id`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
+    /// The permission posture this agent was SPAWNED with (yolo flag + the
+    /// wrapper's robust/auto-continue flags). Stamped at registration because
+    /// neither the CLI argv nor the wrapper flags survive into the index
+    /// otherwise. Mirrors the TS `permissions`. See agent_permissions.rs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<AgentPermissions>,
 }
 
 /// The agent id for this process: adopt a caller-injected `AGENT_YES_AGENT_ID`
@@ -117,6 +124,20 @@ impl PidStore {
         log_file: Option<&str>,
         fifo_file: Option<&str>,
     ) {
+        self.register_full(pid, cli, prompt, cwd, log_file, fifo_file, None);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_full(
+        &self,
+        pid: u32,
+        cli: &str,
+        prompt: Option<&str>,
+        cwd: &str,
+        log_file: Option<&str>,
+        fifo_file: Option<&str>,
+        permissions: Option<AgentPermissions>,
+    ) {
         let record = PidRecord {
             pid,
             cli: cli.to_string(),
@@ -136,6 +157,7 @@ impl PidStore {
                 .ok()
                 .and_then(|s| s.parse::<u32>().ok()),
             agent_id: Some(new_agent_id()),
+            permissions,
         };
         // Hold the cross-runtime lock across the append so a concurrent rewrite
         // (another wrapper's clean_stale / a status update) can't clobber it.
@@ -576,6 +598,7 @@ mod tests {
             wrapper_pid: None,
             parent_pid: None,
             agent_id: None,
+            permissions: None,
         }];
         store.write_all(&records).unwrap();
         let loaded = store.read_all().unwrap();
@@ -613,6 +636,7 @@ mod tests {
                 wrapper_pid: None,
                 parent_pid: None,
                 agent_id: None,
+                permissions: None,
             }])
             .unwrap();
 

--- a/ts/agentPermissions.spec.ts
+++ b/ts/agentPermissions.spec.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { derivePermissions, permissionBadge } from "./agentPermissions.ts";
+import { allowsSkipPermissions } from "./workspaceConfig.ts";
+
+// Issue #236. The pid record is the only place the answer to "was this agent
+// allowed to act without confirmation?" survives — the global index carries no
+// argv, and the wrapper's own flags never reach the CLI's args at all.
+
+describe("derivePermissions", () => {
+  const YES = ["--dangerously-skip-permissions"];
+
+  it("detects the configured yolo flag", () => {
+    expect(
+      derivePermissions({ cliArgs: ["--print", ...YES], yesArgs: YES }).skip_permissions,
+    ).toBe(true);
+  });
+
+  it("detects a dangerous flag the config never declared", () => {
+    // A CLI with no yesArgs must still not hide a flag that disables its gate —
+    // the check is the union of configured and known-dangerous, not just config.
+    expect(derivePermissions({ cliArgs: ["--yolo"] }).skip_permissions).toBe(true);
+    expect(
+      derivePermissions({ cliArgs: ["--dangerously-bypass-approvals-and-sandbox"] })
+        .skip_permissions,
+    ).toBe(true);
+  });
+
+  it("matches the flag part of an --flag=value form", () => {
+    expect(derivePermissions({ cliArgs: ["--full-auto=true"] }).skip_permissions).toBe(true);
+  });
+
+  it("does not flag ordinary args", () => {
+    expect(
+      derivePermissions({ cliArgs: ["--model", "opus", "--continue"], yesArgs: YES })
+        .skip_permissions,
+    ).toBe(false);
+    expect(derivePermissions({ cliArgs: [] }).skip_permissions).toBe(false);
+  });
+
+  it("records the wrapper flags independently of the CLI's", () => {
+    const p = derivePermissions({ cliArgs: [], robust: true, autoContinue: true });
+    expect(p).toEqual({ skip_permissions: false, robust: true, auto_continue: true });
+  });
+
+  it("defaults every flag to false rather than undefined", () => {
+    // The record is serialized to JSON and read by both runtimes; an absent
+    // boolean would read as "unknown" where we mean "no".
+    expect(derivePermissions({ cliArgs: [] })).toEqual({
+      skip_permissions: false,
+      robust: false,
+      auto_continue: false,
+    });
+  });
+
+  it("ignores an empty yesArgs entry rather than matching everything", () => {
+    // A config with a stray "" must not make every arg look like a yolo flag.
+    expect(derivePermissions({ cliArgs: ["--model"], yesArgs: [""] }).skip_permissions).toBe(false);
+  });
+});
+
+describe("permissionBadge", () => {
+  it("reports skip only when the CLI gate is off", () => {
+    expect(permissionBadge({ skip_permissions: true, robust: false, auto_continue: false })).toBe(
+      "skip",
+    );
+    expect(permissionBadge({ skip_permissions: false, robust: false, auto_continue: false })).toBe(
+      "prompt",
+    );
+  });
+
+  it("never lets the wrapper flags soften the label", () => {
+    // robust/auto_continue change how the agent RECOVERS, not what it may do.
+    expect(permissionBadge({ skip_permissions: true, robust: true, auto_continue: true })).toBe(
+      "skip",
+    );
+  });
+
+  it("has nothing to show for a record with no stamp (pre-#236 agent)", () => {
+    expect(permissionBadge(null)).toBeNull();
+    expect(permissionBadge(undefined)).toBeNull();
+  });
+});
+
+describe("allowsSkipPermissions", () => {
+  const original = process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS;
+  afterEach(() => {
+    if (original === undefined) delete process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS;
+    else process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS = original;
+  });
+
+  it("is permissive by default — restricting is an opt-in", () => {
+    delete process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS;
+    expect(allowsSkipPermissions()).toBe(true);
+  });
+
+  it("is restricted by an explicit falsy env value", () => {
+    for (const v of ["0", "false", "no", "off", "FALSE"]) {
+      process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS = v;
+      expect(allowsSkipPermissions()).toBe(false);
+    }
+  });
+
+  it("stays permissive for any other value, including garbage", () => {
+    // Failing closed here would lock spawns out of a host over a typo; the
+    // enforcement point is an explicit opt-in, so an unparseable value must not
+    // silently become a restriction.
+    for (const v of ["1", "true", "yes", "on", "banana"]) {
+      process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS = v;
+      expect(allowsSkipPermissions()).toBe(true);
+    }
+  });
+
+  it("treats an empty env value as unset (falls through to config)", () => {
+    process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS = "   ";
+    expect(allowsSkipPermissions()).toBe(true);
+  });
+});

--- a/ts/agentPermissions.ts
+++ b/ts/agentPermissions.ts
@@ -1,0 +1,80 @@
+/**
+ * The permission posture an agent was actually spawned with — derived once at
+ * registration and stamped into the pid record so it can be audited later.
+ *
+ * Why record it rather than re-derive on read: the global index carries no argv,
+ * and the wrapper's own flags (`--robust`, auto-continue) never appear in the
+ * CLI's args at all. Without stamping, "was this agent running with permission
+ * checks disabled?" is unanswerable after the fact — which is precisely the
+ * question an operator looking at a fleet of agents needs answered.
+ *
+ * Mirrored by `derive_permissions` in rs/src/agentPermissions.rs — keep in sync.
+ *
+ * Issue #236.
+ */
+
+export interface AgentPermissions {
+  /**
+   * The wrapped CLI got its "yolo" flag — the per-CLI `yesArgs` appended by
+   * `-y`/`--yes`, or the same flag passed through directly. This is the one that
+   * matters for audit: it disables the CLI's own confirmation gate, so the agent
+   * can edit files and run commands with no human in the loop.
+   */
+  skip_permissions: boolean;
+  /** agent-yes `--robust`: restart the CLI automatically when it crashes. */
+  robust: boolean;
+  /** agent-yes auto-continue: resume the prior session on restart. */
+  auto_continue: boolean;
+}
+
+/**
+ * Flags that disable a CLI's confirmation gate, recognised regardless of what
+ * `yesArgs` the config declares.
+ *
+ * The configured `yesArgs` are the flags `-y` APPENDS; a user is free to pass
+ * the same flag directly, and a config that omits `yesArgs` entirely (some CLIs
+ * deliberately have none) must not make a genuinely dangerous flag invisible.
+ * So the check is the union: configured flags OR any of these.
+ */
+const DANGEROUS_FLAGS = new Set([
+  "--dangerously-skip-permissions",
+  "--dangerously-bypass-approvals-and-sandbox",
+  "--yolo",
+  "--full-auto",
+]);
+
+/** `--flag=value` and `--flag value` must compare equal — match on the flag part. */
+function flagName(arg: string): string {
+  const eq = arg.indexOf("=");
+  return eq === -1 ? arg : arg.slice(0, eq);
+}
+
+export function derivePermissions(opts: {
+  /** The args handed to the wrapped CLI (after yesArgs were appended). */
+  cliArgs: readonly string[];
+  /** The CLI's configured "yolo" flags, if it declares any. */
+  yesArgs?: readonly string[];
+  robust?: boolean;
+  autoContinue?: boolean;
+}): AgentPermissions {
+  const configured = new Set((opts.yesArgs ?? []).map(flagName).filter(Boolean));
+  const skip = opts.cliArgs.some((a) => {
+    const name = flagName(a);
+    return configured.has(name) || DANGEROUS_FLAGS.has(name);
+  });
+  return {
+    skip_permissions: skip,
+    robust: Boolean(opts.robust),
+    auto_continue: Boolean(opts.autoContinue),
+  };
+}
+
+/**
+ * One-word posture for a badge. `skip` is the only one that changes what the
+ * agent is ALLOWED to do; the wrapper flags change only how it recovers, so
+ * they never soften the label.
+ */
+export function permissionBadge(p: AgentPermissions | null | undefined): "skip" | "prompt" | null {
+  if (!p) return null;
+  return p.skip_permissions ? "skip" : "prompt";
+}

--- a/ts/globalPidIndex.ts
+++ b/ts/globalPidIndex.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir, readFile, rename, unlink, writeFile } from "fs/promises";
 import { homedir } from "os";
+import type { AgentPermissions } from "./agentPermissions.ts";
 import path from "path";
 import { lock } from "proper-lockfile";
 import { logger } from "./logger.ts";
@@ -57,6 +58,13 @@ export interface GlobalPidRecord {
   // (snake_case). Currently per-process; cross-restart re-binding is a follow-up
   // (see docs/agent-sharing.md). Preserved verbatim through merges/compaction.
   agent_id?: string | null;
+  // The permission posture this agent was SPAWNED with — whether the wrapped CLI
+  // got its "yolo" flag, plus the wrapper's own robust/auto-continue flags. The
+  // index carries no argv and the wrapper flags never reach the CLI's args at
+  // all, so without stamping this at registration "was this agent running with
+  // permission checks off?" is unanswerable after the fact. See
+  // ts/agentPermissions.ts (mirrored in rs/src/agent_permissions.rs).
+  permissions?: AgentPermissions | null;
 }
 
 /**

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -44,6 +44,7 @@ import { globalAgentRegistry } from "./agentRegistry.ts";
 import { notifyWebhook } from "./webhookNotifier.ts";
 import { readGlobalPids } from "./globalPidIndex.ts";
 import * as reaper from "./reaper.ts";
+import { derivePermissions } from "./agentPermissions.ts";
 
 export { removeControlCharacters };
 export { AgentContext };
@@ -510,6 +511,15 @@ export default async function agentYes({
       wrapperPid: process.pid,
       // The parent agent's wrapper pid (inherited AGENT_YES_PID), for the tree.
       parentPid,
+      // Audit trail: what this agent is actually allowed to do. `auto_continue`
+      // is robust AND a CLI that declares restoreArgs — robust alone only
+      // restarts, it resumes nothing.
+      permissions: derivePermissions({
+        cliArgs,
+        yesArgs: cliConf.yesArgs,
+        robust,
+        autoContinue: Boolean(robust && cliConf.restoreArgs?.length),
+      }),
     });
   } catch (error) {
     logger.warn(`[pidStore] Failed to register process ${shell.pid}:`, error);

--- a/ts/pidStore.ts
+++ b/ts/pidStore.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { logger } from "./logger.ts";
 import { JsonlStore } from "./JsonlStore.ts";
 import { agentYesHome } from "./agentYesHome.ts";
+import type { AgentPermissions } from "./agentPermissions.ts";
 import {
   appendGlobalPid,
   maybeCompactGlobalPids,
@@ -26,6 +27,8 @@ export interface PidRecord {
   startedAt: number;
   // Stable id minted at registration; mirrored to the global index as `agent_id`.
   agentId?: string;
+  /** Permission posture at spawn time; mirrored to the global index. */
+  permissions?: AgentPermissions;
 }
 
 export class PidStore {
@@ -59,6 +62,7 @@ export class PidStore {
     cwd,
     wrapperPid,
     parentPid,
+    permissions,
   }: {
     pid: number;
     cli: string;
@@ -67,6 +71,7 @@ export class PidStore {
     cwd: string;
     wrapperPid?: number;
     parentPid?: number;
+    permissions?: AgentPermissions;
   }): Promise<PidRecord> {
     const now = Date.now();
     const argsJson = JSON.stringify(args);
@@ -91,6 +96,7 @@ export class PidStore {
       pid,
       cli,
       args: argsJson,
+      permissions,
       prompt,
       cwd,
       logFile,
@@ -133,6 +139,7 @@ export class PidStore {
       wrapper_pid: wrapperPid ?? null,
       parent_pid: parentPid ?? null,
       agent_id: agentId,
+      permissions: permissions ?? null,
     })
       .then(() => maybeCompactGlobalPids())
       .catch(() => null);

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -38,6 +38,7 @@ import {
   type CommonOpts,
 } from "./subcommands.ts";
 import { answerAsk, listAsks } from "./askApi.ts";
+import { permissionBadge } from "./agentPermissions.ts";
 import { TYPING_BADGE } from "./badges.ts";
 import { isTermToken, mintTermToken, verifyTermToken, type TermScope } from "./termToken.ts";
 import { isCallbackRevoked, loadCallbackSecretReadOnly } from "./callback.ts";
@@ -65,6 +66,7 @@ import {
   hasSpawnHook,
   isProvisionAllowed,
   resolveSpawnCwd,
+  allowsSkipPermissions,
 } from "./workspaceConfig.ts";
 
 const DEFAULT_PORT = 0;
@@ -2749,6 +2751,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
             inputs: [textIn, envIn],
             outputs: [textOut],
             renderHints: await hintsOf(r),
+            // What this agent is actually permitted to do, stamped at spawn (see
+            // ts/agentPermissions.ts). Carried on the node so the viewer can badge
+            // the env edge — "skip" means the CLI's confirmation gate is off, i.e.
+            // this agent edits and executes with no human in the loop. Null for
+            // agents registered before the stamp existed, which the viewer renders
+            // as "unknown" rather than as safe.
+            configPublic: {
+              permissions: r.permissions ?? null,
+              permissionBadge: permissionBadge(r.permissions),
+            },
           })),
         );
         // The host environment node: identity + capability flags only (no cwd,
@@ -2776,6 +2788,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
               spawn: true,
               spawnHook: hasSpawnHook(),
               provision: hasProvisionHook(),
+              skipPermissions: allowsSkipPermissions(),
             },
           },
         } as unknown as (typeof nodes)[number]); // configPublic is envelope-legal but absent from the agent-node literal type
@@ -2919,6 +2932,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
           spawn: true, // /api/spawn is always on; hooks below shape it
           spawnHook: hasSpawnHook(),
           provision: hasProvisionHook(),
+          // Whether this environment permits spawning agents with the CLI's own
+          // permission gate disabled. Host-enforced in /api/spawn — a client
+          // that asks anyway gets a 403, not a downgrade.
+          skipPermissions: allowsSkipPermissions(),
         },
       });
     }
@@ -3739,6 +3756,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         cwd?: string;
         from?: string;
         prompt?: string;
+        yes?: boolean;
         fork?: { fromCwd?: string; branch?: string };
       };
       try {
@@ -3750,6 +3768,26 @@ export async function cmdServe(rest: string[]): Promise<number> {
       if (!SUPPORTED_CLIS.includes(cli as never))
         return new Response(`unsupported cli: ${cli}`, { status: 400 });
       const prompt = String(body.prompt ?? "");
+
+      // Capability enforcement, BEFORE admission control and any provisioning: a
+      // request that this environment will never honour must fail immediately,
+      // not after cloning a repo. `yes` appends the CLI's own "yolo" flag, which
+      // disables its confirmation gate — so a restricted environment refuses it
+      // outright rather than silently downgrading to a safe spawn (which would
+      // hand back an agent that looks like what was asked for and isn't). The
+      // environment declares the cap on its env node / GET /api/host, and it is
+      // enforced HERE, host-side, the way agentShare's default-deny is: a client
+      // cannot ask its way past it. Issue #236.
+      const wantsSkipPermissions = body.yes === true;
+      if (wantsSkipPermissions && !allowsSkipPermissions()) {
+        return new Response(
+          `this environment does not permit skip-permissions agents ` +
+            `(caps.skipPermissions=false) — spawn without \`yes\`, or set ` +
+            `"allowSkipPermissions": true in ~/.agent-yes/config.json ` +
+            `(or AGENT_YES_ALLOW_SKIP_PERMISSIONS=1) on the host`,
+          { status: 403 },
+        );
+      }
 
       // Admission control BEFORE any provisioning (clone/worktree) so a capped
       // request fails fast without doing expensive work. Enforces the optional
@@ -3946,7 +3984,15 @@ export async function cmdServe(rest: string[]): Promise<number> {
         process.platform === "win32" && ayBin.toLowerCase().endsWith(".exe")
           ? [ayBin]
           : [process.execPath, ayBin];
-      const agentArgv = [...ayCmd, cli, ...(prompt ? ["--", prompt] : [])];
+      // `-y` goes BEFORE the prompt separator so it is parsed as an agent-yes
+      // flag (global flags precede the CLI's own args), and only after the
+      // capability check above has allowed it.
+      const agentArgv = [
+        ...ayCmd,
+        ...(wantsSkipPermissions ? ["-y"] : []),
+        cli,
+        ...(prompt ? ["--", prompt] : []),
+      ];
       // don't leak our Claude Code session into the agent
       const agentEnv = freshAgentEnv();
       // Correlation id: the spawn response returns the `ay` LAUNCHER pid, which is

--- a/ts/workspaceConfig.ts
+++ b/ts/workspaceConfig.ts
@@ -35,6 +35,13 @@ interface Config {
    */
   provisionHook?: string;
   /**
+   * Whether this environment permits spawning agents with the CLI's permission
+   * gate disabled (`-y` / `--dangerously-skip-permissions` and friends).
+   * Defaults to TRUE — the historical behaviour — so a host opts IN to being
+   * restricted. See {@link allowsSkipPermissions}.
+   */
+  allowSkipPermissions?: boolean;
+  /**
    * Max number of concurrently-live agents the daemon will admit via
    * `/api/spawn`. `0`/unset = unlimited (current behavior). See {@link getMaxAgents}.
    */
@@ -262,4 +269,27 @@ export function resolveSpawnCwd(input?: string): string {
   if (v.startsWith("~")) return path.resolve(expandTilde(v));
   if (v.includes("/") || v.includes("\\") || path.isAbsolute(v)) return path.resolve(v);
   return path.join(root, v);
+}
+
+/**
+ * Whether this environment permits spawning agents that skip the CLI's own
+ * permission gate (`-y` / `--dangerously-skip-permissions` and equivalents).
+ *
+ * This is an ENVIRONMENT capability, not a per-request preference: a restricted
+ * host publishes `caps.skipPermissions: false` on its env node and `/api/spawn`
+ * refuses such a request, host-enforced the way agentShare's default-deny is.
+ * A client can't talk its way past it by asking differently.
+ *
+ * Defaults to TRUE so nothing changes for an existing host — restricting is an
+ * explicit opt-in, via `~/.agent-yes/config.json` (`"allowSkipPermissions": false`)
+ * or env `AGENT_YES_ALLOW_SKIP_PERMISSIONS=0`. Only an explicit falsy value
+ * restricts; anything unset or unparseable leaves the environment permissive
+ * rather than silently locking spawns out.
+ *
+ * Issue #236.
+ */
+export function allowsSkipPermissions(): boolean {
+  const raw = process.env.AGENT_YES_ALLOW_SKIP_PERMISSIONS?.trim();
+  if (raw !== undefined && raw !== "") return !/^(0|false|no|off)$/i.test(raw);
+  return readConfig().allowSkipPermissions !== false;
 }


### PR DESCRIPTION
Closes #236. Follow-up to the environment-node work (#234), which shipped host capability flags. Two halves — both needed before *"what is this fleet actually allowed to do?"* becomes an answerable question.

## 1. Per-agent permission display

The posture an agent was spawned with is derived once at registration and stamped into the pid record, in **both** runtimes:

```jsonc
"permissions": { "skip_permissions": false, "robust": true, "auto_continue": false }
```

It has to be *stamped* rather than re-derived on read: the global index carries no argv, and the wrapper's own flags (`--robust`, auto-continue) never reach the CLI's args at all. Without this, "was this agent running with permission checks disabled?" is unanswerable after the fact.

**`skip_permissions`** is the union of the CLI's configured `yesArgs` **and** a set of known-dangerous flags (`--dangerously-skip-permissions`, `--dangerously-bypass-approvals-and-sandbox`, `--yolo`, `--full-auto`). Union, not just config — a user can pass the flag directly without `-y`, and a CLI that declares no `yesArgs` at all must not be able to hide one. `--flag=value` matches on the flag part.

**`auto_continue`** is `robust` **and** a CLI that declares `restoreArgs` — robust alone restarts, it resumes nothing.

The /rgui agent node carries `configPublic.permissions` plus a one-word `permissionBadge`:

| badge | meaning |
| --- | --- |
| `skip` | the CLI's confirmation gate is off — this agent edits and executes with no human in the loop |
| `prompt` | the gate is on |
| `null` | a record predating the stamp — a viewer must render this as **unknown**, not as safe |

The wrapper flags never soften the badge: they change how an agent *recovers*, not what it *may do*.

## 2. Capability enforcement on spawn

`/api/spawn` had no way to request the yolo flag at all, so there was nothing to enforce. This adds the request field **and** the environment capability that gates it:

- **`allowsSkipPermissions()`** — config `allowSkipPermissions` / env `AGENT_YES_ALLOW_SKIP_PERMISSIONS`. Defaults to **true**, so nothing changes for an existing host; restricting is an explicit opt-in. Only an explicit falsy value restricts — an unparseable value stays permissive rather than silently locking spawns out of a host over a typo.
- Published as `caps.skipPermissions` on `GET /api/host` and on the env node's `configPublic.caps`, so a client can see the restriction *before* asking.
- Enforced **host-side** at the top of `/api/spawn`, before admission control and any provisioning — a request that will never be honoured fails fast instead of after cloning a repo.

A restricted environment **refuses with 403** rather than silently downgrading to a safe spawn. A downgrade would hand back an agent that looks like what was asked for and isn't; that is worse than an error, and it is the same default-deny posture agentShare uses.

## Verification

End-to-end, reading back a real `pids.jsonl` from spawned agents:

| runtime | args | stamped |
| --- | --- | --- |
| TS (`--no-rust`) | plain | `skip_permissions: false` |
| TS (`--no-rust`) | dangerous flag present | `skip_permissions: true` |
| Rust | plain | `skip_permissions: false` |
| Rust | dangerous flag present | `skip_permissions: true` |

Both runtimes agree on every field, including `robust`/`auto_continue`.

Tests: **+14 TS** (derivation table, badge semantics, and the capability's default-permissive / explicit-restrict / garbage-stays-permissive behaviour) and **+7 Rust** (the same derivation table plus the shared wire-format key names both runtimes read out of `pids.jsonl`). Rust 274 green; TS suite green; coverage gate holds; `oxlint` clean; `rustfmt` clean on the touched files.

**Not covered:** the 403 guard itself lives in `serve.ts`, which this repo treats as integration-only — no live daemon was exercised for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)