### PR TITLE
fix(spawn): block nested-detach spawn output until the pid is actually addressable

### DIFF
--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -149,7 +149,8 @@ if (config.useRust) {
     // agent so we don't block the parent's tool call for the whole session, then
     // print how to drive it and exit. `--attach`/AGENT_YES_ATTACH=1 opts out.
     const attach = config.attach || process.env.AGENT_YES_ATTACH === "1";
-    const { shouldForkNested, buildSpawnTutorial, waitForFifo } = await import("./forkNested.ts");
+    const { shouldForkNested, buildSpawnTutorial, waitForRegistration, predictedLogPath } =
+      await import("./forkNested.ts");
     if (
       shouldForkNested({
         isTTY: Boolean(process.stdout.isTTY),
@@ -168,11 +169,13 @@ if (config.useRust) {
         console.error("Failed to spawn agent: no pid.");
         process.exit(1);
       }
-      // Race a fast startup failure against FIFO registration so we never print a
-      // success tutorial for a dead pid. The wrapper keeps its own per-pid log, so
-      // real output stays reachable via `ay tail` even with stdio ignored. Store a
-      // pre-formatted message (not a union) — the callbacks run async, so control-flow
-      // analysis can't narrow a union here anyway.
+      // Race a fast startup failure against registration becoming visible in the
+      // global pid registry — the actual contract `ay tail`/`ay send` need — so we
+      // never print a success tutorial for a pid that's dead OR still unaddressable.
+      // The wrapper keeps its own per-pid log, so real output stays reachable via
+      // `ay tail` even with stdio ignored. Store a pre-formatted message (not a
+      // union) — the callbacks run async, so control-flow analysis can't narrow a
+      // union here anyway.
       let deathMsg: string | null = null;
       forked.on("error", (err) => {
         deathMsg ??= `Failed to spawn agent: ${err.message}`;
@@ -180,14 +183,21 @@ if (config.useRust) {
       forked.on("exit", (code, signal) => {
         deathMsg ??= `Agent exited immediately (${signal ?? `code ${code}`}). See: ay tail ${forkedPid}`;
       });
-      const registered = await waitForFifo(forkedPid, 2000, () => deathMsg !== null);
+      const registered = await waitForRegistration(forkedPid, 5000, () => deathMsg !== null);
       if (deathMsg) {
         console.error(deathMsg);
         process.exit(1);
       }
       forked.unref();
+      if (!registered) {
+        console.error(
+          `Agent pid ${forkedPid} spawned but never became addressable (ay tail/ay send) within 5s.\n` +
+            `Log (if written yet): ${predictedLogPath(process.cwd(), forkedPid)}\n` +
+            `It may still be starting up — retry: ay tail ${forkedPid}`,
+        );
+        process.exit(1);
+      }
       console.log(buildSpawnTutorial(config.cli || "agent", forkedPid));
-      if (!registered) console.log(`(note: still registering — give ay send/tail a moment)`);
       process.exit(0);
     }
 

--- a/ts/forkNested.spec.ts
+++ b/ts/forkNested.spec.ts
@@ -1,8 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { appendFileSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildSpawnTutorial, shouldForkNested, waitForFifo } from "./forkNested";
+import {
+  buildSpawnTutorial,
+  predictedLogPath,
+  shouldForkNested,
+  waitForRegistration,
+} from "./forkNested";
 
 describe("shouldForkNested", () => {
   it("forks when nested (AGENT_YES_PID set) and stdout is not a TTY", () => {
@@ -24,13 +29,15 @@ describe("shouldForkNested", () => {
   });
 });
 
-describe("waitForFifo", () => {
+describe("waitForRegistration", () => {
   let home: string;
   let prevHome: string | undefined;
 
+  const appendPid = (record: Record<string, unknown>) =>
+    appendFileSync(path.join(home, "pids.jsonl"), JSON.stringify(record) + "\n");
+
   beforeEach(() => {
     home = mkdtempSync(path.join(tmpdir(), "ay-forknested-"));
-    mkdirSync(path.join(home, "fifo"), { recursive: true });
     prevHome = process.env.AGENT_YES_HOME;
     process.env.AGENT_YES_HOME = home;
   });
@@ -41,20 +48,57 @@ describe("waitForFifo", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  it("resolves true as soon as the wrapper's stdin FIFO is registered", async () => {
-    // Register the endpoint a poll-tick after the wait starts, like a real spawn.
-    setTimeout(() => writeFileSync(path.join(home, "fifo", "111.stdin"), ""), 60);
-    await expect(waitForFifo(111, 2000)).resolves.toBe(true);
+  it("resolves true once the pid registry has a live record for this pid", async () => {
+    // Register the pid a poll-tick after the wait starts, like a real spawn.
+    setTimeout(
+      () =>
+        appendPid({
+          pid: 111,
+          cli: "claude",
+          prompt: null,
+          cwd: "/tmp",
+          log_file: null,
+          status: "active",
+          exit_code: null,
+          exit_reason: null,
+          started_at: Date.now(),
+        }),
+      60,
+    );
+    await expect(waitForRegistration(111, 2000)).resolves.toBe(true);
   });
 
-  it("times out false when the child never registers", async () => {
-    await expect(waitForFifo(222, 120)).resolves.toBe(false);
+  it("times out false when the agent never registers", async () => {
+    await expect(waitForRegistration(222, 120)).resolves.toBe(false);
+  });
+
+  it("does NOT count a record whose status is already exited", async () => {
+    appendPid({
+      pid: 333,
+      cli: "claude",
+      prompt: null,
+      cwd: "/tmp",
+      log_file: null,
+      status: "exited",
+      exit_code: 1,
+      exit_reason: "crash",
+      started_at: Date.now(),
+    });
+    await expect(waitForRegistration(333, 120)).resolves.toBe(false);
   });
 
   it("fails fast when aborted() reports the child already died", async () => {
     const start = Date.now();
-    await expect(waitForFifo(333, 5000, () => true)).resolves.toBe(false);
+    await expect(waitForRegistration(444, 5000, () => true)).resolves.toBe(false);
     expect(Date.now() - start).toBeLessThan(1000); // no full-timeout wait
+  });
+});
+
+describe("predictedLogPath", () => {
+  it("matches the Rust wrapper's <cwd>/.agent-yes/<pid>.raw.log convention", () => {
+    expect(predictedLogPath("/home/u/proj", 4242)).toBe(
+      path.join("/home/u/proj", ".agent-yes", "4242.raw.log"),
+    );
   });
 });
 

--- a/ts/forkNested.ts
+++ b/ts/forkNested.ts
@@ -1,6 +1,4 @@
-import { existsSync } from "fs";
 import path from "path";
-import { agentYesHome } from "./agentYesHome.ts";
 
 /**
  * Should a nested agent-run detach (fork) instead of blocking the caller?
@@ -42,23 +40,39 @@ export function buildSpawnTutorial(cli: string, pid: number): string {
 }
 
 /**
- * Poll for the spawned wrapper's stdin FIFO to appear, so the tutorial's
- * `ay send`/`ay tail` work the instant we print them (the wrapper registers its
- * FIFO a moment after spawn). Resolves true once registered, false on timeout or
- * if `aborted()` reports the child already died (so a startup failure fails fast
- * instead of waiting out the whole window).
+ * Poll the global pid registry (`~/.agent-yes/pids.jsonl`) for `pid` to become
+ * resolvable — the actual contract `ay tail`/`ay send` depend on (both resolve
+ * through `readGlobalPids()`), not a proxy signal. The wrapper creates its
+ * stdin FIFO BEFORE writing its pid_store record (see rs/src/main.rs), so
+ * polling the FIFO's existence — the previous approach — could report "ready"
+ * before the registration it's meant to confirm had even happened.
+ *
+ * A record with `status: "exited"` doesn't count: the agent registered and
+ * then immediately died, so it's no more "addressable" than never registering.
+ * Resolves true once a live record for this pid appears, false on timeout or
+ * if `aborted()` reports the child already died (so a startup failure fails
+ * fast instead of waiting out the whole window).
  */
-export async function waitForFifo(
+export async function waitForRegistration(
   pid: number,
-  timeoutMs = 2000,
+  timeoutMs = 5000,
   aborted?: () => boolean,
 ): Promise<boolean> {
-  const fifo = path.join(agentYesHome(), "fifo", `${pid}.stdin`);
+  const { readGlobalPids } = await import("./globalPidIndex.ts");
+  const isRegistered = async () =>
+    (await readGlobalPids()).some((r) => r.pid === pid && r.status !== "exited");
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (aborted?.()) return false;
-    if (existsSync(fifo)) return true;
-    await new Promise((r) => setTimeout(r, 50));
+    if (await isRegistered()) return true;
+    await new Promise((r) => setTimeout(r, 100));
   }
-  return existsSync(fifo);
+  return isRegistered();
+}
+
+/** Predicted per-agent raw log path — deterministic from cwd + pid (see
+ *  rs/src/log_files.rs's `project_log_dir`), so it's known even when the
+ *  agent never registered. */
+export function predictedLogPath(cwd: string, pid: number): string {
+  return path.join(cwd, ".agent-yes", `${pid}.raw.log`);
 }

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -2643,7 +2643,9 @@ describe("subcommands.cmdWhoami", () => {
     const text = stdout2.join("");
     expect(text).toMatch(/agent {5}claude #\d+ {2}\(agent_id aaaa0000bbbb\)/);
     expect(text).toMatch(/reply {5}ay send aaaa0000bbbb/);
-    expect(text).toMatch(/<ay-msg from claude #\d+ @ \/repo\/alpha — reply: ay send aaaa0000bbbb "\.\.\.">/);
+    expect(text).toMatch(
+      /<ay-msg from claude #\d+ @ \/repo\/alpha — reply: ay send aaaa0000bbbb "\.\.\.">/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- `ay <cli>` spawned from inside another agent (Bash tool, non-tty stdout) detaches, then unconditionally printed `Spawned … as pid N` and exited 0 — even when the spawned agent never became resolvable by `ay tail`/`ay send`.
- Root cause: the gate it used (`waitForFifo`) only checked that the wrapper's stdin FIFO file existed. The Rust wrapper creates that FIFO **before** writing its pid_store record (`rs/src/main.rs`), so a `true` result never actually proved registration had happened. Worse, the result was discarded either way — success message + exit 0 regardless, with only a soft "still registering" note on timeout.
- Fix: `waitForRegistration()` polls the actual global pid registry (`~/.agent-yes/pids.jsonl`, the same file `ay tail`/`ay send` resolve through) for a live record of the pid, bounded at 5s. On timeout (or a confirmed early death of the wrapper process) the command now prints a diagnostic with the predicted log path and exits non-zero instead of lying about success.

Reported by an inter-agent `ay send` bug report (codex #27675), reproduced independent of model/prompt content on agent-yes v1.246.2.

## Test plan
- [x] `ts/forkNested.spec.ts` — rewrote the `waitForFifo` tests as `waitForRegistration` tests against a fake `~/.agent-yes/pids.jsonl` (success, timeout, exited-record-doesn't-count, fails-fast-on-death) + new `predictedLogPath` test
- [x] `bunx vitest run ts/forkNested.spec.ts ts/subcommands.spec.ts` — 130/130 pass
- [x] Full suite (`bunx vitest run --coverage=false`) — only the 2 pre-existing, unrelated `todoCli.spec.ts` locale failures (yargs emits Japanese error text on this machine)
- [x] `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)