### PR TITLE
feat(ws): bundle provisioning via @snomiao/ws-provision (drop the manual codehost install)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "main",
       "dependencies": {
         "@snomiao/bun-pty": "^0.3.4",
+        "@snomiao/ws-provision": "^0.1.0",
         "@xterm/headless": "^6.0.0",
         "bun-pty": "^0.4.8",
         "execa": "^9.6.1",
@@ -363,6 +364,8 @@
     "@snomiao/bun-pty": ["@snomiao/bun-pty@0.3.4", "", {}, "sha512-7eVzv+fNQrELScC6vmza52rXAxfHJnPiUSi6k2i1C0NS/xCB4+baEfH4tdRaEpGNrsI2DP6rnppNXQu+6kUWFA=="],
 
     "@snomiao/daemon-kit": ["@snomiao/daemon-kit@0.2.0", "", {}, "sha512-Ymp6S/7C3cTGkakXqeYcVzieAN9O0uTmk7GxIeOEi7k2j3pX8mPVxZ5VgCQTSWmZjpNjUKR8zhb2dEkENOS+OQ=="],
+
+    "@snomiao/ws-provision": ["@snomiao/ws-provision@0.1.0", "", {}, "sha512-o8VNzDK8ux2BOY1RoVwuBGY1XPgp9FAQKdDysXCljKTFPkv8fiv6a2OR6HpGk8F1M8TQrR7Ndcl3zGB121eYVw=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   },
   "dependencies": {
     "@snomiao/bun-pty": "^0.3.4",
+    "@snomiao/ws-provision": "^0.1.0",
     "@xterm/headless": "^6.0.0",
     "bun-pty": "^0.4.8",
     "execa": "^9.6.1",

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -38,6 +38,7 @@ import {
   type CommonOpts,
 } from "./subcommands.ts";
 import { answerAsk, listAsks } from "./askApi.ts";
+import { importProvisionModule } from "./ws.ts";
 import { permissionBadge } from "./agentPermissions.ts";
 import { TYPING_BADGE } from "./badges.ts";
 import { isTermToken, mintTermToken, verifyTermToken, type TermScope } from "./termToken.ts";
@@ -3907,11 +3908,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
           }>;
         };
         try {
-          prov = (await import("codehost/provision")) as typeof prov;
+          prov = (await importProvisionModule()) as typeof prov;
         } catch (e) {
           return new Response(
-            `fork needs the 'codehost' package (codehost/provision) — install it ` +
-              `(npm i -g codehost) or 'bun link' it for local dev: ${(e as Error).message}`,
+            `fork needs a provision implementation — '@snomiao/ws-provision' (bundled ` +
+              `dependency) or a bun-linked 'codehost': ${(e as Error).message}`,
             { status: 501 },
           );
         }
@@ -3979,11 +3980,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
           ) => Promise<{ ok: boolean; folder: string; action: string; error?: string }>;
         };
         try {
-          prov = (await import("codehost/provision")) as typeof prov;
+          prov = (await importProvisionModule()) as typeof prov;
         } catch (e) {
           return new Response(
-            `spawn-from needs the 'codehost' package (codehost/provision) — install it ` +
-              `(npm i -g codehost) or 'bun link' it for local dev: ${(e as Error).message}`,
+            `spawn-from needs a provision implementation — '@snomiao/ws-provision' (bundled ` +
+              `dependency) or a bun-linked 'codehost': ${(e as Error).message}`,
             { status: 501 },
           );
         }

--- a/ts/ws.spec.ts
+++ b/ts/ws.spec.ts
@@ -27,7 +27,10 @@ const prov = vi.hoisted(() => ({
   gitAuthHint: vi.fn(),
 }));
 
-vi.mock("codehost/provision", () => ({
+// loadProvision prefers @snomiao/ws-provision (a real installed dependency) and
+// falls back to codehost/provision, so BOTH must be mocked to the same shims —
+// otherwise the preferred path would bypass the mocks and hit real git.
+const provMockFactory = vi.hoisted(() => () => ({
   resolveWsRoot: (w?: string) => w ?? prov.wsRoot,
   folderFor: (spec: { owner: string; repo: string; branch: string }, wsRoot?: string) =>
     path.join(wsRoot ?? prov.wsRoot, spec.owner, spec.repo, "tree", spec.branch),
@@ -38,6 +41,8 @@ vi.mock("codehost/provision", () => ({
   forkWorktree: (opts: unknown) => prov.forkWorktree(opts),
   gitAuthHint: (host?: string) => prov.gitAuthHint(host),
 }));
+vi.mock("@snomiao/ws-provision", provMockFactory);
+vi.mock("codehost/provision", provMockFactory);
 
 describe("isPathInside", () => {
   it("contains itself and descendants", () => {

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -70,13 +70,28 @@ interface Provision {
   gitAuthHint(host?: string): string[];
 }
 
+/**
+ * Provisioning implementation, resolved at call time. @snomiao/ws-provision is
+ * the canonical zero-dependency package (a regular dependency, so npm installs
+ * of agent-yes always have it); codehost/provision — which re-exports the same
+ * module — stays as a fallback for bun-linked dev setups pinned to a codehost
+ * checkout. Shared by `ay ws` and serve's fork/spawn-from provisioning.
+ */
+export async function importProvisionModule(): Promise<unknown> {
+  try {
+    return await import("@snomiao/ws-provision");
+  } catch {
+    return await import("codehost/provision"); // let THIS failure surface to the caller
+  }
+}
+
 export async function loadProvision(): Promise<Provision> {
   try {
-    return (await import("codehost/provision")) as unknown as Provision;
+    return (await importProvisionModule()) as Provision;
   } catch (e) {
     throw new Error(
-      `'ay ws' needs the 'codehost' package (codehost/provision) — install it ` +
-        `(npm i -g codehost) or 'bun link' it for local dev: ${(e as Error).message}`,
+      `'ay ws' needs a provision implementation — '@snomiao/ws-provision' (bundled ` +
+        `as a dependency) or 'codehost/provision' (bun-linked dev): ${(e as Error).message}`,
     );
   }
 }


### PR DESCRIPTION
## What

`ay ws new/fork` and serve's fork/spawn-from provisioning previously required the `codehost` package to be installed or bun-linked separately — a heavy dependency (react, @parcel/watcher, bun-pty, node-datachannel) for what is pure git-subprocess logic, and missing it meant runtime errors / silent 501s on fork.

codehost has now extracted that module into **@snomiao/ws-provision** (zero runtime deps, 36KB unpacked; `codehost/provision` re-exports it — coordinated with the codehost-side agent). This PR:

- adds `@snomiao/ws-provision ^0.1.0` to **dependencies** (ships with agent-yes)
- `importProvisionModule()` in ts/ws.ts prefers it, falling back to `codehost/provision` for bun-linked dev checkouts; `loadProvision` + both serve.ts sites (fork 501 / spawn-from 501) now share this loader
- ws.spec.ts mocks BOTH module ids (hoisted shared factory) so the preferred path can't bypass the mocks into real git

## Why not reimplement in-repo?

Considered and rejected: today's ayrs resolver incident (#356) was exactly duplicated-logic drift. One canonical package, two consumers.

## Tests

ws.spec 37/37, serve.spec 15/15 green; typecheck error count unchanged vs origin/main; live-verified `bun -e 'import("@snomiao/ws-provision")'` and `ay ws ls` from the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)