### PR TITLE
port: three orphaned fixes from the takusym fork (peer-selection map, boxed menu parse, todo phantom badge)

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -684,9 +684,12 @@ export function selSegments(sel, myLast, vy, myRows, peerCols, myCols) {
   const from = Math.max(rA, vy),
     to = Math.min(rB, vy + myRows - 1);
   for (let r = from; r <= to; r++) {
-    const a = r === rA ? cA : 0;
-    const b = r === rB ? cB : myCols;
-    segs.push({ row: r, a: Math.min(mapC(a), mapC(b)), b: Math.max(mapC(a), mapC(b)) });
+    // cA/cB are the PEER's columns, so they go through mapC; 0 and myCols are the
+    // row's own edges, already in OUR space — mapping them would rescale our own
+    // right edge (and could even invert the span when the peer is wider).
+    const a = r === rA ? mapC(cA) : 0;
+    const b = r === rB ? mapC(cB) : myCols;
+    segs.push({ row: r, a: Math.min(a, b), b: Math.max(a, b) });
   }
   return segs;
 }

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -817,6 +817,27 @@ describe("selSegments", () => {
     expect(seg).toEqual({ row: 0, a: 20, b: 40 }); // 10/80*160=20, 20/80*160=40
   });
 
+  // The row-edge sentinel is OUR right edge (myCols), already in our coordinate
+  // space — only the peer's own columns (cA/cB) go through the peer→us mapping.
+  it("ends a multi-row selection at OUR right edge when the peer is NARROWER", () => {
+    // peer 80 wide, we are 160. Two rows: top starts at peer col 70, bottom ends at 5.
+    const s = parseSel("1,70-0,5")!; // myLast 10 → top row 9, bottom row 10
+    expect(selSegments(s, 10, 0, 24, 80, 160)).toEqual([
+      { row: 9, a: 140, b: 160 }, // top: 70/80*160=140 → our edge (160), NOT 320
+      { row: 10, a: 0, b: 10 }, // bottom: 0 → 5/80*160=10
+    ]);
+  });
+
+  it("keeps middle rows FULL width when the peer is WIDER", () => {
+    // peer 160 wide, we are 80. Three rows: top from peer col 100, bottom to col 20.
+    const s = parseSel("2,100-0,20")!; // myLast 10 → rows 8,9,10
+    expect(selSegments(s, 10, 0, 24, 160, 80)).toEqual([
+      { row: 8, a: 50, b: 80 }, // top: 100/160*80=50 → our edge (80)
+      { row: 9, a: 0, b: 80 }, // middle: full width of OUR 80 cols, not 40
+      { row: 10, a: 0, b: 10 }, // bottom: 0 → 20/160*80=10
+    ]);
+  });
+
   it("returns [] for null", () => {
     expect(selSegments(null, 59, 0, 54, 80, 80)).toEqual([]);
   });

--- a/ts/needsInput.spec.ts
+++ b/ts/needsInput.spec.ts
@@ -113,3 +113,41 @@ test("parseMenu: a 'N.M' version in an option label isn't mistaken for another o
   expect(menu!.cursor).toBe(1);
   expect(menu!.options).toEqual([1, 2]);
 });
+
+// Claude renders its permission / AskUserQuestion dialogs INSIDE a rounded box,
+// so every option row arrives with a leading "│" border (the shipped config's own
+// markers show this: a typingRespond keyed on '│ Do you want to use this API key\?'
+// and gemini `enter` rows like "│ ● 1. Yes, allow once"). Option rows must still be
+// collected through that border — otherwise `ay select N` can only ever pick the
+// option the cursor already sits on.
+test("parseMenu: collects options through a box border (claude permission dialog)", () => {
+  const screen = [
+    "╭──────────────────────────────────────────────────────────╮",
+    "│ Do you want to proceed?                                  │",
+    "│ ❯ 1. Yes                                                 │",
+    "│   2. Yes, and don't ask again for rm commands in /repo   │",
+    "│   3. No, and tell Claude what to do differently (esc)    │",
+    "╰──────────────────────────────────────────────────────────╯",
+  ];
+  const menu = parseMenu(screen, claude);
+  expect(menu!.cursor).toBe(1);
+  expect(menu!.options).toEqual([1, 2, 3]);
+});
+
+test("parseMenu: collects boxed bullet rows (gemini '│ ● 1. Yes, allow once')", () => {
+  const screen = [
+    "│ Apply this change?          │",
+    "│ ❯ 1. Yes, allow once        │",
+    "│ ● 2. Yes, allow always      │",
+    "│ ● 3. No (esc)               │",
+  ];
+  const menu = parseMenu(screen, claude);
+  expect(menu!.cursor).toBe(1);
+  expect(menu!.options).toEqual([1, 2, 3]);
+});
+
+test("parseMenu: a boxed 'N.M' version still isn't mistaken for an option", () => {
+  const screen = ["│ Cleanup?              │", "│ ❯ 1. Delete 3.5GB     │", "│   2. Keep             │"];
+  const menu = parseMenu(screen, claude);
+  expect(menu!.options).toEqual([1, 2]);
+});

--- a/ts/needsInput.ts
+++ b/ts/needsInput.ts
@@ -76,9 +76,13 @@ export interface MenuState {
   question: string;
 }
 
-// An option row: an optional cursor glyph / bullet, then "N. " (the trailing
-// space rejects version-like "3.5GB" that isn't a menu option).
-const OPTION_LINE = /^[\s❯›>▶◉○●·*-]*?(\d+)\.\s/;
+// An option row: an optional box border / cursor glyph / bullet, then "N. " (the
+// trailing space rejects version-like "3.5GB" that isn't a menu option). The `│`
+// matters: claude/gemini render their permission + AskUserQuestion menus inside a
+// rounded box, so real option rows arrive as "│ ❯ 1. Yes" — without it only the
+// cursor row is ever collected and `ay select N` can't reach any other option.
+// Keep `-` last in the class so it stays a literal rather than a range.
+const OPTION_LINE = /^[\s❯›>▶◉○●·│*-]*?(\d+)\.\s/;
 
 /**
  * Parse the selection menu a `needs_input` agent is parked on into a cursor

--- a/ts/todoParse.spec.ts
+++ b/ts/todoParse.spec.ts
@@ -65,4 +65,34 @@ describe("parseTaskCounts", () => {
     expect(parseTaskCounts([])).toBeNull();
     expect(parseTaskCounts(lines("just some logs\nnothing here"))).toBeNull();
   });
+
+  // The CLI branches EVERY tool result under the same ⎿ glyph, not just todo
+  // blocks — and ✓ is an ordinary success glyph in program output. So a ⎿ line
+  // that carries its own content is a tool-result header, not a todo anchor;
+  // only a BARE ⎿ anchors the markers below it.
+  it("does not invent a badge from a test run's ✓ output (⎿ tool-result header)", () => {
+    const out = parseTaskCounts(
+      lines(
+        [
+          "⏺ Bash(bun run test)",
+          "  ⎿  RUN  v3.2.4 /repo",
+          "     ✓ ts/badges.spec.ts (18 tests) 12ms",
+          "     ✓ ts/needsInput.spec.ts (12 tests) 9ms",
+          "     ✓ ts/autoRetry.spec.ts (7 tests) 4ms",
+        ].join("\n"),
+      ),
+    );
+    expect(out).toBeNull();
+  });
+
+  it("does not invent a badge from ✓ prose under a ⎿ result header", () => {
+    const out = parseTaskCounts(
+      lines(
+        ["  ⎿  Read 120 lines (ctrl+o to expand)", "     ✓ Tests pass", "     ✓ Lint clean"].join(
+          "\n",
+        ),
+      ),
+    );
+    expect(out).toBeNull();
+  });
 });

--- a/ts/todoParse.ts
+++ b/ts/todoParse.ts
@@ -51,15 +51,27 @@ function markerOf(line: string): Marker | null {
   return null;
 }
 
+// The TUI branches EVERY tool result under the same `⎿` glyph — "⎿  RUN v3.2.4",
+// "⎿  Read 120 lines (ctrl+o to expand)" — not just todo blocks. Such a header
+// carries its own content after the glyph, whereas a todo anchor on the line above
+// its markers is bare. Requiring bare keeps a Bash run that prints ✓ lines (vitest
+// output!) from self-anchoring into a phantom badge, while the todo shapes — the
+// anchor ON the first marker line ("⎿  ☒ Wire up the parser") or a lone "⎿" above
+// them — still qualify.
+function isBareAnchor(line: string): boolean {
+  const s = line.trim();
+  return s.startsWith(ANCHOR) && s.slice(ANCHOR.length).trim() === "";
+}
+
 /**
  * Find the MOST RECENT confidently-detected todo block in the rendered lines and
  * return its {done, total}. Returns null when none qualifies (caller omits the
  * badge entirely — never shows "0/0").
  *
  * A block is a maximal run of consecutive marker lines. It only counts when it
- * is anchored — the `⎿` glyph appears on the run's first line or the line
- * directly above it — and has ≥2 marker lines. The last qualifying block wins,
- * since the agent's current todo state is the one drawn most recently.
+ * is anchored — the `⎿` glyph sits on the run's FIRST line, or a bare `⎿` sits on
+ * the line directly above it — and has ≥2 marker lines. The last qualifying block
+ * wins, since the agent's current todo state is the one drawn most recently.
  */
 export function parseTaskCounts(lines: string[]): TaskCounts | null {
   let best: TaskCounts | null = null;
@@ -71,13 +83,15 @@ export function parseTaskCounts(lines: string[]): TaskCounts | null {
       continue;
     }
     // Start of a marker run at i.
-    let hasAnchor = i > 0 && lines[i - 1]!.includes(ANCHOR);
+    let hasAnchor = i > 0 && isBareAnchor(lines[i - 1]!);
     const counts = { done: 0, inprogress: 0, pending: 0 };
     let j = i;
     for (; j < n; j++) {
       const mk = markerOf(lines[j]!);
       if (mk === null) break;
-      if (lines[j]!.includes(ANCHOR)) hasAnchor = true;
+      // Only the run's FIRST line can carry the anchor (as the doc says); a ⎿ that
+      // turns up mid-run is not an anchor for the run that already started above it.
+      if (j === i && lines[j]!.includes(ANCHOR)) hasAnchor = true;
       counts[mk]++;
     }
     const total = counts.done + counts.inprogress + counts.pending;


### PR DESCRIPTION
## What

Three fixes sat open+unreviewed on the takusym/agent-yes fork for 23 days (takusym#1/#2/#3), all MERGEABLE and all verified ABSENT from upstream main. Cherry-picked with original authorship intact; all three came with their own regression tests.

1. **fix(ui)** `selSegments`: don't rescale our own row edges (0/myCols) through the peer→us column map — mapping our own right edge rescaled it and could invert the span when the peer is wider. (takusym#1)
2. **fix(select)** `OPTION_LINE`: tolerate the `│` box border — claude/gemini render permission + AskUserQuestion menus inside a rounded box, so without it `ay select N` could only ever pick the row the cursor already sat on. Directly load-bearing for fleet needs_input handling. (takusym#2)
3. **fix(todo)** `parseTaskCounts`: a `⎿` line with its own content is a tool-result header, not a todo anchor — running this repo's own test suite inside an agent painted a phantom `3/3` badge from vitest's `✓` lines. (takusym#3)

## Verification

- Fix absence confirmed against origin/main before porting (grep of the exact expressions).
- Clean cherry-picks, no conflicts; `console-logic.spec` + `needsInput.spec` + `todoParse.spec` 154/154 green.

Surfaced by the fleet's stale-work sweep — the fork PRs will be closed pointing here once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)