### PR TITLE
feat(ayrs): oxmgr install fallback + fast dev-build paths

### DIFF
--- a/docs/serve-rust-vs-ts-benchmark.md
+++ b/docs/serve-rust-vs-ts-benchmark.md
@@ -1,0 +1,140 @@
+# Serve daemon benchmark — Rust `ayrs serve` vs TypeScript `ay serve`
+
+A/B comparison of the two browser-console host daemons running on the **same
+machine**, serving the **same local agent fleet**. Room `r2d058f` is hosted by
+the Bun/Node TS `ay serve`; room `r7bcb6271a973` by the standalone Rust
+`ayrs serve --webrtc`. Both read the same `~/.agent-yes/pids.jsonl` and relay to
+the same agent FIFOs, so the only variable is the serve implementation.
+
+Measured 2026-08-01 on the primary dev host (v1.251.0), with the TS serve at its
+real ~40% CPU (the live daemon this session runs under) — i.e. an *under-load*
+comparison, the condition where console jank is actually felt.
+
+## Results
+
+### Open-time — cold WebRTC connect + first relayed request (5 interleaved trials)
+
+| daemon | median | range |
+| --- | --- | --- |
+| TS `ay serve` (bun) | **1466 ms** | 1274–2525 ms (fat tail) |
+| Rust `ayrs serve` | **357 ms** | 339–467 ms (tight) |
+
+→ **ayrs ~4.1× faster to open**, with far lower variance.
+
+### Warm request latency — 30 interleaved `/api/ls` calls on each daemon's localhost HTTP endpoint
+
+Isolates the daemon's request-handling (localhost connect is common-mode ~0 and
+cancels). Both authenticate with the shared `~/.agent-yes/.serve-token` bearer.
+
+| daemon | p50 | p95 | max |
+| --- | --- | --- | --- |
+| TS `ay serve` (bun) | 26.5 ms | **162.7 ms** | 174 ms |
+| Rust `ayrs serve` | **9.1 ms** | **24.3 ms** | 61 ms |
+
+→ **ayrs ~2.9× faster at p50, ~6.7× faster at p95.**
+
+### Resource cost (live)
+
+| daemon | RSS | CPU (under load) |
+| --- | --- | --- |
+| TS `ay serve` (bun) | ~250 MB | ~40% |
+| Rust `ayrs serve` | ~33 MB | ~0.3% |
+
+→ **~8× less memory**, a fraction of the CPU.
+
+## Interpretation
+
+The **p95 gap is the headline** — TS's warm-latency tail (163 ms vs 24 ms) is the
+single-JS-event-loop contention behind the console jank we chased throughout this
+work (same mechanism as the browser perf-beacon `req.end` p95 → 16 s observed
+earlier under real viewer load). The Bun daemon funnels fan-in from all agents +
+fan-out to all viewers + in-process WebRTC through one event loop; under load its
+request latency fans into a fat tail. The Rust daemon has no shared JS event loop
+to stall, so it stays tight.
+
+`ayrs` wins on **every** axis measured — open-time, p50, p95, memory, CPU — which
+makes it the clear cutover target. Retiring the TS `ay serve` is where the win
+lands (250 MB → 33 MB, and the event-loop bottleneck goes away).
+
+## Coexistence (no conflict)
+
+Running both simultaneously does **not** conflict:
+
+- **Room persistence** — `.share-room` (TS) vs `.share-room-ayrs` (Rust): different
+  files, different rooms (by design, `rs/src/serve/share.rs`).
+- **Ports** — TS binds `:7432`; `ayrs serve --webrtc` binds nothing (WebRTC-only).
+- **Pid index** — both read `pids.jsonl` read-only.
+- **Agent FIFOs** — the agent owns the single reader; both hosts are just
+  producers on `send`, same as two viewers on one host.
+
+Incremental cost of adding `ayrs` beside the TS serve: ~+33 MB, ~0% idle CPU, one
+extra (hibernating) signaling WebSocket.
+
+## Build-speed: fast dev-iteration paths
+
+The default `bun run build:rs` (`cargo install --path rs --features swarm`,
+release + full LTO) is slow to iterate on. Benchmarked incremental rebuild (touch
+one source file, rebuild the `ayrs` bin):
+
+| build | incremental | vs default |
+| --- | --- | --- |
+| default: `cargo install`, release + LTO + swarm | ~145 s | 1× |
+| `cargo build`, release, **LTO off**, swarm | ~27 s | 5.4× |
+| `cargo build`, release, LTO off, **no swarm** | ~26 s | 5.6× |
+| `cargo build`, **dev profile (opt0)**, no swarm | ~3 s | **48×** |
+
+Two independent causes, both large:
+1. **`cargo install` can't reuse the incremental cache** — it builds in a temp
+   target dir, so it rebuilds the whole graph (~110 s) even when `cargo build`
+   (which reuses `rs/target`) is ~27 s. The fast paths use `cargo build` + copy.
+2. **Full LTO dominates the rest** — it relinks the entire webrtc binary on every
+   change (145 s → 27 s just from `LTO off`). `swarm` barely affects *incremental*
+   time (its ~65 libp2p crates are already cached) but matters on clean builds;
+   `ayrs` doesn't use libp2p, so the fast paths drop it.
+
+Shipped as `scripts/build-rs.ts` flags (default build unchanged for CI/shipping):
+
+- **`bun run build:rs:fast`** — release, LTO off, ayrs-only → ~27 s. Still
+  opt-level 3, so the binary is a legit optimized console host, safe to run.
+- **`bun run build:rs:dev`** — dev profile (opt0), ayrs-only → ~3 s. Unoptimized;
+  for rapid correctness iteration, not a production host.
+
+Both `cargo build` + atomic-rename the binary over `~/.cargo/bin/ayrs` (an
+in-place copy would `ETXTBSY` when the dest is a running `ayrs serve`).
+
+Optional follow-up (not applied — changes the shipped artifact): the release
+profile could use `lto = "thin"` instead of `lto = true`. Thin LTO is much faster
+to link with ~90% of the runtime benefit, which for an I/O-bound WebRTC daemon
+(time spent in syscalls/network, not hot compute) is a negligible runtime loss
+for a large clean-build/CI speedup.
+
+## Method notes / caveats
+
+- Open-time includes the real WebRTC handshake (real-world open cost); warm
+  latency is localhost (isolates daemon request-handling). Both point the same way.
+- The browser-authentic warm tail (perf-beacon `req.end` p50/p95 over the live
+  datachannel) was not captured this round — the rechrome instrument wedged
+  mid-run. Worth re-running that slice once rechrome is recovered for a
+  fully browser-side confirmation.
+- `ayrs serve install` targets a native OS service (systemd `--user` on Linux) and
+  fails on this host: it writes the unit but `systemctl --user daemon-reload` fails
+  (no user D-Bus in this container). The **working supervision path here is oxmgr**
+  (the same manager that ran the TS `ay serve`), registered directly:
+
+  ```
+  oxmgr start "$(which ayrs) serve --webrtc" --name ayrs-serve --restart always --max-restarts 20
+  ```
+
+  No `--health-cmd`: ayrs has no serve-liveness heartbeat, and unlike the Bun
+  daemon (which could freeze its JS event loop while alive → needed the
+  healthcheck-restart) the Rust host has no such "alive-but-wedged" failure mode,
+  so restart-on-crash suffices. Verified: SIGKILL → oxmgr respawns cleanly, old PID
+  reaped (the oxmgr *daemon* reaps its children), host-lock + room preserved.
+
+  Gotcha: if you kill a *standalone* (non-oxmgr) ayrs, its parent may be the PID-1
+  oxmgr-runtime, which does NOT reap → the process lingers as a `<defunct>` zombie.
+  ayrs's two-hosts-in-one-room guard reads `~/.agent-yes/.share-host-<room>.pid` and
+  does `kill -0` on it — which returns "alive" for a zombie — so a fresh start then
+  falsely refuses with "another ayrs host is already serving." Fix: `rm` the stale
+  `.share-host-<room>.pid` and restart. (Under oxmgr this doesn't happen — the
+  daemon reaps its own children.)

--- a/package.json
+++ b/package.json
@@ -114,6 +114,8 @@
     "build:rgui": "bun scripts/build-rgui.ts",
     "dev:rgui": "bun lab/ui/rgui/dev.ts",
     "build:rs": "bun ./scripts/build-rs.ts",
+    "build:rs:fast": "bun ./scripts/build-rs.ts --fast",
+    "build:rs:dev": "bun ./scripts/build-rs.ts --dev",
     "postbuild": "bun ./ts/postbuild.ts",
     "demo": "bun run build && bun link && claude-yes -- demo",
     "dev": "bun ts/index.ts",

--- a/rs/src/serve/service.rs
+++ b/rs/src/serve/service.rs
@@ -1,15 +1,19 @@
 // Native OS-level service install for `ayrs serve`.
 //
-// Deliberately does NOT go through oxmgr/pm2 the way the TS `ay serve install`
-// does: the whole point of the Rust daemon is to have no Node/Bun process in
-// the tree, so we talk to the platform's own supervisor directly.
+// Prefers the platform's own supervisor so the *ayrs* daemon tree stays pure
+// Rust (no Node/Bun), the whole point of the Rust daemon:
 //
 //   macOS  -> launchd user agent  ~/Library/LaunchAgents/<LABEL>.plist
 //   Linux  -> systemd user unit   ~/.config/systemd/user/<LABEL>.service
 //
-// The label is distinct from anything the TS daemon registers (oxmgr owns
-// `io.oxmgr.daemon`), so both can be installed at the same time during the
-// migration.
+// Fallback: on Linux WITHOUT a usable systemd `--user` bus (e.g. a container),
+// register with oxmgr instead of failing (see the oxmgr block below). oxmgr is a
+// separate supervisor process — the ayrs process it runs is still pure Rust — so
+// the "no Node/Bun in ayrs" invariant holds. This mirrors how the TS `ay serve`
+// is managed on such hosts.
+//
+// The systemd/launchd label is distinct from the oxmgr name the TS daemon
+// registers (`agent-yes`), so both can be installed at once during migration.
 
 use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
@@ -147,6 +151,83 @@ fn run(cmd: &str, args: &[&str]) -> Result<String> {
     Ok(s)
 }
 
+// --- oxmgr fallback -------------------------------------------------------
+// On Linux WITHOUT a systemd `--user` bus (e.g. a container: `systemctl --user`
+// fails with "Failed to connect to bus … $DBUS_SESSION_BUS_ADDRESS and
+// $XDG_RUNTIME_DIR not defined"), there is no native user supervisor to talk to.
+// Rather than fail, fall back to oxmgr — the same supervisor the TS `ay serve`
+// uses. This does NOT reintroduce a Node/Bun process into the *ayrs* daemon tree
+// (oxmgr is a separate supervisor; the process it runs is still pure-Rust ayrs).
+
+/// The oxmgr-managed process name. Matches the TS daemon's convention and stays
+/// distinct from it (`agent-yes`), so both can be registered during migration.
+const OXMGR_NAME: &str = "ayrs-serve";
+
+/// `which`-style PATH lookup for an executable (Linux fallback only).
+fn which(bin: &str) -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(bin);
+        if candidate.is_file() {
+            return Some(candidate.to_string_lossy().into_owned());
+        }
+    }
+    None
+}
+
+/// Is a usable systemd user bus present? Probe with a cheap read-only call — if
+/// the bus is unreachable this fails with the same connection error `install`
+/// would hit, so a `false` here reliably means "don't use systemd --user".
+#[cfg(target_os = "linux")]
+fn systemd_user_available() -> bool {
+    Command::new("systemctl")
+        .args(["--user", "show-environment"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// POSIX single-quote a token so oxmgr's shell-style word splitting keeps it
+/// intact (verified: oxmgr parses `'a b'` as one arg). Safe-charset tokens pass
+/// through unquoted for readability. Guards against spaces in the exe path
+/// (e.g. an unusual install dir) or a future arg.
+fn sh_quote(s: &str) -> String {
+    let safe = !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/._-+@:=".contains(&b));
+    if safe {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+/// The single command string oxmgr's `start <COMMAND>` positional expects; oxmgr
+/// splits it (shell-style) into program + args (verified: stores command=`…/ayrs`,
+/// args=[…]). Each token is shell-quoted so spaces/specials survive the split.
+fn oxmgr_command(exe: &str, args: &[String]) -> String {
+    std::iter::once(sh_quote(exe))
+        .chain(args.iter().map(|a| sh_quote(a)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Register (or re-register) `ayrs serve` under oxmgr with restart-on-crash.
+/// No `--health-cmd`: ayrs has no serve-liveness heartbeat, and unlike the Bun
+/// daemon (which could freeze its JS loop while alive) has no "alive-but-wedged"
+/// failure mode, so restart-always is sufficient supervision.
+fn oxmgr_install(oxmgr: &str, exe: &str, args: &[String]) -> Result<()> {
+    let _ = Command::new(oxmgr).args(["delete", OXMGR_NAME]).output(); // idempotent
+    let cmd = oxmgr_command(exe, args);
+    run(
+        oxmgr,
+        &[
+            "start", &cmd, "--name", OXMGR_NAME, "--restart", "always", "--max-restarts", "20",
+        ],
+    )?;
+    Ok(())
+}
+
 pub fn install(webrtc: &Option<String>, sighost: &str) -> Result<()> {
     let path = unit_path()?;
     let exe = exe()?;
@@ -156,23 +237,31 @@ pub fn install(webrtc: &Option<String>, sighost: &str) -> Result<()> {
     let out_log = dir.join("ayrs-serve.log");
     let err_log = dir.join("ayrs-serve.err.log");
 
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let body = render_unit(
         &exe,
         &args,
         &out_log.to_string_lossy(),
         &err_log.to_string_lossy(),
     );
-    // Reinstalling over a loaded unit: unload first so the new definition
-    // actually takes effect instead of silently keeping the old one running.
-    let _ = uninstall_quiet();
-    std::fs::write(&path, body)?;
-    println!("wrote {}", path.display());
+
+    // Write the native unit + load it. Factored into a closure so the Linux
+    // branch can choose it OR the oxmgr fallback without writing a stray unit
+    // file when systemd isn't usable.
+    let write_native_unit = || -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // Reinstalling over a loaded unit: unload first so the new definition
+        // actually takes effect instead of silently keeping the old one running.
+        let _ = uninstall_quiet();
+        std::fs::write(&path, &body)?;
+        println!("wrote {}", path.display());
+        Ok(())
+    };
 
     #[cfg(target_os = "macos")]
     {
+        write_native_unit()?;
         let uid = unsafe { libc::getuid() };
         run(
             "launchctl",
@@ -182,14 +271,33 @@ pub fn install(webrtc: &Option<String>, sighost: &str) -> Result<()> {
             "launchctl",
             &["kickstart", "-k", &format!("gui/{uid}/{LABEL}")],
         )?;
+        println!("installed {LABEL} ({exe} {})", args.join(" "));
     }
     #[cfg(target_os = "linux")]
     {
-        run("systemctl", &["--user", "daemon-reload"])?;
-        run("systemctl", &["--user", "enable", "--now", LABEL])?;
+        if systemd_user_available() {
+            write_native_unit()?;
+            run("systemctl", &["--user", "daemon-reload"])?;
+            run("systemctl", &["--user", "enable", "--now", LABEL])?;
+            println!("installed {LABEL} ({exe} {})", args.join(" "));
+        } else if let Some(oxmgr) = which("oxmgr") {
+            // No systemd --user bus (typically a container). Supervise via oxmgr
+            // instead of writing an inert unit that never loads. Also clear any
+            // stray unit a prior systemd attempt may have left behind.
+            let _ = std::fs::remove_file(&path);
+            oxmgr_install(&oxmgr, &exe, &args)?;
+            println!("no systemd --user bus — registered with oxmgr as '{OXMGR_NAME}'");
+            println!("installed {OXMGR_NAME} ({exe} {})", args.join(" "));
+        } else {
+            bail!(
+                "no systemd --user bus and no oxmgr on PATH.\n  \
+                 Install oxmgr (bun add -g oxmgr) or run this yourself under a supervisor:\n    \
+                 {exe} {}",
+                args.join(" ")
+            );
+        }
     }
 
-    println!("installed {LABEL} ({exe} {})", args.join(" "));
     println!("webrtc: {webrtc_url}");
     println!("console: {browser_url}");
     println!("logs: {}", out_log.display());
@@ -209,6 +317,11 @@ fn uninstall_quiet() -> Result<()> {
         let _ = Command::new("systemctl")
             .args(["--user", "disable", "--now", LABEL])
             .output();
+        // Also drop the oxmgr fallback registration, if any (harmless no-op when
+        // absent). Covers the container path where install() used oxmgr.
+        if let Some(oxmgr) = which("oxmgr") {
+            let _ = Command::new(oxmgr).args(["delete", OXMGR_NAME]).output();
+        }
     }
     Ok(())
 }
@@ -220,7 +333,7 @@ pub fn uninstall() -> Result<()> {
         std::fs::remove_file(&path)?;
         println!("removed {}", path.display());
     } else {
-        println!("{LABEL} was not installed");
+        println!("{LABEL} uninstalled (or was not installed)");
     }
     Ok(())
 }
@@ -252,11 +365,27 @@ pub fn status() -> Result<()> {
     }
     #[cfg(target_os = "linux")]
     {
-        let s = Command::new("systemctl")
-            .args(["--user", "status", LABEL])
-            .output();
-        if let Ok(o) = s {
-            print!("{}", String::from_utf8_lossy(&o.stdout));
+        if systemd_user_available() {
+            let s = Command::new("systemctl")
+                .args(["--user", "status", LABEL])
+                .output();
+            if let Ok(o) = s {
+                print!("{}", String::from_utf8_lossy(&o.stdout));
+            }
+        } else if let Some(oxmgr) = which("oxmgr") {
+            // Report the oxmgr fallback registration (the container path).
+            println!("supervisor: oxmgr (no systemd --user bus)");
+            let s = Command::new(oxmgr).args(["list"]).output();
+            if let Ok(o) = s {
+                let out = String::from_utf8_lossy(&o.stdout);
+                for line in out.lines() {
+                    if line.contains("NAME") || line.contains(OXMGR_NAME) {
+                        println!("{line}");
+                    }
+                }
+            }
+        } else {
+            println!("state = no supervisor (no systemd --user bus, no oxmgr)");
         }
     }
     Ok(())
@@ -272,6 +401,30 @@ mod tests {
             service_args(&Some(String::new()), "s.agent-yes.com"),
             vec!["serve", "--webrtc", "--sighost", "s.agent-yes.com"]
         );
+    }
+
+    #[test]
+    fn oxmgr_command_joins_exe_and_args() {
+        // oxmgr's `start <COMMAND>` positional takes one string it splits itself.
+        let cmd = oxmgr_command(
+            "/root/.cargo/bin/ayrs",
+            &service_args(&Some(String::new()), "s.agent-yes.com"),
+        );
+        assert_eq!(
+            cmd,
+            "/root/.cargo/bin/ayrs serve --webrtc --sighost s.agent-yes.com"
+        );
+    }
+
+    #[test]
+    fn oxmgr_command_quotes_spaces_and_specials() {
+        // A path with a space must survive oxmgr's shell-style split as ONE token.
+        let cmd = oxmgr_command("/home/a b/ayrs", &["serve".into(), "--webrtc".into()]);
+        assert_eq!(cmd, "'/home/a b/ayrs' serve --webrtc");
+        // embedded single quote → POSIX close/escape/reopen
+        assert_eq!(sh_quote("a'b"), "'a'\\''b'");
+        // safe tokens (incl. the room-URL charset) pass through unquoted
+        assert_eq!(sh_quote("webrtc://r1:e1.ab@s.agent-yes.com"), "webrtc://r1:e1.ab@s.agent-yes.com");
     }
 
     #[test]

--- a/scripts/build-rs.ts
+++ b/scripts/build-rs.ts
@@ -11,7 +11,7 @@
 // On macOS/Linux a running binary can be replaced directly, so this is a no-op
 // there and we just run cargo.
 import { spawnSync } from "child_process";
-import { existsSync, readdirSync, renameSync, rmSync } from "fs";
+import { copyFileSync, existsSync, readdirSync, renameSync, rmSync } from "fs";
 import os from "os";
 import path from "path";
 
@@ -22,7 +22,7 @@ const cargoHome = process.env.CARGO_HOME || path.join(os.homedir(), ".cargo");
 // each [[bin]] in the package. Any of these can be locked by a live process,
 // and cargo install refuses to overwrite an existing installed binary (even
 // with --force it can't delete a locked one), so each must be moved aside.
-const exeNames = ["agent-yes.exe", "ay-spawn-hidden.exe"];
+const exeNames = ["agent-yes.exe", "ay-spawn-hidden.exe", "ayrs.exe"];
 const targets = exeNames.flatMap((exe) => [
   path.join(repoRoot, "rs", "target", "release", exe),
   path.join(cargoHome, "bin", exe),
@@ -69,14 +69,11 @@ function moveLockedBinariesAside(): Array<{ original: string; aside: string }> {
 
 const moved = process.platform === "win32" ? moveLockedBinariesAside() : [];
 
-const args = ["install", "--path", "rs", "--features", "swarm", ...process.argv.slice(2)];
-console.log(`[build-rs] cargo ${args.join(" ")}`);
-const result = spawnSync("cargo", args, { cwd: repoRoot, stdio: "inherit" });
-
-// On failure cargo never wrote the fresh originals, so restore anything we
-// moved aside — otherwise a build error would leave agent-yes.exe missing
-// from PATH until the next successful build.
-if (result.status !== 0) {
+// On a failed build cargo never wrote the fresh originals, so restore anything
+// moveLockedBinariesAside() set aside — otherwise a build error leaves the .exe
+// missing from PATH until the next successful build. Shared by both the default
+// and the fast/dev paths.
+function restoreMoved(): void {
   for (const { original, aside } of moved) {
     if (!existsSync(original) && existsSync(aside)) {
       try {
@@ -88,5 +85,66 @@ if (result.status !== 0) {
     }
   }
 }
+
+// Dev-iteration fast paths. The default full build (release + full LTO +
+// --features swarm) takes ~145s incremental — dominated by LTO relinking the
+// whole webrtc binary every change (benchmarked; see docs/serve-rust-vs-ts-
+// benchmark.md). These flags trade shipped-binary optimization for build speed:
+//
+//   --fast   ayrs-only, no swarm, LTO OFF  →  ~26s (5.6x). Still opt-level 3, so
+//            the binary is a legit optimized console host — safe to actually run.
+//   --dev    ayrs-only, no swarm, dev profile (opt0)  →  ~3s (48x). Unoptimized;
+//            for rapid correctness iteration, NOT for a production host.
+//
+// Both build ONLY the `ayrs` bin (skips the ~65-crate libp2p tree that only the
+// `agent-yes` P2P binary needs). CI / shipping uses the flagless full build.
+const rawArgs = process.argv.slice(2);
+const fast = rawArgs.includes("--fast");
+const dev = rawArgs.includes("--dev");
+const passthrough = rawArgs.filter((a) => a !== "--fast" && a !== "--dev");
+
+// Fast dev paths use `cargo build` + copy, NOT `cargo install`: install builds in
+// a temp target dir and can't reuse the rs/target incremental cache, so it rebuilds
+// the whole graph (~110s) even when `cargo build` reuses the cache (~27s / ~3s).
+if (fast || dev) {
+  const env = { ...process.env } as Record<string, string>;
+  // --manifest-path (not just --path like `cargo install`) so `cargo build` finds
+  // the crate while cwd stays at repoRoot for the copy paths below.
+  const buildArgs = ["build", "--manifest-path", path.join("rs", "Cargo.toml"), "--bin", "ayrs"]; // no swarm (ayrs doesn't use libp2p)
+  if (!dev) {
+    buildArgs.push("--release");
+    env.CARGO_PROFILE_RELEASE_LTO = "false"; // the dominant incremental cost
+  }
+  buildArgs.push(...passthrough);
+  console.log(
+    `[build-rs] FAST dev build (${dev ? "dev/opt0" : "release/no-LTO"}, ayrs only, no swarm): cargo ${buildArgs.join(" ")}`,
+  );
+  const build = spawnSync("cargo", buildArgs, { cwd: repoRoot, stdio: "inherit", env });
+  if (build.status === 0) {
+    const exe = process.platform === "win32" ? "ayrs.exe" : "ayrs";
+    const built = path.join(repoRoot, "rs", "target", dev ? "debug" : "release", exe);
+    const dest = path.join(cargoHome, "bin", exe); // moveLockedBinariesAside already freed a locked dest on Windows
+    // Copy to a temp name then rename over the dest: an in-place copy fails with
+    // ETXTBSY when the dest binary is currently executing (e.g. `ayrs serve`
+    // running under oxmgr), but an atomic rename replaces the name while the live
+    // process keeps its old inode — the same trick `cargo install` uses.
+    const tmp = `${dest}.new-${process.pid}`;
+    copyFileSync(built, tmp);
+    renameSync(tmp, dest);
+    console.log(`[build-rs] installed ${dest}`);
+    console.log(`[build-rs] NOTE: dev build — run \`bun run build:rs\` for the fully-optimized shipped binary`);
+  } else {
+    // Build failed and cargo never wrote a fresh binary — restore anything the
+    // Windows lock-aside moved, else ayrs.exe would be missing from PATH.
+    restoreMoved();
+  }
+  process.exit(build.status ?? 1);
+}
+
+const args = ["install", "--path", "rs", "--features", "swarm", ...passthrough];
+console.log(`[build-rs] cargo ${args.join(" ")}`);
+const result = spawnSync("cargo", args, { cwd: repoRoot, stdio: "inherit" });
+
+if (result.status !== 0) restoreMoved();
 
 process.exit(result.status ?? 1);


### PR DESCRIPTION
Two independent ayrs dev-workflow improvements (2 commits).

## 1. `ayrs serve install` falls back to oxmgr when systemd --user is unavailable
`ayrs serve install` hardcoded systemd `--user`, so it failed in containers with no user D-Bus (the `systemctl --user daemon-reload` "Failed to connect to bus" error — hit it repeatedly on this host). Now it probes `systemctl --user show-environment`; if the bus answers it uses systemd as before, otherwise it registers `ayrs serve --webrtc` under **oxmgr** (`--restart always`, the same supervisor the TS `ay serve` uses) — no inert unit left behind. `uninstall`/`status` handle the oxmgr registration too. The "no Node/Bun in the ayrs tree" invariant holds (oxmgr is a separate supervisor; the process it runs is pure-Rust ayrs).

**Verified:** `ayrs serve install` → exit 0, registered + running under oxmgr; SIGKILL → clean respawn.

## 2. Fast dev-build paths (`build:rs --fast` / `--dev`)
Default `build:rs` incremental ≈ **145s**. Benchmarked (touch one file, rebuild ayrs):

| build | time | |
|---|---|---|
| default (`cargo install`, release+LTO+swarm) | 145s | 1× |
| release, **LTO off**, no swarm (`--fast`) | 27s | **5.6×** |
| dev profile opt0, no swarm (`--dev`) | 3s | **48×** |

Two causes, both large: `cargo install` can't reuse the `rs/target` cache (temp dir → rebuilds the graph); full LTO relinks the whole webrtc binary every change. Fast paths use `cargo build` + atomic-rename (avoids ETXTBSY on a running `ayrs serve`), ayrs-only (skips the ~65-crate libp2p tree). Default build unchanged for CI/shipping.

## Codex review (round 1) — both fixed
- oxmgr command now shell-quotes each argv token (survives spaces in the exe path).
- Windows fast-build restores lock-aside binaries on failure; `ayrs.exe` added to the aside set.

## Tests
5 Rust `serve::service` tests pass (incl. new quoting test); both fast paths verified to hit their times and install a working binary; `ayrs serve install` verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)