### PR TITLE
feat(whoami): `ay whoami` — the calling agent's own registry identity

### DIFF
--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -20,8 +20,8 @@ use std::env;
 /// Management subcommands handled by the TypeScript CLI, not this runner.
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
-    "ls", "list", "ps", "status", "result", "notify", "notifyd", "read", "cat", "tail", "head",
-    "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
+    "ls", "list", "ps", "status", "whoami", "result", "notify", "notifyd", "read", "cat", "tail",
+    "head", "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
     "term", "widget", "mint", "serve", "schedule", "remote", "expose", "callback", "reap", "help",
 ];
 

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -2537,3 +2537,112 @@ describe("subcommands.resolveResumeArgs", () => {
     });
   });
 });
+
+describe("subcommands.cmdWhoami", () => {
+  const envKey = "AGENT_YES_PID";
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[envKey];
+    delete process.env[envKey];
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[envKey];
+    else process.env[envKey] = savedEnv;
+  });
+
+  it("outside an agent (no AGENT_YES_PID) exits 1 with a human-shell hint", async () => {
+    const { runSubcommand } = await loadModule();
+    const stderr: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (s: any) => {
+      stderr.push(String(s));
+      return true;
+    };
+    try {
+      const code = await runSubcommand(["bun", "cli.js", "whoami"]);
+      expect(code).toBe(1);
+      expect(stderr.join("")).toMatch(/AGENT_YES_PID is unset/);
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+
+  it("a set-but-unregistered AGENT_YES_PID reports 'unregistered' in --json and exits 1", async () => {
+    const { runSubcommand } = await loadModule();
+    process.env[envKey] = "999999";
+    const stdout: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    (process.stdout as any).write = (s: any) => {
+      stdout.push(String(s));
+      return true;
+    };
+    try {
+      const code = await runSubcommand(["bun", "cli.js", "whoami", "--json"]);
+      expect(code).toBe(1);
+    } finally {
+      process.stdout.write = orig;
+    }
+    expect(JSON.parse(stdout.join(""))).toEqual({ agent: null, reason: "unregistered" });
+  });
+
+  it("resolves the caller via wrapper_pid and prints identity + reply address", async () => {
+    const mod = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    await appendGlobalPid({
+      pid: process.pid, // alive, so live-state derivation doesn't read it as exited
+      cli: "claude",
+      prompt: "whoami test",
+      cwd: "/repo/alpha",
+      log_file: null,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+      wrapper_pid: 424242,
+      parent_pid: null,
+      agent_id: "aaaa0000bbbb",
+    });
+    process.env[envKey] = "424242";
+
+    const stdout: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    (process.stdout as any).write = (s: any) => {
+      stdout.push(String(s));
+      return true;
+    };
+    try {
+      const code = await mod.runSubcommand(["bun", "cli.js", "whoami", "--json"]);
+      expect(code).toBe(0);
+    } finally {
+      process.stdout.write = orig;
+    }
+    const parsed = JSON.parse(stdout.join(""));
+    expect(parsed).toMatchObject({
+      pid: process.pid,
+      cli: "claude",
+      cwd: "/repo/alpha",
+      agent_id: "aaaa0000bbbb",
+      wrapper_pid: 424242,
+      reply: "ay send aaaa0000bbbb",
+    });
+    expect(typeof parsed.state).toBe("string");
+
+    // Human-readable form carries the traceable envelope template.
+    const stdout2: string[] = [];
+    (process.stdout as any).write = (s: any) => {
+      stdout2.push(String(s));
+      return true;
+    };
+    try {
+      const code = await mod.runSubcommand(["bun", "cli.js", "whoami"]);
+      expect(code).toBe(0);
+    } finally {
+      process.stdout.write = orig;
+    }
+    const text = stdout2.join("");
+    expect(text).toMatch(/agent {5}claude #\d+ {2}\(agent_id aaaa0000bbbb\)/);
+    expect(text).toMatch(/reply {5}ay send aaaa0000bbbb/);
+    expect(text).toMatch(/<ay-msg from claude #\d+ @ \/repo\/alpha — reply: ay send aaaa0000bbbb "\.\.\.">/);
+  });
+});

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -278,6 +278,63 @@ async function senderContext(): Promise<{ key: string; agent: GlobalPidRecord | 
 }
 
 /**
+ * `ay whoami` — the calling agent's own canonical registration, resolved from
+ * AGENT_YES_PID (see resolveSender). One command answers "which agent am I,
+ * per the registry?": after a fleet restore, several agents can share a cwd
+ * and a resumed conversation can believe it is a different lane than the
+ * process actually registered as — the registry record is the ground truth
+ * every routing surface (console, ay send, heartbeats) actually uses. Also
+ * prints the traceable reply address so an agent can stamp outgoing messages
+ * (`<ay-msg … reply: ay send <id> "...">`) without re-deriving its identity.
+ */
+async function cmdWhoami(rest: string[]): Promise<number> {
+  const y = yargs(rest)
+    .usage("Usage: ay whoami [--json]")
+    .option("json", { type: "boolean", default: false, description: "Machine-readable output" })
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+  const argv = await y.parseAsync();
+  const self = await resolveSender();
+  if (!self) {
+    // Two distinct failures: no agent context at all (human shell), or a set
+    // AGENT_YES_PID that resolves to nothing (stale env / record aged out).
+    const reason = process.env.AGENT_YES_PID ? "unregistered" : "no-agent-context";
+    if (argv.json) {
+      process.stdout.write(JSON.stringify({ agent: null, reason }) + "\n");
+    } else {
+      process.stderr.write(
+        reason === "unregistered"
+          ? `ay whoami: AGENT_YES_PID=${process.env.AGENT_YES_PID} is set but matches no record in the registry (stale env, or the record aged out)\n`
+          : `ay whoami: not inside an agent-yes session — AGENT_YES_PID is unset (human shell)\n`,
+      );
+    }
+    return 1;
+  }
+  const { state, question } = await deriveLiveState(self);
+  const replyKw = self.agent_id ?? String(self.pid);
+  const reply = `ay send ${replyKw}`;
+  if (argv.json) {
+    process.stdout.write(JSON.stringify({ ...self, state, question, reply }, null, 2) + "\n");
+    return 0;
+  }
+  const ageMin = Math.max(0, Math.round((Date.now() - self.started_at) / 60_000));
+  const lines = [
+    `agent     ${self.cli} #${self.pid}${self.agent_id ? `  (agent_id ${self.agent_id})` : ""}`,
+    `state     ${state}${question ? ` — ${question}` : ""}`,
+    `cwd       ${self.cwd}`,
+    `started   ${new Date(self.started_at).toISOString()}  (${ageMin}m ago)`,
+    `wrapper   ${self.wrapper_pid ?? "-"}    parent ${self.parent_pid ?? "- (top-level)"}`,
+    `log       ${self.log_file ?? "-"}`,
+    `fifo      ${self.fifo_file ?? "-"}`,
+    `reply     ${reply} "..."`,
+    `envelope  <ay-msg from ${self.cli} #${self.pid} @ ${self.cwd} — reply: ${reply} "...">…</ay-msg>`,
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+  return 0;
+}
+
+/**
  * Read the per-cwd TS PidStore JSONL and convert to the global record shape,
  * so pre-existing TS agents that were spawned before the global-index mirror
  * shipped still show up in `ay ls`. Merging is done in `mergeRecords`.
@@ -346,6 +403,7 @@ const SUBCOMMANDS = new Set([
   "list",
   "ps",
   "status",
+  "whoami",
   "result",
   "notify",
   "notifyd",
@@ -468,6 +526,8 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdLs(rest);
       case "status":
         return await cmdStatus(rest);
+      case "whoami":
+        return await cmdWhoami(rest);
       case "result":
         return await cmdResult(rest);
       case "notify":
@@ -672,6 +732,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay exit <keyword> [reason]          graceful shutdown, recording who/why (= 'ay send <kw> exit')\n` +
       `  ay restart <keyword> [--fresh]      stop (if live) + relaunch resuming the session; --fresh replays the prompt\n` +
       `  ay status <keyword>                 agent status snapshot\n` +
+      `  ay whoami [--json]                  (inside an agent) your own registry identity + reply address\n` +
       `  ay result <keyword> [--wait]        pull an agent's structured result envelope\n` +
       `  ay result set '<json>'              (inside an agent) deposit your result envelope\n` +
       `  ay reap                             kill process groups leaked by dead agents\n` +


### PR DESCRIPTION
## What

`ay whoami [--json]` prints the calling agent's canonical registration, resolved from `AGENT_YES_PID` (same mapping as `resolveSender`):

```
agent     claude #72075  (agent_id 5f6993a10f18)
state     active
cwd       /Users/sno/ws/snomiao/agent-yes/tree/main
started   2026-08-06T07:31:31.209Z  (102m ago)
wrapper   72075    parent - (top-level)
log       …/.agent-yes/72075.raw.log
fifo      ~/.agent-yes/fifo/72075.stdin
reply     ay send 5f6993a10f18 "..."
envelope  <ay-msg from claude #72075 @ … — reply: ay send 5f6993a10f18 "...">…</ay-msg>
```

Exit 1 with distinct reasons for a human shell (`AGENT_YES_PID` unset) vs a stale pin that matches no record (`--json` → `{"agent":null,"reason":…}`).

## Why

After a fleet restore, several agents can share a cwd and a resumed conversation can believe it's a different lane than the process actually registered as. The registry record is the ground truth every routing surface (console, `ay send`, heartbeats) uses — this makes it introspectable in one command, and gives agents a copy-pasteable traceable-envelope reply address for inter-agent messages.

## Notes

- Registered in TS `SUBCOMMANDS` + dispatch + help text; mirrored in `rs/src/cli.rs SUBCOMMANDS` (Rust delegates these to the JS layer).
- 3 new tests (human shell, unregistered pin, wrapper_pid resolution incl. envelope rendering); `ts/subcommands.spec.ts` 118/118 green; `cargo test --bin agent-yes cli` 42/42 green; typecheck error count unchanged vs origin/main (34 pre-existing).
- Live-verified inside a real agent session (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)