### PR TITLE
feat(setup): link bun-global CLIs into /usr/local/bin (durable PATH fix)

### DIFF
--- a/ts/hist.spec.ts
+++ b/ts/hist.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { renderRecord, snippet } from "./hist.ts";
+import type { HistRecord } from "./histStore.ts";
+
+const rec: HistRecord = {
+  ts: "2026-08-06T09:29:37.533Z",
+  role: "user",
+  text: "hello there",
+  source: "claude",
+  sessionId: "ff1f38ee-78aa-48a6",
+  file: "/tmp/x.jsonl",
+  offset: 0,
+};
+
+describe("snippet", () => {
+  it("leaves short text alone", () => {
+    expect(snippet("short", 100)).toBe("short");
+  });
+
+  it("truncates and reports what was withheld", () => {
+    const out = snippet("a".repeat(50) + "\n" + "b".repeat(50), 10);
+    expect(out.startsWith("a".repeat(10))).toBe(true);
+    expect(out).toContain("+91 chars");
+    expect(out).toContain("2 more lines");
+  });
+
+  it("treats max 0 as unlimited, for --full", () => {
+    const long = "x".repeat(5000);
+    expect(snippet(long, 0)).toBe(long);
+  });
+});
+
+describe("renderRecord", () => {
+  it("labels the human as user and the agent by its source", () => {
+    expect(renderRecord(rec, { color: false, max: 0 })).toContain("user");
+    expect(
+      renderRecord({ ...rec, role: "assistant" }, { color: false, max: 0 }),
+    ).toContain("claude");
+    expect(
+      renderRecord({ ...rec, role: "assistant", source: "codex" }, { color: false, max: 0 }),
+    ).toContain("codex");
+  });
+
+  it("emits no ANSI when color is off, so pipes stay clean", () => {
+    const out = renderRecord(rec, { color: false, max: 0 });
+    // eslint-disable-next-line no-control-regex
+    expect(/\x1b\[/.test(out)).toBe(false);
+  });
+
+  it("indents the body and shows a short session id", () => {
+    const out = renderRecord(rec, { color: false, max: 0 });
+    expect(out).toContain("\n  hello there");
+    expect(out).toContain("ff1f38ee");
+    expect(out).not.toContain("ff1f38ee-78aa");
+  });
+
+  it("survives a missing timestamp", () => {
+    expect(renderRecord({ ...rec, ts: null }, { color: false, max: 0 })).toContain("??:??");
+  });
+});

--- a/ts/hist.ts
+++ b/ts/hist.ts
@@ -1,0 +1,136 @@
+/**
+ * `ay hist` — CLI surface over {@link ./histStore.ts}.
+ *
+ * Reads past coding-agent conversations (Claude Code, Codex) that already exist
+ * on disk. Distinct from `ay tail`, which follows the live PTY log of a process
+ * agent-yes spawned; `ay hist` reads the CLI's own durable transcript, so it
+ * still works for sessions that already exited.
+ */
+
+import yargs from "yargs";
+import { histPage, type HistRecord, type HistSource } from "./histStore.ts";
+
+const DEFAULT_LIMIT = 6;
+const DEFAULT_SNIPPET = 600;
+
+const DIM = "\x1b[2m";
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const RESET = "\x1b[0m";
+
+function shortTime(ts: string | null): string {
+  if (!ts) return "??:??";
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "??:??";
+  const now = Date.now();
+  const sameDay = new Date(now).toDateString() === d.toDateString();
+  const hhmm = d.toTimeString().slice(0, 5);
+  return sameDay ? hhmm : `${d.toISOString().slice(5, 10)} ${hhmm}`;
+}
+
+/** Collapse a turn to `max` chars, noting how much was withheld. */
+export function snippet(text: string, max: number): string {
+  const trimmed = text.trim();
+  if (max <= 0 || trimmed.length <= max) return trimmed;
+  const head = trimmed.slice(0, max);
+  const hiddenLines = trimmed.slice(max).split("\n").length;
+  return `${head}… ${DIM}(+${trimmed.length - max} chars, ${hiddenLines} more lines)${RESET}`;
+}
+
+export function renderRecord(r: HistRecord, opts: { color: boolean; max: number }): string {
+  const who = r.role === "user" ? "user" : r.source;
+  const tint = opts.color ? (r.role === "user" ? CYAN : GREEN) : "";
+  const dim = opts.color ? DIM : "";
+  const off = opts.color ? RESET : "";
+  const body = snippet(r.text, opts.max)
+    .split("\n")
+    .map((l) => `  ${l}`)
+    .join("\n");
+  const head = `${tint}${who}${off} ${dim}${shortTime(r.ts)} ${r.sessionId.slice(0, 8)}${off}`;
+  return `${head}\n${body}\n`;
+}
+
+export async function cmdHist(rest: string[]): Promise<number> {
+  const y = yargs(rest)
+    .usage(
+      "Usage: ay hist [options]\n\n" +
+        "Tail past coding-agent conversations (Claude Code, Codex) from this machine.\n" +
+        "Defaults to sessions for the current directory, newest last.\n\n" +
+        "Pagination: rerun with --before <cursor> using the cursor printed at the end.",
+    )
+    .option("n", {
+      type: "number",
+      default: DEFAULT_LIMIT,
+      description: `Number of turns (default ${DEFAULT_LIMIT}; 0 = no cap)`,
+    })
+    .option("all", {
+      type: "boolean",
+      default: false,
+      description: "All projects, not just the current directory",
+    })
+    .option("cwd", { type: "string", description: "Scope to this directory instead of $PWD" })
+    .option("source", {
+      choices: ["claude", "codex"] as const,
+      description: "Only one agent's transcripts",
+    })
+    .option("role", {
+      choices: ["user", "assistant"] as const,
+      description: "Only my prompts, or only the agent's replies",
+    })
+    .option("before", {
+      type: "string",
+      description: "Cursor: only turns older than this ISO timestamp",
+    })
+    .option("tools", {
+      type: "boolean",
+      default: false,
+      description: "Include tool calls/results and thinking as markers",
+    })
+    .option("sidechains", {
+      type: "boolean",
+      default: false,
+      description: "Include Claude sub-agent turns",
+    })
+    .option("full", { type: "boolean", default: false, description: "Do not truncate turns" })
+    .option("json", { type: "boolean", default: false, description: "JSONL for scripts/agents" })
+    .help();
+
+  const argv = await y.parse();
+
+  const cwd = argv.all ? undefined : ((argv.cwd as string | undefined) ?? process.cwd());
+  const page = await histPage({
+    cwd,
+    limit: Number(argv.n),
+    before: argv.before as string | undefined,
+    role: argv.role as "user" | "assistant" | undefined,
+    sources: argv.source ? ([argv.source] as HistSource[]) : undefined,
+    includeTools: Boolean(argv.tools),
+    includeSidechains: Boolean(argv.sidechains),
+  });
+
+  if (argv.json) {
+    for (const r of page.records) process.stdout.write(JSON.stringify(r) + "\n");
+    return page.records.length ? 0 : 1;
+  }
+
+  if (!page.records.length) {
+    const where = cwd ? `for ${cwd}` : "on this machine";
+    process.stderr.write(
+      `no agent conversation history ${where} (scanned ${page.scanned} transcript${
+        page.scanned === 1 ? "" : "s"
+      }).\n` + (cwd ? `try: ay hist --all\n` : ""),
+    );
+    return 1;
+  }
+
+  const color = process.stdout.isTTY === true;
+  const max = argv.full ? 0 : DEFAULT_SNIPPET;
+  for (const r of page.records) process.stdout.write(renderRecord(r, { color, max }) + "\n");
+
+  if (page.cursor) {
+    const dim = color ? DIM : "";
+    const off = color ? RESET : "";
+    process.stderr.write(`${dim}older: ay hist --before ${page.cursor}${off}\n`);
+  }
+  return 0;
+}

--- a/ts/histStore.spec.ts
+++ b/ts/histStore.spec.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import {
+  discoverTranscripts,
+  encodeProjectSlug,
+  histPage,
+  projectRecord,
+  readCodexCwd,
+  readLinesBackward,
+  tailTranscript,
+  type TranscriptFile,
+} from "./histStore.ts";
+
+// histStore takes `home` explicitly rather than calling homedir(), so these
+// tests point it at a tempdir instead of mocking the os module.
+let home: string;
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(tmpdir(), "agent-yes-hist-"));
+});
+
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true }).catch(() => null);
+});
+
+const CWD = "/code/snomiao/agent-yes/tree/main";
+
+function claudeTurn(role: "user" | "assistant", text: string, ts: string, extra = {}) {
+  return JSON.stringify({
+    type: role,
+    timestamp: ts,
+    cwd: CWD,
+    message: { role, content: [{ type: "text", text }] },
+    ...extra,
+  });
+}
+
+function codexEvent(kind: "user_message" | "agent_message", message: string, ts: string) {
+  return JSON.stringify({ timestamp: ts, type: "event_msg", payload: { type: kind, message } });
+}
+
+async function writeClaudeSession(session: string, lines: string[], cwd = CWD) {
+  const dir = path.join(home, ".claude", "projects", encodeProjectSlug(cwd));
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${session}.jsonl`);
+  await writeFile(file, lines.length ? lines.join("\n") + "\n" : "");
+  return file;
+}
+
+async function writeCodexSession(session: string, lines: string[], cwd = CWD) {
+  const dir = path.join(home, ".codex", "sessions", "2026", "08", "03");
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, `rollout-${session}.jsonl`);
+  const meta = JSON.stringify({
+    timestamp: "2026-08-03T00:00:00.000Z",
+    type: "session_meta",
+    payload: { session_id: session, cwd },
+  });
+  await writeFile(file, [meta, ...lines].join("\n") + "\n");
+  return file;
+}
+
+function asFile(p: string, source: "claude" | "codex"): TranscriptFile {
+  return { path: p, source, sessionId: path.basename(p, ".jsonl"), mtimeMs: 0, size: 0 };
+}
+
+describe("encodeProjectSlug", () => {
+  it("matches Claude's cwd-to-directory encoding", () => {
+    expect(encodeProjectSlug("/code/snomiao/agent-yes/tree/main")).toBe(
+      "-code-snomiao-agent-yes-tree-main",
+    );
+  });
+
+  it("collapses dots, as Claude does for domain-shaped directories", () => {
+    expect(encodeProjectSlug("/code/snomiao/cv.snomiao.com/tree/main")).toBe(
+      "-code-snomiao-cv-snomiao-com-tree-main",
+    );
+  });
+});
+
+describe("readLinesBackward", () => {
+  it("yields lines newest-first with correct byte offsets", async () => {
+    const file = path.join(home, "a.jsonl");
+    await writeFile(file, "one\ntwo\nthree\n");
+    const got = [];
+    for await (const l of readLinesBackward(file)) got.push(l);
+    expect(got.map((g) => g.text)).toEqual(["three", "two", "one"]);
+    expect(got.map((g) => g.offset)).toEqual([8, 4, 0]);
+  });
+
+  it("reassembles lines that straddle chunk boundaries", async () => {
+    const file = path.join(home, "big.jsonl");
+    const lines = Array.from({ length: 200 }, (_, i) => `line-${i}-${"x".repeat(i % 37)}`);
+    await writeFile(file, lines.join("\n") + "\n");
+    const got = [];
+    // A chunk far smaller than the file forces the carry-over path repeatedly.
+    for await (const l of readLinesBackward(file, { chunkSize: 16 })) got.push(l.text);
+    expect(got).toEqual([...lines].reverse());
+  });
+
+  it("handles a file with no trailing newline", async () => {
+    const file = path.join(home, "b.jsonl");
+    await writeFile(file, "one\ntwo");
+    const got = [];
+    for await (const l of readLinesBackward(file)) got.push(l.text);
+    // "two" is unterminated, so it is treated as a partial write and skipped.
+    expect(got).toEqual(["one"]);
+  });
+
+  it("drops a half-written trailing record from a live session", async () => {
+    const file = path.join(home, "live.jsonl");
+    await writeFile(file, `${claudeTurn("user", "done", "2026-08-01T00:00:00Z")}\n{"type":"assi`);
+    const got = [];
+    for await (const l of readLinesBackward(file)) got.push(l.text);
+    expect(got).toHaveLength(1);
+    expect(got[0]).toContain("done");
+  });
+
+  it("reads only what the consumer asks for", async () => {
+    const file = path.join(home, "huge.jsonl");
+    // 5MB of records; taking one must not depend on reading them all.
+    const lines = Array.from({ length: 500 }, (_, i) => `${i}:${"y".repeat(10_000)}`);
+    await writeFile(file, lines.join("\n") + "\n");
+    const it = readLinesBackward(file, { chunkSize: 4096 })[Symbol.asyncIterator]();
+    const first = await it.next();
+    expect(first.value?.text.startsWith("499:")).toBe(true);
+    await it.return?.(undefined);
+  });
+
+  it("returns nothing for an empty file", async () => {
+    const file = path.join(home, "empty.jsonl");
+    await writeFile(file, "");
+    const got = [];
+    for await (const l of readLinesBackward(file)) got.push(l);
+    expect(got).toEqual([]);
+  });
+});
+
+describe("projectRecord", () => {
+  it("extracts Claude text turns", () => {
+    const r = projectRecord(claudeTurn("assistant", "hello", "2026-08-01T00:00:00Z"), "claude");
+    expect(r).toEqual({ ts: "2026-08-01T00:00:00Z", role: "assistant", text: "hello" });
+  });
+
+  it("skips Claude sidechains unless asked", () => {
+    const line = claudeTurn("assistant", "sub", "2026-08-01T00:00:00Z", { isSidechain: true });
+    expect(projectRecord(line, "claude")).toBeNull();
+    expect(projectRecord(line, "claude", { includeSidechains: true })?.text).toBe("sub");
+  });
+
+  it("drops tool plumbing by default and marks it when requested", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-08-01T00:00:00Z",
+      message: { role: "assistant", content: [{ type: "tool_use", name: "Bash", input: {} }] },
+    });
+    expect(projectRecord(line, "claude")).toBeNull();
+    expect(projectRecord(line, "claude", { includeTools: true })?.text).toBe("[tool: Bash]");
+  });
+
+  it("accepts Claude's string-shaped content", () => {
+    const line = JSON.stringify({
+      type: "user",
+      timestamp: "2026-08-01T00:00:00Z",
+      message: { role: "user", content: "plain" },
+    });
+    expect(projectRecord(line, "claude")?.text).toBe("plain");
+  });
+
+  it("reads Codex event messages and ignores duplicate response_items", () => {
+    expect(projectRecord(codexEvent("agent_message", "hi", "2026-08-03T01:00:00Z"), "codex")).toEqual(
+      { ts: "2026-08-03T01:00:00Z", role: "assistant", text: "hi" },
+    );
+    const dup = JSON.stringify({
+      timestamp: "2026-08-03T01:00:00Z",
+      type: "response_item",
+      payload: { type: "message", role: "assistant", content: [{ text: "hi" }] },
+    });
+    expect(projectRecord(dup, "codex")).toBeNull();
+  });
+
+  it("ignores metadata and malformed lines rather than throwing", () => {
+    expect(projectRecord("{not json", "claude")).toBeNull();
+    expect(projectRecord(JSON.stringify({ type: "ai-title" }), "claude")).toBeNull();
+    expect(projectRecord(JSON.stringify({ type: "session_meta" }), "codex")).toBeNull();
+  });
+});
+
+describe("discoverTranscripts", () => {
+  it("finds both sources and filters Claude by cwd slug", async () => {
+    await writeClaudeSession("s1", [claudeTurn("user", "a", "2026-08-01T00:00:00Z")]);
+    await writeClaudeSession("s2", [claudeTurn("user", "b", "2026-08-01T00:00:00Z")], "/other/repo");
+    await writeCodexSession("c1", [codexEvent("user_message", "c", "2026-08-03T00:00:01Z")]);
+
+    const all = await discoverTranscripts({ home });
+    expect(all.map((f) => f.sessionId).sort()).toEqual(["rollout-c1", "s1", "s2"]);
+
+    const scoped = await discoverTranscripts({ home, cwd: CWD });
+    expect(scoped.map((f) => f.sessionId).sort()).toEqual(["rollout-c1", "s1"]);
+  });
+
+  it("filters Codex by the cwd inside session_meta", async () => {
+    await writeCodexSession("c1", [codexEvent("user_message", "c", "2026-08-03T00:00:01Z")]);
+    await writeCodexSession(
+      "c2",
+      [codexEvent("user_message", "d", "2026-08-03T00:00:02Z")],
+      "/elsewhere",
+    );
+    const scoped = await discoverTranscripts({ home, cwd: CWD });
+    expect(scoped.map((f) => f.sessionId)).toEqual(["rollout-c1"]);
+  });
+
+  it("ignores codex history.jsonl and empty files", async () => {
+    const dir = path.join(home, ".codex", "sessions");
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "history.jsonl"), '{"x":1}\n');
+    await writeClaudeSession("empty", []);
+    expect(await discoverTranscripts({ home })).toEqual([]);
+  });
+
+  it("returns empty when no agent transcripts exist at all", async () => {
+    expect(await discoverTranscripts({ home })).toEqual([]);
+  });
+});
+
+describe("readCodexCwd", () => {
+  it("reads cwd without consuming the whole file", async () => {
+    const file = await writeCodexSession("c1", [
+      codexEvent("user_message", "x".repeat(200_000), "2026-08-03T00:00:01Z"),
+    ]);
+    expect(await readCodexCwd(file)).toBe(CWD);
+  });
+});
+
+describe("tailTranscript", () => {
+  it("returns the newest N records oldest-first", async () => {
+    const file = await writeClaudeSession(
+      "s1",
+      Array.from({ length: 20 }, (_, i) =>
+        claudeTurn("user", `msg-${i}`, `2026-08-01T00:00:${String(i).padStart(2, "0")}Z`),
+      ),
+    );
+    const got = await tailTranscript(asFile(file, "claude"), { limit: 3 });
+    expect(got.map((r) => r.text)).toEqual(["msg-17", "msg-18", "msg-19"]);
+  });
+
+  it("honours the before cursor and role filter", async () => {
+    const file = await writeClaudeSession("s1", [
+      claudeTurn("user", "q1", "2026-08-01T00:00:01Z"),
+      claudeTurn("assistant", "a1", "2026-08-01T00:00:02Z"),
+      claudeTurn("user", "q2", "2026-08-01T00:00:03Z"),
+    ]);
+    const f = asFile(file, "claude");
+    expect(
+      (await tailTranscript(f, { limit: 10, before: "2026-08-01T00:00:03Z" })).map((r) => r.text),
+    ).toEqual(["q1", "a1"]);
+    expect((await tailTranscript(f, { limit: 10, role: "user" })).map((r) => r.text)).toEqual([
+      "q1",
+      "q2",
+    ]);
+  });
+});
+
+describe("histPage", () => {
+  it("merges sessions chronologically and caps to the limit", async () => {
+    await writeClaudeSession("s1", [
+      claudeTurn("user", "claude-early", "2026-08-01T00:00:01Z"),
+      claudeTurn("assistant", "claude-late", "2026-08-01T00:00:05Z"),
+    ]);
+    await writeCodexSession("c1", [
+      codexEvent("user_message", "codex-mid", "2026-08-01T00:00:03Z"),
+    ]);
+
+    const page = await histPage({ home, cwd: CWD, limit: 2 });
+    expect(page.records.map((r) => r.text)).toEqual(["codex-mid", "claude-late"]);
+    expect(page.scanned).toBe(2);
+  });
+
+  it("returns a cursor that pages backwards without overlap", async () => {
+    await writeClaudeSession(
+      "s1",
+      Array.from({ length: 10 }, (_, i) =>
+        claudeTurn("user", `m${i}`, `2026-08-01T00:00:${String(i).padStart(2, "0")}Z`),
+      ),
+    );
+    const first = await histPage({ home, cwd: CWD, limit: 3 });
+    expect(first.records.map((r) => r.text)).toEqual(["m7", "m8", "m9"]);
+    expect(first.cursor).toBeTruthy();
+
+    const second = await histPage({ home, cwd: CWD, limit: 3, before: first.cursor! });
+    expect(second.records.map((r) => r.text)).toEqual(["m4", "m5", "m6"]);
+  });
+
+  it("pages through records that share one timestamp without losing any", async () => {
+    // Transcripts routinely record several turns inside the same millisecond.
+    // A bare-timestamp cursor drops every record tying with the page boundary.
+    const ts = "2026-08-01T00:00:00.000Z";
+    await writeClaudeSession(
+      "s1",
+      ["a", "b", "c", "d"].map((t) => claudeTurn("user", t, ts)),
+    );
+
+    const first = await histPage({ home, cwd: CWD, limit: 2 });
+    expect(first.records.map((r) => r.text)).toEqual(["c", "d"]);
+    const second = await histPage({ home, cwd: CWD, limit: 2, before: first.cursor! });
+    expect(second.records.map((r) => r.text)).toEqual(["a", "b"]);
+    expect(second.cursor).toBeNull();
+  });
+
+  it("walks the entire history in pages without gaps or repeats", async () => {
+    await writeClaudeSession(
+      "s1",
+      Array.from({ length: 7 }, (_, i) => claudeTurn("user", `x${i}`, "2026-08-01T00:00:00.000Z")),
+    );
+    await writeCodexSession(
+      "c1",
+      Array.from({ length: 5 }, (_, i) =>
+        codexEvent("user_message", `y${i}`, "2026-08-01T00:00:00.000Z"),
+      ),
+    );
+
+    const seen: string[] = [];
+    let before: string | undefined;
+    for (let guard = 0; guard < 20; guard++) {
+      const page = await histPage({ home, cwd: CWD, limit: 3, before });
+      seen.unshift(...page.records.map((r) => r.text));
+      if (!page.cursor) break;
+      before = page.cursor;
+    }
+    expect(seen).toHaveLength(12);
+    expect(new Set(seen).size).toBe(12);
+  });
+
+  it("still accepts a hand-typed ISO timestamp for --before", async () => {
+    await writeClaudeSession("s1", [
+      claudeTurn("user", "old", "2026-08-01T00:00:01Z"),
+      claudeTurn("user", "new", "2026-08-01T00:00:09Z"),
+    ]);
+    const page = await histPage({ home, cwd: CWD, limit: 5, before: "2026-08-01T00:00:05Z" });
+    expect(page.records.map((r) => r.text)).toEqual(["old"]);
+  });
+
+  it("reports no cursor once the history is exhausted", async () => {
+    await writeClaudeSession("s1", [claudeTurn("user", "only", "2026-08-01T00:00:01Z")]);
+    const page = await histPage({ home, cwd: CWD, limit: 6 });
+    expect(page.records).toHaveLength(1);
+    expect(page.cursor).toBeNull();
+  });
+});

--- a/ts/histStore.ts
+++ b/ts/histStore.ts
@@ -1,0 +1,494 @@
+/**
+ * `ay hist` — read the tail of *coding-agent conversation transcripts* that
+ * already exist on this machine (Claude Code, Codex), newest-last.
+ *
+ * This is deliberately NOT `ay tail`. `ay tail` follows the live PTY log of an
+ * agent process agent-yes spawned; `ay hist` reads the durable JSONL transcript
+ * the CLI itself writes, including sessions from before agent-yes was involved
+ * and sessions whose process already exited.
+ *
+ * Design notes (the two that actually matter):
+ *
+ * 1. **Read backwards.** Transcript lines are whole JSON records and routinely
+ *    reach 1.3MB (tool outputs, base64 images). Reading a file forward — or
+ *    `readFile().split("\n")` — costs megabytes to show six records. We seek to
+ *    EOF and walk back in chunks, stopping as soon as the caller has enough, so
+ *    cost is proportional to what's displayed, not to session length.
+ *
+ * 2. **No index.** These files are append-only, so a sidecar index storing
+ *    `indexed_up_to_bytes` would let a future `ay hist search` re-scan only the
+ *    tail delta. Tailing needs none of that, and the 90% case is tailing — so
+ *    v1 ships with zero index, zero daemon, zero cache invalidation.
+ */
+
+import { readdir, open, stat } from "fs/promises";
+import type { FileHandle } from "fs/promises";
+import { homedir } from "os";
+import path from "path";
+
+const NEWLINE = 0x0a;
+
+/** Which coding agent produced a transcript. */
+export type HistSource = "claude" | "codex";
+
+export interface TranscriptFile {
+  path: string;
+  source: HistSource;
+  /** Session identifier — the file's basename for both supported sources. */
+  sessionId: string;
+  mtimeMs: number;
+  size: number;
+  /**
+   * Working directory the session ran in, when known without reading the file.
+   * Claude encodes it in the parent directory name; Codex only stores it inside
+   * the file's `session_meta` record, so it stays undefined until resolved.
+   */
+  cwd?: string;
+}
+
+export interface HistRecord {
+  /** ISO timestamp, or null for records that carry none. */
+  ts: string | null;
+  role: "user" | "assistant";
+  text: string;
+  source: HistSource;
+  sessionId: string;
+  file: string;
+  /** Byte offset of the record's first byte, usable as a stable cursor. */
+  offset: number;
+}
+
+/**
+ * Claude Code names each project directory after its cwd with every
+ * non-alphanumeric byte replaced by `-`:
+ * `/code/snomiao/cv.snomiao.com` → `-code-snomiao-cv-snomiao-com`.
+ *
+ * Encoding the cwd and comparing is exact and costs no file reads — decoding
+ * the slug back to a path is not possible, since `-` is ambiguous.
+ */
+export function encodeProjectSlug(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+export function claudeProjectsDir(home = homedir()): string {
+  return path.join(home, ".claude", "projects");
+}
+
+export function codexSessionsDir(home = homedir()): string {
+  return path.join(home, ".codex", "sessions");
+}
+
+async function listJsonlDeep(dir: string, out: string[] = [], depth = 0): Promise<string[]> {
+  // Codex nests transcripts under YYYY/MM/DD; Claude is flat under the project
+  // slug. A depth cap keeps a stray symlink from turning discovery into a walk
+  // of the whole home directory.
+  if (depth > 4) return out;
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out; // absent source (e.g. Codex never installed) is not an error
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) await listJsonlDeep(full, out, depth + 1);
+    else if (e.isFile() && e.name.endsWith(".jsonl")) out.push(full);
+  }
+  return out;
+}
+
+export interface DiscoverOpts {
+  home?: string;
+  /** Restrict to sessions whose cwd matches. Omit for every project. */
+  cwd?: string;
+  sources?: readonly HistSource[];
+}
+
+/**
+ * Locate transcripts, newest first. Only stats files — never opens them — so
+ * this stays cheap even with thousands of sessions on disk.
+ */
+export async function discoverTranscripts(opts: DiscoverOpts = {}): Promise<TranscriptFile[]> {
+  const home = opts.home ?? homedir();
+  const sources = opts.sources ?? (["claude", "codex"] as const);
+  const found: TranscriptFile[] = [];
+
+  if (sources.includes("claude")) {
+    const root = claudeProjectsDir(home);
+    const wanted = opts.cwd ? encodeProjectSlug(opts.cwd) : null;
+    let projects: string[] = [];
+    try {
+      projects = (await readdir(root, { withFileTypes: true }))
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
+    } catch {
+      projects = [];
+    }
+    for (const slug of projects) {
+      if (wanted && slug !== wanted) continue;
+      for (const file of await listJsonlDeep(path.join(root, slug))) {
+        const st = await stat(file).catch(() => null);
+        if (!st?.isFile() || st.size === 0) continue;
+        found.push({
+          path: file,
+          source: "claude",
+          sessionId: path.basename(file, ".jsonl"),
+          mtimeMs: st.mtimeMs,
+          size: st.size,
+        });
+      }
+    }
+  }
+
+  if (sources.includes("codex")) {
+    for (const file of await listJsonlDeep(codexSessionsDir(home))) {
+      if (!path.basename(file).startsWith("rollout-")) continue; // skip history.jsonl
+      const st = await stat(file).catch(() => null);
+      if (!st?.isFile() || st.size === 0) continue;
+      found.push({
+        path: file,
+        source: "codex",
+        sessionId: path.basename(file, ".jsonl"),
+        mtimeMs: st.mtimeMs,
+        size: st.size,
+      });
+    }
+  }
+
+  found.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  if (opts.cwd && sources.includes("codex")) {
+    // Codex hides cwd inside the file, so it can only be filtered by peeking at
+    // the head record. Done after sorting and only for Codex files, so the
+    // common `--cwd` case reads at most a few KB per candidate session.
+    const kept: TranscriptFile[] = [];
+    for (const f of found) {
+      if (f.source !== "codex") {
+        kept.push(f);
+        continue;
+      }
+      const cwd = await readCodexCwd(f.path);
+      if (cwd === opts.cwd) kept.push({ ...f, cwd });
+    }
+    return kept;
+  }
+
+  return found;
+}
+
+/** Read the leading `session_meta` record of a Codex rollout to learn its cwd. */
+export async function readCodexCwd(file: string): Promise<string | undefined> {
+  let fh: FileHandle | undefined;
+  try {
+    fh = await open(file, "r");
+    const buf = Buffer.alloc(64 * 1024);
+    const { bytesRead } = await fh.read(buf, 0, buf.length, 0);
+    const nl = buf.indexOf(NEWLINE);
+    const end = nl === -1 ? bytesRead : nl;
+    const rec = JSON.parse(buf.subarray(0, end).toString("utf8")) as {
+      payload?: { cwd?: string };
+    };
+    return rec.payload?.cwd;
+  } catch {
+    return undefined;
+  } finally {
+    await fh?.close();
+  }
+}
+
+export interface BackwardOpts {
+  chunkSize?: number;
+  maxRecordBytes?: number;
+}
+
+/**
+ * Yield whole lines from EOF toward the start, newest first, as
+ * `{ offset, text }`. Lazy: the generator only reads another chunk when the
+ * consumer asks for another line, so `take(6)` reads ~one chunk regardless of
+ * whether the file is 4KB or 400MB.
+ *
+ * A trailing partial line (a session being appended to right now) is dropped —
+ * we stop at the last complete newline rather than hand back half a record.
+ */
+export async function* readLinesBackward(
+  file: string,
+  opts: BackwardOpts = {},
+): AsyncGenerator<{ offset: number; text: string }> {
+  const chunkSize = opts.chunkSize ?? 64 * 1024;
+  const maxRecordBytes = opts.maxRecordBytes ?? 16 * 1024 * 1024;
+
+  const fh = await open(file, "r");
+  try {
+    const st = await fh.stat();
+    let pos = st.size;
+    if (pos === 0) return;
+
+    // `pending` holds bytes to the LEFT of everything already yielded, whose
+    // owning line has not been closed by a newline yet. `base` is its offset.
+    let pending = Buffer.alloc(0);
+    let base = pos;
+    let first = true;
+
+    while (pos > 0) {
+      const len = Math.min(chunkSize, pos);
+      pos -= len;
+      const buf = Buffer.alloc(len);
+      await fh.read(buf, 0, len, pos);
+
+      const combined = pending.length ? Buffer.concat([buf, pending]) : buf;
+      base = pos;
+
+      let end = combined.length;
+      if (first) {
+        first = false;
+        // Drop anything after the final newline: either the empty string from a
+        // well-formed trailing "\n", or a half-written record.
+        const last = combined.lastIndexOf(NEWLINE);
+        end = last === -1 ? 0 : last;
+      }
+
+      while (end > 0) {
+        const nl = combined.lastIndexOf(NEWLINE, end - 1);
+        if (nl === -1) break; // line starts before this chunk — carry it over
+        const text = combined.subarray(nl + 1, end).toString("utf8");
+        if (text.trim()) yield { offset: base + nl + 1, text };
+        end = nl;
+      }
+
+      pending = combined.subarray(0, end);
+      if (pending.length > maxRecordBytes) {
+        // A single record larger than the cap means a corrupt or pathological
+        // transcript (the largest legitimate record seen in practice is ~1.3MB).
+        // Drop the partial buffer and resync at this chunk edge rather than
+        // buffering without bound — losing one unreadable record is preferable
+        // to holding the whole file in memory.
+        pending = Buffer.alloc(0);
+      }
+    }
+
+    // Whatever remains starts at byte 0 — the file's first line, unterminated
+    // on its left by definition.
+    const head = pending.toString("utf8");
+    if (head.trim()) yield { offset: 0, text: head };
+  } finally {
+    await fh.close();
+  }
+}
+
+interface ClaudeBlock {
+  type?: string;
+  text?: string;
+  name?: string;
+  thinking?: string;
+}
+
+function claudeText(content: unknown, includeTools: boolean): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const raw of content as ClaudeBlock[]) {
+    if (!raw || typeof raw !== "object") continue;
+    if (raw.type === "text" && typeof raw.text === "string") parts.push(raw.text);
+    else if (includeTools && raw.type === "thinking" && typeof raw.thinking === "string")
+      parts.push(`(thinking) ${raw.thinking}`);
+    else if (includeTools && raw.type === "tool_use") parts.push(`[tool: ${raw.name ?? "?"}]`);
+    else if (includeTools && raw.type === "tool_result") parts.push(`[tool result]`);
+  }
+  return parts.join("\n").trim();
+}
+
+export interface ProjectOpts {
+  /** Render tool calls/results/thinking as markers instead of dropping them. */
+  includeTools?: boolean;
+  /** Include Claude sub-agent (sidechain) turns. Off by default: high volume. */
+  includeSidechains?: boolean;
+}
+
+/**
+ * Reduce one raw transcript line to a displayable turn, or null when the record
+ * is not conversational (metadata, token counts, tool plumbing, …).
+ *
+ * Returning null for the great majority of records is the point: it is what
+ * makes six records of *conversation* cost six records of output rather than
+ * six records of JSON noise.
+ */
+export function projectRecord(
+  line: string,
+  source: HistSource,
+  opts: ProjectOpts = {},
+): Pick<HistRecord, "ts" | "role" | "text"> | null {
+  let rec: Record<string, any>;
+  try {
+    rec = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!rec || typeof rec !== "object") return null;
+
+  if (source === "claude") {
+    if (rec.type !== "user" && rec.type !== "assistant") return null;
+    if (rec.isSidechain && !opts.includeSidechains) return null;
+    const role = rec.message?.role === "assistant" ? "assistant" : "user";
+    const text = claudeText(rec.message?.content, opts.includeTools ?? false);
+    if (!text) return null;
+    return { ts: typeof rec.timestamp === "string" ? rec.timestamp : null, role, text };
+  }
+
+  // Codex writes each turn twice: as a raw `response_item` and as a rendered
+  // `event_msg`. The event stream is the clean one, so we read only that and
+  // avoid emitting every turn twice.
+  if (rec.type !== "event_msg") return null;
+  const kind = rec.payload?.type;
+  if (kind !== "user_message" && kind !== "agent_message") return null;
+  const text = typeof rec.payload?.message === "string" ? rec.payload.message.trim() : "";
+  if (!text) return null;
+  return {
+    ts: typeof rec.timestamp === "string" ? rec.timestamp : null,
+    role: kind === "user_message" ? "user" : "assistant",
+    text,
+  };
+}
+
+/**
+ * Position of a single record in the global ordering.
+ *
+ * Paging on a bare timestamp loses data: transcripts routinely contain several
+ * records sharing one millisecond, so `ts < cursor` drops every record that
+ * ties with the page boundary. `(ts, sessionId, offset)` is a total order —
+ * `(sessionId, offset)` is unique by construction — so paging on it can neither
+ * skip nor repeat a record.
+ */
+export interface Cursor {
+  ts: string;
+  sessionId: string;
+  offset: number;
+}
+
+export function encodeCursor(r: HistRecord): string {
+  return `${r.ts ?? ""}|${r.sessionId}|${r.offset}`;
+}
+
+/** Parse an encoded cursor; returns null for a bare timestamp or garbage. */
+export function decodeCursor(raw: string): Cursor | null {
+  const parts = raw.split("|");
+  if (parts.length !== 3) return null;
+  const offset = Number(parts[2]);
+  if (!Number.isFinite(offset)) return null;
+  return { ts: parts[0]!, sessionId: parts[1]!, offset };
+}
+
+/** Total order over records: timestamp, then session, then byte offset. */
+export function compareRecords(
+  a: Pick<HistRecord, "ts" | "sessionId" | "offset">,
+  b: Pick<HistRecord, "ts" | "sessionId" | "offset">,
+): number {
+  return (
+    (a.ts ?? "").localeCompare(b.ts ?? "") ||
+    a.sessionId.localeCompare(b.sessionId) ||
+    a.offset - b.offset
+  );
+}
+
+export interface TailOpts extends ProjectOpts, BackwardOpts {
+  /** Max records to return. */
+  limit: number;
+  /** Only records strictly older than this ISO timestamp. */
+  before?: string;
+  /** Only records strictly before this position. Takes precedence over `before`. */
+  cursor?: Cursor;
+  role?: "user" | "assistant";
+}
+
+/**
+ * Newest `limit` conversational records of one transcript, oldest-first.
+ *
+ * Stops reading as soon as `limit` records are collected — the whole reason the
+ * backward reader is a generator.
+ */
+export async function tailTranscript(
+  file: TranscriptFile,
+  opts: TailOpts,
+): Promise<HistRecord[]> {
+  const out: HistRecord[] = [];
+  for await (const { offset, text } of readLinesBackward(file.path, opts)) {
+    const projected = projectRecord(text, file.source, opts);
+    if (!projected) continue;
+    if (opts.role && projected.role !== opts.role) continue;
+    const record: HistRecord = {
+      ...projected,
+      source: file.source,
+      sessionId: file.sessionId,
+      file: file.path,
+      offset,
+    };
+    if (opts.cursor) {
+      if (compareRecords(record, opts.cursor) >= 0) continue;
+    } else if (opts.before && projected.ts && projected.ts >= opts.before) {
+      continue;
+    }
+    out.push(record);
+    if (out.length >= opts.limit) break;
+  }
+  return out.reverse();
+}
+
+export interface HistPage {
+  records: HistRecord[];
+  /**
+   * Opaque cursor to pass as `--before` for the next (older) page, or null when
+   * the history is exhausted. Opaque rather than a numeric offset: sessions are
+   * appended to constantly, so `--skip N` would shift under the caller between
+   * pages.
+   */
+  cursor: string | null;
+  /** Transcripts consulted, for reporting when nothing matched. */
+  scanned: number;
+}
+
+export interface HistQuery extends TailOpts {
+  home?: string;
+  cwd?: string;
+  sources?: readonly HistSource[];
+  /**
+   * Cap on transcripts to tail before merging. Sessions are sorted newest-first,
+   * so a low cap only excludes sessions too old to appear in the page anyway.
+   */
+  maxFiles?: number;
+}
+
+/**
+ * Merge the tails of the most recently touched transcripts into one
+ * chronological page — "what have my agents been saying", across sessions.
+ */
+export async function histPage(q: HistQuery): Promise<HistPage> {
+  const files = await discoverTranscripts({ home: q.home, cwd: q.cwd, sources: q.sources });
+  const considered = files.slice(0, q.maxFiles ?? 40);
+
+  // Over-read by one per transcript. Without it, a page filled entirely by a
+  // single session would look exhausted — we would have stopped at exactly
+  // `limit` and had no evidence that older records remained.
+  const perFile = q.limit > 0 ? q.limit + 1 : Number.MAX_SAFE_INTEGER;
+  // `--before` accepts either an encoded cursor or a bare ISO timestamp typed by
+  // hand; only the former can page without losing timestamp ties.
+  const cursor = q.cursor ?? (q.before ? decodeCursor(q.before) : null);
+  const tails = await Promise.all(
+    considered.map((f) =>
+      tailTranscript(f, { ...q, limit: perFile, cursor: cursor ?? undefined }),
+    ),
+  );
+  const merged = tails.flat();
+
+  // Records without a timestamp sort oldest, so a well-timestamped page is
+  // never displaced by metadata-poor records.
+  merged.sort(compareRecords);
+
+  const records = q.limit > 0 ? merged.slice(-q.limit) : merged;
+  const oldest = records[0];
+  const more = merged.length > records.length;
+
+  return {
+    records,
+    cursor: more && oldest ? encodeCursor(oldest) : null,
+    scanned: considered.length,
+  };
+}

--- a/ts/systemPathLink.spec.ts
+++ b/ts/systemPathLink.spec.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, lstatSync, readlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { linkBunBinsToSystemPath } from "./systemPathLink.ts";
+
+describe("systemPathLink.linkBunBinsToSystemPath", () => {
+  let root: string;
+  let bunDir: string;
+  let target: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "ay-pathlink-"));
+    bunDir = path.join(root, "bun", "bin");
+    target = path.join(root, "usr-local-bin");
+    mkdirSync(bunDir, { recursive: true });
+    for (const name of ["ay", "cy", "qq"]) writeFileSync(path.join(bunDir, name), "#!/bin/sh\n");
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("symlinks every bun bin into the target dir", () => {
+    const r = linkBunBinsToSystemPath({ bunDir, target })!;
+    expect(r.linked.sort()).toEqual(["ay", "cy", "qq"]);
+    for (const name of ["ay", "cy", "qq"]) {
+      const dest = path.join(target, name);
+      expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+      expect(path.resolve(target, readlinkSync(dest))).toBe(path.join(bunDir, name));
+    }
+  });
+
+  it("never clobbers a foreign (real) binary already in the target", () => {
+    mkdirSync(target, { recursive: true });
+    writeFileSync(path.join(target, "cy"), "#!/bin/sh\n# a different real cy\n");
+    const r = linkBunBinsToSystemPath({ bunDir, target })!;
+    expect(r.linked.sort()).toEqual(["ay", "qq"]); // cy left alone
+    expect(r.skipped).toContain("cy");
+    expect(lstatSync(path.join(target, "cy")).isSymbolicLink()).toBe(false); // still the real file
+  });
+
+  it("is idempotent — re-running skips links it already owns", () => {
+    linkBunBinsToSystemPath({ bunDir, target });
+    const r2 = linkBunBinsToSystemPath({ bunDir, target })!;
+    expect(r2.linked).toEqual([]);
+    expect(r2.skipped.sort()).toEqual(["ay", "cy", "qq"]);
+  });
+
+  it("refreshes a dangling symlink it owns (name points into bunDir but target gone)", () => {
+    mkdirSync(target, { recursive: true });
+    // a stale link named "ay" pointing at a now-missing path INSIDE bunDir
+    symlinkSync(path.join(bunDir, "ay-old-removed"), path.join(target, "ay"));
+    const r = linkBunBinsToSystemPath({ bunDir, target })!;
+    expect(r.refreshed).toContain("ay");
+    expect(path.resolve(target, readlinkSync(path.join(target, "ay")))).toBe(path.join(bunDir, "ay"));
+  });
+
+  it("returns null when the bun dir is absent", () => {
+    expect(linkBunBinsToSystemPath({ bunDir: path.join(root, "nope"), target })).toBeNull();
+  });
+});

--- a/ts/systemPathLink.ts
+++ b/ts/systemPathLink.ts
@@ -1,0 +1,134 @@
+// Make bun-global CLIs (ay, cy, the *-yes family, qq, rech, …) resolvable from
+// EVERY shell context, including the hard case: non-interactive non-login shells
+// and Claude Code's Bash tool.
+//
+// Why this is needed: Claude Code's Bash tool sources a per-session shell
+// *snapshot* that statically `export`s a PATH captured at session start. If that
+// PATH didn't include `~/.bun/bin` (e.g. the session was spawned from a context
+// whose PATH lacked it), every bun-global CLI is "command not found" — even
+// though an interactive login shell would have them. There is no bash file that
+// reliably augments PATH for non-interactive non-login shells.
+//
+// The robust fix: symlink the bun-global bins into `/usr/local/bin`, which is on
+// PATH in EVERY context — the bare non-login default
+// (`/usr/local/bin:/usr/local/sbin:/usr/bin:…`), every snapshot, and login
+// shells. Non-clobbering (never overwrites an existing entry) and best-effort
+// (a scheduling/permission hiccup must never break setup). POSIX only — Windows
+// uses a different PATH model and isn't the reported failure surface.
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  symlinkSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+/** Did a (now-dangling) symlink at `linkPath` point into `dir`? Used to adopt
+ * only stale links we previously created, never a foreign broken link. */
+function danglingPointsInto(linkPath: string, dir: string): boolean {
+  try {
+    const oldTarget = path.resolve(path.dirname(linkPath), readlinkSync(linkPath));
+    return path.resolve(path.dirname(oldTarget)) === path.resolve(dir);
+  } catch {
+    return false;
+  }
+}
+
+/** The directory bun installs global binaries into, or null if absent. */
+export function bunBinDir(env: NodeJS.ProcessEnv = process.env): string | null {
+  const install = env.BUN_INSTALL || path.join(homedir(), ".bun");
+  const dir = path.join(install, "bin");
+  return existsSync(dir) ? dir : null;
+}
+
+export interface LinkResult {
+  target: string;
+  linked: string[]; // names newly symlinked
+  skipped: string[]; // names already present (not ours to touch)
+  refreshed: string[]; // our own dangling/stale symlinks repointed
+}
+
+/**
+ * Symlink each entry of the bun-global bin dir into `target` (default
+ * /usr/local/bin). Skips a name that already exists UNLESS it's a symlink we
+ * previously created into the same bun dir (those we refresh, so a rebuilt/moved
+ * bun bin stays valid). Returns null on an unsupported platform or when neither
+ * the bun dir nor the target is usable. Never throws.
+ */
+export function linkBunBinsToSystemPath(opts?: {
+  bunDir?: string | null;
+  target?: string;
+  env?: NodeJS.ProcessEnv;
+}): LinkResult | null {
+  if (process.platform === "win32") return null;
+  const env = opts?.env ?? process.env;
+  const bunDir = opts?.bunDir ?? bunBinDir(env);
+  if (!bunDir) return null;
+  const target = opts?.target ?? "/usr/local/bin";
+
+  try {
+    if (!existsSync(target)) mkdirSync(target, { recursive: true });
+  } catch {
+    return null; // can't create the target dir (permissions) — best-effort give up
+  }
+
+  const result: LinkResult = { target, linked: [], skipped: [], refreshed: [] };
+  let entries: string[];
+  try {
+    entries = readdirSync(bunDir);
+  } catch {
+    return null;
+  }
+
+  for (const name of entries) {
+    const src = path.join(bunDir, name);
+    const dest = path.join(target, name);
+    let existing: ReturnType<typeof lstatSync> | null = null;
+    try {
+      existing = lstatSync(dest);
+    } catch {
+      existing = null; // dest absent
+    }
+    if (existing) {
+      // Only touch a symlink WE own (points back into this bun dir). Anything
+      // else (a real binary, or a link elsewhere) is not ours to replace.
+      let ours = false;
+      if (existing.isSymbolicLink()) {
+        try {
+          ours = path.resolve(target, readlinkSync(dest)) === src;
+        } catch {
+          ours = false;
+        }
+      }
+      if (ours) {
+        result.skipped.push(name); // already correctly linked — nothing to do
+      } else if (existing.isSymbolicLink() && !existsSync(dest) && danglingPointsInto(dest, bunDir)) {
+        // A dangling symlink that USED to point into our bun dir (a bin that
+        // moved/rebuilt) — repoint it. We check the old target dir so we never
+        // hijack an unrelated broken link that merely shares a name.
+        try {
+          unlinkSync(dest);
+          symlinkSync(src, dest);
+          result.refreshed.push(name);
+        } catch {
+          result.skipped.push(name);
+        }
+      } else {
+        result.skipped.push(name); // a real/foreign entry — never clobber
+      }
+      continue;
+    }
+    try {
+      symlinkSync(src, dest);
+      result.linked.push(name);
+    } catch {
+      result.skipped.push(name); // permission/race — best effort
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Makes the operational PATH fix durable by moving it into `ay setup`.

## Problem
Claude Code's Bash tool sources a per-session shell snapshot that statically `export`s a PATH captured at session start. Some agents' sessions captured a PATH **missing `~/.bun/bin`**, so `ay`/`cy`/`qq`/`claude-yes` were "command not found" — even though an interactive login shell had them. No bash file reliably augments PATH for non-interactive non-login shells.

## Fix
`ay setup` now symlinks each `~/.bun/bin` entry into **`/usr/local/bin`** — the one user-relevant dir on PATH in *every* context (the bare non-login default `/usr/local/bin:/usr/local/sbin:/usr/bin:…`, every snapshot, login shells).

- `ts/systemPathLink.ts` — `linkBunBinsToSystemPath()`: **non-clobbering** (never overwrites a foreign entry), **idempotent**, refreshes only a dangling symlink that pointed into the bun dir, **POSIX-only**, **best-effort** (a permission/race never breaks setup).
- `ts/setup.ts` — runs it as step 1b, prints a one-line summary when it links anything.

## Verification
- 5/5 unit tests (link, non-clobber, idempotent, dangling-refresh, absent-dir).
- Live: even sourcing a **bun-lacking** snapshot, `command -v ay qq cy` → exit 0; `ay --version` runs.
- Safety self-review: none of the 42 bun bins shadow a dangerous system tool (`sudo`/`rm`/`bash`/…); foreign `/usr/local/bin` entries untouched.

Note: **codex review was unavailable** (hit its usage limit) — self-reviewed instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)