### PR TITLE
feat(ayrs): pure-Rust `ayrs serve --webrtc` share host

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -15,6 +15,12 @@ path = "src/main.rs"
 # window (CREATE_NO_WINDOW) under a kill-on-close Job Object, so a process manager
 # (oxmgr) can spawn console programs without flashing a window onto the desktop.
 # On non-Windows it's a no-op stub. See src/bin/ay-spawn-hidden.rs.
+# Standalone Rust serve daemon (`ayrs serve --webrtc`). Kept as a separate
+# binary so it can coexist with the TS `ay serve` daemon during the migration.
+[[bin]]
+name = "ayrs"
+path = "src/bin/ayrs.rs"
+
 [[bin]]
 name = "ay-spawn-hidden"
 path = "src/bin/ay-spawn-hidden.rs"
@@ -83,11 +89,17 @@ libp2p = { version = "0.54", features = [
 # URL encoding for swarm URLs
 urlencoding = { version = "2", optional = true }
 
-# Random number generation for room codes
-rand = { version = "0.8", optional = true }
+# Random number generation for room codes / E2E nonces
+rand = "0.8"
 
 # UUID for agent identification
 uuid = { version = "1", features = ["v4"] }
+webrtc = "0.17.2"
+tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"] }
+hkdf = "0.13.0"
+sha2 = "0.11.0"
+aes-gcm = "0.11.0"
+hex = "0.4.3"
 
 # Unix-specific
 [target.'cfg(unix)'.dependencies]
@@ -110,7 +122,7 @@ windows-sys = { version = "0.59", features = [
 
 [features]
 default = []
-swarm = ["libp2p", "urlencoding", "rand"]
+swarm = ["libp2p", "urlencoding"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/rs/src/bin/ayrs.rs
+++ b/rs/src/bin/ayrs.rs
@@ -4,6 +4,8 @@
 // (separate room persisted in ~/.agent-yes/.share-room-ayrs).
 #![allow(dead_code)]
 
+#[path = "../agent_permissions.rs"]
+mod agent_permissions;
 #[path = "../pid_store.rs"]
 mod pid_store;
 #[path = "../log_files.rs"]

--- a/rs/src/bin/ayrs.rs
+++ b/rs/src/bin/ayrs.rs
@@ -1,0 +1,51 @@
+// `ayrs` — standalone pure-Rust ay-serve daemon (experimental). Currently
+// implements `ayrs serve --webrtc`: host a browser-console share room over
+// WebRTC with no Bun/Node process involved. Coexists with the TS `ay serve`
+// (separate room persisted in ~/.agent-yes/.share-room-ayrs).
+#![allow(dead_code)]
+
+#[path = "../pid_store.rs"]
+mod pid_store;
+#[path = "../log_files.rs"]
+mod log_files;
+#[path = "../fifo.rs"]
+mod fifo;
+#[path = "../serve/mod.rs"]
+mod serve;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "ayrs", version, about = "agent-yes Rust serve daemon (experimental)")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Serve local agents to the browser console
+    Serve {
+        /// Host a WebRTC share room (webrtc://room:e1.<hex>@sighost to pin an
+        /// explicit room; omit the value to load/mint the persisted one)
+        #[arg(long, num_args = 0..=1, default_missing_value = "")]
+        webrtc: Option<String>,
+        /// Signaling host when minting a room
+        #[arg(long, default_value = serve::share::DEFAULT_SIGHOST)]
+        sighost: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Serve { webrtc, sighost } => {
+            let Some(webrtc) = webrtc else {
+                anyhow::bail!("ayrs serve currently requires --webrtc (HTTP mode still lives in `ay serve`)");
+            };
+            let url = if webrtc.is_empty() { None } else { Some(webrtc) };
+            serve::share::run_share(serve::share::ShareConfig { url, sighost }).await
+        }
+    }
+}

--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -1,0 +1,574 @@
+// Native Rust port of the minimal ay-serve API surface the browser console
+// needs over a WebRTC room: /api/ls, /api/ls/subscribe, /api/whoami,
+// /api/version, /api/host, /api/size/:kw, /api/tail/:kw, /api/send.
+// Everything else 404s — the console tolerates that and degrades.
+//
+// Response shapes mirror ts/serve.ts exactly (see that file for the source of
+// truth); data comes from the same files the TS daemon uses: pids.jsonl,
+// <cwd>/.agent-yes/<pid>.raw.log, and the per-pid stdin FIFOs.
+use crate::pid_store::{is_process_alive, PidRecord};
+use serde_json::{json, Value};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+const TAIL_SNAPSHOT_BYTES: u64 = 65_536;
+const SSE_PING_MS: u64 = 15_000;
+const LS_TICK_MS: u64 = 1_000;
+const TAIL_POLL_MS: u64 = 200;
+/// Consider an agent "active" if its log grew within this window, else "idle".
+const ACTIVE_WINDOW_MS: i64 = 60_000;
+
+pub enum Body {
+    Full(Vec<u8>),
+    /// Streaming body (SSE). The channel closing ends the stream.
+    Stream(mpsc::Receiver<Vec<u8>>),
+}
+
+pub struct ApiResponse {
+    pub status: u16,
+    pub content_type: String,
+    pub body: Body,
+}
+
+fn text(status: u16, s: impl Into<String>) -> ApiResponse {
+    ApiResponse {
+        status,
+        content_type: "text/plain".into(),
+        body: Body::Full(s.into().into_bytes()),
+    }
+}
+
+fn json_res(status: u16, v: &Value) -> ApiResponse {
+    ApiResponse {
+        status,
+        content_type: "application/json".into(),
+        body: Body::Full(serde_json::to_vec(v).unwrap_or_default()),
+    }
+}
+
+fn global_dir() -> PathBuf {
+    if let Ok(h) = std::env::var("AGENT_YES_HOME") {
+        return PathBuf::from(h);
+    }
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join(".agent-yes")
+}
+
+/// Load or mint the serve API bearer token — same file the TS daemon uses
+/// (`~/.agent-yes/.serve-token`), so links/tokens stay interchangeable.
+pub fn load_or_create_token() -> std::io::Result<String> {
+    let path = global_dir().join(".serve-token");
+    if let Ok(t) = std::fs::read_to_string(&path) {
+        let t = t.trim().to_string();
+        if !t.is_empty() {
+            return Ok(t);
+        }
+    }
+    let token = crate::serve::e2e::random_hex(24);
+    std::fs::create_dir_all(global_dir())?;
+    std::fs::write(&path, &token)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(token)
+}
+
+// ---- pids.jsonl -------------------------------------------------------------
+
+fn read_records() -> Vec<PidRecord> {
+    let path = global_dir().join("pids.jsonl");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    // merge by pid, last line wins (same as the TS/Rust stores)
+    let mut order: Vec<u32> = Vec::new();
+    let mut by_pid: std::collections::HashMap<u32, PidRecord> = std::collections::HashMap::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(r) = serde_json::from_str::<PidRecord>(line) {
+            if !by_pid.contains_key(&r.pid) {
+                order.push(r.pid);
+            }
+            by_pid.insert(r.pid, r);
+        }
+    }
+    order.into_iter().filter_map(|p| by_pid.remove(&p)).collect()
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn file_mtime_ms(path: &str) -> Option<i64> {
+    let meta = std::fs::metadata(path).ok()?;
+    let m = meta.modified().ok()?;
+    Some(m.duration_since(std::time::UNIX_EPOCH).ok()?.as_millis() as i64)
+}
+
+fn last_stdin_at(pid: u32) -> Option<i64> {
+    let p = global_dir().join("activity").join(format!("{pid}.stdin"));
+    std::fs::read_to_string(p).ok()?.trim().parse().ok()
+}
+
+/// One /api/ls entry: the raw record plus the derived fields the console reads.
+fn with_meta(r: &PidRecord) -> Value {
+    let alive = is_process_alive(r.pid);
+    let exited = r.status == "exited" || !alive;
+    let last_active = r.log_file.as_deref().and_then(file_mtime_ms);
+    let status = if exited {
+        "exited"
+    } else if r.unresponsive {
+        "stuck"
+    } else if last_active.map(|t| now_ms() - t < ACTIVE_WINDOW_MS).unwrap_or(false) {
+        "active"
+    } else {
+        "idle"
+    };
+    let dir_name = r
+        .cwd
+        .rsplit(['/', '\\'])
+        .find(|s| !s.is_empty())
+        .unwrap_or(&r.cwd);
+    let mut v = serde_json::to_value(r).unwrap_or_else(|_| json!({}));
+    let o = v.as_object_mut().unwrap();
+    o.insert("status".into(), json!(status));
+    o.insert("title".into(), json!(format!("{} — {}", r.cli, dir_name)));
+    o.insert("status_text".into(), Value::Null);
+    o.insert("question".into(), Value::Null);
+    o.insert("git".into(), Value::Null);
+    o.insert("tasks".into(), Value::Null);
+    o.insert("badges".into(), json!([]));
+    o.insert("last_active_at".into(), json!(last_active));
+    o.insert("last_stdin_at".into(), json!(last_stdin_at(r.pid)));
+    v
+}
+
+fn matches_keyword(r: &PidRecord, kw: &str) -> bool {
+    if kw.is_empty() {
+        return true;
+    }
+    if r.pid.to_string() == kw {
+        return true;
+    }
+    if let Some(id) = &r.agent_id {
+        if id.starts_with(&kw.to_ascii_lowercase()) {
+            return true;
+        }
+    }
+    let kwl = kw.to_lowercase();
+    r.cwd.to_lowercase().contains(&kwl)
+        || r.cli.to_lowercase().contains(&kwl)
+        || r.prompt.as_deref().map(|p| p.to_lowercase().contains(&kwl)).unwrap_or(false)
+}
+
+fn resolve_one(kw: &str) -> Result<PidRecord, String> {
+    let mut recs: Vec<PidRecord> = read_records().into_iter().filter(|r| matches_keyword(r, kw)).collect();
+    recs.sort_by_key(|r| -r.started_at);
+    // prefer a living agent over exited ones
+    if let Some(r) = recs.iter().find(|r| r.status != "exited" && is_process_alive(r.pid)) {
+        return Ok(r.clone());
+    }
+    recs.into_iter().next().ok_or_else(|| format!("no agent matches {kw:?}"))
+}
+
+fn ls_json(all: bool, active: bool) -> Vec<Value> {
+    let mut recs = read_records();
+    recs.sort_by_key(|r| -r.started_at);
+    recs.iter()
+        .filter(|r| all || r.status != "exited")
+        .filter(|r| !active || is_process_alive(r.pid))
+        .map(with_meta)
+        .collect()
+}
+
+// ---- SSE helpers ------------------------------------------------------------
+
+fn sse_frame(payload: &Value) -> Vec<u8> {
+    format!("data: {}\n\n", payload).into_bytes()
+}
+
+fn spawn_ls_subscribe(all: bool, active: bool) -> mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel::<Vec<u8>>(64);
+    tokio::spawn(async move {
+        let mut known: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
+        let mut first = true;
+        let mut last_ping = std::time::Instant::now();
+        loop {
+            let entries = tokio::task::spawn_blocking(move || ls_json(all, active))
+                .await
+                .unwrap_or_default();
+            let mut upsert: Vec<Value> = Vec::new();
+            let mut seen: std::collections::HashSet<i64> = std::collections::HashSet::new();
+            for e in &entries {
+                let pid = e.get("pid").and_then(|p| p.as_i64()).unwrap_or(0);
+                seen.insert(pid);
+                let ser = e.to_string();
+                if known.get(&pid) != Some(&ser) {
+                    known.insert(pid, ser);
+                    upsert.push(e.clone());
+                }
+            }
+            let removed: Vec<i64> = known.keys().copied().filter(|p| !seen.contains(p)).collect();
+            for p in &removed {
+                known.remove(p);
+            }
+            let frame = if first {
+                first = false;
+                Some(sse_frame(&json!({"full": true, "upsert": entries, "remove": []})))
+            } else if !upsert.is_empty() || !removed.is_empty() {
+                Some(sse_frame(&json!({"upsert": upsert, "remove": removed})))
+            } else if last_ping.elapsed() >= Duration::from_millis(SSE_PING_MS) {
+                Some(b": ping\n\n".to_vec())
+            } else {
+                None
+            };
+            if let Some(f) = frame {
+                if f.starts_with(b": ping") {
+                    last_ping = std::time::Instant::now();
+                }
+                if tx.send(f).await.is_err() {
+                    return; // client went away
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(LS_TICK_MS)).await;
+        }
+    });
+    rx
+}
+
+fn spawn_tail(log_file: String, raw: bool) -> mpsc::Receiver<Vec<u8>> {
+    let (tx, rx) = mpsc::channel::<Vec<u8>>(64);
+    tokio::spawn(async move {
+        let mut offset: u64 = 0;
+        // snapshot: last 64KB of the file
+        let snapshot = tokio::task::spawn_blocking({
+            let log_file = log_file.clone();
+            move || -> std::io::Result<(u64, Vec<u8>)> {
+                let mut f = std::fs::File::open(&log_file)?;
+                let size = f.metadata()?.len();
+                let start = size.saturating_sub(TAIL_SNAPSHOT_BYTES);
+                f.seek(SeekFrom::Start(start))?;
+                let mut buf = Vec::new();
+                f.read_to_end(&mut buf)?;
+                Ok((size, buf))
+            }
+        })
+        .await
+        .unwrap_or_else(|e| Err(std::io::Error::other(e)));
+        match snapshot {
+            Ok((size, buf)) => {
+                offset = size;
+                let text = decode_log(&buf, raw);
+                if tx.send(sse_frame(&json!(text))).await.is_err() {
+                    return;
+                }
+            }
+            Err(_) => {
+                // no log yet — start at 0 and stream once it appears
+            }
+        }
+        let mut last_ping = std::time::Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_millis(TAIL_POLL_MS)).await;
+            let read = tokio::task::spawn_blocking({
+                let log_file = log_file.clone();
+                move || -> std::io::Result<(u64, Vec<u8>)> {
+                    let mut f = std::fs::File::open(&log_file)?;
+                    let size = f.metadata()?.len();
+                    if size < offset {
+                        return Ok((size, Vec::new())); // truncated/compacted
+                    }
+                    if size == offset {
+                        return Ok((size, Vec::new()));
+                    }
+                    f.seek(SeekFrom::Start(offset))?;
+                    let mut buf = Vec::new();
+                    f.read_to_end(&mut buf)?;
+                    Ok((size, buf))
+                }
+            })
+            .await
+            .unwrap_or_else(|e| Err(std::io::Error::other(e)));
+            match read {
+                Ok((size, buf)) => {
+                    offset = size;
+                    if !buf.is_empty() {
+                        let text = decode_log(&buf, raw);
+                        let skip = !raw && text.trim().is_empty();
+                        if !skip && tx.send(sse_frame(&json!(text))).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(_) => { /* file missing — keep polling */ }
+            }
+            if last_ping.elapsed() >= Duration::from_millis(SSE_PING_MS) {
+                last_ping = std::time::Instant::now();
+                if tx.send(b": ping\n\n".to_vec()).await.is_err() {
+                    return;
+                }
+            }
+        }
+    });
+    rx
+}
+
+fn decode_log(buf: &[u8], raw: bool) -> String {
+    if raw {
+        String::from_utf8_lossy(buf).into_owned()
+    } else {
+        let stripped = strip_ansi_escapes::strip(buf);
+        String::from_utf8_lossy(&stripped).into_owned()
+    }
+}
+
+// ---- /api/send --------------------------------------------------------------
+
+fn control_code(name: &str) -> &'static str {
+    match name {
+        "enter" | "cr" | "return" => "\r",
+        "esc" | "escape" => "\x1b",
+        "ctrl-c" | "ctrl+c" => "\x03",
+        "ctrl-y" | "ctrl+y" => "\x19",
+        "ctrl-d" | "ctrl+d" => "\x04",
+        "ctrl-\\" | "ctrl+\\" => "\x1c",
+        "tab" => "\t",
+        "up" => "\x1b[A",
+        "down" => "\x1b[B",
+        "right" => "\x1b[C",
+        "left" => "\x1b[D",
+        _ => "",
+    }
+}
+
+fn write_fifo(path: &str, data: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(path)?;
+        f.write_all(data)?;
+        return Ok(());
+    }
+    #[cfg(not(unix))]
+    {
+        let mut f = std::fs::OpenOptions::new().write(true).open(path)?;
+        f.write_all(data)?;
+        Ok(())
+    }
+}
+
+async fn handle_send(body: &str) -> ApiResponse {
+    let Ok(req) = serde_json::from_str::<Value>(body) else {
+        return text(400, "invalid JSON body");
+    };
+    let kw = req.get("keyword").and_then(|v| v.as_str()).unwrap_or("");
+    if kw.is_empty() {
+        return text(400, "missing keyword");
+    }
+    let msg = req.get("msg").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let code = req.get("code").and_then(|v| v.as_str()).unwrap_or("enter").to_lowercase();
+    let rec = match resolve_one(kw) {
+        Ok(r) => r,
+        Err(e) => return text(404, e),
+    };
+    let Some(fifo) = rec.fifo_file.clone() else {
+        return text(409, format!("pid {}: no fifo_file", rec.pid));
+    };
+    let trailing = control_code(&code);
+    let write = |data: Vec<u8>| {
+        let fifo = fifo.clone();
+        tokio::task::spawn_blocking(move || write_fifo(&fifo, &data))
+    };
+    let result = if !msg.is_empty() && !trailing.is_empty() {
+        // typed text first, control code 200 ms later (mirrors the TS daemon)
+        match write(msg.clone().into_bytes()).await.unwrap_or_else(|e| Err(std::io::Error::other(e))) {
+            Ok(()) => {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                write(trailing.as_bytes().to_vec()).await.unwrap_or_else(|e| Err(std::io::Error::other(e)))
+            }
+            Err(e) => Err(e),
+        }
+    } else {
+        write(format!("{msg}{trailing}").into_bytes())
+            .await
+            .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+    };
+    match result {
+        Ok(()) => {
+            crate::fifo::touch_stdin_activity(rec.pid);
+            json_res(
+                200,
+                &json!({
+                    "ok": true,
+                    "pid": rec.pid,
+                    "cli": rec.cli,
+                    "cwd": rec.cwd,
+                    "agentId": rec.agent_id,
+                }),
+            )
+        }
+        Err(e) => text(409, format!("pid {}: fifo write failed: {e}", rec.pid)),
+    }
+}
+
+// ---- misc endpoints ----------------------------------------------------------
+
+fn hostname() -> String {
+    #[cfg(unix)]
+    {
+        let mut buf = [0u8; 256];
+        unsafe {
+            if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) == 0 {
+                if let Some(end) = buf.iter().position(|&b| b == 0) {
+                    if let Ok(s) = std::str::from_utf8(&buf[..end]) {
+                        return s.split('.').next().unwrap_or(s).to_string();
+                    }
+                }
+            }
+        }
+    }
+    std::env::var("COMPUTERNAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown".into())
+}
+
+fn whoami_host() -> String {
+    let user = std::env::var("USER").or_else(|_| std::env::var("USERNAME")).ok();
+    match user {
+        Some(u) if !u.is_empty() => format!("{u}@{}", hostname()),
+        _ => hostname(),
+    }
+}
+
+fn host_info() -> Value {
+    let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(0);
+    let mut loadavg = [0f64; 3];
+    #[cfg(unix)]
+    unsafe {
+        libc::getloadavg(loadavg.as_mut_ptr(), 3);
+    }
+    json!({
+        "host": hostname(),
+        "platform": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "cpus": cpus,
+        "loadavg": loadavg,
+        "mem": { "total": 0, "free": 0 },
+        "uptime": 0,
+        "caps": { "send": true, "kill": false, "spawn": false, "spawnHook": false, "provision": false },
+    })
+}
+
+// ---- router -------------------------------------------------------------------
+
+fn parse_query(query: &str) -> std::collections::HashMap<String, String> {
+    query
+        .split('&')
+        .filter_map(|kv| {
+            let mut it = kv.splitn(2, '=');
+            Some((it.next()?.to_string(), it.next().unwrap_or("").to_string()))
+        })
+        .collect()
+}
+
+fn url_decode(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        match b[i] {
+            b'%' if i + 2 < b.len() => {
+                if let Ok(v) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                    out.push(v);
+                    i += 3;
+                } else {
+                    out.push(b'%');
+                    i += 1;
+                }
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            c => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Handle one API request. `path_with_query` like "/api/ls?all=1".
+/// Auth is the caller's job (the WebRTC bridge injects the master token).
+pub async fn handle(method: &str, path_with_query: &str, body: &str) -> ApiResponse {
+    let (path, query) = match path_with_query.split_once('?') {
+        Some((p, q)) => (p, q),
+        None => (path_with_query, ""),
+    };
+    let q = parse_query(query);
+    let all = q.get("all").map(|v| v == "1").unwrap_or(false);
+    let active = q.get("active").map(|v| v == "1").unwrap_or(false);
+
+    match (method, path) {
+        ("GET", "/api/ls") => {
+            let entries = tokio::task::spawn_blocking(move || ls_json(all, active))
+                .await
+                .unwrap_or_default();
+            json_res(200, &Value::Array(entries))
+        }
+        ("GET", "/api/ls/subscribe") => ApiResponse {
+            status: 200,
+            content_type: "text/event-stream".into(),
+            body: Body::Stream(spawn_ls_subscribe(all, active)),
+        },
+        ("GET", "/api/whoami") => json_res(200, &json!({ "host": whoami_host() })),
+        ("GET", "/api/version") => {
+            json_res(200, &json!({ "version": env!("CARGO_PKG_VERSION") }))
+        }
+        ("GET", "/api/host") => json_res(200, &host_info()),
+        ("GET", p) if p.starts_with("/api/size/") => {
+            let kw = url_decode(&p["/api/size/".len()..]);
+            match resolve_one(&kw) {
+                Ok(r) => json_res(
+                    200,
+                    &json!({
+                        "pid": r.pid, "cols": null, "rows": null,
+                        "cwd": r.cwd, "cli": r.cli, "nego": false,
+                    }),
+                ),
+                Err(e) => text(404, e),
+            }
+        }
+        ("GET", p) if p.starts_with("/api/tail/") => {
+            let kw = url_decode(&p["/api/tail/".len()..]);
+            let raw = q.get("raw").map(|v| v == "1").unwrap_or(false);
+            match resolve_one(&kw) {
+                Ok(r) => match r.log_file {
+                    Some(log) => ApiResponse {
+                        status: 200,
+                        content_type: "text/event-stream".into(),
+                        body: Body::Stream(spawn_tail(log, raw)),
+                    },
+                    None => text(404, format!("pid {}: no log_file", r.pid)),
+                },
+                Err(e) => text(404, e),
+            }
+        }
+        ("POST", "/api/send") => handle_send(body).await,
+        ("OPTIONS", _) => text(204, ""),
+        _ => text(404, "not found"),
+    }
+}

--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -546,13 +546,41 @@ pub async fn handle(method: &str, path_with_query: &str, body: &str) -> ApiRespo
         ("GET", p) if p.starts_with("/api/size/") => {
             let kw = url_decode(&p["/api/size/".len()..]);
             match resolve_one(&kw) {
-                Ok(r) => json_res(
-                    200,
-                    &json!({
-                        "pid": r.pid, "cols": null, "rows": null,
-                        "cwd": r.cwd, "cli": r.cli, "nego": false,
-                    }),
-                ),
+                Ok(r) => {
+                    let size = crate::serve::nego::read_ptysize(r.pid);
+                    json_res(
+                        200,
+                        &json!({
+                            "pid": r.pid,
+                            "cols": size.map(|s| s.0),
+                            "rows": size.map(|s| s.1),
+                            "cwd": r.cwd, "cli": r.cli, "nego": true,
+                        }),
+                    )
+                }
+                Err(e) => text(404, e),
+            }
+        }
+        ("GET", "/api/presence") => json_res(200, &crate::serve::nego::presence_get().await),
+        ("POST", "/api/presence") => {
+            let Ok(v) = serde_json::from_str::<Value>(body) else {
+                return text(400, "invalid JSON body");
+            };
+            match crate::serve::nego::presence_post(&v).await {
+                Ok(()) => text(204, ""),
+                Err((status, msg)) => text(status, msg),
+            }
+        }
+        ("POST", p) if p.starts_with("/api/resize/") => {
+            let kw = url_decode(&p["/api/resize/".len()..]);
+            let Ok(v) = serde_json::from_str::<Value>(body) else {
+                return text(400, "invalid JSON body");
+            };
+            match resolve_one(&kw) {
+                Ok(r) => match crate::serve::nego::resize_post(r.pid, &v).await {
+                    Ok(res) => json_res(200, &res),
+                    Err((status, msg)) => text(status, msg),
+                },
                 Err(e) => text(404, e),
             }
         }

--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -433,7 +433,11 @@ fn hostname() -> String {
             if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) == 0 {
                 if let Some(end) = buf.iter().position(|&b| b == 0) {
                     if let Ok(s) = std::str::from_utf8(&buf[..end]) {
-                        return s.split('.').next().unwrap_or(s).to_string();
+                        // Keep the FULL hostname (e.g. "tak.local") — the TS
+                        // daemon reports os.hostname() verbatim, and the console
+                        // dedupes agents by host label; a stripped domain would
+                        // make the same machine look like two hosts.
+                        return s.to_string();
                     }
                 }
             }

--- a/rs/src/serve/e2e.rs
+++ b/rs/src/serve/e2e.rs
@@ -1,0 +1,315 @@
+// Rust port of lab/ui/e2e.js — agent-yes end-to-end encryption for the WebRTC
+// share DataChannel (protocol "ay-e2e-1", URL marker "e1."). Must stay
+// byte-identical to the JS implementation; see that file for the threat model.
+use aes_gcm::aead::{Aead, Payload};
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use anyhow::{anyhow, bail, Result};
+use hkdf::Hkdf;
+use sha2::{Digest, Sha256};
+
+pub const PROTO: &str = "ay-e2e-1";
+pub const MARKER: &str = "e1.";
+const INFO_AUTH: &str = "ay/ay-e2e-1/auth";
+const INFO_H2C: &str = "ay/ay-e2e-1/key/host->client";
+const INFO_C2H: &str = "ay/ay-e2e-1/key/client->host";
+pub const MAX_CHUNK: usize = 12_000; // plaintext bytes per sealed frame
+pub const CONFIRM_TIMEOUT_MS: u64 = 5_000;
+
+const VER: u8 = 0x01;
+pub const FLAG_CONFIRM: u8 = 0x01;
+const HEADER_LEN: usize = 14; // VER(1) + FLAGS(1) + NONCE(12)
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// Reject anything that isn't a full-entropy 64-hex secret. Fail-closed and
+/// never echoes the input.
+pub fn validate_s(s: &str) -> Result<&str> {
+    if !is_hex64(s) {
+        bail!("invalid share token");
+    }
+    Ok(s)
+}
+
+fn ikm_from_s(s: &str) -> Result<Vec<u8>> {
+    Ok(hex::decode(validate_s(s)?)?)
+}
+
+fn hkdf32(ikm: &[u8], salt: &[u8], info: &str) -> [u8; 32] {
+    let hk = Hkdf::<Sha256>::new(Some(salt), ikm);
+    let mut okm = [0u8; 32];
+    hk.expand(info.as_bytes(), &mut okm).expect("hkdf expand 32");
+    okm
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+/// The ONLY value the signaling server sees; one-way from S.
+pub fn derive_auth_token(s: &str, room: &str, sighost: &str) -> Result<String> {
+    let salt = sha256(format!("{room}\n{sighost}").as_bytes());
+    Ok(hex::encode(hkdf32(&ikm_from_s(s)?, &salt, INFO_AUTH)))
+}
+
+pub struct DirKeys {
+    pub h2c: Aes256Gcm, // host encrypts with H2C
+    pub c2h: Aes256Gcm, // host decrypts with C2H
+}
+
+pub fn derive_dir_keys(s: &str, transcript_hash: &[u8; 32]) -> Result<DirKeys> {
+    let ikm = ikm_from_s(s)?;
+    let h2c = hkdf32(&ikm, transcript_hash, INFO_H2C);
+    let c2h = hkdf32(&ikm, transcript_hash, INFO_C2H);
+    Ok(DirKeys {
+        h2c: Aes256Gcm::new((&h2c).into()),
+        c2h: Aes256Gcm::new((&c2h).into()),
+    })
+}
+
+// ---- transcript hash (channel binding) ------------------------------------
+
+fn all_fingerprints(sdp: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in sdp.lines() {
+        let line = line.trim_end_matches('\r');
+        // JS: /^a=fingerprint:(.*)$/gim — case-insensitive prefix match
+        let lower = line.to_ascii_lowercase();
+        if let Some(rest) = lower.strip_prefix("a=fingerprint:") {
+            // value taken from the ORIGINAL line then lowercased+trimmed,
+            // which equals taking it from the lowered line
+            out.push(rest.trim().to_string());
+        }
+    }
+    out
+}
+
+fn first_attr(sdp: &str, name: &str) -> String {
+    let prefix = format!("a={name}:");
+    for line in sdp.lines() {
+        let line = line.trim_end_matches('\r');
+        let lower = line.to_ascii_lowercase();
+        if let Some(rest) = lower.strip_prefix(&prefix) {
+            return rest.trim().to_string();
+        }
+    }
+    String::new()
+}
+
+/// Bind the session to the DTLS handshake; used as HKDF salt AND AEAD AAD.
+/// Host passes offer=local / answer=remote.
+pub fn compute_transcript_hash(offer_sdp: &str, answer_sdp: &str) -> Result<[u8; 32]> {
+    let mut offer_fps = all_fingerprints(offer_sdp);
+    let mut answer_fps = all_fingerprints(answer_sdp);
+    offer_fps.sort();
+    answer_fps.sort();
+    if offer_fps.is_empty() || answer_fps.is_empty() {
+        bail!("e2e: missing DTLS fingerprint");
+    }
+    for fp in offer_fps.iter().chain(answer_fps.iter()) {
+        if !fp.starts_with("sha-256") {
+            bail!("e2e: non-sha-256 DTLS fingerprint");
+        }
+    }
+    let input = format!(
+        "{PROTO}\noffer={};setup={};ufrag={}\nanswer={};setup={};ufrag={}",
+        offer_fps.join(","),
+        first_attr(offer_sdp, "setup"),
+        first_attr(offer_sdp, "ice-ufrag"),
+        answer_fps.join(","),
+        first_attr(answer_sdp, "setup"),
+        first_attr(answer_sdp, "ice-ufrag"),
+    );
+    Ok(sha256(input.as_bytes()))
+}
+
+// ---- AEAD frame seal / open -------------------------------------------------
+// Wire frame: VER(1) | FLAGS(1) | NONCE(12) | CIPHERTEXT | TAG(16)
+//   NONCE = [4-byte BE epoch = 0] | [8-byte BE monotonic per-direction counter]
+//   AAD   = header(14) | transcriptHash(32)
+
+fn nonce_from_counter(ctr: u64) -> [u8; NONCE_LEN] {
+    let mut n = [0u8; NONCE_LEN];
+    n[4..].copy_from_slice(&ctr.to_be_bytes());
+    n
+}
+
+pub struct SendState {
+    pub send_ctr: u64,
+}
+pub struct RecvState {
+    /// None until the first frame; the JS side uses -1n.
+    pub last_seen: Option<u64>,
+}
+
+pub fn seal(
+    key: &Aes256Gcm,
+    send: &mut SendState,
+    flags: u8,
+    th: &[u8; 32],
+    plaintext: &[u8],
+) -> Result<Vec<u8>> {
+    let ctr = send.send_ctr;
+    if ctr == u64::MAX {
+        bail!("e2e: nonce counter overflow");
+    }
+    send.send_ctr = ctr + 1;
+    let nonce = nonce_from_counter(ctr);
+    let mut header = [0u8; HEADER_LEN];
+    header[0] = VER;
+    header[1] = flags;
+    header[2..].copy_from_slice(&nonce);
+    let mut aad = Vec::with_capacity(HEADER_LEN + 32);
+    aad.extend_from_slice(&header);
+    aad.extend_from_slice(th);
+    let sealed = key
+        .encrypt((&nonce).into(), Payload { msg: plaintext, aad: &aad })
+        .map_err(|_| anyhow!("e2e: encrypt failed"))?;
+    let mut out = Vec::with_capacity(HEADER_LEN + sealed.len());
+    out.extend_from_slice(&header);
+    out.extend_from_slice(&sealed);
+    Ok(out)
+}
+
+pub struct Opened {
+    pub counter: u64,
+    pub flags: u8,
+    pub plaintext: Vec<u8>,
+}
+
+pub fn open(
+    key: &Aes256Gcm,
+    frame: &[u8],
+    th: &[u8; 32],
+    recv: &mut RecvState,
+) -> Result<Opened> {
+    if frame.len() < HEADER_LEN + TAG_LEN {
+        bail!("e2e: short frame");
+    }
+    if frame[0] != VER {
+        bail!("e2e: bad version");
+    }
+    let header = &frame[..HEADER_LEN];
+    let nonce = &frame[2..HEADER_LEN];
+    if nonce[..4] != [0, 0, 0, 0] {
+        bail!("e2e: bad epoch");
+    }
+    let ctr = u64::from_be_bytes(nonce[4..12].try_into().unwrap());
+    let mut aad = Vec::with_capacity(HEADER_LEN + 32);
+    aad.extend_from_slice(header);
+    aad.extend_from_slice(th);
+    let plaintext = key
+        .decrypt(&Nonce::try_from(nonce).expect("12-byte nonce"), Payload { msg: &frame[HEADER_LEN..], aad: &aad })
+        .map_err(|_| anyhow!("e2e: auth failed"))?;
+    // First accepted frame of a session MUST be counter-0 (the confirmation).
+    match recv.last_seen {
+        None if ctr != 0 => bail!("e2e: first frame must be counter-0"),
+        Some(last) if ctr <= last => bail!("e2e: replay/reorder"),
+        _ => {}
+    }
+    recv.last_seen = Some(ctr);
+    Ok(Opened { counter: ctr, flags: header[1], plaintext })
+}
+
+/// Parse the secret slot of a share link. Ok((s, v2)).
+pub fn parse_secret(token: &str) -> Result<(String, bool)> {
+    if let Some(rest) = token.strip_prefix(MARKER) {
+        if !is_hex64(rest) {
+            bail!("malformed encrypted link");
+        }
+        return Ok((rest.to_string(), true));
+    }
+    // "e<digit>…" that isn't exactly e1.<64hex> must fail closed
+    let b = token.as_bytes();
+    if b.len() >= 2 && (b[0] == b'e' || b[0] == b'E') && b[1].is_ascii_digit() {
+        bail!("malformed encrypted link");
+    }
+    Ok((token.to_string(), false))
+}
+
+pub fn random_hex(n_bytes: usize) -> String {
+    use rand::RngCore;
+    let mut b = vec![0u8; n_bytes];
+    rand::rngs::OsRng.fill_bytes(&mut b);
+    hex::encode(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const S: &str = "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52";
+
+    #[test]
+    fn auth_token_matches_js() {
+        // Vector generated with lab/ui/e2e.js under bun; pinned so any drift
+        // from the JS implementation fails loudly.
+        let t = derive_auth_token(S, "rdeadbeef0000", "s.agent-yes.com").unwrap();
+        assert_eq!(t, "a50a14d9be1ce496e132a6b7147757b4e01b30876550f28f855f5089b6b9aa20");
+    }
+
+    #[test]
+    fn opens_js_sealed_frame() {
+        // Frame sealed by lab/ui/e2e.js (client->host key, counter 0,
+        // FLAG_CONFIRM, th = 32×0x07) — must decrypt byte-identically.
+        let th = [7u8; 32];
+        let keys = derive_dir_keys(S, &th).unwrap();
+        let frame = hex::decode(
+            "010100000000000000000000000038c8b7906c875c4f489d24550a6d4a1d44e364598d86c4392c56d6b344308233e0216e64b0b7f077ef02a2c2",
+        )
+        .unwrap();
+        let mut recv = RecvState { last_seen: None };
+        let o = open(&keys.c2h, &frame, &th, &mut recv).unwrap();
+        assert_eq!(o.flags, FLAG_CONFIRM);
+        assert_eq!(o.plaintext, br#"{"t":"confirm","nonce":"aa"}"#);
+    }
+
+    #[test]
+    fn seal_open_roundtrip() {
+        let th = [7u8; 32];
+        let keys = derive_dir_keys(S, &th).unwrap();
+        let mut send = SendState { send_ctr: 0 };
+        let mut recv = RecvState { last_seen: None };
+        let f = seal(&keys.h2c, &mut send, FLAG_CONFIRM, &th, b"{\"t\":\"confirm\"}").unwrap();
+        let o = open(&keys.h2c, &f, &th, &mut recv).unwrap();
+        assert_eq!(o.counter, 0);
+        assert_eq!(o.flags, FLAG_CONFIRM);
+        assert_eq!(o.plaintext, b"{\"t\":\"confirm\"}");
+        // replay must fail
+        assert!(open(&keys.h2c, &f, &th, &mut recv).is_err());
+    }
+
+    #[test]
+    fn first_frame_must_be_counter_zero() {
+        let th = [9u8; 32];
+        let keys = derive_dir_keys(S, &th).unwrap();
+        let mut send = SendState { send_ctr: 5 };
+        let mut recv = RecvState { last_seen: None };
+        let f = seal(&keys.h2c, &mut send, 0, &th, b"x").unwrap();
+        assert!(open(&keys.h2c, &f, &th, &mut recv).is_err());
+    }
+
+    #[test]
+    fn parse_secret_grammar() {
+        assert!(parse_secret(&format!("e1.{S}")).unwrap().1);
+        assert!(parse_secret("e1.short").is_err());
+        assert!(parse_secret("e2.0000").is_err());
+        assert!(!parse_secret("customtoken").unwrap().1);
+    }
+
+    #[test]
+    fn transcript_hash_symmetry_and_failclosed() {
+        let offer = "v=0\r\na=fingerprint:sha-256 AA:BB\r\na=setup:actpass\r\na=ice-ufrag:abcd\r\n";
+        let answer = "v=0\r\na=fingerprint:SHA-256 CC:DD\r\na=setup:active\r\na=ice-ufrag:efgh\r\n";
+        let h = compute_transcript_hash(offer, answer).unwrap();
+        assert_eq!(h, compute_transcript_hash(offer, answer).unwrap());
+        assert!(compute_transcript_hash("v=0", answer).is_err());
+        let sha1 = "a=fingerprint:sha-1 AA\r\na=setup:actpass\r\na=ice-ufrag:x\r\n";
+        assert!(compute_transcript_hash(sha1, answer).is_err());
+    }
+}

--- a/rs/src/serve/mod.rs
+++ b/rs/src/serve/mod.rs
@@ -5,4 +5,5 @@
 // signaling room, while sharing the same pids.jsonl / logs / fifos data plane.
 pub mod api;
 pub mod e2e;
+pub mod nego;
 pub mod share;

--- a/rs/src/serve/mod.rs
+++ b/rs/src/serve/mod.rs
@@ -1,0 +1,8 @@
+// `ayrs serve` — pure-Rust port of the ay-serve WebRTC share host. Kept as a
+// separate binary/module tree so it can coexist with the TS `ay serve` daemon
+// during the migration: it persists its room in `.share-room-ayrs` (NOT the TS
+// `.share-room`), so both hosts can run side by side without fighting over the
+// signaling room, while sharing the same pids.jsonl / logs / fifos data plane.
+pub mod api;
+pub mod e2e;
+pub mod share;

--- a/rs/src/serve/nego.rs
+++ b/rs/src/serve/nego.rs
@@ -1,0 +1,526 @@
+// PTY size negotiation — Rust port of ts/sizeNego.ts + the serve-side cap
+// store / applyNego machinery (ts/serve.ts, PR #266 "smallest client wins").
+//
+// Mechanism (identical to the TS daemon, byte-compatible file formats so both
+// daemons can negotiate over the same agents concurrently):
+//   - each viewer reports a size cap via POST /api/presence {cap:{cols,rows}}
+//   - serve persists one cap file per (daemon, viewer):
+//       ~/.agent-yes/caps/<agent_pid>/d<serve_pid>:<viewer>
+//     containing "<cols> <rows> <ts_ms> <role>\n"; TTL 12s
+//   - negotiation = elementwise min over live caps, floored at 40x10
+//   - the winner is written to ~/.agent-yes/winsize/<pid> ("<cols> <rows> <ts>\n")
+//     followed by SIGWINCH; the agent runtime (rs pty_spawner / ts index) reads
+//     the file on SIGWINCH (or polls on Windows) and resizes the real PTY
+//   - when the last cap disappears, withdraw after a 30s grace — but only for
+//     agents that still have a real TTY (never snap a headless agent to 80x24),
+//     and only if the winsize file still holds our own last write
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+pub const CAP_MIN_COLS: u32 = 20;
+pub const CAP_MAX_COLS: u32 = 500;
+pub const CAP_MIN_ROWS: u32 = 5;
+pub const CAP_MAX_ROWS: u32 = 200;
+pub const NEGO_FLOOR_COLS: u32 = 40;
+pub const NEGO_FLOOR_ROWS: u32 = 10;
+pub const CAP_TTL_MS: i64 = 12_000;
+pub const PRESENCE_TTL_MS: i64 = 12_000;
+const NEGO_DEBOUNCE_MS: u64 = 350;
+const NEGO_SWEEP_MS: u64 = 5_000;
+const NEGO_WITHDRAW_GRACE_MS: i64 = 30_000;
+/// ±1-cell dead band against the on-disk winsize, absorbing viewer jitter and
+/// duplicate writes from sibling daemons negotiating the same union of caps.
+const DEAD_BAND: i64 = 1;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Cap {
+    pub cols: u32,
+    pub rows: u32,
+}
+
+/// Floor to ints, reject out-of-range (mirrors sanitizeCap).
+pub fn sanitize_cap(cols: f64, rows: f64) -> Option<Cap> {
+    if !cols.is_finite() || !rows.is_finite() {
+        return None;
+    }
+    let (c, r) = (cols.floor() as i64, rows.floor() as i64);
+    if c < CAP_MIN_COLS as i64
+        || c > CAP_MAX_COLS as i64
+        || r < CAP_MIN_ROWS as i64
+        || r > CAP_MAX_ROWS as i64
+    {
+        return None;
+    }
+    Some(Cap { cols: c as u32, rows: r as u32 })
+}
+
+/// Elementwise min over caps, clamped up to the floor (mirrors negotiateSize).
+pub fn negotiate_size(caps: &[Cap]) -> Option<Cap> {
+    let first = caps.first()?;
+    let mut eff = *first;
+    for c in &caps[1..] {
+        eff.cols = eff.cols.min(c.cols);
+        eff.rows = eff.rows.min(c.rows);
+    }
+    eff.cols = eff.cols.max(NEGO_FLOOR_COLS);
+    eff.rows = eff.rows.max(NEGO_FLOOR_ROWS);
+    Some(eff)
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn global_dir() -> PathBuf {
+    if let Ok(h) = std::env::var("AGENT_YES_HOME") {
+        return PathBuf::from(h);
+    }
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join(".agent-yes")
+}
+
+fn caps_dir(pid: u32) -> PathBuf {
+    global_dir().join("caps").join(pid.to_string())
+}
+
+fn winsize_path(pid: u32) -> PathBuf {
+    global_dir().join("winsize").join(pid.to_string())
+}
+
+pub fn ptysize_path(pid: u32) -> PathBuf {
+    global_dir().join("ptysize").join(pid.to_string())
+}
+
+/// Read the agent's current PTY size sidecar ("<cols> <rows>\n"), for /api/size.
+pub fn read_ptysize(pid: u32) -> Option<(u32, u32)> {
+    let s = std::fs::read_to_string(ptysize_path(pid)).ok()?;
+    let mut it = s.split_whitespace();
+    let cols: u32 = it.next()?.parse().ok()?;
+    let rows: u32 = it.next()?.parse().ok()?;
+    if cols == 0 || rows == 0 {
+        return None;
+    }
+    Some((cols, rows))
+}
+
+/// Cap filename: d<serve_pid>:<viewer> with [^\w.:-] replaced by "_",
+/// byte-compatible with the TS capFile().
+fn cap_file(pid: u32, viewer: &str) -> PathBuf {
+    let raw = format!("d{}:{}", std::process::id(), viewer);
+    let safe: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == ':' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    caps_dir(pid).join(safe)
+}
+
+pub fn publish_cap(pid: u32, viewer: &str, cap: Cap, role: &str) {
+    let dir = caps_dir(pid);
+    let _ = std::fs::create_dir_all(&dir);
+    let _ = std::fs::write(
+        cap_file(pid, viewer),
+        format!("{} {} {} {}\n", cap.cols, cap.rows, now_ms(), role),
+    );
+}
+
+pub fn withdraw_cap(pid: u32, viewer: &str) {
+    let _ = std::fs::remove_file(cap_file(pid, viewer));
+}
+
+/// Read every live cap for an agent, pruning files older than CAP_TTL_MS.
+fn read_shared_caps(pid: u32) -> Vec<Cap> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(caps_dir(pid)) else {
+        return out;
+    };
+    let now = now_ms();
+    for e in entries.flatten() {
+        let path = e.path();
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let mut it = content.split_whitespace();
+        let cap = (|| {
+            let cols: f64 = it.next()?.parse().ok()?;
+            let rows: f64 = it.next()?.parse().ok()?;
+            let ts: i64 = it.next()?.parse().ok()?;
+            if now - ts > CAP_TTL_MS {
+                return None; // stale — prune below
+            }
+            sanitize_cap(cols, rows)
+        })();
+        match cap {
+            Some(c) => out.push(c),
+            None => {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+    out
+}
+
+/// `ps -o tty= -p <pid>` — "?"/"??"/empty/error ⇒ no real TTY ⇒ never withdraw
+/// (a headless agent would snap back to 80x24).
+fn has_real_tty(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let out = std::process::Command::new("ps")
+            .args(["-o", "tty=", "-p", &pid.to_string()])
+            .output();
+        match out {
+            Ok(o) if o.status.success() => {
+                let tty = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                !(tty.is_empty() || tty == "?" || tty == "??")
+            }
+            _ => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+fn sigwinch(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(pid as i32, libc::SIGWINCH);
+    }
+    #[cfg(not(unix))]
+    let _ = pid; // Windows runtime polls the winsize file every 250ms
+}
+
+// ---- presence + nego state ---------------------------------------------------
+
+#[derive(Clone)]
+pub struct PresenceEntry {
+    pub viewer: String,
+    pub agent: String, // pid, stringified like the TS map
+    pub cols: u32,
+    pub rows: u32,
+    pub sel: Option<String>,
+    pub cap: Option<Cap>,
+    pub ts: i64,
+}
+
+struct AppliedWrite {
+    content: String, // exact bytes we last wrote to winsize/<pid>
+}
+
+#[derive(Default)]
+struct NegoState {
+    presence: HashMap<String, PresenceEntry>,
+    applied: HashMap<u32, AppliedWrite>,
+    caps_gone_at: HashMap<u32, i64>,
+    pending: HashSet<u32>,
+    sweep_running: bool,
+}
+
+static STATE: Lazy<Mutex<NegoState>> = Lazy::new(|| Mutex::new(NegoState::default()));
+
+/// Debounced negotiation trigger (mirrors scheduleNego, 350ms). Also lazily
+/// starts the 5s grow-back sweep that re-negotiates every applied pid so cap
+/// TTL expiry / foreign winsize drift heals without any POST.
+pub async fn schedule_nego(pid: u32) {
+    let mut st = STATE.lock().await;
+    if !st.sweep_running {
+        st.sweep_running = true;
+        tokio::spawn(async {
+            loop {
+                tokio::time::sleep(Duration::from_millis(NEGO_SWEEP_MS)).await;
+                let pids: Vec<u32> = STATE.lock().await.applied.keys().copied().collect();
+                for pid in pids {
+                    schedule_nego_inner(pid).await;
+                }
+            }
+        });
+    }
+    if st.pending.contains(&pid) {
+        return;
+    }
+    st.pending.insert(pid);
+    drop(st);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(NEGO_DEBOUNCE_MS)).await;
+        STATE.lock().await.pending.remove(&pid);
+        apply_nego(pid).await;
+    });
+}
+
+async fn schedule_nego_inner(pid: u32) {
+    // sweep path skips the debounce-dedup bookkeeping; apply directly
+    apply_nego(pid).await;
+}
+
+async fn apply_nego(pid: u32) {
+    let caps = tokio::task::spawn_blocking(move || read_shared_caps(pid))
+        .await
+        .unwrap_or_default();
+    let eff = negotiate_size(&caps);
+    let mut st = STATE.lock().await;
+    match eff {
+        Some(eff) => {
+            st.caps_gone_at.remove(&pid);
+            // dead band vs the ON-DISK winsize (not our prev write): absorbs
+            // jitter and heals foreign writes only when they truly differ
+            let curr = std::fs::read_to_string(winsize_path(pid)).ok().and_then(|s| {
+                let mut it = s.split_whitespace();
+                Some((it.next()?.parse::<i64>().ok()?, it.next()?.parse::<i64>().ok()?))
+            });
+            if let Some((c, r)) = curr {
+                if (c - eff.cols as i64).abs() <= DEAD_BAND && (r - eff.rows as i64).abs() <= DEAD_BAND {
+                    // still record that nego owns this pid so the sweep keeps watching
+                    st.applied.entry(pid).or_insert(AppliedWrite {
+                        content: format!("{} {}", eff.cols, eff.rows),
+                    });
+                    return;
+                }
+            }
+            let content = format!("{} {} {}\n", eff.cols, eff.rows, now_ms());
+            let path = winsize_path(pid);
+            if let Some(dir) = path.parent() {
+                let _ = std::fs::create_dir_all(dir);
+            }
+            if std::fs::write(&path, &content).is_ok() {
+                st.applied.insert(pid, AppliedWrite { content: content.clone() });
+                sigwinch(pid);
+                eprintln!(
+                    "[api/resize] pid={pid} {}x{} src=presence-nego daemon=d{} caps={}",
+                    eff.cols,
+                    eff.rows,
+                    std::process::id(),
+                    caps.len(),
+                );
+            }
+        }
+        None => {
+            // no live caps: withdraw only if we ever applied, after a grace
+            // period, and only for agents with a real TTY
+            let Some(prev) = st.applied.get(&pid).map(|a| a.content.clone()) else {
+                return;
+            };
+            let gone_at = *st.caps_gone_at.entry(pid).or_insert_with(now_ms);
+            if now_ms() - gone_at < NEGO_WITHDRAW_GRACE_MS {
+                return;
+            }
+            drop(st);
+            let tty = tokio::task::spawn_blocking(move || has_real_tty(pid))
+                .await
+                .unwrap_or(false);
+            let mut st = STATE.lock().await;
+            if !tty {
+                return; // headless — leave the negotiated size in place forever
+            }
+            // only unlink if the file still holds OUR last write; a different
+            // content means `ay attach` / a forced resize owns it now
+            let path = winsize_path(pid);
+            if std::fs::read_to_string(&path).map(|c| c == prev).unwrap_or(false) {
+                let _ = std::fs::remove_file(&path);
+                sigwinch(pid);
+                eprintln!(
+                    "[api/resize] pid={pid} withdraw src=presence-nego daemon=d{}",
+                    std::process::id()
+                );
+            }
+            st.applied.remove(&pid);
+            st.caps_gone_at.remove(&pid);
+        }
+    }
+}
+
+// ---- /api/presence handlers ----------------------------------------------------
+
+/// POST /api/presence — returns Err((status, msg)) for protocol errors.
+pub async fn presence_post(body: &Value) -> Result<(), (u16, String)> {
+    let viewer: String = body
+        .get("viewer")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .chars()
+        .take(64)
+        .collect();
+    if viewer.is_empty() {
+        return Err((400, "missing viewer".into()));
+    }
+    let agent: Option<u32> = match body.get("agent") {
+        None | Some(Value::Null) => None,
+        Some(Value::Number(n)) => n.as_u64().map(|v| v as u32),
+        Some(Value::String(s)) => s.parse().ok(),
+        _ => None,
+    };
+    let cap = body.get("cap").and_then(|c| {
+        let cols = c.get("cols")?.as_f64()?;
+        let rows = c.get("rows")?.as_f64()?;
+        Some((cols, rows))
+    });
+    let mut st = STATE.lock().await;
+    let prev_agent: Option<u32> = st.presence.get(&viewer).and_then(|e| e.agent.parse().ok());
+    match agent {
+        None => {
+            // clear this viewer's entry (and its cap on the previous agent)
+            st.presence.remove(&viewer);
+            drop(st);
+            if let Some(prev) = prev_agent {
+                let v = viewer.clone();
+                tokio::task::spawn_blocking(move || withdraw_cap(prev, &v)).await.ok();
+                schedule_nego(prev).await;
+            }
+        }
+        Some(pid) => {
+            if let Some(prev) = prev_agent {
+                if prev != pid {
+                    let v = viewer.clone();
+                    tokio::task::spawn_blocking(move || withdraw_cap(prev, &v)).await.ok();
+                    schedule_nego(prev).await;
+                }
+            }
+            let sane = cap.and_then(|(c, r)| sanitize_cap(c, r));
+            st.presence.insert(
+                viewer.clone(),
+                PresenceEntry {
+                    viewer: viewer.clone(),
+                    agent: pid.to_string(),
+                    cols: body.get("cols").and_then(|v| v.as_f64()).map(|v| v.max(0.0) as u32).unwrap_or(0),
+                    rows: body.get("rows").and_then(|v| v.as_f64()).map(|v| v.max(0.0) as u32).unwrap_or(0),
+                    sel: body
+                        .get("sel")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.chars().take(200).collect()),
+                    cap: sane,
+                    ts: now_ms(),
+                },
+            );
+            drop(st);
+            let v = viewer.clone();
+            match sane {
+                Some(c) => {
+                    tokio::task::spawn_blocking(move || publish_cap(pid, &v, c, "viewer"))
+                        .await
+                        .ok();
+                }
+                None => {
+                    tokio::task::spawn_blocking(move || withdraw_cap(pid, &v)).await.ok();
+                }
+            }
+            schedule_nego(pid).await;
+        }
+    }
+    Ok(())
+}
+
+/// GET /api/presence — live entries, TTL-pruned.
+pub async fn presence_get() -> Value {
+    let mut st = STATE.lock().await;
+    let now = now_ms();
+    st.presence.retain(|_, e| now - e.ts <= PRESENCE_TTL_MS);
+    let entries: Vec<Value> = st
+        .presence
+        .values()
+        .map(|e| {
+            json!({
+                "viewer": e.viewer,
+                "agent": e.agent,
+                "cols": e.cols,
+                "rows": e.rows,
+                "sel": e.sel,
+                "cap": e.cap.map(|c| json!({"cols": c.cols, "rows": c.rows})),
+                "ts": e.ts,
+            })
+        })
+        .collect();
+    Value::Array(entries)
+}
+
+/// POST /api/resize/:pid — cap mode by default, force mode with force:true
+/// (the WebRTC bridge always carries the master token, so force is honored).
+pub async fn resize_post(pid: u32, body: &Value) -> Result<Value, (u16, String)> {
+    let cols = body.get("cols").and_then(|v| v.as_f64()).map(|v| v.floor().max(1.0)).unwrap_or(0.0);
+    let rows = body.get("rows").and_then(|v| v.as_f64()).map(|v| v.floor().max(1.0)).unwrap_or(0.0);
+    if cols < 1.0 || rows < 1.0 {
+        return Err((400, "missing cols/rows".into()));
+    }
+    let force = body.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+    if force {
+        let content = format!("{} {} {}\n", cols as u32, rows as u32, now_ms());
+        let path = winsize_path(pid);
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        std::fs::write(&path, &content).map_err(|e| (500, e.to_string()))?;
+        sigwinch(pid);
+        eprintln!(
+            "[api/resize] pid={pid} {}x{} src=api-resize-FORCED daemon=d{}",
+            cols as u32,
+            rows as u32,
+            std::process::id()
+        );
+        return Ok(json!({"ok": true, "pid": pid, "cols": cols as u32, "rows": rows as u32, "forced": true}));
+    }
+    let Some(cap) = sanitize_cap(cols, rows) else {
+        return Err((400, "cols/rows out of range".into()));
+    };
+    let viewer: String = body
+        .get("viewer")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("api-resize")
+        .chars()
+        .take(64)
+        .collect();
+    let v = viewer.clone();
+    tokio::task::spawn_blocking(move || publish_cap(pid, &v, cap, "viewer")).await.ok();
+    schedule_nego(pid).await;
+    eprintln!(
+        "[api/resize] pid={pid} {}x{} src=api-resize-cap daemon=d{}",
+        cap.cols,
+        cap.rows,
+        std::process::id()
+    );
+    Ok(json!({"ok": true, "pid": pid, "cols": cap.cols, "rows": cap.rows, "mode": "cap"}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_bounds() {
+        assert_eq!(sanitize_cap(100.7, 30.9), Some(Cap { cols: 100, rows: 30 }));
+        assert_eq!(sanitize_cap(19.0, 30.0), None);
+        assert_eq!(sanitize_cap(501.0, 30.0), None);
+        assert_eq!(sanitize_cap(100.0, 4.0), None);
+        assert_eq!(sanitize_cap(100.0, 201.0), None);
+        assert_eq!(sanitize_cap(f64::NAN, 30.0), None);
+    }
+
+    #[test]
+    fn negotiate_min_and_floor() {
+        let caps = [Cap { cols: 120, rows: 40 }, Cap { cols: 90, rows: 50 }];
+        assert_eq!(negotiate_size(&caps), Some(Cap { cols: 90, rows: 40 }));
+        // floor clamps tiny mins up to 40x10
+        let caps = [Cap { cols: 20, rows: 5 }];
+        assert_eq!(negotiate_size(&caps), Some(Cap { cols: 40, rows: 10 }));
+        assert_eq!(negotiate_size(&[]), None);
+    }
+
+    #[test]
+    fn cap_file_sanitizes_name() {
+        let p = cap_file(1, "we/ird viewer");
+        let name = p.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(name.starts_with(&format!("d{}:", std::process::id())));
+        assert!(name.ends_with("we_ird_viewer"));
+    }
+}

--- a/rs/src/serve/share.rs
+++ b/rs/src/serve/share.rs
@@ -1,0 +1,712 @@
+// `ayrs serve --webrtc` host peer — Rust port of ts/share.ts. Connects to the
+// signaling server as a room host and bridges each browser peer's WebRTC
+// DataChannel to the native API handler (serve/api.rs), no HTTP port needed.
+//
+// Coexistence: the room persists in `~/.agent-yes/.share-room-ayrs` — a
+// DIFFERENT file from the TS daemon's `.share-room` — so the Rust host never
+// steals the signaling room out from under a running `ay serve --webrtc`.
+use super::api;
+use super::e2e;
+use anyhow::{anyhow, bail, Context, Result};
+use futures::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message;
+use webrtc::api::APIBuilder;
+use webrtc::data_channel::data_channel_message::DataChannelMessage;
+use webrtc::data_channel::RTCDataChannel;
+use webrtc::ice_transport::ice_candidate::RTCIceCandidateInit;
+use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::peer_connection::configuration::RTCConfiguration;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::peer_connection::RTCPeerConnection;
+
+const SUB: &str = "ay-signal-1";
+pub const DEFAULT_SIGHOST: &str = "s.agent-yes.com";
+const HOST_HEARTBEAT_MS: u64 = 20_000;
+const SIG_REFRESH_MS: u64 = 4 * 60_000;
+const STUN_URL: &str = "stun:stun.l.google.com:19302";
+const MAX_ROTATES: u32 = 5;
+
+fn global_dir() -> PathBuf {
+    if let Ok(h) = std::env::var("AGENT_YES_HOME") {
+        return PathBuf::from(h);
+    }
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join(".agent-yes")
+}
+
+fn share_room_path() -> PathBuf {
+    global_dir().join(".share-room-ayrs")
+}
+
+pub struct RoomUrl {
+    pub room: String,
+    pub token: String, // "e1.<64hex>"
+    pub host: String,
+}
+
+pub fn parse_share_url(s: &str) -> Result<RoomUrl> {
+    // webrtc://room:token@host
+    let rest = s
+        .strip_prefix("webrtc://")
+        .ok_or_else(|| anyhow!("bad --webrtc url: {s} (want webrtc://room:token@host)"))?;
+    let (roomtok, host) = rest
+        .rsplit_once('@')
+        .ok_or_else(|| anyhow!("bad --webrtc url: missing @host"))?;
+    let (room, token) = roomtok
+        .split_once(':')
+        .ok_or_else(|| anyhow!("bad --webrtc url: missing :token"))?;
+    if room.is_empty() || token.is_empty() || host.is_empty() {
+        bail!("bad --webrtc url: {s}");
+    }
+    Ok(RoomUrl { room: room.into(), token: token.into(), host: host.into() })
+}
+
+fn mint_room(host: &str) -> RoomUrl {
+    RoomUrl {
+        room: format!("r{}", e2e::random_hex(6)),
+        token: format!("{}{}", e2e::MARKER, e2e::random_hex(32)),
+        host: host.to_string(),
+    }
+}
+
+fn persist_room(r: &RoomUrl) {
+    let _ = std::fs::create_dir_all(global_dir());
+    let url = format!("webrtc://{}:{}@{}", r.room, r.token, r.host);
+    let _ = std::fs::write(share_room_path(), &url);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(share_room_path(), std::fs::Permissions::from_mode(0o600));
+    }
+}
+
+pub fn load_or_create_room(sighost: &str) -> RoomUrl {
+    if let Ok(url) = std::fs::read_to_string(share_room_path()) {
+        if let Ok(r) = parse_share_url(url.trim()) {
+            if r.token.starts_with(e2e::MARKER) {
+                return r;
+            }
+        }
+    }
+    let r = mint_room(sighost);
+    persist_room(&r);
+    r
+}
+
+/// The browser console URL for a room (mirrors ts/share.ts formatShareLink).
+pub fn format_share_link(room: &str, s: &str, host: &str) -> String {
+    if host == DEFAULT_SIGHOST {
+        format!("https://agent-yes.com/w/#{room}:{}{s}", e2e::MARKER)
+    } else {
+        format!("http://localhost:7778/w/#{room}:{}{s}@{host}", e2e::MARKER)
+    }
+}
+
+// ---- per-peer state ----------------------------------------------------------
+
+struct Peer {
+    pc: Arc<RTCPeerConnection>,
+    /// Sealed-frame sender task input: (flags, envelope). Sealing is serialized
+    /// by the single sender task so wire order == counter order.
+    out_tx: mpsc::UnboundedSender<(u8, Value)>,
+    /// Raw offer SDP as sent to the browser (transcript-hash input).
+    offer_sdp: String,
+    /// In-flight request tasks by envelope id, for {t:"abort"}.
+    reqs: HashMap<String, tokio::task::JoinHandle<()>>,
+    crypto: Option<Arc<PeerCrypto>>,
+    recv: e2e::RecvState,
+    my_nonce: String,
+    confirmed_in: bool,
+    confirmed_out: bool,
+    confirmed: bool,
+}
+
+struct PeerCrypto {
+    keys: e2e::DirKeys,
+    th: [u8; 32],
+}
+
+type Peers = Arc<Mutex<HashMap<String, Peer>>>;
+
+/// Messages from callbacks/tasks back to the signaling writer.
+enum SigOut {
+    Send(String),
+}
+
+pub struct ShareConfig {
+    pub url: Option<String>,
+    pub sighost: String,
+}
+
+pub async fn run_share(cfg: ShareConfig) -> Result<()> {
+    let explicit = cfg.url.is_some();
+    let mut room = match &cfg.url {
+        Some(u) => parse_share_url(u)?,
+        None => load_or_create_room(&cfg.sighost),
+    };
+    let (s, v2) = e2e::parse_secret(&room.token)?;
+    if !v2 {
+        bail!("refusing to host an unencrypted room — delete ~/.agent-yes/.share-room-ayrs to rotate");
+    }
+    let mut secret = s;
+    let api_token = api::load_or_create_token().context("serve token")?;
+
+    let peers: Peers = Arc::new(Mutex::new(HashMap::new()));
+    let mut rotates = 0u32;
+
+    let link = format_share_link(&room.room, &secret, &room.host);
+    eprintln!("[ayrs share] room {} via {}", room.room, room.host);
+    println!("{link}");
+
+    loop {
+        match connect_once(&room, &secret, &api_token, peers.clone()).await {
+            Ok(SessionEnd::Refresh) => {
+                // periodic re-hello (see ts/share.ts SIG_REFRESH_MS rationale)
+                continue;
+            }
+            Ok(SessionEnd::Rejected) => {
+                if explicit || rotates >= MAX_ROTATES {
+                    bail!("room rejected by signaling server (1008) — delete ~/.agent-yes/.share-room-ayrs to rotate");
+                }
+                rotates += 1;
+                room = mint_room(&room.host);
+                secret = e2e::parse_secret(&room.token)?.0;
+                persist_room(&room);
+                let link = format_share_link(&room.room, &secret, &room.host);
+                eprintln!("[ayrs share] room rotated: {link}");
+            }
+            Ok(SessionEnd::Dropped) => {
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+            }
+            Err(e) => {
+                eprintln!("[ayrs share] signaling error: {e:#}");
+                tokio::time::sleep(Duration::from_millis(2000)).await;
+            }
+        }
+    }
+}
+
+enum SessionEnd {
+    Refresh,
+    Rejected,
+    Dropped,
+}
+
+async fn connect_once(
+    room: &RoomUrl,
+    secret: &str,
+    api_token: &str,
+    peers: Peers,
+) -> Result<SessionEnd> {
+    let scheme = if room.host.starts_with("localhost") || room.host.starts_with("127.") {
+        "ws"
+    } else {
+        "wss"
+    };
+    let url = format!("{scheme}://{}/{}", room.host, room.room);
+    let mut req = url.clone().into_client_request()?;
+    req.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        SUB.parse().expect("static subprotocol header"),
+    );
+    let (ws, _resp) = tokio_tungstenite::connect_async(req).await.context("ws connect")?;
+    let (mut sink, mut stream) = ws.split();
+
+    let auth_token = e2e::derive_auth_token(secret, &room.room, &room.host)?;
+    sink.send(Message::Text(
+        json!({"type": "hello", "role": "host", "v": 2, "token": auth_token})
+            .to_string()
+            .into(),
+    ))
+    .await?;
+
+    // signaling writer fan-in: peer tasks (ICE candidates, offers) → socket
+    let (sig_tx, mut sig_rx) = mpsc::unbounded_channel::<SigOut>();
+
+    let mut hb = tokio::time::interval(Duration::from_millis(HOST_HEARTBEAT_MS));
+    hb.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let refresh = tokio::time::sleep(Duration::from_millis(SIG_REFRESH_MS));
+    tokio::pin!(refresh);
+    let mut last_recv = std::time::Instant::now();
+
+    loop {
+        tokio::select! {
+            _ = &mut refresh => {
+                let _ = sink.close().await;
+                return Ok(SessionEnd::Refresh);
+            }
+            _ = hb.tick() => {
+                if last_recv.elapsed() > Duration::from_millis(HOST_HEARTBEAT_MS * 2 + 5000) {
+                    let _ = sink.close().await;
+                    return Ok(SessionEnd::Dropped);
+                }
+                let _ = sink.send(Message::Text(json!({"type":"ping"}).to_string().into())).await;
+            }
+            Some(out) = sig_rx.recv() => {
+                match out {
+                    SigOut::Send(text) => { let _ = sink.send(Message::Text(text.into())).await; }
+                }
+            }
+            msg = stream.next() => {
+                let Some(msg) = msg else { return Ok(SessionEnd::Dropped) };
+                let msg = match msg {
+                    Ok(m) => m,
+                    Err(_) => return Ok(SessionEnd::Dropped),
+                };
+                last_recv = std::time::Instant::now();
+                match msg {
+                    Message::Close(frame) => {
+                        if frame.map(|f| u16::from(f.code) == 1008).unwrap_or(false) {
+                            return Ok(SessionEnd::Rejected);
+                        }
+                        return Ok(SessionEnd::Dropped);
+                    }
+                    Message::Text(t) => {
+                        let Ok(m) = serde_json::from_str::<Value>(&t) else { continue };
+                        handle_signal(m, secret, api_token, &peers, &sig_tx).await;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+async fn handle_signal(
+    m: Value,
+    secret: &str,
+    api_token: &str,
+    peers: &Peers,
+    sig_tx: &mpsc::UnboundedSender<SigOut>,
+) {
+    match m.get("type").and_then(|t| t.as_str()) {
+        Some("pong") | Some("welcome") => {}
+        Some("peer-join") => {
+            let Some(peer_id) = m.get("peer").map(value_to_id) else { return };
+            if peers.lock().await.contains_key(&peer_id) {
+                return;
+            }
+            eprintln!("[ayrs share] peer-join {peer_id}");
+            if let Err(e) = start_peer(peer_id.clone(), api_token, peers, sig_tx).await {
+                eprintln!("[ayrs share] peer setup failed: {e:#}");
+                close_peer(peers, &peer_id).await;
+            }
+        }
+        Some("answer") => {
+            let Some(from) = m.get("from").map(value_to_id) else { return };
+            let sdp = m.get("sdp").and_then(|s| s.as_str()).unwrap_or("").to_string();
+            if let Err(e) = on_answer(&from, sdp, secret, peers).await {
+                eprintln!("[ayrs share] answer failed for {from}: {e:#}");
+                close_peer(peers, &from).await;
+            }
+        }
+        Some("candidate") => {
+            let Some(from) = m.get("from").map(value_to_id) else { return };
+            let Some(cand) = m.get("candidate") else { return };
+            let init: RTCIceCandidateInit = match serde_json::from_value(cand.clone()) {
+                Ok(c) => c,
+                Err(_) => return,
+            };
+            let pc = {
+                let map = peers.lock().await;
+                map.get(&from).map(|p| p.pc.clone())
+            };
+            if let Some(pc) = pc {
+                let _ = pc.add_ice_candidate(init).await;
+            }
+        }
+        Some("peer-leave") => {
+            if let Some(peer) = m.get("peer").map(value_to_id) {
+                close_peer(peers, &peer).await;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn value_to_id(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+async fn close_peer(peers: &Peers, peer_id: &str) {
+    let removed = peers.lock().await.remove(peer_id);
+    if let Some(p) = removed {
+        for (_, h) in p.reqs {
+            h.abort();
+        }
+        let _ = p.pc.close().await;
+    }
+}
+
+async fn start_peer(
+    peer_id: String,
+    api_token: &str,
+    peers: &Peers,
+    sig_tx: &mpsc::UnboundedSender<SigOut>,
+) -> Result<()> {
+    let api = APIBuilder::new().build();
+    let config = RTCConfiguration {
+        ice_servers: vec![RTCIceServer { urls: vec![STUN_URL.to_string()], ..Default::default() }],
+        ..Default::default()
+    };
+    let pc = Arc::new(api.new_peer_connection(config).await?);
+
+    // trickle ICE → signaling writer
+    {
+        let sig_tx = sig_tx.clone();
+        let peer_id = peer_id.clone();
+        pc.on_ice_candidate(Box::new(move |c| {
+            let sig_tx = sig_tx.clone();
+            let peer_id = peer_id.clone();
+            Box::pin(async move {
+                if let Some(c) = c {
+                    if let Ok(init) = c.to_json() {
+                        if let Ok(cand) = serde_json::to_value(&init) {
+                            let _ = sig_tx.send(SigOut::Send(
+                                json!({"type":"candidate","to":peer_id,"candidate":cand})
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+            })
+        }));
+    }
+
+    // dead-peer cleanup
+    {
+        let peers2 = peers.clone();
+        let peer_id = peer_id.clone();
+        pc.on_peer_connection_state_change(Box::new(move |st| {
+            let peers2 = peers2.clone();
+            let peer_id = peer_id.clone();
+            Box::pin(async move {
+                if matches!(
+                    st,
+                    RTCPeerConnectionState::Failed
+                        | RTCPeerConnectionState::Closed
+                        | RTCPeerConnectionState::Disconnected
+                ) {
+                    close_peer(&peers2, &peer_id).await;
+                }
+            })
+        }));
+    }
+
+    let dc = pc.create_data_channel("api", None).await?;
+
+    // sealed-frame sender task: (flags, envelope) → seal in order → dc.send
+    let (out_tx, out_rx) = mpsc::unbounded_channel::<(u8, Value)>();
+    spawn_sender(dc.clone(), out_rx, peers.clone(), peer_id.clone());
+
+    // inbound frames → per-peer handler (serialized by the channel)
+    let (in_tx, in_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    {
+        let in_tx = in_tx.clone();
+        dc.on_message(Box::new(move |msg: DataChannelMessage| {
+            let in_tx = in_tx.clone();
+            Box::pin(async move {
+                if !msg.is_string {
+                    let _ = in_tx.send(msg.data.to_vec());
+                }
+            })
+        }));
+    }
+    spawn_receiver(peers.clone(), peer_id.clone(), in_rx, api_token.to_string());
+
+    // on open: start the mandatory key-confirmation handshake
+    {
+        let peers2 = peers.clone();
+        let peer_id2 = peer_id.clone();
+        dc.on_open(Box::new(move || {
+            let peers2 = peers2.clone();
+            let peer_id2 = peer_id2.clone();
+            Box::pin(async move {
+                let mut map = peers2.lock().await;
+                if let Some(p) = map.get_mut(&peer_id2) {
+                    let nonce = p.my_nonce.clone();
+                    let _ = p.out_tx.send((e2e::FLAG_CONFIRM, json!({"t":"confirm","nonce":nonce})));
+                }
+                drop(map);
+                // confirm deadline: close the peer if the handshake stalls
+                tokio::time::sleep(Duration::from_millis(e2e::CONFIRM_TIMEOUT_MS)).await;
+                let confirmed = peers2
+                    .lock()
+                    .await
+                    .get(&peer_id2)
+                    .map(|p| p.confirmed)
+                    .unwrap_or(true);
+                if !confirmed {
+                    close_peer(&peers2, &peer_id2).await;
+                }
+            })
+        }));
+    }
+
+    let offer = pc.create_offer(None).await?;
+    let offer_sdp = offer.sdp.clone();
+    pc.set_local_description(offer).await?;
+
+    peers.lock().await.insert(
+        peer_id.clone(),
+        Peer {
+            pc: pc.clone(),
+            out_tx,
+            offer_sdp: offer_sdp.clone(),
+            reqs: HashMap::new(),
+            crypto: None,
+            recv: e2e::RecvState { last_seen: None },
+            my_nonce: e2e::random_hex(16),
+            confirmed_in: false,
+            confirmed_out: false,
+            confirmed: false,
+        },
+    );
+
+    let ice_servers = json!([{ "urls": STUN_URL }]);
+    let _ = sig_tx.send(SigOut::Send(
+        json!({"type":"offer","to":peer_id,"sdp":offer_sdp,"iceServers":ice_servers}).to_string(),
+    ));
+    Ok(())
+}
+
+async fn on_answer(peer_id: &str, sdp: String, secret: &str, peers: &Peers) -> Result<()> {
+    let (pc, offer_sdp) = {
+        let map = peers.lock().await;
+        let p = map.get(peer_id).ok_or_else(|| anyhow!("unknown peer"))?;
+        (p.pc.clone(), p.offer_sdp.clone())
+    };
+    let answer = RTCSessionDescription::answer(sdp.clone())?;
+    pc.set_remote_description(answer).await?;
+    // Host's offer is local, the browser's answer is remote.
+    let th = e2e::compute_transcript_hash(&offer_sdp, &sdp)?;
+    let keys = e2e::derive_dir_keys(secret, &th)?;
+    let mut map = peers.lock().await;
+    if let Some(p) = map.get_mut(peer_id) {
+        p.crypto = Some(Arc::new(PeerCrypto { keys, th }));
+    }
+    Ok(())
+}
+
+/// The sealing sender: owns the send counter so wire order == counter order.
+fn spawn_sender(
+    dc: Arc<RTCDataChannel>,
+    mut out_rx: mpsc::UnboundedReceiver<(u8, Value)>,
+    peers: Peers,
+    peer_id: String,
+) {
+    tokio::spawn(async move {
+        let mut send = e2e::SendState { send_ctr: 0 };
+        while let Some((flags, env)) = out_rx.recv().await {
+            let crypto = {
+                let map = peers.lock().await;
+                match map.get(&peer_id).and_then(|p| p.crypto.clone()) {
+                    Some(c) => c,
+                    None => continue, // keys not derived yet — drop (mirrors TS guard)
+                }
+            };
+            let plaintext = env.to_string().into_bytes();
+            let frame = match e2e::seal(&crypto.keys.h2c, &mut send, flags, &crypto.th, &plaintext) {
+                Ok(f) => f,
+                Err(_) => {
+                    close_peer(&peers, &peer_id).await; // counter overflow — fail closed
+                    return;
+                }
+            };
+            if dc.send(&frame.into()).await.is_err() {
+                // peer vanished mid-send; dropping the frame is correct
+            }
+        }
+    });
+}
+
+/// The decrypting receiver: opens frames in arrival order (replay counter),
+/// runs the confirm handshake, then dispatches req/abort envelopes.
+fn spawn_receiver(
+    peers: Peers,
+    peer_id: String,
+    mut in_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    api_token: String,
+) {
+    tokio::spawn(async move {
+        while let Some(frame) = in_rx.recv().await {
+            let crypto = {
+                let map = peers.lock().await;
+                match map.get(&peer_id).and_then(|p| p.crypto.clone()) {
+                    Some(c) => c,
+                    None => {
+                        close_peer(&peers, &peer_id).await;
+                        return;
+                    }
+                }
+            };
+            let opened = {
+                let mut map = peers.lock().await;
+                let Some(p) = map.get_mut(&peer_id) else { return };
+                match e2e::open(&crypto.keys.c2h, &frame, &crypto.th, &mut p.recv) {
+                    Ok(o) => o,
+                    Err(_) => {
+                        drop(map);
+                        close_peer(&peers, &peer_id).await; // fail closed
+                        return;
+                    }
+                }
+            };
+            let Ok(env) = serde_json::from_slice::<Value>(&opened.plaintext) else {
+                close_peer(&peers, &peer_id).await;
+                return;
+            };
+            let t = env.get("t").and_then(|t| t.as_str()).unwrap_or("");
+            let confirmed = {
+                let map = peers.lock().await;
+                map.get(&peer_id).map(|p| p.confirmed).unwrap_or(false)
+            };
+            if !confirmed {
+                if t != "confirm" {
+                    close_peer(&peers, &peer_id).await;
+                    return;
+                }
+                let mut map = peers.lock().await;
+                let Some(p) = map.get_mut(&peer_id) else { return };
+                if let Some(nonce) = env.get("nonce").and_then(|n| n.as_str()) {
+                    if !p.confirmed_out {
+                        let my = p.my_nonce.clone();
+                        let _ = p.out_tx.send((
+                            e2e::FLAG_CONFIRM,
+                            json!({"t":"confirm","nonce":my,"echo":nonce}),
+                        ));
+                        p.confirmed_out = true;
+                    }
+                }
+                if env.get("echo").and_then(|e| e.as_str()) == Some(p.my_nonce.as_str()) {
+                    p.confirmed_in = true;
+                }
+                if p.confirmed_in && p.confirmed_out {
+                    p.confirmed = true;
+                    eprintln!("[ayrs share] peer {peer_id} key-confirmed");
+                }
+                continue;
+            }
+            match t {
+                "confirm" => {} // stray confirm after handshake — ignore
+                "abort" => {
+                    if let Some(id) = env.get("id").and_then(|i| i.as_str()) {
+                        let mut map = peers.lock().await;
+                        if let Some(p) = map.get_mut(&peer_id) {
+                            if let Some(h) = p.reqs.remove(id) {
+                                h.abort();
+                            }
+                        }
+                    }
+                }
+                "req" => {
+                    let id = env.get("id").map(value_to_id).unwrap_or_default();
+                    if std::env::var("AYRS_SHARE_LOG").is_ok() {
+                        eprintln!(
+                            "[ayrs share] req {} {}",
+                            env.get("method").and_then(|m| m.as_str()).unwrap_or("GET"),
+                            env.get("path").and_then(|p| p.as_str()).unwrap_or("/"),
+                        );
+                    }
+                    let method = env
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("GET")
+                        .to_string();
+                    let path = env.get("path").and_then(|p| p.as_str()).unwrap_or("/").to_string();
+                    let body = env.get("body").and_then(|b| b.as_str()).unwrap_or("").to_string();
+                    let out_tx = {
+                        let map = peers.lock().await;
+                        match map.get(&peer_id) {
+                            Some(p) => p.out_tx.clone(),
+                            None => return,
+                        }
+                    };
+                    let _ = api_token; // auth is implicit: the bridge IS the local API
+                    let peers2 = peers.clone();
+                    let peer_id2 = peer_id.clone();
+                    let id2 = id.clone();
+                    let handle = tokio::spawn(async move {
+                        serve_request(out_tx, id2.clone(), method, path, body).await;
+                        // done — drop our own abort registration
+                        let mut map = peers2.lock().await;
+                        if let Some(p) = map.get_mut(&peer_id2) {
+                            p.reqs.remove(&id2);
+                        }
+                    });
+                    let mut map = peers.lock().await;
+                    if let Some(p) = map.get_mut(&peer_id) {
+                        p.reqs.insert(id, handle);
+                    } else {
+                        handle.abort();
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+}
+
+/// Run one bridged request against the native API and stream the response back
+/// as {t:"res"} / {t:"data"} / {t:"end"} envelopes.
+async fn serve_request(
+    out_tx: mpsc::UnboundedSender<(u8, Value)>,
+    id: String,
+    method: String,
+    path: String,
+    body: String,
+) {
+    let res = api::handle(&method, &path, &body).await;
+    let _ = out_tx.send((
+        0,
+        json!({"t":"res","id":id,"status":res.status,"ct":res.content_type}),
+    ));
+    let mut seq: u64 = 0;
+    let send_text = |text: &str, seq: &mut u64| -> bool {
+        // Slice to MAX_CHUNK units; receiver reassembles by seq-order concat.
+        let mut rest = text;
+        while !rest.is_empty() {
+            let mut end = rest.len().min(e2e::MAX_CHUNK);
+            while !rest.is_char_boundary(end) {
+                end -= 1;
+            }
+            let (chunk, tail) = rest.split_at(end);
+            if out_tx
+                .send((0, json!({"t":"data","id":id,"seq":*seq,"chunk":chunk})))
+                .is_err()
+            {
+                return false;
+            }
+            *seq += 1;
+            rest = tail;
+        }
+        true
+    };
+    match res.body {
+        api::Body::Full(bytes) => {
+            let text = String::from_utf8_lossy(&bytes);
+            if !text.is_empty() {
+                send_text(&text, &mut seq);
+            }
+        }
+        api::Body::Stream(mut rx) => {
+            while let Some(chunk) = rx.recv().await {
+                let text = String::from_utf8_lossy(&chunk);
+                if !send_text(&text, &mut seq) {
+                    return;
+                }
+            }
+        }
+    }
+    let _ = out_tx.send((0, json!({"t":"end","id":id,"seq":seq})));
+}


### PR DESCRIPTION
## What

A pure-Rust port of the `ay serve --webrtc` share host, shipped as a **separate `ayrs` binary** so it coexists with the running TS daemon (its room persists in `~/.agent-yes/.share-room-ayrs`, never touching `.share-room`). Goal: get the always-on share daemon off Bun/node-datachannel (memory leaks, CPU churn, the libdatachannel freeze mitigations in ts/share.ts).

- `rs/src/serve/e2e.rs` — byte-identical port of `lab/ui/e2e.js` (ay-e2e-1): HKDF auth token, directional AES-256-GCM keys salted by the DTLS transcript hash, counter nonces, fail-closed `open`. Unit tests pin vectors generated by the JS implementation under bun.
- `rs/src/serve/share.rs` — ay-signal-1 signaling client (hello/offer/answer/candidate, 20 s ping + silent-drop detection, 4 min re-hello, 1008 auto-rotate) and webrtc-rs host peer speaking the `req/res/data/end` envelope.
- `rs/src/serve/api.rs` — native handlers for `/api/ls`, `/api/ls/subscribe`, `/api/whoami`, `/api/version`, `/api/host`, `/api/size/:kw`, `/api/tail/:kw` (SSE), `/api/send` (FIFO write), reading the same `pids.jsonl` / raw logs / fifos as the TS daemon; everything else 404s and the console degrades.

## Verified live (s.agent-yes.com)

- Browser console joined the Rust-hosted room, completed the bidirectional key-confirmation, and streamed `/api/ls/subscribe`, `/api/whoami`, `/api/ls`.
- `ay ls <link>` (TS webrtc client) returned the full agent table through the Rust host.
- Bridge script round-tripped `/api/tail?raw=1` (SSE snapshot), `POST /api/send` (`{ok:true,…}`), `/api/size`.
- `cargo test --bin ayrs`: 40 tests green, incl. cross-implementation crypto vectors.

## Not in scope (follow-ups)

- `--http` listener, TURN credential minting (STUN-only for now), scoped term tokens, size negotiation (`nego:false`), spawn/kill caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)