### PR TITLE
fix(cli): consume agent-yes flags placed after the CLI name

### DIFF
--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -625,6 +625,11 @@ impl AgentContext {
 
         // Set terminal to raw mode for proper signal handling
         let _raw_mode = terminal::enable_raw_mode();
+        // Windows: also enable VT input so keys arrive as VT bytes (Backspace =
+        // 0x7f, not 0x08 — which ConPTY would hand to the child as
+        // Ctrl+Backspace = delete-word, #349). See enable_vt_input.
+        #[cfg(windows)]
+        let saved_console_in_mode = crate::pty_spawner::enable_vt_input();
 
         // Watch channel for terminal resize events (SIGWINCH → child PTY).
         // watch semantics: sender never blocks, receiver always sees the latest value.
@@ -955,6 +960,12 @@ impl AgentContext {
 
         // Restore terminal mode
         let _ = terminal::disable_raw_mode();
+        // disable_raw_mode only ORs crossterm's own bits back — put the input
+        // mode back exactly as we found it (clears VT input if we enabled it).
+        #[cfg(windows)]
+        if let Some(mode) = saved_console_in_mode {
+            crate::pty_spawner::restore_console_input_mode(mode);
+        }
 
         // Cancel stdin reader and stdout writer
         stdin_handle.abort();

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -162,6 +162,57 @@ pub fn console_size() -> Option<(u16, u16)> {
     }
 }
 
+/// Turn on `ENABLE_VIRTUAL_TERMINAL_INPUT` on the console's input handle and
+/// return the previous mode so the caller can restore it on exit.
+///
+/// crossterm's `enable_raw_mode()` only clears LINE/ECHO/PROCESSED on the
+/// input handle — it leaves VT input off, so the console delivers Backspace as
+/// 0x08 (and special keys as key events rather than CSI sequences). ConPTY
+/// then re-interprets a forwarded 0x08 as Ctrl+Backspace for the child, which
+/// is how "Backspace deletes a whole word" (#349) happens. With VT input on,
+/// Backspace arrives as 0x7f — the byte every VT terminal sends — matching
+/// what Node's `setRawMode(true)` (the TS runtime) already does.
+///
+/// Returns `None` (and changes nothing) when stdin isn't a console — piped or
+/// redirected input has no console mode to speak of.
+#[cfg(windows)]
+pub fn enable_vt_input() -> Option<u32> {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
+        GetConsoleMode, GetStdHandle, SetConsoleMode, ENABLE_VIRTUAL_TERMINAL_INPUT,
+        STD_INPUT_HANDLE,
+    };
+    unsafe {
+        let h = GetStdHandle(STD_INPUT_HANDLE);
+        if h == INVALID_HANDLE_VALUE || h.is_null() {
+            return None;
+        }
+        let mut mode: u32 = 0;
+        if GetConsoleMode(h, &mut mode) == 0 {
+            return None; // not a console (piped/redirected stdin)
+        }
+        if SetConsoleMode(h, mode | ENABLE_VIRTUAL_TERMINAL_INPUT) == 0 {
+            return None;
+        }
+        Some(mode)
+    }
+}
+
+/// Restore the console input mode saved by [`enable_vt_input`]. Called after
+/// crossterm's `disable_raw_mode()` (which only ORs its own three bits back and
+/// would otherwise leave VT input stuck on for the parent shell).
+#[cfg(windows)]
+pub fn restore_console_input_mode(mode: u32) {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{GetStdHandle, SetConsoleMode, STD_INPUT_HANDLE};
+    unsafe {
+        let h = GetStdHandle(STD_INPUT_HANDLE);
+        if h != INVALID_HANDLE_VALUE && !h.is_null() {
+            let _ = SetConsoleMode(h, mode);
+        }
+    }
+}
+
 /// Max age of an externally-supplied winsize before we ignore it. After this,
 /// a stale attach client that died holding the lock would otherwise pin our
 /// PTY at the wrong size forever.

--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -430,14 +430,43 @@ describe("CLI argument parsing", () => {
     expect(result.useStdinAppend).toBe(true);
   });
 
-  it("respects --no-stdpush opt-out only when placed before the CLI positional", () => {
-    // halt-at-non-option means agent-yes flags must precede the CLI positional.
+  it("respects --no-stdpush opt-out on either side of the CLI positional", () => {
+    // Usage promises `ay [cli] [agent-yes args] [agent-cli args]` — agent-yes
+    // flags are consumed after the CLI name too (#349).
     const beforeCli = parseCliArgs(["node", "/path/to/ay", "--no-stdpush", "claude"]);
     const afterCli = parseCliArgs(["node", "/path/to/ay", "claude", "--no-stdpush"]);
 
     expect(beforeCli.useStdinAppend).toBe(false);
-    expect(afterCli.useStdinAppend).toBe(true);
-    expect(afterCli.cliArgs).toContain("--no-stdpush");
+    expect(afterCli.useStdinAppend).toBe(false);
+    expect(afterCli.cliArgs).not.toContain("--no-stdpush");
+  });
+
+  it("consumes agent-yes flags after the CLI name and forwards unknown flags (#349)", () => {
+    // The reporter's table: `ay claude --no-rust` / `--timeout=30s` were
+    // silently forwarded to the child instead of applying to agent-yes.
+    const noRust = parseCliArgs(["node", "/path/to/ay", "claude", "--no-rust"]);
+    expect(noRust.useRust).toBe(false);
+    expect(noRust.cliArgs).toEqual([]);
+
+    const timeout = parseCliArgs(["node", "/path/to/ay", "claude", "--timeout=30s"]);
+    expect(timeout.exitOnIdle).toBe(30000);
+    expect(timeout.cliArgs).toEqual([]);
+
+    // Separate-value form, mixed with prompt words and a child flag.
+    const mixed = parseCliArgs([
+      "node",
+      "/path/to/ay",
+      "claude",
+      "--timeout",
+      "30s",
+      "--model",
+      "opus",
+      "fix",
+      "bugs",
+    ]);
+    expect(mixed.exitOnIdle).toBe(30000);
+    expect(mixed.cliArgs).toEqual(["--model", "opus"]); // unknown → child
+    expect(mixed.prompt).toBe("fix bugs");
   });
 
   it("consumes --attach as an agent-yes flag before the CLI positional", () => {

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -184,8 +184,13 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
       alias: "v",
     })
     .parserConfiguration({
+      // Unknown options (the wrapped CLI's flags, e.g. --model) stay in `_`
+      // untouched and are forwarded to the child below. Known agent-yes
+      // options are consumed WHEREVER they appear — the usage string promises
+      // `$0 [cli] [agent-yes args] [agent-cli args]`, and with the former
+      // "halt-at-non-option" everything after the cli positional was skipped,
+      // so `ay claude --timeout=30s` silently dropped the timeout (#349).
       "unknown-options-as-args": true,
-      "halt-at-non-option": true,
     })
     .parseSync();
 
@@ -217,12 +222,27 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
 
   const cliArgsForSpawn = (() => {
     if (parsedArgv._[0] && !cliName) {
-      // Explicit CLI name provided as positional arg — separate flags from bare words
+      // Explicit CLI name provided as positional arg — flags agent-yes itself
+      // consumed are filtered out (same rule as the cli-bound branch below),
+      // remaining flags go to the child, bare words become prompt text.
       const allAfterCli = rawArgs.slice((cliArgIndex ?? 0) + 1, dashIndex ?? undefined);
       const result: string[] = [];
       for (let i = 0; i < allAfterCli.length; i++) {
         const arg = allAfterCli[i]!;
-        if (arg.startsWith("-")) {
+        const [flag] = arg.split("=");
+        // Check both the flag itself and its --no- negation (yargs stores --no-x as key "x")
+        const isConsumed =
+          (flag && yargsConsumed.has(flag)) ||
+          (flag?.startsWith("--no-") && yargsConsumed.has(`--${flag.slice(5)}`));
+        if (isConsumed) {
+          // Skip consumed flag and its value if separate
+          if (!arg.includes("=") && i + 1 < allAfterCli.length) {
+            const nextArg = allAfterCli[i + 1];
+            if (nextArg && !nextArg.startsWith("-")) {
+              i++; // Skip value
+            }
+          }
+        } else if (arg.startsWith("-")) {
           result.push(arg);
           // Consume the next arg as the flag's value if separate (--flag value)
           if (!arg.includes("=") && i + 1 < allAfterCli.length) {


### PR DESCRIPTION
Fixes the flag-forwarding bug reported in the follow-up comment of #349.

## Before → after (reporter's table)

| invocation | before | after |
|---|---|---|
| `ay claude --no-rust` | forwarded to claude → fatal `unknown option` | `useRust: false`, nothing forwarded |
| `ay claude --timeout=30s` | timeout silently dropped | `exitOnIdle: 30000` |
| `ay claude --timeout 30s --model opus fix bugs` | timeout dropped | timeout applies, `--model opus` forwards to claude, `fix bugs` is the prompt |

## Mechanism

- Drop `halt-at-non-option` — `unknown-options-as-args` already protects the child's flags (they stay in `_` and forward untouched); known agent-yes options are now consumed wherever they appear, per the documented usage `$0 [cli] [agent-yes args] [agent-cli args]`.
- The positional-CLI branch gets the same consumed-flag filter the `cy` branch has always had — `ay claude X` ≡ `cy X`.

## Behavior change (intentional)

Flags agent-yes defines (`-p`, `-c`, `--verbose`, …) placed after the CLI name are now consumed by agent-yes instead of reaching the child — the rule `cy` has always applied. Child-only flags (`--model`, `--dangerously-skip-permissions`, …) forward as before.

## Tests

- New spec cases covering the reporter's table + mixed separate-value/child-flag/prompt case.
- Updated the one spec that asserted the old halt behavior.
- Full suite: 1314 vitest + 50 bun-test parseCliArgs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)