### PR TITLE
fix(rs): Windows Backspace deleted a whole word — enable VT input on the console

### DIFF
--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -625,6 +625,11 @@ impl AgentContext {
 
         // Set terminal to raw mode for proper signal handling
         let _raw_mode = terminal::enable_raw_mode();
+        // Windows: also enable VT input so keys arrive as VT bytes (Backspace =
+        // 0x7f, not 0x08 — which ConPTY would hand to the child as
+        // Ctrl+Backspace = delete-word, #349). See enable_vt_input.
+        #[cfg(windows)]
+        let saved_console_in_mode = crate::pty_spawner::enable_vt_input();
 
         // Watch channel for terminal resize events (SIGWINCH → child PTY).
         // watch semantics: sender never blocks, receiver always sees the latest value.
@@ -955,6 +960,12 @@ impl AgentContext {
 
         // Restore terminal mode
         let _ = terminal::disable_raw_mode();
+        // disable_raw_mode only ORs crossterm's own bits back — put the input
+        // mode back exactly as we found it (clears VT input if we enabled it).
+        #[cfg(windows)]
+        if let Some(mode) = saved_console_in_mode {
+            crate::pty_spawner::restore_console_input_mode(mode);
+        }
 
         // Cancel stdin reader and stdout writer
         stdin_handle.abort();

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -162,6 +162,57 @@ pub fn console_size() -> Option<(u16, u16)> {
     }
 }
 
+/// Turn on `ENABLE_VIRTUAL_TERMINAL_INPUT` on the console's input handle and
+/// return the previous mode so the caller can restore it on exit.
+///
+/// crossterm's `enable_raw_mode()` only clears LINE/ECHO/PROCESSED on the
+/// input handle — it leaves VT input off, so the console delivers Backspace as
+/// 0x08 (and special keys as key events rather than CSI sequences). ConPTY
+/// then re-interprets a forwarded 0x08 as Ctrl+Backspace for the child, which
+/// is how "Backspace deletes a whole word" (#349) happens. With VT input on,
+/// Backspace arrives as 0x7f — the byte every VT terminal sends — matching
+/// what Node's `setRawMode(true)` (the TS runtime) already does.
+///
+/// Returns `None` (and changes nothing) when stdin isn't a console — piped or
+/// redirected input has no console mode to speak of.
+#[cfg(windows)]
+pub fn enable_vt_input() -> Option<u32> {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
+        GetConsoleMode, GetStdHandle, SetConsoleMode, ENABLE_VIRTUAL_TERMINAL_INPUT,
+        STD_INPUT_HANDLE,
+    };
+    unsafe {
+        let h = GetStdHandle(STD_INPUT_HANDLE);
+        if h == INVALID_HANDLE_VALUE || h.is_null() {
+            return None;
+        }
+        let mut mode: u32 = 0;
+        if GetConsoleMode(h, &mut mode) == 0 {
+            return None; // not a console (piped/redirected stdin)
+        }
+        if SetConsoleMode(h, mode | ENABLE_VIRTUAL_TERMINAL_INPUT) == 0 {
+            return None;
+        }
+        Some(mode)
+    }
+}
+
+/// Restore the console input mode saved by [`enable_vt_input`]. Called after
+/// crossterm's `disable_raw_mode()` (which only ORs its own three bits back and
+/// would otherwise leave VT input stuck on for the parent shell).
+#[cfg(windows)]
+pub fn restore_console_input_mode(mode: u32) {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{GetStdHandle, SetConsoleMode, STD_INPUT_HANDLE};
+    unsafe {
+        let h = GetStdHandle(STD_INPUT_HANDLE);
+        if h != INVALID_HANDLE_VALUE && !h.is_null() {
+            let _ = SetConsoleMode(h, mode);
+        }
+    }
+}
+
 /// Max age of an externally-supplied winsize before we ignore it. After this,
 /// a stale attach client that died holding the lock would otherwise pin our
 /// PTY at the wrong size forever.


### PR DESCRIPTION
Fixes the primary defect in #349.

## Mechanism

- crossterm `enable_raw_mode()` on Windows clears `ENABLE_LINE_INPUT|ECHO|PROCESSED` but does **not** set `ENABLE_VIRTUAL_TERMINAL_INPUT` — so the console hands the Rust runtime Backspace as `0x08`.
- The runtime forwards raw bytes into ConPTY, and ConPTY's input parser maps `0x08` to **Ctrl+Backspace** for the child — Claude Code's editor deletes the whole word.
- Node's `setRawMode(true)` enables VT input (Backspace = `0x7f`), which is why the TS runtime is unaffected and why `claude` run directly behaves.

## Change

- `pty_spawner::enable_vt_input()": sets `ENABLE_VIRTUAL_TERMINAL_INPUT` on the stdin console handle right after `enable_raw_mode()`, returning the saved mode; no-op for piped/headless stdin.
- Exact mode restore on exit (`disable_raw_mode()` alone would leave VT input stuck on for the parent shell).
- Windows-gated; zero change on unix.

## Verification

- `cargo test` native: 277+151+10 pass. windows-sys 0.59 symbols/types verified against the vendored crate; Windows CI matrix + zigbuild binaries gate the rest.
- Functional repro needs real Windows — @tgsAvylaar, a check on this build would be very welcome. Side effect to watch: arrow keys/Home/End now arrive as CSI sequences (as in the TS runtime) rather than console key events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)