### PR TITLE
perf(build): release profile uses thin LTO (145s → 72s)

### DIFF
--- a/docs/serve-rust-vs-ts-benchmark.md
+++ b/docs/serve-rust-vs-ts-benchmark.md
@@ -102,11 +102,11 @@ Shipped as `scripts/build-rs.ts` flags (default build unchanged for CI/shipping)
 Both `cargo build` + atomic-rename the binary over `~/.cargo/bin/ayrs` (an
 in-place copy would `ETXTBSY` when the dest is a running `ayrs serve`).
 
-Optional follow-up (not applied — changes the shipped artifact): the release
-profile could use `lto = "thin"` instead of `lto = true`. Thin LTO is much faster
-to link with ~90% of the runtime benefit, which for an I/O-bound WebRTC daemon
-(time spent in syscalls/network, not hot compute) is a negligible runtime loss
-for a large clean-build/CI speedup.
+Applied to the release profile: `lto = "thin"` (was `lto = true` / fat LTO). Thin
+LTO links far faster with ~90% of the runtime benefit — negligible for an
+I/O-bound WebRTC daemon (time in syscalls/network, not hot compute). Measured: the
+release+swarm incremental build dropped from **145s → 72s (2×)**, and this also
+speeds up every clean/CI build.
 
 ## Method notes / caveats
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -134,7 +134,12 @@ predicates = "3"
 
 [profile.release]
 opt-level = 3
-lto = true
+# Thin LTO (was `true` = fat LTO). Fat LTO relinks the whole webrtc/libp2p binary
+# on every build (~145s incremental — benchmarked, see
+# docs/serve-rust-vs-ts-benchmark.md); thin LTO links far faster with ~90% of the
+# runtime benefit, and for these I/O-bound daemons (time in syscalls/network, not
+# hot compute) the runtime loss is negligible while clean/CI builds speed up a lot.
+lto = "thin"
 strip = true
 
 # Register cfg names we set ourselves so the unexpected_cfgs lint (Rust 1.80+)


### PR DESCRIPTION
Applies the thin-LTO follow-up from #350.

Fat LTO (`lto = true`) relinks the entire webrtc/libp2p binary on every build. Thin LTO links far faster with ~90% of the runtime benefit — negligible for an I/O-bound WebRTC daemon (time in syscalls/network, not hot compute).

**Measured:** release + swarm incremental build **145s → 72s (2×)**; clean/CI builds benefit too. Binary verified working (`ayrs --version`).

Complements the `build:rs --fast/--dev` dev-iteration paths from #350; this one speeds up the default/CI/shipped build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)