### PR TITLE
fix(send): warn on already-<ay-msg>-wrapped bodies (double-envelope footgun)

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -2646,3 +2646,149 @@ describe("subcommands.cmdWhoami", () => {
     expect(text).toMatch(/<ay-msg from claude #\d+ @ \/repo\/alpha — reply: ay send aaaa0000bbbb "\.\.\.">/);
   });
 });
+
+describe("subcommands.cmdSend double-envelope warning", () => {
+  const itUnix = process.platform === "linux" || process.platform === "darwin";
+
+  it.skipIf(!itUnix)(
+    "warns when an agent sender's body is already <ay-msg …>-wrapped (still delivers, still wraps)",
+    async () => {
+      const { runSubcommand } = await loadModule();
+      const { appendGlobalPid } = await import("./globalPidIndex.ts");
+      const { spawnSync } = await import("child_process");
+      const tmp = await mkdtemp(path.join(tmpdir(), "ay-fifo-"));
+      try {
+        const fifo = path.join(tmp, "warn.fifo");
+        if (spawnSync("mkfifo", [fifo]).status !== 0) return;
+        const fs = await import("fs");
+        const rdwrFd = fs.openSync(fifo, fs.constants.O_RDWR);
+        // Target agent (owns the fifo) …
+        await appendGlobalPid({
+          pid: process.pid,
+          cli: "claude",
+          prompt: null,
+          cwd: "/repo/alpha",
+          log_file: null,
+          fifo_file: fifo,
+          status: "active",
+          exit_code: null,
+          exit_reason: null,
+          started_at: Date.now(),
+        });
+        // … and a registered SENDER so cmdSend resolves an agent context and
+        // engages the auto-envelope path the warning guards.
+        await appendGlobalPid({
+          pid: 900001,
+          cli: "claude",
+          prompt: null,
+          cwd: "/repo/beta",
+          log_file: null,
+          status: "active",
+          exit_code: null,
+          exit_reason: null,
+          started_at: Date.now(),
+          wrapper_pid: 424242,
+          agent_id: "cccc0000dddd",
+        });
+        const savedAyPid = process.env.AGENT_YES_PID;
+        process.env.AGENT_YES_PID = "424242";
+        const stderr: string[] = [];
+        const origErr = process.stderr.write.bind(process.stderr);
+        (process.stderr as any).write = (s: any) => (stderr.push(String(s)), true);
+        const origOut = process.stdout.write.bind(process.stdout);
+        (process.stdout as any).write = () => true;
+        try {
+          const code = await runSubcommand([
+            "bun",
+            "cli.js",
+            "send",
+            String(process.pid),
+            '<ay-msg deadbeef from claude #900001 @ /repo/beta — reply: ay send 900001 "...">hi</ay-msg deadbeef>',
+            "--force",
+          ]);
+          expect(code).toBe(0);
+          expect(stderr.join("")).toMatch(/DOUBLE wrapper/);
+        } finally {
+          process.stderr.write = origErr;
+          process.stdout.write = origOut;
+          if (savedAyPid === undefined) delete process.env.AGENT_YES_PID;
+          else process.env.AGENT_YES_PID = savedAyPid;
+        }
+        // Delivered bytes carry BOTH envelopes — transport stamp outermost.
+        const buf = Buffer.alloc(8192);
+        const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
+        const received = buf.subarray(0, n).toString();
+        expect(received).toMatch(/^<ay-msg [0-9a-f]{8} from claude #900001 @ /);
+        expect(received).toContain("<ay-msg deadbeef");
+        fs.closeSync(rdwrFd);
+      } finally {
+        await rm(tmp, { recursive: true, force: true }).catch(() => null);
+      }
+    },
+  );
+
+  it.skipIf(!itUnix)("plain agent-sender bodies do not trigger the warning", async () => {
+    const { runSubcommand } = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const { spawnSync } = await import("child_process");
+    const tmp = await mkdtemp(path.join(tmpdir(), "ay-fifo-"));
+    try {
+      const fifo = path.join(tmp, "plain.fifo");
+      if (spawnSync("mkfifo", [fifo]).status !== 0) return;
+      const fs = await import("fs");
+      const rdwrFd = fs.openSync(fifo, fs.constants.O_RDWR);
+      await appendGlobalPid({
+        pid: process.pid,
+        cli: "claude",
+        prompt: null,
+        cwd: "/repo/alpha",
+        log_file: null,
+        fifo_file: fifo,
+        status: "active",
+        exit_code: null,
+        exit_reason: null,
+        started_at: Date.now(),
+      });
+      await appendGlobalPid({
+        pid: 900001,
+        cli: "claude",
+        prompt: null,
+        cwd: "/repo/beta",
+        log_file: null,
+        status: "active",
+        exit_code: null,
+        exit_reason: null,
+        started_at: Date.now(),
+        wrapper_pid: 424242,
+        agent_id: "cccc0000dddd",
+      });
+      const savedAyPid = process.env.AGENT_YES_PID;
+      process.env.AGENT_YES_PID = "424242";
+      const stderr: string[] = [];
+      const origErr = process.stderr.write.bind(process.stderr);
+      (process.stderr as any).write = (s: any) => (stderr.push(String(s)), true);
+      const origOut = process.stdout.write.bind(process.stdout);
+      (process.stdout as any).write = () => true;
+      try {
+        const code = await runSubcommand([
+          "bun",
+          "cli.js",
+          "send",
+          String(process.pid),
+          "plain body, quoting <ay-msg deadbeef …> mid-text is fine",
+          "--force",
+        ]);
+        expect(code).toBe(0);
+        expect(stderr.join("")).not.toMatch(/DOUBLE wrapper/);
+      } finally {
+        process.stderr.write = origErr;
+        process.stdout.write = origOut;
+        if (savedAyPid === undefined) delete process.env.AGENT_YES_PID;
+        else process.env.AGENT_YES_PID = savedAyPid;
+      }
+      fs.closeSync(rdwrFd);
+    } finally {
+      await rm(tmp, { recursive: true, force: true }).catch(() => null);
+    }
+  });
+});

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -3255,6 +3255,18 @@ async function cmdSend(rest: string[]): Promise<number> {
     nonce = randomBytes(4).toString("hex");
     prefix = `<ay-msg ${nonce} from ${sender.agent.cli} #${sender.agent.pid} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${replyTarget} "...">\n`;
     suffix = `\n</ay-msg ${nonce}>`;
+    // A body that itself starts with an <ay-msg …> header is usually an agent
+    // hand-wrapping what this send is about to wrap again — the recipient then
+    // sees a double envelope with two (possibly conflicting) reply targets.
+    // Warn but still wrap: the transport stamp is the authoritative identity
+    // (skipping it on a pre-wrapped body would let a sender forge attribution),
+    // and a quoted envelope is legitimate when deliberately forwarding.
+    if (/^\s*<ay-msg\s/.test(body)) {
+      process.stderr.write(
+        `warning: body already starts with an <ay-msg …> header — ay send adds the envelope automatically, so the recipient will see a DOUBLE wrapper. ` +
+          `Send the bare body instead (or pass --raw if you really mean to deliver a pre-built envelope verbatim; forwarding a quoted message inside a plain body is fine).\n`,
+      );
+    }
   }
 
   const fullBody = prefix + body + suffix;


### PR DESCRIPTION
## What / why

`ay send` from an agent context auto-wraps the body in a nonce-stamped `<ay-msg …>` envelope. An agent that hand-wraps its body too (it happened in live inter-agent traffic today — reported via the fleet) delivers a **double envelope** with two reply targets, one of them wrong (inner pid vs outer agent_id).

This adds a stderr warning when the body itself starts with an `<ay-msg` header, while **still wrapping**: the transport stamp stays authoritative (auto-skipping the wrap for pre-wrapped bodies would let a sender forge attribution), and forwarding a quoted envelope inside a plain body stays legitimate — `--raw` already exists for deliberate verbatim delivery.

## Tests

Two new FIFO-backed specs: warning fires for a pre-wrapped agent-sender body (and delivery still carries transport stamp outermost), and plain bodies that merely quote `<ay-msg` mid-text don't warn. `ts/subcommands.spec.ts` 120/120 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)