### PR TITLE
ui(console): compact left panel — drop the per-row cwd line

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -1365,35 +1365,6 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      .rowcwd {
-        display: flex;
-        font-family: var(--mono);
-        color: var(--muted);
-        font-size: 11px;
-        min-width: 0;
-      }
-      .rowcwd .tbranch {
-        /* Invisible spacer matching the row's own tree-rail prefix, so the cwd
-           line indents under the name column at any nesting depth instead of
-           a magic constant that only lines up at depth 0. */
-        visibility: hidden;
-      }
-      .rowcwd .rowcwd-lead {
-        flex: none;
-      }
-      .rowcwd .rowcwd-path {
-        flex: 1;
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        /* Absolute paths share a long, boring prefix (/Users/x/ws/…) — the
-           informative part is the tail, so ellipsize from the left/start
-           instead of the (default) end. Characters stay in reading order
-           (this only flips which end gets clipped, via the bidi algorithm). */
-        direction: rtl;
-        text-align: left;
-      }
       .rowtitle {
         color: var(--fg);
         font-size: 12.5px;
@@ -1410,19 +1381,14 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      /* compact view: dot + cli + live title (or prompt), age — plus the agent's
-         cwd as a 2nd line (.rowcwd) underneath. */
+      /* compact view: one line per agent — dot + cli + live title (or prompt),
+         age. The agent's cwd lives in the right-pane title bar (.rcwd), not
+         here — a 2nd line per row costs half the list's density. */
       .row.crow {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-        padding: 6px 18px;
-      }
-      .crow1 {
         display: flex;
         align-items: center;
         gap: 8px;
-        min-width: 0;
+        padding: 6px 18px;
       }
       /* Tree branch prefix for nested (sub)agents — monospace so the box-drawing
          glyphs line up into continuous │ ├ └ rails across rows. */
@@ -1574,8 +1540,10 @@
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        /* Ellipsize the boring home/ws prefix, not the informative tail — see
-           the matching comment on .rowcwd-path. */
+        /* Absolute paths share a long, boring prefix (/Users/x/ws/…) — the
+           informative part is the tail, so ellipsize from the left/start
+           instead of the (default) end. Characters stay in reading order
+           (this only flips which end gets clipped, via the bidi algorithm). */
         direction: rtl;
         text-align: left;
       }
@@ -5732,7 +5700,6 @@ my.translate = async (text, lang) => {
                 const id = compactIdent(e, ctx, 3, r.parentEntry);
                 const cli = cliLabel(e);
                 return `<div class="row crow ${e._key === sel ? "sel" : ""}${rowFlags(e)}" data-key="${esc(e._key)}">
-        <div class="crow1">
         ${r.branch ? `<span class="tbranch">${esc(r.branch)}</span>` : ""}
         ${pinMarkHtml(e)}
         <span class="dot ${esc(e.status)}"></span>
@@ -5744,19 +5711,7 @@ my.translate = async (text, lang) => {
         ${badgeChipsHtml(e)}
         ${gitChipHtml(e)}
         ${peerChipHtml(e)}
-        <span class="age">${age(e)}</span></div>
-        ${
-          e.cwd
-            ? // The leading "/" sits right at the bidi paragraph edge of the
-              // rtl-ellipsis trick below and gets reordered to the far end —
-              // pin it outside that span so only the actual path direction-flips.
-              (() => {
-                const lead = e.cwd.startsWith("/") ? "/" : "";
-                const rest = e.cwd.slice(lead.length);
-                return `<div class="rowcwd" title="${esc(e.cwd)}">${r.branch ? `<span class="tbranch">${esc(r.branch)}</span>` : ""}<span class="rowcwd-lead">${esc(lead)}</span><span class="rowcwd-path">${esc(rest)}</span></div>`;
-              })()
-            : ""
-        }</div>`;
+        <span class="age">${age(e)}</span></div>`;
               })
               .join("") || `<div class="empty">no match</div>`;
           renderSendWires(); // rows were replaced — re-draw the overlay (see below)
@@ -5983,9 +5938,9 @@ my.translate = async (text, lang) => {
         $("rname").textContent = rname;
         refreshDocTitle(); // tab title follows the selected agent (name + status)
         $("rpid").textContent = "pid " + e.pid;
-        // Split off the leading "/" before the rtl-ellipsis path span (see the
-        // matching .rowcwd-lead comment) — it sits at the bidi paragraph edge
-        // and would otherwise get reordered to the far end of the line.
+        // Split off the leading "/" before the rtl-ellipsis path span — it sits
+        // at the bidi paragraph edge and would otherwise get reordered to the
+        // far end of the line (see the .rcwd-path comment).
         const cwd = e.cwd || "";
         const cwdLead = cwd.startsWith("/") ? "/" : "";
         $("rcwdlead").textContent = cwdLead;


### PR DESCRIPTION
Per taku: the cwd in the title bar (#360) is enough — showing it again as a 2nd line under every left-panel row doubles row height and halves list density.

- Removes the `.rowcwd` second line (+ its CSS) from the compact list rows; rows are one line again.
- Keeps the right-pane title-bar cwd (`.rcwd`) untouched.
- ui-dom: 25/25 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)