### PR TITLE
fix(cli): revert #366 — flags after the CLI name are the child's by design; warn instead

### DIFF
--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -430,43 +430,14 @@ describe("CLI argument parsing", () => {
     expect(result.useStdinAppend).toBe(true);
   });
 
-  it("respects --no-stdpush opt-out on either side of the CLI positional", () => {
-    // Usage promises `ay [cli] [agent-yes args] [agent-cli args]` — agent-yes
-    // flags are consumed after the CLI name too (#349).
+  it("respects --no-stdpush opt-out only when placed before the CLI positional", () => {
+    // halt-at-non-option means agent-yes flags must precede the CLI positional.
     const beforeCli = parseCliArgs(["node", "/path/to/ay", "--no-stdpush", "claude"]);
     const afterCli = parseCliArgs(["node", "/path/to/ay", "claude", "--no-stdpush"]);
 
     expect(beforeCli.useStdinAppend).toBe(false);
-    expect(afterCli.useStdinAppend).toBe(false);
-    expect(afterCli.cliArgs).not.toContain("--no-stdpush");
-  });
-
-  it("consumes agent-yes flags after the CLI name and forwards unknown flags (#349)", () => {
-    // The reporter's table: `ay claude --no-rust` / `--timeout=30s` were
-    // silently forwarded to the child instead of applying to agent-yes.
-    const noRust = parseCliArgs(["node", "/path/to/ay", "claude", "--no-rust"]);
-    expect(noRust.useRust).toBe(false);
-    expect(noRust.cliArgs).toEqual([]);
-
-    const timeout = parseCliArgs(["node", "/path/to/ay", "claude", "--timeout=30s"]);
-    expect(timeout.exitOnIdle).toBe(30000);
-    expect(timeout.cliArgs).toEqual([]);
-
-    // Separate-value form, mixed with prompt words and a child flag.
-    const mixed = parseCliArgs([
-      "node",
-      "/path/to/ay",
-      "claude",
-      "--timeout",
-      "30s",
-      "--model",
-      "opus",
-      "fix",
-      "bugs",
-    ]);
-    expect(mixed.exitOnIdle).toBe(30000);
-    expect(mixed.cliArgs).toEqual(["--model", "opus"]); // unknown → child
-    expect(mixed.prompt).toBe("fix bugs");
+    expect(afterCli.useStdinAppend).toBe(true);
+    expect(afterCli.cliArgs).toContain("--no-stdpush");
   });
 
   it("consumes --attach as an agent-yes flag before the CLI positional", () => {

--- a/ts/parseCliArgs.spec.ts
+++ b/ts/parseCliArgs.spec.ts
@@ -431,13 +431,36 @@ describe("CLI argument parsing", () => {
   });
 
   it("respects --no-stdpush opt-out only when placed before the CLI positional", () => {
-    // halt-at-non-option means agent-yes flags must precede the CLI positional.
+    // By design, everything after the CLI name belongs to the wrapped CLI:
+    // `ay [agent-yes args] <cli> [agent-cli args]`.
     const beforeCli = parseCliArgs(["node", "/path/to/ay", "--no-stdpush", "claude"]);
     const afterCli = parseCliArgs(["node", "/path/to/ay", "claude", "--no-stdpush"]);
 
     expect(beforeCli.useStdinAppend).toBe(false);
     expect(afterCli.useStdinAppend).toBe(true);
     expect(afterCli.cliArgs).toContain("--no-stdpush");
+  });
+
+  it("warns when an agent-yes flag is placed after the CLI name, still forwarding it (#349)", () => {
+    // `ay claude --timeout=30s` — the timeout belongs before the CLI name; the
+    // flag is forwarded to claude by design, but silently losing the timeout is
+    // the #349 footgun, so a stderr warning points at the fix.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = parseCliArgs(["node", "/path/to/ay", "claude", "--timeout=30s"]);
+      expect(result.exitOnIdle).toBe(0); // NOT applied — child territory
+      expect(result.cliArgs).toContain("--timeout=30s"); // forwarded unchanged
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("--timeout"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("BEFORE the CLI name"));
+
+      warn.mockClear();
+      // A flag agent-yes doesn't define stays silent.
+      const clean = parseCliArgs(["node", "/path/to/ay", "claude", "--model", "opus"]);
+      expect(clean.cliArgs).toEqual(["--model", "opus"]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("consumes --attach as an agent-yes flag before the CLI positional", () => {

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -12,10 +12,13 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
   const cliName = invokedCliName(argv);
 
   // Parse args with yargs (same logic as cli.ts:16-73)
-  const parsedArgv = yargs(hideBin(argv))
-    .usage("Usage: $0 [cli] [agent-yes args] [agent-cli args] [--] [prompts...]")
+  const yargsInstance = yargs(hideBin(argv))
+    // Everything after the CLI name is the wrapped CLI's territory — by
+    // design, agent-yes never claims flags there (so `ay claude -c` reaches
+    // claude). agent-yes's own flags go BEFORE the CLI name.
+    .usage("Usage: $0 [agent-yes args] [cli] [agent-cli args] [--] [prompts...]")
     .example(
-      "$0 claude --timeout=30s -- solve all todos in my codebase, commit one by one",
+      "$0 --timeout=30s claude -- solve all todos in my codebase, commit one by one",
       "Run Claude with a 30 seconds idle timeout (will type /exit when timeout), everything after `--` will be treated as the prompt",
     )
     .example(
@@ -186,8 +189,19 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
     .parserConfiguration({
       "unknown-options-as-args": true,
       "halt-at-non-option": true,
-    })
-    .parseSync();
+    });
+  const parsedArgv = yargsInstance.parseSync();
+
+  // Every option name agent-yes defines (canonical + aliases), as "--flag"
+  // strings — used only for the misplaced-flag warning below. Unlike
+  // `yargsConsumed`, this includes no-default options (--timeout, --prompt…)
+  // whether or not they were passed.
+  const knownAyFlags = new Set<string>(
+    Object.entries(yargsInstance.getOptions().alias ?? {})
+      .flatMap(([key, aliases]) => [key, ...(aliases as string[])])
+      .concat(Object.keys(yargsInstance.getOptions().key ?? {}))
+      .map((k) => `--${k}`),
+  );
 
   // Extract cli args and dash prompt (same logic as cli.ts:76-91)
   const optionalIndex = (e: number) => (0 <= e ? e : undefined);
@@ -217,8 +231,28 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
 
   const cliArgsForSpawn = (() => {
     if (parsedArgv._[0] && !cliName) {
-      // Explicit CLI name provided as positional arg — separate flags from bare words
+      // Explicit CLI name provided as positional arg — separate flags from bare
+      // words. Every flag here is forwarded to the wrapped CLI BY DESIGN (its
+      // flags must stay reachable), but a flag that agent-yes also defines is a
+      // likely misplacement — `ay claude --timeout=30s` would silently drop the
+      // timeout (#349) — so warn on those without changing what's forwarded.
       const allAfterCli = rawArgs.slice((cliArgIndex ?? 0) + 1, dashIndex ?? undefined);
+      const misplaced = allAfterCli.filter((arg) => {
+        const [flag] = arg.split("=");
+        return (
+          (flag?.startsWith("--") &&
+            (knownAyFlags.has(flag) ||
+              (flag.startsWith("--no-") && knownAyFlags.has(`--${flag.slice(5)}`)))) ||
+          false
+        );
+      });
+      if (misplaced.length > 0) {
+        const cli = String(parsedArgv._[0]);
+        console.warn(
+          `\x1b[33m⚠ ${misplaced.join(", ")}: agent-yes flags must come BEFORE the CLI name to apply ` +
+            `(e.g. \`ay ${misplaced[0]!.split("=")[0]} ${cli}\`). Placed after \`${cli}\` they are passed to ${cli} instead.\x1b[0m`,
+        );
+      }
       const result: string[] = [];
       for (let i = 0; i < allAfterCli.length; i++) {
         const arg = allAfterCli[i]!;

--- a/ts/parseCliArgs.ts
+++ b/ts/parseCliArgs.ts
@@ -184,13 +184,8 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
       alias: "v",
     })
     .parserConfiguration({
-      // Unknown options (the wrapped CLI's flags, e.g. --model) stay in `_`
-      // untouched and are forwarded to the child below. Known agent-yes
-      // options are consumed WHEREVER they appear — the usage string promises
-      // `$0 [cli] [agent-yes args] [agent-cli args]`, and with the former
-      // "halt-at-non-option" everything after the cli positional was skipped,
-      // so `ay claude --timeout=30s` silently dropped the timeout (#349).
       "unknown-options-as-args": true,
+      "halt-at-non-option": true,
     })
     .parseSync();
 
@@ -222,27 +217,12 @@ export function parseCliArgs(argv: string[], supportedClis?: readonly string[]) 
 
   const cliArgsForSpawn = (() => {
     if (parsedArgv._[0] && !cliName) {
-      // Explicit CLI name provided as positional arg — flags agent-yes itself
-      // consumed are filtered out (same rule as the cli-bound branch below),
-      // remaining flags go to the child, bare words become prompt text.
+      // Explicit CLI name provided as positional arg — separate flags from bare words
       const allAfterCli = rawArgs.slice((cliArgIndex ?? 0) + 1, dashIndex ?? undefined);
       const result: string[] = [];
       for (let i = 0; i < allAfterCli.length; i++) {
         const arg = allAfterCli[i]!;
-        const [flag] = arg.split("=");
-        // Check both the flag itself and its --no- negation (yargs stores --no-x as key "x")
-        const isConsumed =
-          (flag && yargsConsumed.has(flag)) ||
-          (flag?.startsWith("--no-") && yargsConsumed.has(`--${flag.slice(5)}`));
-        if (isConsumed) {
-          // Skip consumed flag and its value if separate
-          if (!arg.includes("=") && i + 1 < allAfterCli.length) {
-            const nextArg = allAfterCli[i + 1];
-            if (nextArg && !nextArg.startsWith("-")) {
-              i++; // Skip value
-            }
-          }
-        } else if (arg.startsWith("-")) {
+        if (arg.startsWith("-")) {
           result.push(arg);
           // Consume the next arg as the flag's value if separate (--flag value)
           if (!arg.includes("=") && i + 1 < allAfterCli.length) {


### PR DESCRIPTION
Reverts #366 per design intent (taku): the argument contract is `ay [agent-yes args] <cli> [agent-cli args] [--] [prompts]` — everything after the CLI name is forwarded to the wrapped CLI, so its own `-c`/`--verbose`/etc. stay reachable.

What #349's follow-up comment actually needs is loudness, not consumption:

- **Revert**: `ay claude --no-stdpush` again forwards `--no-stdpush` to claude; agent-yes flags only apply before the CLI name.
- **Warning**: an agent-yes-defined flag placed after the CLI name still forwards unchanged, but prints one stderr line: `⚠ --timeout=30s: agent-yes flags must come BEFORE the CLI name to apply (e.g. \`ay --timeout claude\`). Placed after \`claude\` they are passed to claude instead.` — no more silent drops.
- **Docs**: usage string + example previously documented the broken order (`$0 [cli] [agent-yes args] …`); now show `$0 [agent-yes args] [cli] [agent-cli args] …`.
- Known-flag list is derived from the yargs option table (includes no-default options like --timeout that the consumed-set approach misses).

Tests: reverted specs restored; new spec covers warn-and-forward + no warning for child-only flags. Full suite 1314 + 50 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)