### PR TITLE
feat(ayrs): scoped share (/api/share*) を Rust serve に移植

### DIFF
--- a/rs/src/serve/agent_share.rs
+++ b/rs/src/serve/agent_share.rs
@@ -1,0 +1,561 @@
+// Single-agent, view-only shares — Rust port of ts/agentShare.ts (Option X from
+// docs/agent-sharing.md).
+//
+// A scoped share stands up its OWN e2ee WebRTC room (a fresh, unpersisted room —
+// never the persisted master fleet room) that exposes exactly ONE agent,
+// read-only by default. The room's bridge routes every request through
+// `scoped_handle`, which DEFAULT-DENIES and permits only read paths, each
+// verified to resolve to the shared `agent_id` (the stable per-process id, not
+// the reusable pid). Read-only is enforced here on the host — the browser hiding
+// controls is only UX.
+//
+// Shares are ephemeral (no disk persistence): a daemon restart drops them, and a
+// restarted agent mints a fresh agent_id, so the holder re-shares (a deliberate
+// NON-GOAL per the design).
+use super::api::{self, ApiResponse, Body};
+use super::e2e;
+use super::share;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::Mutex;
+use tokio::sync::{mpsc, watch};
+
+pub const MAX_SHARES: usize = 8;
+pub const DEFAULT_SHARE_TTL_MS: i64 = 24 * 60 * 60 * 1000; // 24h
+
+/// What a bridged room is allowed to reach on the local API.
+pub enum Scope {
+    /// The master fleet room: the full API surface.
+    Full,
+    /// A scoped share: one agent, read-only unless `rw`.
+    Agent { agent_id: String, rw: bool },
+}
+
+struct ShareEntry {
+    agent_id: String,
+    perm: &'static str, // "r" | "rw"
+    room: String,
+    link: String,
+    label: String,
+    created_at: i64,
+    expires_at: i64,
+    /// Flipping this to true shuts the session down (ws + every peer pc).
+    cancel: watch::Sender<bool>,
+}
+
+fn registry() -> &'static Mutex<HashMap<String, ShareEntry>> {
+    static SHARES: std::sync::OnceLock<Mutex<HashMap<String, ShareEntry>>> =
+        std::sync::OnceLock::new();
+    SHARES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// ts/agentShare.ts hashStr: Java-style 31-multiplier hash over UTF-16 units,
+/// i32 wraparound — kept bit-identical so share ids look the same either daemon.
+fn hash_str(s: &str) -> i32 {
+    let mut h: i32 = 0;
+    for u in s.encode_utf16() {
+        h = h.wrapping_mul(31).wrapping_add(u as i32);
+    }
+    h
+}
+
+fn to_base36(mut n: u64) -> String {
+    const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    if n == 0 {
+        return "0".into();
+    }
+    let mut out = Vec::new();
+    while n > 0 {
+        out.push(DIGITS[(n % 36) as usize]);
+        n /= 36;
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap_or_default()
+}
+
+fn entry_json(id: &str, e: &ShareEntry) -> Value {
+    json!({
+        "shareId": id,
+        "agentId": e.agent_id,
+        "perm": e.perm,
+        "room": e.room,
+        "link": e.link,
+        "label": e.label,
+        "createdAt": e.created_at,
+        "expiresAt": e.expires_at,
+    })
+}
+
+pub fn list_json() -> Value {
+    let map = registry().lock().unwrap();
+    let mut rows: Vec<(&String, &ShareEntry)> = map.iter().collect();
+    rows.sort_by_key(|(_, e)| -e.created_at);
+    Value::Array(rows.into_iter().map(|(id, e)| entry_json(id, e)).collect())
+}
+
+pub fn revoke(share_id: &str) -> bool {
+    let entry = registry().lock().unwrap().remove(share_id);
+    match entry {
+        Some(e) => {
+            let _ = e.cancel.send(true);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Resolve a keyword to a live agent and mint a fresh view-only room for it.
+/// Errors carry the HTTP status the route answers with (contract: ts/serve.ts).
+pub async fn create(agent: &str, perm: &str, sighost: &str) -> Result<Value, (u16, String)> {
+    if registry().lock().unwrap().len() >= MAX_SHARES {
+        return Err((
+            409,
+            format!("too many active shares (max {MAX_SHARES}) — revoke one first"),
+        ));
+    }
+    let rec = api::resolve_one_all(agent).map_err(|e| (404, e))?;
+    let Some(agent_id) = rec.agent_id.clone() else {
+        // Only agents registered with a stable id can be scoped safely; pid alone
+        // is reused and unsafe as the security key.
+        return Err((
+            404,
+            format!(
+                "agent {} has no stable agent_id — cannot share (restart it)",
+                rec.pid
+            ),
+        ));
+    };
+    let base = rec.cwd.split('/').rfind(|s| !s.is_empty());
+    let label = match base {
+        Some(b) => format!("{} · {}", rec.cli, b),
+        None => rec.cli.clone(),
+    };
+
+    // Fresh, unpersisted room — never claim_room/persist_room (ephemeral by design).
+    let room = share::mint_room(sighost);
+    let (secret, _) = e2e::parse_secret(&room.token).map_err(|e| (500, e.to_string()))?;
+    let link = share::format_share_link(&room.room, &secret, &room.host);
+
+    let share_id = format!(
+        "s{}",
+        to_base36(
+            i64::from(hash_str(&format!("{}{}{}", room.room, agent_id, link))).unsigned_abs()
+        )
+    );
+    let created_at = now_ms();
+    let expires_at = created_at + DEFAULT_SHARE_TTL_MS;
+
+    let rw = perm == "rw";
+    let scope = Arc::new(Scope::Agent {
+        agent_id: agent_id.clone(),
+        rw,
+    });
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    tokio::spawn(share::run_scoped_session(
+        room.room.clone(),
+        secret,
+        room.host.clone(),
+        scope,
+        cancel_rx,
+    ));
+    // TTL expiry — mirrors the TS setTimeout(revoke, ttl).
+    {
+        let share_id = share_id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(
+                DEFAULT_SHARE_TTL_MS as u64,
+            ))
+            .await;
+            revoke(&share_id);
+        });
+    }
+
+    let entry = ShareEntry {
+        agent_id,
+        perm: if rw { "rw" } else { "r" },
+        room: room.room.clone(),
+        link,
+        label,
+        created_at,
+        expires_at,
+        cancel: cancel_tx,
+    };
+    let out = entry_json(&share_id, &entry);
+    registry().lock().unwrap().insert(share_id, entry);
+    Ok(out)
+}
+
+// ---- the scope filter (ts/agentShare.ts scopedFetch) ------------------------
+
+fn forbidden(msg: &str) -> ApiResponse {
+    ApiResponse {
+        status: 403,
+        content_type: "text/plain".into(),
+        body: Body::Full(msg.as_bytes().to_vec()),
+    }
+}
+
+fn target_is_agent(keyword: &str, agent_id: &str) -> bool {
+    match api::resolve_one_all(keyword) {
+        Ok(rec) => rec.agent_id.as_deref() == Some(agent_id),
+        Err(_) => false,
+    }
+}
+
+/// Route a bridged request through the scope. Full passes straight to the API;
+/// Agent default-denies and permits only the scoped read (and rw-steer) paths.
+pub async fn scoped_handle(
+    scope: &Scope,
+    method: &str,
+    path_with_query: &str,
+    body: &str,
+) -> ApiResponse {
+    let (agent_id, rw) = match scope {
+        Scope::Full => return api::handle(method, path_with_query, body).await,
+        Scope::Agent { agent_id, rw } => (agent_id.as_str(), *rw),
+    };
+    let (path, query) = match path_with_query.split_once('?') {
+        Some((p, q)) => (p, q),
+        None => (path_with_query, ""),
+    };
+
+    // Static host metadata, no agent data.
+    if method == "GET" && path == "/api/version" {
+        return api::handle(method, path_with_query, body).await;
+    }
+    // Self-describing capability so the viewer console can enter read-only UI.
+    // The host stays the real boundary (writes are 403'd regardless).
+    if method == "GET" && path == "/api/whoami" {
+        let res = api::handle(method, path_with_query, body).await;
+        return with_share_flag(res, agent_id, rw);
+    }
+
+    // Agent list: force keyword=agent_id (cheap server-side narrowing) then
+    // post-filter by EXACT agent_id — the keyword matcher can fuzzy-match a
+    // sibling whose cwd/prompt contains the hex, so the hint is not a boundary.
+    if method == "GET" && (path == "/api/ls" || path == "/api/ls/subscribe") {
+        let mut params: Vec<String> = query
+            .split('&')
+            .filter(|kv| !kv.is_empty() && !kv.starts_with("keyword=") && !kv.starts_with("all="))
+            .map(|s| s.to_string())
+            .collect();
+        params.push(format!("keyword={agent_id}"));
+        let scoped_path = format!("{path}?{}", params.join("&"));
+        let res = api::handle(method, &scoped_path, body).await;
+        return if path == "/api/ls" {
+            filter_ls_json(res, agent_id)
+        } else {
+            filter_ls_sse(res, agent_id.to_string())
+        };
+    }
+
+    // Per-agent reads — verify the target resolves to OUR agent_id.
+    if method == "GET" {
+        for prefix in ["/api/read/", "/api/tail/", "/api/status/", "/api/size/"] {
+            if let Some(rest) = path.strip_prefix(prefix) {
+                if !rest.is_empty() {
+                    if !target_is_agent(&api::url_decode(rest), agent_id) {
+                        return forbidden("agent not shared");
+                    }
+                    return api::handle(method, path_with_query, body).await;
+                }
+            }
+        }
+    }
+
+    // Steer (rw): a read-write share may drive THIS agent — send input, resize
+    // its PTY, self-report presence. It still may NOT control it (kill/restart/
+    // spawn are machine-admin) nor touch any other agent.
+    if rw {
+        if method == "POST" && path == "/api/send" {
+            let kw = serde_json::from_str::<Value>(body)
+                .ok()
+                .and_then(|v| v.get("keyword").map(super::share::value_to_id));
+            let Some(kw) = kw else {
+                return forbidden("bad body");
+            };
+            if !target_is_agent(&kw, agent_id) {
+                return forbidden("agent not shared");
+            }
+            return api::handle(method, path_with_query, body).await;
+        }
+        if method == "POST" {
+            if let Some(rest) = path.strip_prefix("/api/resize/") {
+                if !rest.is_empty() {
+                    if !target_is_agent(&api::url_decode(rest), agent_id) {
+                        return forbidden("agent not shared");
+                    }
+                    return api::handle(method, path_with_query, body).await;
+                }
+            }
+        }
+        if method == "POST" && path == "/api/presence" {
+            return api::handle(method, path_with_query, body).await;
+        }
+    }
+
+    // Everything else (kill, restart, spawn, notes, spawn-config, share*, …, and
+    // — for a view-only share — send/resize/presence too) is denied.
+    forbidden("read-only share")
+}
+
+fn with_share_flag(res: ApiResponse, agent_id: &str, rw: bool) -> ApiResponse {
+    if res.status != 200 {
+        return res;
+    }
+    let Body::Full(bytes) = res.body else {
+        return res;
+    };
+    let mut obj = match serde_json::from_slice::<Value>(&bytes) {
+        Ok(Value::Object(o)) => o,
+        _ => {
+            return ApiResponse {
+                status: res.status,
+                content_type: res.content_type,
+                body: Body::Full(bytes),
+            }
+        }
+    };
+    obj.insert(
+        "share".into(),
+        json!({ "perm": if rw { "rw" } else { "r" }, "agent_id": agent_id, "readonly": !rw }),
+    );
+    ApiResponse {
+        status: res.status,
+        content_type: res.content_type,
+        body: Body::Full(serde_json::to_vec(&Value::Object(obj)).unwrap_or_default()),
+    }
+}
+
+fn filter_ls_json(res: ApiResponse, agent_id: &str) -> ApiResponse {
+    if res.status != 200 {
+        return res;
+    }
+    let Body::Full(bytes) = res.body else {
+        return res;
+    };
+    let kept: Vec<Value> = match serde_json::from_slice::<Value>(&bytes) {
+        Ok(Value::Array(rows)) => rows
+            .into_iter()
+            .filter(|r| r.get("agent_id").and_then(|a| a.as_str()) == Some(agent_id))
+            .collect(),
+        _ => Vec::new(),
+    };
+    ApiResponse {
+        status: res.status,
+        content_type: "application/json".into(),
+        body: Body::Full(serde_json::to_vec(&Value::Array(kept)).unwrap_or_default()),
+    }
+}
+
+/// Filter the /api/ls/subscribe SSE so only the shared agent's deltas cross the
+/// channel. Buffers across chunk boundaries (events are blank-line separated)
+/// and forwards removes only for pids it actually forwarded.
+fn filter_ls_sse(res: ApiResponse, agent_id: String) -> ApiResponse {
+    if res.status != 200 {
+        return res;
+    }
+    let Body::Stream(mut rx) = res.body else {
+        return res;
+    };
+    let (tx, out_rx) = mpsc::channel::<Vec<u8>>(16);
+    tokio::spawn(async move {
+        let mut buf = String::new();
+        let mut forwarded: HashSet<i64> = HashSet::new();
+        while let Some(chunk) = rx.recv().await {
+            buf.push_str(&String::from_utf8_lossy(&chunk));
+            while let Some(sep) = buf.find("\n\n") {
+                let raw_event = buf[..sep].to_string();
+                buf.drain(..sep + 2);
+                if let Some(out) = transform_event(&raw_event, &agent_id, &mut forwarded) {
+                    if tx.send(format!("{out}\n\n").into_bytes()).await.is_err() {
+                        return; // viewer gone — dropping rx cancels the upstream
+                    }
+                }
+            }
+        }
+    });
+    ApiResponse {
+        status: 200,
+        content_type: "text/event-stream".into(),
+        body: Body::Stream(out_rx),
+    }
+}
+
+/// Returns the rewritten SSE event text, or None to drop it entirely. Passes
+/// through comment lines (": ping" heartbeats) and non-data frames unchanged.
+fn transform_event(
+    raw_event: &str,
+    agent_id: &str,
+    forwarded: &mut HashSet<i64>,
+) -> Option<String> {
+    let trimmed = raw_event.replace('\r', "");
+    if trimmed.trim().is_empty() {
+        return None;
+    }
+    if !trimmed.lines().any(|l| l.starts_with("data:")) {
+        return Some(trimmed); // comments/heartbeats pass through
+    }
+    // Reassemble the `data:` payload (SSE allows multiple data: lines per event).
+    let payload = trimmed
+        .lines()
+        .filter(|l| l.starts_with("data:"))
+        .map(|l| l[5..].strip_prefix(' ').unwrap_or(&l[5..]))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let obj = serde_json::from_str::<Value>(&payload).ok()?; // malformed — drop, don't leak
+    let full = obj.get("full").and_then(|f| f.as_bool()).unwrap_or(false);
+    let upsert: Vec<Value> = obj
+        .get("upsert")
+        .and_then(|u| u.as_array())
+        .map(|rows| {
+            rows.iter()
+                .filter(|r| r.get("agent_id").and_then(|a| a.as_str()) == Some(agent_id))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
+    for r in &upsert {
+        if let Some(pid) = r.get("pid").and_then(|p| p.as_i64()) {
+            forwarded.insert(pid);
+        }
+    }
+    let remove: Vec<i64> = obj
+        .get("remove")
+        .and_then(|r| r.as_array())
+        .map(|pids| {
+            pids.iter()
+                .filter_map(|p| p.as_i64())
+                .filter(|pid| forwarded.contains(pid))
+                .collect()
+        })
+        .unwrap_or_default();
+    for pid in &remove {
+        forwarded.remove(pid);
+    }
+    // On the first snapshot always emit (even if empty) so the viewer knows it's
+    // connected; later ticks only when something relevant changed.
+    if !full && upsert.is_empty() && remove.is_empty() {
+        return None;
+    }
+    let next = if full {
+        json!({ "full": true, "upsert": upsert, "remove": remove })
+    } else {
+        json!({ "upsert": upsert, "remove": remove })
+    };
+    Some(format!("data: {next}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // hashStr vectors pinned from ts/agentShare.ts (bun): the ids must be
+    // bit-identical so a share minted by either daemon hashes the same way.
+    #[test]
+    fn hash_str_matches_js() {
+        assert_eq!(hash_str(""), 0);
+        assert_eq!(hash_str("a"), 97);
+        assert_eq!(hash_str("日本語"), 25921943);
+        let v = "rabc123deadbeef0011https://agent-yes.com/w/#rabc123:e1.ff";
+        assert_eq!(hash_str(v), 17749077);
+        assert_eq!(
+            format!("s{}", to_base36(i64::from(hash_str(v)).unsigned_abs())),
+            "sakf9x"
+        );
+    }
+
+    fn agent_scope() -> Scope {
+        Scope::Agent {
+            agent_id: "aaaa0000bbbb".into(),
+            rw: false,
+        }
+    }
+
+    async fn status_of(method: &str, path: &str, body: &str) -> u16 {
+        scoped_handle(&agent_scope(), method, path, body)
+            .await
+            .status
+    }
+
+    // The default-deny table from ts/agentShare.spec.ts: nothing outside the
+    // allowlist may cross a view-only share, including the share-mint routes.
+    #[tokio::test]
+    async fn view_only_share_default_denies() {
+        for (method, path) in [
+            ("POST", "/api/kill"),
+            ("POST", "/api/restart"),
+            ("POST", "/api/spawn"),
+            ("GET", "/api/notes"),
+            ("GET", "/api/spawn-config"),
+            ("GET", "/api/graph"),
+            ("GET", "/api/search?q=x"),
+            ("POST", "/api/share"),
+            ("GET", "/api/shares"),
+            ("DELETE", "/api/share/s123"),
+            ("POST", "/api/send"),
+            ("POST", "/api/resize/123"),
+            ("POST", "/api/presence"),
+            ("GET", "/api/tail/unknown-kw"),
+        ] {
+            assert_eq!(status_of(method, path, "{}").await, 403, "{method} {path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn version_passes_through() {
+        let res = scoped_handle(&agent_scope(), "GET", "/api/version", "").await;
+        assert_eq!(res.status, 200);
+    }
+
+    #[tokio::test]
+    async fn whoami_advertises_share_capability() {
+        let res = scoped_handle(&agent_scope(), "GET", "/api/whoami", "").await;
+        assert_eq!(res.status, 200);
+        let Body::Full(bytes) = res.body else {
+            panic!("expected full body")
+        };
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["share"]["perm"], "r");
+        assert_eq!(v["share"]["readonly"], true);
+        assert_eq!(v["share"]["agent_id"], "aaaa0000bbbb");
+    }
+
+    #[test]
+    fn transform_event_filters_and_tracks_removes() {
+        let mut fwd = HashSet::new();
+        // heartbeat comment passes through
+        assert_eq!(
+            transform_event(": ping", "id1", &mut fwd).as_deref(),
+            Some(": ping")
+        );
+        // full snapshot: keep only ours, always emit
+        let ev = r#"data: {"full":true,"upsert":[{"pid":1,"agent_id":"id1"},{"pid":2,"agent_id":"other"}],"remove":[]}"#;
+        let out = transform_event(ev, "id1", &mut fwd).unwrap();
+        assert!(out.contains(r#""full":true"#), "{out}");
+        assert!(out.contains("id1"));
+        assert!(!out.contains("other"));
+        // delta touching only the sibling is dropped entirely
+        let ev = r#"data: {"upsert":[{"pid":2,"agent_id":"other"}],"remove":[]}"#;
+        assert!(transform_event(ev, "id1", &mut fwd).is_none());
+        // sibling removal stays hidden; our forwarded pid's removal passes
+        let ev = r#"data: {"upsert":[],"remove":[2]}"#;
+        assert!(transform_event(ev, "id1", &mut fwd).is_none());
+        let ev = r#"data: {"upsert":[],"remove":[1]}"#;
+        let out = transform_event(ev, "id1", &mut fwd).unwrap();
+        assert!(out.contains(r#""remove":[1]"#), "{out}");
+        // a remove for a pid we never forwarded again drops (set was cleared)
+        let ev = r#"data: {"upsert":[],"remove":[1]}"#;
+        assert!(transform_event(ev, "id1", &mut fwd).is_none());
+        // malformed JSON drops rather than leaks
+        assert!(transform_event("data: {nope", "id1", &mut fwd).is_none());
+    }
+}

--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -985,7 +985,7 @@ fn parse_query(query: &str) -> std::collections::HashMap<String, String> {
         .collect()
 }
 
-fn url_decode(s: &str) -> String {
+pub(crate) fn url_decode(s: &str) -> String {
     let mut out = Vec::with_capacity(s.len());
     let b = s.as_bytes();
     let mut i = 0;
@@ -1225,20 +1225,53 @@ pub async fn handle(method: &str, path_with_query: &str, body: &str) -> ApiRespo
             }
         }
 
-        // /api/share + /api/expose mint scoped share tokens and drive the edge
-        // relay through the JS agentShare/expose modules; the Rust daemon has
-        // no scoped-token store or relay client, so it declines rather than
-        // shipping a weaker look-alike.
-        ("POST", "/api/share")
-        | ("GET", "/api/shares")
-        | ("POST", "/api/expose")
-        | ("GET", "/api/exposes") => text(
+        // ── Single-agent view-only shares (ts/agentShare.ts port) ───────────
+        // Mint / list / revoke scoped share rooms. Reachable by whoever already
+        // holds full control of this host — a scoped viewer can't get here (its
+        // scope filter default-denies /api/share*).
+        ("POST", "/api/share") => {
+            let Ok(v) = serde_json::from_str::<Value>(body) else {
+                return text(400, "invalid JSON body");
+            };
+            let Some(agent) = v.get("agent").and_then(|a| a.as_str()).filter(|a| !a.is_empty())
+            else {
+                return text(400, "agent required");
+            };
+            let perm = v.get("perm").and_then(|p| p.as_str()).unwrap_or("r");
+            if perm != "r" && perm != "rw" {
+                return text(400, format!("invalid perm {perm} (want r or rw)"));
+            }
+            match crate::serve::agent_share::create(
+                agent,
+                perm,
+                crate::serve::share::DEFAULT_SIGHOST,
+            )
+            .await
+            {
+                Ok(share) => json_res(200, &share),
+                Err((status, msg)) => text(status, msg),
+            }
+        }
+        ("GET", "/api/shares") => json_res(200, &crate::serve::agent_share::list_json()),
+        ("DELETE", p) if p.starts_with("/api/share/") => {
+            let id = url_decode(&p["/api/share/".len()..]);
+            if crate::serve::agent_share::revoke(&id) {
+                text(200, "revoked")
+            } else {
+                text(404, "no such share")
+            }
+        }
+
+        // /api/expose drives the edge relay through the JS codehost/tunnel
+        // module; the Rust daemon has no relay client, so it declines rather
+        // than shipping a weaker look-alike.
+        ("POST", "/api/expose") | ("GET", "/api/exposes") => text(
             501,
-            "share/expose need the JS scoped-token + relay modules — use `ay serve`",
+            "expose needs the JS codehost/tunnel relay client — use `ay serve`",
         ),
-        ("DELETE", p) if p.starts_with("/api/share/") || p.starts_with("/api/expose/") => text(
+        ("DELETE", p) if p.starts_with("/api/expose/") => text(
             501,
-            "share/expose need the JS scoped-token + relay modules — use `ay serve`",
+            "expose needs the JS codehost/tunnel relay client — use `ay serve`",
         ),
 
         ("OPTIONS", _) => text(204, ""),

--- a/rs/src/serve/mod.rs
+++ b/rs/src/serve/mod.rs
@@ -3,6 +3,7 @@
 // during the migration: it persists its room in `.share-room-ayrs` (NOT the TS
 // `.share-room`), so both hosts can run side by side without fighting over the
 // signaling room, while sharing the same pids.jsonl / logs / fifos data plane.
+pub mod agent_share;
 pub mod api;
 pub mod control;
 pub mod discover;

--- a/rs/src/serve/share.rs
+++ b/rs/src/serve/share.rs
@@ -5,6 +5,7 @@
 // Coexistence: the room persists in `~/.agent-yes/.share-room-ayrs` — a
 // DIFFERENT file from the TS daemon's `.share-room` — so the Rust host never
 // steals the signaling room out from under a running `ay serve --webrtc`.
+use super::agent_share::Scope;
 use super::api;
 use super::e2e;
 use anyhow::{anyhow, bail, Context, Result};
@@ -14,7 +15,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
 use webrtc::api::APIBuilder;
@@ -78,7 +79,7 @@ pub fn parse_share_url(s: &str) -> Result<RoomUrl> {
     })
 }
 
-fn mint_room(host: &str) -> RoomUrl {
+pub(super) fn mint_room(host: &str) -> RoomUrl {
     RoomUrl {
         room: format!("r{}", e2e::random_hex(6)),
         token: format!("{}{}", e2e::MARKER, e2e::random_hex(32)),
@@ -278,8 +279,20 @@ pub async fn run_share(cfg: ShareConfig) -> Result<()> {
     eprintln!("[ayrs share] room {} via {}", room.room, room.host);
     println!("{link}");
 
+    // The master room never cancels; the dummy sender stays alive for the loop.
+    let (_cancel_tx, cancel_rx) = watch::channel(false);
+    let scope = Arc::new(Scope::Full);
     loop {
-        match connect_once(&room, &secret, &api_token, peers.clone()).await {
+        match connect_once(
+            &room,
+            &secret,
+            &api_token,
+            peers.clone(),
+            scope.clone(),
+            cancel_rx.clone(),
+        )
+        .await
+        {
             Ok(SessionEnd::Refresh) => {
                 // periodic re-hello (see ts/share.ts SIG_REFRESH_MS rationale)
                 continue;
@@ -296,6 +309,7 @@ pub async fn run_share(cfg: ShareConfig) -> Result<()> {
                 let link = format_share_link(&room.room, &secret, &room.host);
                 eprintln!("[ayrs share] room rotated: {link}");
             }
+            Ok(SessionEnd::Cancelled) => unreachable!("master room has no canceller"),
             Ok(SessionEnd::Dropped) => {
                 tokio::time::sleep(Duration::from_millis(1000)).await;
             }
@@ -307,10 +321,70 @@ pub async fn run_share(cfg: ShareConfig) -> Result<()> {
     }
 }
 
+/// One scoped-share room (ts/agentShare.ts createScopedShare's startShare call):
+/// fresh unpersisted room, no claim lock, no rotation — a 1008 reject is fatal
+/// for the share rather than rotated, since the link was already handed out.
+/// Runs until `cancel` flips (revoke / TTL expiry), then closes every peer so
+/// browsers see an immediate DataChannel close.
+pub async fn run_scoped_session(
+    room: String,
+    secret: String,
+    sighost: String,
+    scope: Arc<Scope>,
+    mut cancel: watch::Receiver<bool>,
+) {
+    let room = RoomUrl {
+        room,
+        token: String::new(), // auth derives from the secret; token is unused here
+        host: sighost,
+    };
+    let peers: Peers = Arc::new(Mutex::new(HashMap::new()));
+    loop {
+        if *cancel.borrow() {
+            break;
+        }
+        match connect_once(
+            &room,
+            &secret,
+            "",
+            peers.clone(),
+            scope.clone(),
+            cancel.clone(),
+        )
+        .await
+        {
+            Ok(SessionEnd::Refresh) => continue,
+            Ok(SessionEnd::Cancelled) => break,
+            Ok(SessionEnd::Rejected) => {
+                eprintln!("[ayrs share] scoped room {} rejected by signaling server — share is dead until revoked/re-minted", room.room);
+                break;
+            }
+            Ok(SessionEnd::Dropped) => {
+                tokio::select! {
+                    _ = cancel.changed() => {}
+                    _ = tokio::time::sleep(Duration::from_millis(1000)) => {}
+                }
+            }
+            Err(e) => {
+                eprintln!("[ayrs share] scoped signaling error: {e:#}");
+                tokio::select! {
+                    _ = cancel.changed() => {}
+                    _ = tokio::time::sleep(Duration::from_millis(2000)) => {}
+                }
+            }
+        }
+    }
+    let ids: Vec<String> = peers.lock().await.keys().cloned().collect();
+    for id in ids {
+        close_peer(&peers, &id).await;
+    }
+}
+
 enum SessionEnd {
     Refresh,
     Rejected,
     Dropped,
+    Cancelled,
 }
 
 async fn connect_once(
@@ -318,6 +392,8 @@ async fn connect_once(
     secret: &str,
     api_token: &str,
     peers: Peers,
+    scope: Arc<Scope>,
+    mut cancel: watch::Receiver<bool>,
 ) -> Result<SessionEnd> {
     let scheme = if room.host.starts_with("localhost") || room.host.starts_with("127.") {
         "ws"
@@ -354,6 +430,12 @@ async fn connect_once(
 
     loop {
         tokio::select! {
+            _ = cancel.changed() => {
+                if *cancel.borrow() {
+                    let _ = sink.close().await;
+                    return Ok(SessionEnd::Cancelled);
+                }
+            }
             _ = &mut refresh => {
                 let _ = sink.close().await;
                 return Ok(SessionEnd::Refresh);
@@ -386,7 +468,7 @@ async fn connect_once(
                     }
                     Message::Text(t) => {
                         let Ok(m) = serde_json::from_str::<Value>(&t) else { continue };
-                        handle_signal(m, secret, api_token, &peers, &sig_tx).await;
+                        handle_signal(m, secret, api_token, &peers, &sig_tx, &scope).await;
                     }
                     _ => {}
                 }
@@ -401,6 +483,7 @@ async fn handle_signal(
     api_token: &str,
     peers: &Peers,
     sig_tx: &mpsc::UnboundedSender<SigOut>,
+    scope: &Arc<Scope>,
 ) {
     match m.get("type").and_then(|t| t.as_str()) {
         Some("pong") | Some("welcome") => {}
@@ -412,7 +495,9 @@ async fn handle_signal(
                 return;
             }
             eprintln!("[ayrs share] peer-join {peer_id}");
-            if let Err(e) = start_peer(peer_id.clone(), api_token, peers, sig_tx).await {
+            if let Err(e) =
+                start_peer(peer_id.clone(), api_token, peers, sig_tx, scope.clone()).await
+            {
                 eprintln!("[ayrs share] peer setup failed: {e:#}");
                 close_peer(peers, &peer_id).await;
             }
@@ -459,7 +544,7 @@ async fn handle_signal(
     }
 }
 
-fn value_to_id(v: &Value) -> String {
+pub(super) fn value_to_id(v: &Value) -> String {
     match v {
         Value::String(s) => s.clone(),
         other => other.to_string(),
@@ -481,6 +566,7 @@ async fn start_peer(
     api_token: &str,
     peers: &Peers,
     sig_tx: &mpsc::UnboundedSender<SigOut>,
+    scope: Arc<Scope>,
 ) -> Result<()> {
     let api = APIBuilder::new().build();
     let config = RTCConfiguration {
@@ -553,7 +639,13 @@ async fn start_peer(
             })
         }));
     }
-    spawn_receiver(peers.clone(), peer_id.clone(), in_rx, api_token.to_string());
+    spawn_receiver(
+        peers.clone(),
+        peer_id.clone(),
+        in_rx,
+        api_token.to_string(),
+        scope,
+    );
 
     // on open: start the mandatory key-confirmation handshake
     {
@@ -671,6 +763,7 @@ fn spawn_receiver(
     peer_id: String,
     mut in_rx: mpsc::UnboundedReceiver<Vec<u8>>,
     api_token: String,
+    scope: Arc<Scope>,
 ) {
     tokio::spawn(async move {
         while let Some(frame) = in_rx.recv().await {
@@ -782,8 +875,9 @@ fn spawn_receiver(
                     let peers2 = peers.clone();
                     let peer_id2 = peer_id.clone();
                     let id2 = id.clone();
+                    let scope2 = scope.clone();
                     let handle = tokio::spawn(async move {
-                        serve_request(out_tx, id2.clone(), method, path, body).await;
+                        serve_request(out_tx, id2.clone(), method, path, body, scope2).await;
                         // done — drop our own abort registration
                         let mut map = peers2.lock().await;
                         if let Some(p) = map.get_mut(&peer_id2) {
@@ -811,8 +905,9 @@ async fn serve_request(
     method: String,
     path: String,
     body: String,
+    scope: Arc<Scope>,
 ) {
-    let res = api::handle(&method, &path, &body).await;
+    let res = super::agent_share::scoped_handle(&scope, &method, &path, &body).await;
     let _ = out_tx.send((
         0,
         json!({"t":"res","id":id,"status":res.status,"ct":res.content_type}),


### PR DESCRIPTION
## 概要

Rust daemon (`ayrs serve`) の /api/share・/api/shares・DELETE /api/share/:id は 501 を返しており、Web console の share 機能が使えなかった。ts/agentShare.ts の単一 agent 限定共有を Rust に移植して実装する。

## 変更点

- **serve/agent_share.rs (新規)**: default-deny の scope フィルタ。許可するのは version / whoami (share capability 付与) / ls・ls/subscribe (agent_id 完全一致で後段フィルタ) / read・tail・status・size (対象が共有 agent に解決される場合のみ)。rw share は send・resize・presence を追加許可。kill/restart/spawn などの管理系は rw でも 403。
- **共有レジストリ**: 上限 8 件、TTL 24h。revoke は watch チャネル経由で session を止め、全 peer pc を閉じる (abort でタスクを切らないので leak しない)。
- **scoped room は無永続**: 毎回新規 mint し、claim_room / persist_room を通らない (TS と同じ設計。daemon 再起動で共有は消える)。
- **shareId は TS の hashStr と bit 一致** (bun で採ったベクタを Rust テストに固定)。
- **HTTP 契約は ts/serve.ts:4196-4241 と同一 (400 / 404 / 409 / 500、レスポンス JSON のキーも同名)。
- expose は未移植のまま 501 (メッセージを expose 専用に更新)。別 PR で対応予定。

## テスト

- default-deny テーブル (agentShare.spec.ts から移植)
- SSE transform (兄弟 agent の削除は隠す・forwarded pid 追跡)
- hashStr の JS 互換ベクタ
- `cargo test` 全 443 件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)