### PR TITLE
feat(ay console): agent row right-click opens the full ⋯ menu, not just pin

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1939,6 +1939,9 @@
         overflow: hidden;
         text-overflow: ellipsis;
       }
+      .ctxmenu-item.danger {
+        color: var(--red, #f85149);
+      }
       .ctxmenu-sep {
         height: 1px;
         margin: 4px 6px;
@@ -4875,6 +4878,7 @@ my.translate = async (text, lang) => {
           it.className = "ctxmenu-item";
           it.textContent = label;
           it.setAttribute("role", "menuitem");
+          if (opts && opts.danger) it.classList.add("danger");
           if (opts && opts.hint) {
             const h = document.createElement("span");
             h.className = "ctxmenu-hint";
@@ -4989,17 +4993,35 @@ my.translate = async (text, lang) => {
 
         openCtxMenu(menu, ev);
       }
-      // Right-click menu for a left-panel agent row: pin/unpin to the top of the
-      // list (a pin also surfaces the agent in /r/'s screen-fixed palette).
+      // Right-click menu for a left-panel agent row. Same agent actions as the
+      // terminal header's ⋯ overflow menu (share / stop / restart / force-kill),
+      // but bound to the RIGHT-CLICKED row rather than the selected agent — so you
+      // can act on an agent without switching to it first. Plus pin/unpin to the
+      // top of the list (a pin also surfaces the agent in /r/'s screen-fixed
+      // palette). View prefs (font size, perf HUD) stay in the ⋯ menu: they're
+      // properties of the terminal pane, not of an agent.
       function showAgentMenu(ev, key) {
         ev.preventDefault();
         hideTermMenu();
         const e = entries.find((x) => x._key === key);
         if (!e) return;
-        const { menu, addItem } = ctxMenuShell();
+        const { menu, addItem, addSep } = ctxMenuShell();
         const name = cliLabel(e) || ident(e) || "pid " + e.pid;
-        if (isPinned(key)) addItem("Unpin “" + name + "”", { hint: "📌" }, () => togglePin(key));
-        else addItem("Pin “" + name + "” to top", { hint: "📌" }, () => togglePin(key));
+        addItem(name, { disabled: true, hint: "pid " + e.pid }, () => {});
+        addSep();
+        if (isPinned(key)) addItem("Unpin from top", { hint: "📌" }, () => togglePin(key));
+        else addItem("Pin to top", { hint: "📌" }, () => togglePin(key));
+        // A shared read-only view can't re-share or steer its host's agent —
+        // mirrors the .app.steer-agent rule that hides these in the ⋯ menu.
+        if (!isReadonlyEnt(e) && !sharePermOf(e)) {
+          addSep();
+          addItem("👁 Share (view-only)", {}, () => shareAgent("r", e));
+          addItem("✏️ Share (read-write)…", {}, () => shareAgent("rw", e));
+          addSep();
+          addItem("⏹ Stop agent", {}, () => stopAgent(false, e));
+          addItem("↻ Restart (resume)", {}, () => restartAgent(e));
+          addItem("✕ Force-kill (SIGKILL)", { danger: true }, () => stopAgent(true, e));
+        }
         openCtxMenu(menu, ev);
       }
       // Lightweight editor: overlay + textarea of `Label | template` lines. Save

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -322,6 +322,46 @@ describe("console DOM behaviour", () => {
     }
   });
 
+  it("right-clicking a row opens the full agent menu, acting on THAT row", async () => {
+    // The row menu used to offer only "Pin to top"; it now mirrors the terminal
+    // header's ⋯ menu (share / stop / restart / force-kill) — bound to the
+    // right-clicked agent, not the selected one.
+    const { ctx, page } = await openConsole(browser, url);
+    const posts: { path: string; body: any }[] = [];
+    page.on("request", (r) => {
+      const u = new URL(r.url());
+      if (r.method() === "POST" && u.pathname === "/api/kill") {
+        try {
+          posts.push({ path: u.pathname, body: r.postDataJSON() });
+        } catch {}
+      }
+    });
+    page.on("dialog", (d) => d.accept());
+    try {
+      // Open 101, then right-click a DIFFERENT row (102).
+      await page.click('.list .row[data-key="local#101"]');
+      await expect.poll(() => page.locator(".row.sel").getAttribute("data-key")).toBe("local#101");
+      await page.click('.list .row[data-key="local#102"]', { button: "right" });
+      await expect.poll(() => page.locator(".ctxmenu").isVisible()).toBe(true);
+      const items = (await page.locator(".ctxmenu").innerText()).toLowerCase();
+      expect(items).toContain("pin to top");
+      expect(items).toContain("share (view-only)");
+      expect(items).toContain("share (read-write)");
+      expect(items).toContain("stop agent");
+      expect(items).toContain("restart");
+      expect(items).toContain("force-kill");
+
+      // Force-kill targets 102 (the right-clicked row), not the open 101.
+      await page.locator(".ctxmenu-item", { hasText: "Force-kill" }).click();
+      await expect.poll(() => posts.length).toBe(1);
+      expect(posts[0].body.keyword).toBe("102");
+      // The selection never moved.
+      expect(await page.locator(".row.sel").getAttribute("data-key")).toBe("local#101");
+    } finally {
+      await ctx.close();
+    }
+  });
+
   it("Cmd+K /filter sets and clears the left panel filter box", async () => {
     const { ctx, page } = await openConsole(browser, url);
     try {


### PR DESCRIPTION
Right-clicking an agent row in the left panel showed only **Pin to top**. Every real action (share / stop / restart / force-kill) lived in the terminal header's `⋯` menu, which acts on the *selected* agent — so acting on another agent meant switching to it first.

## Change
- The row context menu now mirrors the `⋯` menu, bound to the **right-clicked** row: 👁 Share (view-only), ✏️ Share (read-write), ⏹ Stop, ↻ Restart, ✕ Force-kill — plus Pin/Unpin and a disabled header line (name + pid).
- Font size / Perf HUD stay in the `⋯` menu: they're terminal-pane view prefs, not agent actions.
- Shared read-only views hide the actions, mirroring the existing `.app.steer-agent` CSS rule.
- New `danger` option on `ctxMenuShell().addItem` for the force-kill entry.

## Test
New ui-dom regression: open agent 101, right-click row 102, assert the full item set, click Force-kill → `POST /api/kill {keyword:"102"}` and the selection stays on 101. Full ui-dom suite green (25/25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)