### PR TITLE
fix(ayrs): numeric keyword is an identity selector — stop widget stdin/tail misroute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,16 @@
 # agent-yes
 
+## No real fleet data in committed artifacts
+
+This repo is public. Tests, fixtures, code comments, help examples, docs, and
+PR bodies must use **synthetic data only** — never copy real values from the
+operator's live fleet or terminals. That includes: real pids and agent ids,
+real cwd/worktree paths, org/repo/product names of private downstream
+projects, people's names, prompts, and terminal transcripts. Use neutral
+stand-ins instead (`pid 1111`, `/repo/alpha`, `/x/acme/acme/tree/...`,
+`"alice"`). When a regression came from a live incident, describe the
+*mechanism* generically; keep the concrete details out of the commit.
+
 ## Scratch / debug / temp scripts → `./tmp/`
 
 Put throwaway debug, probe, capture, and scratch scripts (and their output —

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -80,7 +80,7 @@ so config lives per host, never synced between peers.
   "provisionAllowlist": ["snomiao"],
   // koho-style: pick the account per owner, then allow (exit 0). This REPLACES
   // provisionAllowlist as the gate — a non-zero exit denies the provision.
-  "provisionHook": "case \"$KOHO_OWNER\" in symval) gh auth switch --user snomiao;; snomiao) gh auth switch --user snomiao;; *) echo \"unknown owner $KOHO_OWNER\"; exit 1;; esac",
+  "provisionHook": "case \"$KOHO_OWNER\" in acme) gh auth switch --user snomiao;; snomiao) gh auth switch --user snomiao;; *) echo \"unknown owner $KOHO_OWNER\"; exit 1;; esac",
 }
 ```
 

--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -556,8 +556,23 @@ fn matches_keyword(r: &PidRecord, kw: &str) -> bool {
     if kw.is_empty() {
         return true;
     }
-    if r.pid.to_string() == kw {
-        return true;
+    // A purely-numeric keyword is an IDENTITY selector — exact pid, or an
+    // agent_id prefix (ids are 12 random hex, so they can be all-digits). Never
+    // fall through to the cwd/cli/prompt substring rules: a pid frequently
+    // appears inside OTHER agents' prompts (a resume prompt listing peer pids,
+    // a shared `/w/#room:<pid>` URL), and a newer such record would win the
+    // newest-first tiebreak in resolve_one — sending the console's tail/stdin
+    // for `#room:<pid>` to a sibling's terminal. Mirrors ts/subcommands.ts
+    // matchKeyword (fix #72), which never reached this Rust port.
+    if kw.chars().all(|c| c.is_ascii_digit()) {
+        if r.pid.to_string() == kw {
+            return true;
+        }
+        return r
+            .agent_id
+            .as_deref()
+            .map(|id| id.starts_with(&kw.to_ascii_lowercase()))
+            .unwrap_or(false);
     }
     if let Some(id) = &r.agent_id {
         if id.starts_with(&kw.to_ascii_lowercase()) {
@@ -573,6 +588,15 @@ fn matches_keyword(r: &PidRecord, kw: &str) -> bool {
 fn resolve_one(kw: &str) -> Result<PidRecord, String> {
     let mut recs: Vec<PidRecord> = read_records().into_iter().filter(|r| matches_keyword(r, kw)).collect();
     recs.sort_by_key(|r| -r.started_at);
+    // Exact identity beats everything: when the keyword IS a record's pid, that
+    // record wins even if an all-digit agent_id prefix also matched (parity with
+    // ts/subcommands.ts resolveOne).
+    if kw.chars().all(|c| c.is_ascii_digit()) {
+        let by_pid: Vec<&PidRecord> = recs.iter().filter(|r| r.pid.to_string() == kw).collect();
+        if by_pid.len() == 1 {
+            return Ok(by_pid[0].clone());
+        }
+    }
     // prefer a living agent over exited ones
     if let Some(r) = recs.iter().find(|r| r.status != "exited" && is_process_alive(r.pid)) {
         return Ok(r.clone());
@@ -1239,6 +1263,40 @@ mod tests {
         let braille = vec!["⠋ Working on it".to_string()];
         assert_eq!(parse_status_text(&braille).as_deref(), Some("⠋ Working on it"));
         assert_eq!(parse_status_text(&["plain text".to_string()]), None);
+    }
+
+    #[test]
+    fn numeric_keyword_is_identity_not_substring() {
+        // Regression: after a fleet restore, one agent's resume prompt listed a
+        // peer's pid. That record was newer, so `/w/#room:<pid>` tail+stdin
+        // resolved to the wrong terminal while the pane header showed the
+        // requested pid.
+        let rec = |j: serde_json::Value| -> PidRecord { serde_json::from_value(j).unwrap() };
+        let target = rec(json!({
+            "pid": 1111, "cli": "claude", "cwd": "/repo/alpha",
+            "prompt": "resume your lane",
+            "log_file": null, "status": "active", "exit_code": null,
+            "exit_reason": null, "started_at": 1_000, "agent_id": "aaaa0000bbbb"
+        }));
+        let peer = rec(json!({
+            "pid": 2222, "cli": "claude", "cwd": "/repo/beta",
+            "prompt": "peers respawned: alpha 1111, gamma 3333",
+            "log_file": null, "status": "active", "exit_code": null,
+            "exit_reason": null, "started_at": 2_000, "agent_id": "cccc0000dddd"
+        }));
+        // pid match stays exact; the pid inside another agent's prompt no longer matches
+        assert!(matches_keyword(&target, "1111"));
+        assert!(!matches_keyword(&peer, "1111"));
+        // numeric keyword still reaches an all-digit agent_id prefix
+        let digits = rec(json!({
+            "pid": 42, "cli": "claude", "cwd": "/x", "prompt": null,
+            "log_file": null, "status": "active", "exit_code": null,
+            "exit_reason": null, "started_at": 3_000, "agent_id": "111134abcdef"
+        }));
+        assert!(matches_keyword(&digits, "1111"));
+        // non-numeric keywords keep the substring rules
+        assert!(matches_keyword(&peer, "repo/beta"));
+        assert!(matches_keyword(&peer, "gamma"));
     }
 
     #[test]

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -79,9 +79,9 @@ describe("repoBranch", () => {
   it("surfaces a submodule leaf below the worktree as `sub`", () => {
     // cwd inside a submodule keeps the superproject's owner/repo/branch (git
     // resolves it that way) but exposes the submodule dir so it's distinguishable.
-    expect(repoBranch(agent({ cwd: "/x/symval/symval/tree/share/lib/bot" }))).toEqual({
-      owner: "symval",
-      repo: "symval",
+    expect(repoBranch(agent({ cwd: "/x/acme/acme/tree/share/lib/bot" }))).toEqual({
+      owner: "acme",
+      repo: "acme",
       branch: "share",
       sub: "bot",
     });
@@ -192,8 +192,8 @@ describe("compactIdent (omit-if-uniform, separators kept)", () => {
   });
   it("appends a submodule leaf with → when the cwd is nested", () => {
     const list = [
-      agent({ cwd: "/x/symval/symval/tree/share/lib/bot" }),
-      agent({ cwd: "/x/symval/symval/tree/share/lib/api" }),
+      agent({ cwd: "/x/acme/acme/tree/share/lib/bot" }),
+      agent({ cwd: "/x/acme/acme/tree/share/lib/api" }),
     ];
     const ctx = identContext(list);
     // owner/repo/branch uniform → blanked; only the submodule leaf differs.
@@ -204,11 +204,11 @@ describe("compactIdent (omit-if-uniform, separators kept)", () => {
 
 describe("compactIdent (parent-relative omission in a tree)", () => {
   it("omits fields a subagent shares with its tree parent, keeping the submodule delta", () => {
-    const parent = agent({ cwd: "/x/symval/symval/tree/share" });
+    const parent = agent({ cwd: "/x/acme/acme/tree/share" });
     const list = [
       parent,
-      agent({ cwd: "/x/symval/symval/tree/share/lib/bot" }),
-      agent({ cwd: "/x/symval/symval/tree/syn" }),
+      agent({ cwd: "/x/acme/acme/tree/share/lib/bot" }),
+      agent({ cwd: "/x/acme/acme/tree/syn" }),
     ];
     const ctx = identContext(list);
     // Same owner/repo/branch as the parent → blanked; only →bot remains.
@@ -218,8 +218,8 @@ describe("compactIdent (parent-relative omission in a tree)", () => {
     expect(compactIdent(list[2], ctx, 3, parent)).toBe("//syn");
   });
   it("hides the identity entirely for a subagent in the very same checkout", () => {
-    const parent = agent({ cwd: "/x/symval/symval/tree/share" });
-    const child = agent({ cwd: "/x/symval/symval/tree/share" });
+    const parent = agent({ cwd: "/x/acme/acme/tree/share" });
+    const child = agent({ cwd: "/x/acme/acme/tree/share" });
     const ctx = identContext([parent, child, agent()]);
     const id = compactIdent(child, ctx, 3, parent);
     expect(id).toBe("//");
@@ -229,12 +229,12 @@ describe("compactIdent (parent-relative omission in a tree)", () => {
 
 describe("layeredRows parentEntry", () => {
   it("links a subagent row to its superagent's entry, null for roots/headers", () => {
-    const root = agent({ pid: 1, wrapper_pid: 1, cwd: "/x/symval/symval/tree/share" });
+    const root = agent({ pid: 1, wrapper_pid: 1, cwd: "/x/acme/acme/tree/share" });
     const child = agent({
       pid: 2,
       wrapper_pid: 2,
       parent_pid: 1,
-      cwd: "/x/symval/symval/tree/share/lib/bot",
+      cwd: "/x/acme/acme/tree/share/lib/bot",
     });
     const rows = layeredRows([root, child]);
     const rootRow = rows.find((r) => r.entry?.pid === 1);

--- a/ts/askApi.spec.ts
+++ b/ts/askApi.spec.ts
@@ -41,18 +41,18 @@ describe("askApi", () => {
     const choice = await s.create({ summary: "pick a channel", kind: "decision" });
     await s.setBlock(choice._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "canary or beta?",
       options: ["canary", "beta"],
     });
     const action = await s.create({ summary: "finish oauth", kind: "human" });
     await s.setBlock(action._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       actionLink: "https://example/oauth",
     });
     const bare = await s.create({ summary: "just fyi", kind: "human" });
-    await s.setBlock(bare._id, { type: "blocked-by-human", who: "taku" });
+    await s.setBlock(bare._id, { type: "blocked-by-human", who: "alice" });
     const notHuman = await s.create({ summary: "not an ask", kind: "code" });
     await s.setBlock(notHuman._id, { type: "blocked-by-external", signal: "ci" });
     const unblocked = await s.create({ summary: "no block at all", kind: "code" });
@@ -74,7 +74,7 @@ describe("askApi", () => {
   it("listAsks aggregates across multiple project roots, skipping ones with no store at all", async () => {
     const sA = await openStore(ROOT_A);
     const tA = await sA.create({ summary: "a", kind: "human" });
-    await sA.setBlock(tA._id, { type: "blocked-by-human", who: "taku" });
+    await sA.setBlock(tA._id, { type: "blocked-by-human", who: "alice" });
     const sB = await openStore(ROOT_B);
     const tB = await sB.create({ summary: "b", kind: "human" });
     await sB.setBlock(tB._id, { type: "blocked-by-human", who: "cto" });
@@ -88,7 +88,7 @@ describe("askApi", () => {
   it("listAsks isolates a per-project failure — one unreadable/broken store must not take down the whole cross-project panel (codex-review round-14 Important)", async () => {
     const sA = await openStore(ROOT_A);
     const tA = await sA.create({ summary: "healthy ask", kind: "human" });
-    await sA.setBlock(tA._id, { type: "blocked-by-human", who: "taku" });
+    await sA.setBlock(tA._id, { type: "blocked-by-human", who: "alice" });
 
     // ROOT_B's todos.jsonl is a DIRECTORY, not a file — a real, easy way to
     // force listAsksForProject(ROOT_B) to genuinely reject (EISDIR) rather
@@ -102,11 +102,11 @@ describe("askApi", () => {
   it("answerAsk on a bare acknowledge-shape ask: clears the block, advances the human kind's pending->decided gate as the asked human, then decided->done is ungated", async () => {
     const s = await openStore(ROOT_A);
     const t = await s.create({ summary: "just fyi", kind: "human" });
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice" });
     const { record: answered } = await answerAsk(ROOT_A, t._id, { acknowledged: true });
     expect(answered.block).toBeNull();
     expect(answered.state).toBe("decided"); // human-replied gate satisfied, advanced
-    expect(answered.verifyEvidence[0]).toMatchObject({ gate: "human-replied", validator: "taku" });
+    expect(answered.verifyEvidence[0]).toMatchObject({ gate: "human-replied", validator: "alice" });
   });
 
   it("answerAsk on a choice-shape ask records the choice text as evidence note, and rejects a choice not among the offered options", async () => {
@@ -114,7 +114,7 @@ describe("askApi", () => {
     const t = await s.create({ summary: "pick a channel", kind: "decision" });
     await s.setBlock(t._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       options: ["canary", "beta"],
     });
     await expect(answerAsk(ROOT_A, t._id, { choice: "stable" })).rejects.toThrow(
@@ -130,7 +130,7 @@ describe("askApi", () => {
     const t = await s.create({ summary: "x", kind: "human" });
     await s.setBlock(t._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       options: ["canary", "beta"],
       actionLink: "https://example/oauth",
     });
@@ -148,9 +148,9 @@ describe("askApi", () => {
 
   it("answerAsk leaves the task's block INTACT (not silently cleared) if the gate/transition step fails — atomicity means a failure never strands the task in limbo (codex-review round-9 Important)", async () => {
     const s = await openStore(ROOT_A);
-    const t = await s.create({ summary: "pick a channel", kind: "decision", owner: "taku" });
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku", options: ["a", "b"] });
-    // "taku" is both the task's owner AND the asked human — approve() will
+    const t = await s.create({ summary: "pick a channel", kind: "decision", owner: "alice" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice", options: ["a", "b"] });
+    // "alice" is both the task's owner AND the asked human — approve() will
     // throw "independent verification required" for this specific task,
     // simulating a mid-sequence failure without needing to mock anything.
     await expect(answerAsk(ROOT_A, t._id, { choice: "a" })).rejects.toThrow(
@@ -164,7 +164,7 @@ describe("askApi", () => {
     const stillBlocked = (await openStore(ROOT_A)).get(t._id)!;
     expect(stillBlocked.block).toEqual({
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       options: ["a", "b"],
     });
     expect(stillBlocked.state).toBe("deciding"); // unchanged
@@ -173,11 +173,11 @@ describe("askApi", () => {
   it("answerAsk NEVER erases a block that was replaced by a DIFFERENT one WHILE the answer was being processed — the final clear only removes the SPECIFIC block this call decided to answer, not whatever block happens to be there by the time it gets around to clearing (codex-review round-15 Important)", async () => {
     const s = await openStore(ROOT_A);
     const t = await s.create({ summary: "x", kind: "human" });
-    const original = { type: "blocked-by-human", who: "taku", question: "original ask" } as const;
+    const original = { type: "blocked-by-human", who: "alice", question: "original ask" } as const;
     await s.setBlock(t._id, original);
     const newerBlock = {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "a brand new ask",
     } as const;
 
@@ -219,7 +219,7 @@ describe("askApi", () => {
   it("a naive retry after answerAsk already fully succeeded is cleanly refused — it never duplicates evidence or re-transitions, because the gate/transition/clear are now ONE atomic write with no partial-completion state for a retry to resume from (codex-review round-18: replaces the old approve()+transition()+clearBlockIfMatches composition's retry-idempotency workaround, which is no longer needed)", async () => {
     const s = await openStore(ROOT_A);
     const t = await s.create({ summary: "pick a channel", kind: "decision" });
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku", options: ["a", "b"] });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice", options: ["a", "b"] });
     const { record: first } = await answerAsk(ROOT_A, t._id, { choice: "a" });
     expect(first.state).toBe("decided");
     expect(first.verifyEvidence).toHaveLength(1);
@@ -237,7 +237,7 @@ describe("askApi", () => {
   it("answerAsk IGNORES an unvalidated `choice` sent alongside `acknowledged: true` on a non-choice-shape ask — an arbitrary attacker-supplied string must never become the recorded/relayed answer just because it rode along with a valid acknowledgement (codex-review round-14 Important)", async () => {
     const s = await openStore(ROOT_A);
     const bare = await s.create({ summary: "just fyi", kind: "human" });
-    await s.setBlock(bare._id, { type: "blocked-by-human", who: "taku" });
+    await s.setBlock(bare._id, { type: "blocked-by-human", who: "alice" });
     const bareResult = await answerAsk(ROOT_A, bare._id, {
       acknowledged: true,
       choice: "attacker-controlled garbage\nrm -rf /",
@@ -248,7 +248,7 @@ describe("askApi", () => {
     const action = await s.create({ summary: "finish oauth", kind: "human" });
     await s.setBlock(action._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       actionLink: "https://example/oauth",
     });
     const actionResult = await answerAsk(ROOT_A, action._id, {
@@ -261,7 +261,7 @@ describe("askApi", () => {
   it("answerAsk requires an actual answer for a choice-shape ask (no bare acknowledged)", async () => {
     const s = await openStore(ROOT_A);
     const t = await s.create({ summary: "pick a channel", kind: "decision" });
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku", options: ["a", "b"] });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice", options: ["a", "b"] });
     await expect(answerAsk(ROOT_A, t._id, { acknowledged: true })).rejects.toThrow(
       /requires a choice/,
     );
@@ -284,7 +284,7 @@ describe("askApi", () => {
     const t = await s.create({ summary: "x", kind: "code" }); // doing -> merged is ungated
     await s.setBlock(t._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "still working on this?",
     });
     const { record: answered } = await answerAsk(ROOT_A, t._id, { acknowledged: true });
@@ -305,7 +305,7 @@ describe("askApi", () => {
     await s.transition(t._id, "merged");
     await s.transition(t._id, "shipped");
     await s.transition(t._id, "verifying");
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku", question: "any concerns?" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice", question: "any concerns?" });
     const { record: answered } = await answerAsk(ROOT_A, t._id, { acknowledged: true });
     expect(answered.block).toBeNull();
     expect(answered.state).toBe("verifying"); // unchanged — code kind never auto-transitions on a human answer
@@ -317,7 +317,7 @@ describe("askApi", () => {
     const t = await s.create({ summary: "pick a channel", kind: "decision" });
     const identicalBlock: TodoBlock = {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "canary or beta?",
       options: ["canary", "beta"],
     };
@@ -350,7 +350,7 @@ describe("askApi", () => {
   it("answerAsk without expectedBlockRev (a direct/programmatic caller that doesn't track it) still works exactly as before — the check is opt-in, not required", async () => {
     const s = await openStore(ROOT_A);
     const t = await s.create({ summary: "x", kind: "human" });
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice" });
     const { record: answered } = await answerAsk(ROOT_A, t._id, { acknowledged: true });
     expect(answered.block).toBeNull();
     expect(answered.state).toBe("decided");

--- a/ts/channels.spec.ts
+++ b/ts/channels.spec.ts
@@ -53,7 +53,7 @@ describe("formatMessage", () => {
   const base: Message = {
     id: "a@h",
     author: "a",
-    name: "taku",
+    name: "alice",
     role: "human",
     hlc: "h",
     text: "hello",
@@ -62,7 +62,7 @@ describe("formatMessage", () => {
     ms: Date.UTC(2026, 0, 1, 3, 4, 5),
   };
   it("renders time, name(role initial), and text", () => {
-    expect(formatMessage(base)).toBe("03:04:05  taku(h): hello");
+    expect(formatMessage(base)).toBe("03:04:05  alice(h): hello");
   });
   it("shows (deleted) and reaction counts", () => {
     expect(formatMessage({ ...base, deleted: true, text: "" })).toContain("(deleted)");
@@ -88,17 +88,17 @@ describe("ay ch CLI (local-only)", () => {
   });
 
   it("mk → send → read round-trips a message", async () => {
-    const mk = await capture(() => cmdCh(["mk", "demo", "--name", "taku", "--role", "human"]));
+    const mk = await capture(() => cmdCh(["mk", "demo", "--name", "alice", "--role", "human"]));
     expect(mk.code).toBe(0);
     expect(mk.out).toContain("ay://ch/");
 
     const reg = await readRegistry(cwd);
     expect(reg.channels.demo).toBeTruthy();
-    expect(reg.channels.demo!.name).toBe("taku");
+    expect(reg.channels.demo!.name).toBe("alice");
 
     expect((await capture(() => cmdCh(["send", "demo", "hello", "world"]))).code).toBe(0);
     const read = await capture(() => cmdCh(["read", "demo"]));
-    expect(read.out).toContain("taku(h): hello world");
+    expect(read.out).toContain("alice(h): hello world");
   });
 
   it("lists channels with message counts", async () => {

--- a/ts/channels/op.spec.ts
+++ b/ts/channels/op.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { isValidOp, makeOp, opId } from "./op.ts";
 
-const base = { author: "a1", name: "taku", role: "human" as const, hlc: "h1" };
+const base = { author: "a1", name: "alice", role: "human" as const, hlc: "h1" };
 
 describe("op", () => {
   it("derives a stable id from author + hlc", () => {

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -40,7 +40,7 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   }
   // Footgun guard: on the manager entry, a bare first word that is neither a
   // subcommand nor a known CLI is a typo or a newer subcommand on an older build
-  // — error instead of silently spawning an agent with it as the prompt (taku
+  // — error instead of silently spawning an agent with it as the prompt (operator
   // 2026-07-26). A spawn must name a CLI: `ay <cli> …` or `ay --cli <cli> …`.
   {
     const { SUPPORTED_CLIS } = await import("./SUPPORTED_CLIS.ts");

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -431,7 +431,7 @@ export function isSubcommand(name: string | undefined, managerCommands = true): 
  * Footgun guard for the MANAGER entry (`ay`/`agent-yes`): true when the first arg
  * is a bare word (not a flag) that is neither a subcommand nor a known CLI — a
  * typo, or a newer subcommand run on an older build. The caller should error
- * rather than silently spawn an agent with the word as a prompt (taku 2026-07-26:
+ * rather than silently spawn an agent with the word as a prompt (operator 2026-07-26:
  * bare `ay <prompt>` is too dangerous; a spawn must name a CLI — `ay <cli> …` or
  * `--cli`). Never fires for cli-bound aliases (cy/claude-yes/…), where the first
  * word is legitimately the prompt, nor for flags or an empty invocation.
@@ -1691,7 +1691,7 @@ async function cmdLs(rest: string[]): Promise<number> {
     .example("ay ls --all", "include exited agents")
     .example("ay ls --json", "machine-readable output")
     .example("ay ls --watch", "stream state transitions for a whole fan-out as NDJSON")
-    .example("ay ls symval", "filter by cwd/prompt keyword")
+    .example("ay ls myrepo", "filter by cwd/prompt keyword")
     .help(false)
     .version(false)
     .exitProcess(false);

--- a/ts/terminal/browser.ts
+++ b/ts/terminal/browser.ts
@@ -318,7 +318,7 @@ export class AyTerminal {
     // grid and CSS-scale it to fit the panel — NEVER resizing the shared PTY. A
     // widget panel is a SECONDARY view; auto-resizing the agent's real terminal to
     // a small floating panel (or, worse, a mis-measured viewport) scrambled the
-    // agent's own/other viewers' TUI (taku's "xterm looks weird"). Interactive only
+    // agent's own/other viewers' TUI (operator report: "xterm looks weird"). Interactive only
     // adds keystroke input (start(), /api/send), not a resize.
     const reflow = () => {
       // Collapsed/hidden interactive panel → withdraw our cap and DON'T re-arm the

--- a/ts/todoAutomation.spec.ts
+++ b/ts/todoAutomation.spec.ts
@@ -45,7 +45,7 @@ describe("reconcileTodos: orphan detection", () => {
   });
 
   it("does not orphan a task whose owner id has NO record at all in the agent registry — assumed to be a human owner, not a tracked agent (a human obviously never appears there)", () => {
-    const tasks = [task({ _id: "T1", owner: "taku", state: "doing" })];
+    const tasks = [task({ _id: "T1", owner: "alice", state: "doing" })];
     expect(reconcileTodos(tasks, [], new Set())).toEqual([]);
   });
 
@@ -183,7 +183,7 @@ describe("reconcileTodos: auto-verify eligibility", () => {
   });
 
   it("does not flag an already-orphaned task even if it sits in a gate-eligible state", () => {
-    const t = task({ _id: "T1", kind: "code", state: "orphaned", owner: "taku" });
+    const t = task({ _id: "T1", kind: "code", state: "orphaned", owner: "alice" });
     expect(reconcileTodos([t], [], new Set(["verify-green"]))).toEqual([]);
   });
 });

--- a/ts/todoAutomation.ts
+++ b/ts/todoAutomation.ts
@@ -4,7 +4,7 @@
  * of requiring every state change to be typed by hand.
  *
  * `reconcileTodos` is pure — decision logic only, no I/O — exactly the same
- * "decide" / "do" split `symval-dev-cli`'s existing `watchdog.ts`
+ * "decide" / "do" split a private sibling CLI's existing `watchdog.ts`
  * (`decideActions`) already uses successfully: the hard-to-get-right parts
  * (edge cases) live in a function that takes plain data in and returns plain
  * data out, so they are trivially unit-testable without a real store, real

--- a/ts/todoBlock.spec.ts
+++ b/ts/todoBlock.spec.ts
@@ -34,10 +34,10 @@ describe("todoBlock", () => {
   it("describeBlock includes the actionLink when a blocked-by-human ask is action-shaped (A7)", () => {
     const rendered = describeBlock({
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       actionLink: "https://example/oauth",
     });
-    expect(rendered).toContain("taku");
+    expect(rendered).toContain("alice");
     expect(rendered).toContain("https://example/oauth");
   });
 });

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -194,11 +194,11 @@ describe("ay todo CLI", () => {
       "--type",
       "blocked-by-human",
       "--who",
-      "taku",
+      "alice",
       "--question",
       "canary or beta?",
     );
-    expect(human.out).toContain("waiting on taku: canary or beta?");
+    expect(human.out).toContain("waiting on alice: canary or beta?");
     const unblocked = await run("unblock", "T1");
     expect(unblocked.out).toContain("unblocked T1");
 
@@ -229,16 +229,16 @@ describe("ay todo CLI", () => {
       "--type",
       "blocked-by-human",
       "--who",
-      "taku",
+      "alice",
       "--action-link",
       "https://example/oauth",
     );
-    expect(action.out).toContain("taku");
+    expect(action.out).toContain("alice");
     expect(action.out).toContain("https://example/oauth");
     const got = await run("get", "T1", "--format", "json");
     expect(JSON.parse(got.out).block).toEqual({
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       actionLink: "https://example/oauth",
     });
   });
@@ -252,7 +252,7 @@ describe("ay todo CLI", () => {
         "--type",
         "blocked-by-human",
         "--who",
-        "taku",
+        "alice",
         "--options",
         "a",
         "b",
@@ -271,7 +271,7 @@ describe("ay todo CLI", () => {
         "--type",
         "blocked-by-human",
         "--who",
-        "taku",
+        "alice",
         "--action-link",
         "javascript:alert(1)",
       ),
@@ -283,7 +283,7 @@ describe("ay todo CLI", () => {
         "--type",
         "blocked-by-human",
         "--who",
-        "taku",
+        "alice",
         "--action-link",
         "data:text/html,x",
       ),
@@ -294,7 +294,7 @@ describe("ay todo CLI", () => {
       "--type",
       "blocked-by-human",
       "--who",
-      "taku",
+      "alice",
       "--action-link",
       "https://example/oauth",
     );
@@ -309,7 +309,7 @@ describe("ay todo CLI", () => {
       "--type",
       "blocked-by-human",
       "--who",
-      "taku",
+      "alice",
       "--action-link",
       "https://example/oauth\tinjected",
     );
@@ -455,7 +455,7 @@ describe("ay todo CLI", () => {
     expect(got.out).toContain("[criteria: reviewed by a human]");
   });
 
-  it("--help resolves cleanly (exit 0, no throw) — a real yargs command tree auto-generates the verb listing (taku feedback); yargs' own help writer bypasses the stdout mock in this harness, so content is verified manually rather than asserted here", async () => {
+  it("--help resolves cleanly (exit 0, no throw) — a real yargs command tree auto-generates the verb listing (operator feedback); yargs' own help writer bypasses the stdout mock in this harness, so content is verified manually rather than asserted here", async () => {
     const cap = captureStdout();
     let code: number | undefined;
     try {

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -18,8 +18,8 @@
  * Argument parsing: a real yargs COMMAND TREE — one `yargs(argv)` instance
  * with a `CommandModule` per verb registered via `.command()`, `--root`/
  * `--format` declared once as `global: true` options on that same instance —
- * matching the pattern `tools/symval-dev-cli`'s `sv` CLI already uses
- * (`todoCommand`/`lsCmd` etc. in that repo's `commands/todo.ts`), per taku's
+ * matching the pattern a private sibling repo's CLI already uses
+ * (`todoCommand`/`lsCmd` etc. in that repo's `commands/todo.ts`), per the operator's
  * explicit feedback that this gives better help behavior for free: a real
  * `.command()` tree yields an auto-generated `ay todo --help` listing every
  * verb with its description, and per-verb `--help`/usage, neither of which

--- a/ts/todoDigest.spec.ts
+++ b/ts/todoDigest.spec.ts
@@ -166,7 +166,7 @@ describe("renderDigest", () => {
         state: "shipped",
         tags: ["proj-y"],
         blockedBy: ["T2"],
-        block: { type: "blocked-by-human", who: "taku" },
+        block: { type: "blocked-by-human", who: "alice" },
       }),
     ];
     const out = renderDigest(tasks);

--- a/ts/todoDigest.ts
+++ b/ts/todoDigest.ts
@@ -5,7 +5,7 @@
  * (`todoCli.ts`) and any future web view.
  *
  * `unblockedTasks` is ported near-verbatim from the equivalent, already
- * mutation-tested algorithm in symval-dev-cli's `deps.ts` (a closed-source
+ * mutation-tested algorithm in a private sibling CLI's `deps.ts` (a closed-source
  * downstream consumer of an earlier, less general version of this idea) —
  * generalized here to the new `TodoRecord` shape and the `done` state name
  * from `todoLifecycle.ts` instead of a hardcoded status string.

--- a/ts/todoLifecycle.spec.ts
+++ b/ts/todoLifecycle.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "./todoLifecycle";
 
 describe("todoLifecycle", () => {
-  it("defines all five kinds with the exact graphs taku specified", () => {
+  it("defines all five kinds with the exact graphs the operator specified", () => {
     expect(Object.keys(LIFECYCLES).sort()).toEqual([
       "code",
       "decision",
@@ -53,7 +53,7 @@ describe("todoLifecycle", () => {
     expect(nextStates("code", "verify-failed")).toEqual(["doing"]);
   });
 
-  it("the human kind has no merge/ship/QA transitions at all (taku decision #6)", () => {
+  it("the human kind has no merge/ship/QA transitions at all (operator decision #6)", () => {
     const humanStates = new Set(statesOf("human"));
     for (const s of ["merged", "shipped", "verifying", "verify-failed"]) {
       expect(humanStates.has(s)).toBe(false);

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -388,7 +388,7 @@ describe("TodoStore", () => {
     expect(s.list({ blocked: true }).map((t) => t.summary)).toEqual(["b"]);
   });
 
-  it("a done task with a leftover block is not counted by --blocked (mirrors symval-dev-cli's equivalent fix)", async () => {
+  it("a done task with a leftover block is not counted by --blocked (mirrors a private sibling CLI's equivalent fix)", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "a", kind: "human" });
     await s.setBlock(t._id, { type: "blocked-by-human", who: "x" });
@@ -534,7 +534,7 @@ describe("TodoStore", () => {
     await expect(s.markOrphaned(t._id, "dead-agent", [])).rejects.toThrow(/already "orphaned"/);
 
     const done = await s.create({ summary: "y", kind: "human", owner: "dead-agent" });
-    await s.approve(done._id, "human-replied", "taku");
+    await s.approve(done._id, "human-replied", "alice");
     await s.transition(done._id, "decided");
     await s.transition(done._id, "done");
     await expect(s.markOrphaned(done._id, "dead-agent", [])).rejects.toThrow(/already "done"/);
@@ -566,12 +566,12 @@ describe("TodoStore", () => {
     const cleared = await s.clearWaitingOnAgentBlock(t._id, "a1");
     expect(cleared.block).toBeNull();
 
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice" });
     await expect(s.clearWaitingOnAgentBlock(t._id, "a1")).rejects.toThrow(
       /block changed since this was decided/,
     );
     // refused, not erased: the newer block is still exactly what it was
-    expect(s.get(t._id)?.block).toEqual({ type: "blocked-by-human", who: "taku" });
+    expect(s.get(t._id)?.block).toEqual({ type: "blocked-by-human", who: "alice" });
   });
 
   it("clearBlockIfMatches() — the generalized guard — clears only when the FRESH record's blockRev still equals the snapshot, and refuses (without erasing) a block that changed since decided (codex-review round-15 Important)", async () => {
@@ -579,7 +579,7 @@ describe("TodoStore", () => {
     const t = await s.create({ summary: "x", kind: "code" });
     const original = {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "canary or beta?",
     } as const;
     const afterSet = await s.setBlock(t._id, original);
@@ -588,7 +588,7 @@ describe("TodoStore", () => {
 
     const afterReplace = await s.setBlock(t._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "a NEW question",
     });
     await expect(s.clearBlockIfMatches(t._id, (afterReplace.blockRev ?? 0) - 1)).rejects.toThrow(
@@ -597,7 +597,7 @@ describe("TodoStore", () => {
     // refused, not erased: the newer block survives untouched
     expect(s.get(t._id)?.block).toEqual({
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "a NEW question",
     });
   });
@@ -607,7 +607,7 @@ describe("TodoStore", () => {
     const t = await s.create({ summary: "x", kind: "code" });
     const identicalBlock = {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       question: "canary or beta?",
     } as const;
     const firstSet = await s.setBlock(t._id, identicalBlock);
@@ -628,44 +628,44 @@ describe("TodoStore", () => {
     const t = await s.create({ summary: "pick a channel", kind: "decision" });
     const afterSet = await s.setBlock(t._id, {
       type: "blocked-by-human",
-      who: "taku",
+      who: "alice",
       options: ["canary", "beta"],
     });
     const answered = await s.answerHumanBlock(t._id, afterSet.blockRev ?? 0, {
       name: "human-decided",
       toState: "decided",
-      validator: "taku",
+      validator: "alice",
       note: "canary",
     });
     expect(answered.block).toBeNull();
     expect(answered.state).toBe("decided");
     expect(answered.verifyEvidence).toEqual([
-      expect.objectContaining({ gate: "human-decided", validator: "taku", note: "canary" }),
+      expect.objectContaining({ gate: "human-decided", validator: "alice", note: "canary" }),
     ]);
   });
 
   it("answerHumanBlock() refuses (without applying anything) a stale expectedBlockRev, and separately refuses independent-verification violations (validator === owner) — matching approve()'s own unconditional rule (codex-review round-18 Important)", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "decision" });
-    const afterSet = await s.setBlock(t._id, { type: "blocked-by-human", who: "taku" });
-    await s.setBlock(t._id, { type: "blocked-by-human", who: "taku" }); // bumps blockRev again
+    const afterSet = await s.setBlock(t._id, { type: "blocked-by-human", who: "alice" });
+    await s.setBlock(t._id, { type: "blocked-by-human", who: "alice" }); // bumps blockRev again
     await expect(
       s.answerHumanBlock(t._id, afterSet.blockRev ?? 0, {
         name: "human-decided",
         toState: "decided",
-        validator: "taku",
+        validator: "alice",
         note: "acknowledged",
       }),
     ).rejects.toThrow(/this ask has changed since it was loaded/);
     expect(s.get(t._id)?.state).toBe("deciding"); // unchanged — refused before any write
 
-    const owned = await s.create({ summary: "y", kind: "decision", owner: "taku" });
-    const ownedBlock = await s.setBlock(owned._id, { type: "blocked-by-human", who: "taku" });
+    const owned = await s.create({ summary: "y", kind: "decision", owner: "alice" });
+    const ownedBlock = await s.setBlock(owned._id, { type: "blocked-by-human", who: "alice" });
     await expect(
       s.answerHumanBlock(owned._id, ownedBlock.blockRev ?? 0, {
         name: "human-decided",
         toState: "decided",
-        validator: "taku", // same identity as owner
+        validator: "alice", // same identity as owner
         note: "acknowledged",
       }),
     ).rejects.toThrow(/independent verification required/);
@@ -676,7 +676,7 @@ describe("TodoStore", () => {
   it("answerHumanBlock() re-validates canTransition against the FRESH state, not a value captured before the call — a state change UNRELATED to block (so invisible to the blockRev check alone) must still be caught, matching transition()'s own concurrent-state-drift defense (codex-review round-18 Important)", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "decision" });
-    const afterSet = await s.setBlock(t._id, { type: "blocked-by-human", who: "taku" });
+    const afterSet = await s.setBlock(t._id, { type: "blocked-by-human", who: "alice" });
     // Simulate a concurrent writer moving the task's STATE (not its block)
     // to "done" — the same append-only-merge-line technique the
     // markOrphaned() test above uses. blockRev is untouched, so the
@@ -690,7 +690,7 @@ describe("TodoStore", () => {
       s.answerHumanBlock(t._id, afterSet.blockRev ?? 0, {
         name: "human-decided",
         toState: "decided",
-        validator: "taku",
+        validator: "alice",
         note: "acknowledged",
       }),
     ).rejects.toThrow(/no transition done -> decided.*state changed concurrently/);

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -828,7 +828,7 @@ export class TodoStore {
     }));
   }
 
-  /** True when `from` transitively depends on `target` via `blockedBy` edges. Ported from the equivalent, already-tested algorithm in symval-dev-cli's store.ts. */
+  /** True when `from` transitively depends on `target` via `blockedBy` edges. Ported from the equivalent, already-tested algorithm in a private sibling CLI's store.ts. */
   private dependsOn(from: string, target: string, seen: Set<string> = new Set()): boolean {
     if (from === target) return true;
     if (seen.has(from)) return false;


### PR DESCRIPTION
## Problem

The Rust share host (`ayrs serve`) resolved a numeric keyword with the same substring rules as text: a pid appearing inside **another agent's prompt** (e.g. a fleet-restore prompt listing peer pids) matched that agent too, and `resolve_one`'s newest-first pick could route the console widget's tail + stdin for `/w/#room:<pid>` to a **different agent's terminal** while the pane header showed the requested pid. Reproduced live: typing into a widget anchored to one pid landed keystrokes in a sibling's PTY (verified by probe markers in the raw logs; the `ay send` CLI path was unaffected since TS got this fix in #72).

## Fix

Port the #72 semantics to `rs/src/serve/api.rs`:
- `matches_keyword`: an all-digit keyword only matches an exact pid or an agent_id prefix — never cwd/cli/prompt substrings.
- `resolve_one`: when the keyword is numeric and exactly one record has that pid, that record wins (TS parity).
- Regression test with synthetic fixtures.

Also: scrub live-fleet names (org paths, person names, a private repo name) from committed tests/comments/docs, and add a CLAUDE.md rule requiring synthetic fixture data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)