### PR TITLE
feat(ws): surface codehost's auth-missing diagnosis in `ay ws new`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ real cwd/worktree paths, org/repo/product names of private downstream
 projects, people's names, prompts, and terminal transcripts. Use neutral
 stand-ins instead (`pid 1111`, `/repo/alpha`, `/x/acme/acme/tree/...`,
 `"alice"`). When a regression came from a live incident, describe the
-*mechanism* generically; keep the concrete details out of the commit.
+_mechanism_ generically; keep the concrete details out of the commit.
 
 ## Scratch / debug / temp scripts → `./tmp/`
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@vitest/coverage-v8": "4.1.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
-        "codehost": "^0.32.0",
+        "codehost": "^0.39.0",
         "html2canvas-pro": "^2.3.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
@@ -628,7 +628,7 @@
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
-    "codehost": ["codehost@0.32.0", "", { "dependencies": { "@parcel/watcher": "^2.5.6", "@snomiao/daemon-kit": "^0.2.0", "@xterm/addon-clipboard": "^0.2.0", "@xterm/addon-fit": "^0.11.0", "@xterm/addon-search": "^0.15.0", "@xterm/addon-unicode11": "^0.9.0", "@xterm/addon-web-links": "^0.11.0", "@xterm/headless": "^6.0.0", "@xterm/xterm": "^6.0.0", "bun-pty": "^0.4.8", "hono": "^4.12.16", "node-datachannel": "^0.32.3", "oxmgr": "^0.4.0", "react": "^19.1.1", "react-dom": "^19.1.1", "yaml": "^2.9.0", "yargs": "^17.7.2" }, "bin": { "codehost": "src/cli/index.ts", "ch": "src/cli/index.ts" } }, "sha512-sv/5Y/VMZg9Cu8vungcLs0c7kgHO9lxKL+J4AMAAYdavr2Pnboyo9ChgdulbxumQIw5jxk6EYNUUIJBvZqeGxw=="],
+    "codehost": ["codehost@0.39.0", "", { "dependencies": { "@parcel/watcher": "^2.5.6", "@snomiao/daemon-kit": "^0.2.0", "@xterm/addon-clipboard": "^0.2.0", "@xterm/addon-fit": "^0.11.0", "@xterm/addon-search": "^0.15.0", "@xterm/addon-unicode11": "^0.9.0", "@xterm/addon-web-links": "^0.11.0", "@xterm/headless": "^6.0.0", "@xterm/xterm": "^6.0.0", "bun-pty": "^0.4.8", "hono": "^4.12.16", "node-datachannel": "^0.32.3", "oxmgr": "^0.4.0", "react": "^19.1.1", "react-dom": "^19.1.1", "yaml": "^2.9.0", "yargs": "^17.7.2" }, "bin": { "codehost": "src/cli/index.ts", "ch": "src/cli/index.ts" } }, "sha512-6zs7hrTdQO2OuQ9NfxWFctqrDCH6iZKuwnReKHcIu7qMW54jN8+nvawFZKisHB1QMPHTKd7pt5jkAa3/ZHAlzQ=="],
 
     "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
 

--- a/docs/serve-rust-vs-ts-benchmark.md
+++ b/docs/serve-rust-vs-ts-benchmark.md
@@ -7,17 +7,17 @@ the Bun/Node TS `ay serve`; room `r7bcb6271a973` by the standalone Rust
 the same agent FIFOs, so the only variable is the serve implementation.
 
 Measured 2026-08-01 on the primary dev host (v1.251.0), with the TS serve at its
-real ~40% CPU (the live daemon this session runs under) — i.e. an *under-load*
+real ~40% CPU (the live daemon this session runs under) — i.e. an _under-load_
 comparison, the condition where console jank is actually felt.
 
 ## Results
 
 ### Open-time — cold WebRTC connect + first relayed request (5 interleaved trials)
 
-| daemon | median | range |
-| --- | --- | --- |
+| daemon              | median      | range                   |
+| ------------------- | ----------- | ----------------------- |
 | TS `ay serve` (bun) | **1466 ms** | 1274–2525 ms (fat tail) |
-| Rust `ayrs serve` | **357 ms** | 339–467 ms (tight) |
+| Rust `ayrs serve`   | **357 ms**  | 339–467 ms (tight)      |
 
 → **ayrs ~4.1× faster to open**, with far lower variance.
 
@@ -26,19 +26,19 @@ comparison, the condition where console jank is actually felt.
 Isolates the daemon's request-handling (localhost connect is common-mode ~0 and
 cancels). Both authenticate with the shared `~/.agent-yes/.serve-token` bearer.
 
-| daemon | p50 | p95 | max |
-| --- | --- | --- | --- |
-| TS `ay serve` (bun) | 26.5 ms | **162.7 ms** | 174 ms |
-| Rust `ayrs serve` | **9.1 ms** | **24.3 ms** | 61 ms |
+| daemon              | p50        | p95          | max    |
+| ------------------- | ---------- | ------------ | ------ |
+| TS `ay serve` (bun) | 26.5 ms    | **162.7 ms** | 174 ms |
+| Rust `ayrs serve`   | **9.1 ms** | **24.3 ms**  | 61 ms  |
 
 → **ayrs ~2.9× faster at p50, ~6.7× faster at p95.**
 
 ### Resource cost (live)
 
-| daemon | RSS | CPU (under load) |
-| --- | --- | --- |
-| TS `ay serve` (bun) | ~250 MB | ~40% |
-| Rust `ayrs serve` | ~33 MB | ~0.3% |
+| daemon              | RSS     | CPU (under load) |
+| ------------------- | ------- | ---------------- |
+| TS `ay serve` (bun) | ~250 MB | ~40%             |
+| Rust `ayrs serve`   | ~33 MB  | ~0.3%            |
 
 → **~8× less memory**, a fraction of the CPU.
 
@@ -76,19 +76,20 @@ The default `bun run build:rs` (`cargo install --path rs --features swarm`,
 release + full LTO) is slow to iterate on. Benchmarked incremental rebuild (touch
 one source file, rebuild the `ayrs` bin):
 
-| build | incremental | vs default |
-| --- | --- | --- |
-| default: `cargo install`, release + LTO + swarm | ~145 s | 1× |
-| `cargo build`, release, **LTO off**, swarm | ~27 s | 5.4× |
-| `cargo build`, release, LTO off, **no swarm** | ~26 s | 5.6× |
-| `cargo build`, **dev profile (opt0)**, no swarm | ~3 s | **48×** |
+| build                                           | incremental | vs default |
+| ----------------------------------------------- | ----------- | ---------- |
+| default: `cargo install`, release + LTO + swarm | ~145 s      | 1×         |
+| `cargo build`, release, **LTO off**, swarm      | ~27 s       | 5.4×       |
+| `cargo build`, release, LTO off, **no swarm**   | ~26 s       | 5.6×       |
+| `cargo build`, **dev profile (opt0)**, no swarm | ~3 s        | **48×**    |
 
 Two independent causes, both large:
+
 1. **`cargo install` can't reuse the incremental cache** — it builds in a temp
    target dir, so it rebuilds the whole graph (~110 s) even when `cargo build`
    (which reuses `rs/target`) is ~27 s. The fast paths use `cargo build` + copy.
 2. **Full LTO dominates the rest** — it relinks the entire webrtc binary on every
-   change (145 s → 27 s just from `LTO off`). `swarm` barely affects *incremental*
+   change (145 s → 27 s just from `LTO off`). `swarm` barely affects _incremental_
    time (its ~65 libp2p crates are already cached) but matters on clean builds;
    `ayrs` doesn't use libp2p, so the fast paths drop it.
 
@@ -129,9 +130,9 @@ speeds up every clean/CI build.
   daemon (which could freeze its JS event loop while alive → needed the
   healthcheck-restart) the Rust host has no such "alive-but-wedged" failure mode,
   so restart-on-crash suffices. Verified: SIGKILL → oxmgr respawns cleanly, old PID
-  reaped (the oxmgr *daemon* reaps its children), host-lock + room preserved.
+  reaped (the oxmgr _daemon_ reaps its children), host-lock + room preserved.
 
-  Gotcha: if you kill a *standalone* (non-oxmgr) ayrs, its parent may be the PID-1
+  Gotcha: if you kill a _standalone_ (non-oxmgr) ayrs, its parent may be the PID-1
   oxmgr-runtime, which does NOT reap → the process lingers as a `<defunct>` zombie.
   ayrs's two-hosts-in-one-room guard reads `~/.agent-yes/.share-host-<room>.pid` and
   does `kill -0` on it — which returns "alive" for a zombie — so a fresh start then

--- a/docs/subagent-notify.md
+++ b/docs/subagent-notify.md
@@ -282,7 +282,7 @@ What remains:
   inbox is GC'd automatically once that parent is dead and unreferenced.
 
 - **Postmortem reads are read-only and single-incarnation.** `ay notify read
-  --postmortem` inspects a finished parent's inbox without registering a watcher
+--postmortem` inspects a finished parent's inbox without registering a watcher
   or starting the daemon, filtering to one incarnation taken from the inbox's own
   `parent_started_at` stamps. If the pid was reused across sessions the inbox
   holds more than one agent's edges and the command refuses, listing the

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -6118,7 +6118,8 @@ my.translate = async (text, lang) => {
             // native click so focus + link handling still work.
             const now = Date.now();
             const near =
-              Math.abs(p.clientX - lastTapX) < DBL_SLOP && Math.abs(p.clientY - lastTapY) < DBL_SLOP;
+              Math.abs(p.clientX - lastTapX) < DBL_SLOP &&
+              Math.abs(p.clientY - lastTapY) < DBL_SLOP;
             tapCount = now - lastTapAt < DBL_MS && near ? tapCount + 1 : 1;
             lastTapAt = now;
             lastTapX = p.clientX;

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "@vitest/coverage-v8": "4.1.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
-    "codehost": "^0.32.0",
+    "codehost": "^0.39.0",
     "html2canvas-pro": "^2.3.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",

--- a/scripts/build-rs.ts
+++ b/scripts/build-rs.ts
@@ -132,7 +132,9 @@ if (fast || dev) {
     copyFileSync(built, tmp);
     renameSync(tmp, dest);
     console.log(`[build-rs] installed ${dest}`);
-    console.log(`[build-rs] NOTE: dev build — run \`bun run build:rs\` for the fully-optimized shipped binary`);
+    console.log(
+      `[build-rs] NOTE: dev build — run \`bun run build:rs\` for the fully-optimized shipped binary`,
+    );
   } else {
     // Build failed and cargo never wrote a fresh binary — restore anything the
     // Windows lock-aside moved, else ayrs.exe would be missing from PATH.

--- a/ts/agentPermissions.spec.ts
+++ b/ts/agentPermissions.spec.ts
@@ -10,9 +10,9 @@ describe("derivePermissions", () => {
   const YES = ["--dangerously-skip-permissions"];
 
   it("detects the configured yolo flag", () => {
-    expect(
-      derivePermissions({ cliArgs: ["--print", ...YES], yesArgs: YES }).skip_permissions,
-    ).toBe(true);
+    expect(derivePermissions({ cliArgs: ["--print", ...YES], yesArgs: YES }).skip_permissions).toBe(
+      true,
+    );
   });
 
   it("detects a dangerous flag the config never declared", () => {

--- a/ts/notifyInbox.spec.ts
+++ b/ts/notifyInbox.spec.ts
@@ -234,7 +234,7 @@ describe("notifyInbox — emergency rotation (#169.3)", () => {
 
   it("returns events in ascending seq order (append order preserved)", () => {
     const kept = emergencyKeep(many(), 1, 10);
-    expect(kept.map((e) => e.seq)).toEqual([...kept.map((e) => e.seq)].sort((a, b) => a - b));
+    expect(kept.map((e) => e.seq)).toEqual(kept.map((e) => e.seq).sort((a, b) => a - b));
   });
 });
 

--- a/ts/ownerHeartbeat.spec.ts
+++ b/ts/ownerHeartbeat.spec.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { startInlineHeartbeat, startOwnerHeartbeat, type OwnerHeartbeat } from "./ownerHeartbeat.ts";
+import {
+  startInlineHeartbeat,
+  startOwnerHeartbeat,
+  type OwnerHeartbeat,
+} from "./ownerHeartbeat.ts";
 
 // Issue #169 item 5. The daemon's proof-of-life is a `ts` it refreshes in the
 // lock owner file; if that stamp goes stale another `ay notify watch` steals the
@@ -58,7 +62,12 @@ for (const [name, start] of [
     it("refreshes ts while the owner still carries our token", async () => {
       const file = await ownerFile("tok-a");
       track(
-        start({ ownerPath: file, token: "tok-a", payload: { token: "tok-a" }, intervalMs: BEAT_MS }),
+        start({
+          ownerPath: file,
+          token: "tok-a",
+          payload: { token: "tok-a" },
+          intervalMs: BEAT_MS,
+        }),
       );
       expect(await beaten(file)).toBe(true);
     });
@@ -97,7 +106,12 @@ for (const [name, start] of [
       // the rename instead of resurrecting an owner file it no longer owns.
       const file = await ownerFile("tok-c");
       track(
-        start({ ownerPath: file, token: "tok-c", payload: { token: "tok-c" }, intervalMs: BEAT_MS }),
+        start({
+          ownerPath: file,
+          token: "tok-c",
+          payload: { token: "tok-c" },
+          intervalMs: BEAT_MS,
+        }),
       );
       expect(await beaten(file)).toBe(true);
       await rm(path.dirname(file), { recursive: true, force: true });

--- a/ts/procStartTime.spec.ts
+++ b/ts/procStartTime.spec.ts
@@ -36,9 +36,7 @@ describe("osProcessStartToken", () => {
   const stat = `7 (agent) ${after("555")}`;
 
   it("uses /proc on linux", () => {
-    expect(
-      osProcessStartToken(7, { platform: "linux", readProcStat: () => stat }),
-    ).toBe("555");
+    expect(osProcessStartToken(7, { platform: "linux", readProcStat: () => stat })).toBe("555");
   });
 
   it("uses ps lstart on darwin/bsd", () => {

--- a/ts/procStartTime.ts
+++ b/ts/procStartTime.ts
@@ -37,7 +37,10 @@ import { readFileSync } from "node:fs";
 export function parseLinuxStartTime(stat: string): string | null {
   const close = stat.lastIndexOf(")");
   if (close < 0) return null;
-  const fields = stat.slice(close + 1).trim().split(/\s+/);
+  const fields = stat
+    .slice(close + 1)
+    .trim()
+    .split(/\s+/);
   const starttime = fields[19];
   return starttime && /^\d+$/.test(starttime) ? starttime : null;
 }

--- a/ts/widget/browser.ts
+++ b/ts/widget/browser.ts
@@ -218,12 +218,7 @@ export class AyWidget {
     return null;
   }
 
-  private async h2c(
-    el: any,
-    viewport: boolean,
-    rect?: any,
-    unclipSelector?: string,
-  ): Promise<any> {
+  private async h2c(el: any, viewport: boolean, rect?: any, unclipSelector?: string): Promise<any> {
     const g = globalThis as any;
     // html2canvas-pro (fork) supports color-mix()/oklch()/lab() — the modern CSS
     // the original html2canvas silently fails on. Deferred: only loaded on a screenshot.

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -24,6 +24,7 @@ const prov = vi.hoisted(() => ({
   provision: vi.fn(),
   createBranch: vi.fn(),
   forkWorktree: vi.fn(),
+  gitAuthHint: vi.fn(),
 }));
 
 vi.mock("codehost/provision", () => ({
@@ -35,6 +36,7 @@ vi.mock("codehost/provision", () => ({
   provision: (spec: unknown, opts?: unknown) => prov.provision(spec, opts),
   createBranch: (spec: unknown, opts?: unknown) => prov.createBranch(spec, opts),
   forkWorktree: (opts: unknown) => prov.forkWorktree(opts),
+  gitAuthHint: (host?: string) => prov.gitAuthHint(host),
 }));
 
 describe("isPathInside", () => {
@@ -206,6 +208,7 @@ describe("cmdWs (mocked provision)", () => {
     prov.provision.mockReset();
     prov.createBranch.mockReset();
     prov.forkWorktree.mockReset();
+    prov.gitAuthHint.mockReset().mockReturnValue([]);
     out = [];
     err = [];
     vi.spyOn(process.stdout, "write").mockImplementation((s: any) => (out.push(String(s)), true));
@@ -418,6 +421,26 @@ describe("cmdWs (mocked provision)", () => {
     expect(await cmdWs(["new", "o/r"])).toBe(1);
     const msg = err.join("");
     expect(msg).toContain("repo-not-found");
+    expect(msg).not.toContain("--create");
+  });
+
+  it("new: auth-missing prints codehost's gitAuthHint lines", async () => {
+    prov.provision.mockResolvedValue({
+      ok: false,
+      action: "error",
+      reason: "auth-missing",
+      error: "could not read Username",
+    });
+    prov.gitAuthHint.mockReturnValue([
+      "⚠ this repo may be private, and no github.com credentials are available on this host.",
+      "To fix, run on the host:",
+      "   gh auth login && gh auth setup-git",
+      "then retry this link.",
+    ]);
+    expect(await cmdWs(["new", "o/r"])).toBe(1);
+    const msg = err.join("");
+    expect(msg).toContain("auth-missing");
+    expect(msg).toContain("gh auth login && gh auth setup-git");
     expect(msg).not.toContain("--create");
   });
 

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -52,7 +52,7 @@ interface ProvisionResult {
   action: string;
   git?: GitStatus;
   error?: string;
-  reason?: "branch-not-found" | "repo-not-found" | "other";
+  reason?: "branch-not-found" | "repo-not-found" | "auth-missing" | "other";
 }
 interface Provision {
   resolveWsRoot(wsRoot?: string): string;
@@ -67,6 +67,7 @@ interface Provision {
     wsRoot?: string;
     wip?: boolean;
   }): Promise<ProvisionResult>;
+  gitAuthHint(host?: string): string[];
 }
 
 export async function loadProvision(): Promise<Provision> {
@@ -480,6 +481,9 @@ async function cmdWsNew(args: string[]): Promise<number> {
           ? `  (branch missing on the remote — re-run with --create to branch off the default)\n`
           : ""),
     );
+    if (res.reason === "auth-missing") {
+      for (const line of prov.gitAuthHint()) process.stderr.write(`  ${line}\n`);
+    }
     return 1;
   }
   process.stdout.write(`${res.action}  ${res.folder}\n`);


### PR DESCRIPTION
## What

When `ay ws new` fails to provision a private repo because the host has no git credentials, codehost >=0.39.0 now classifies it as `reason: "auth-missing"` (instead of GitHub's misleading "repository not found") and exports `gitAuthHint()` with the fix. This PR:

- bumps `codehost` `^0.32.0` → `^0.39.0` (+ lockfile; verified on npm)
- adds `"auth-missing"` to the locally-typed `ProvisionResult` reason union and `gitAuthHint` to the local `Provision` interface (lazy-import/local-typing pattern unchanged)
- prints the hint lines (`gh auth login && gh auth setup-git`) under the `provision failed (auth-missing)` message

## Tests

New spec: `new: auth-missing prints codehost's gitAuthHint lines` — `ts/ws.spec.ts` 37/37 green with codehost@0.39.0 installed; typecheck error count unchanged vs origin/main.

Requested by the codehost-side agent following codehost's 0.39.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)