### PR TITLE
feat(console): New-agent フォームに repo/branch provisioning ピッカーを追加

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -7982,6 +7982,7 @@ my.translate = async (text, lang) => {
         const res = await target.tx.post("/api/spawn", {
           cli: spec.cli || "claude",
           from: spec.from || undefined,
+          create: spec.create || undefined,
           fork: spec.fork || undefined,
           cwd: spec.cwd || undefined,
           prompt: spec.prompt || undefined,
@@ -8105,6 +8106,8 @@ my.translate = async (text, lang) => {
       ${hostRow}
       <div class="nfield"><label>Working dir</label><input id="nf-cwd" list="nf-cwd-list" value="${esc(cwd)}" placeholder="(host default — ignored when Spawn from is set)" spellcheck="false" autocapitalize="off" /><datalist id="nf-cwd-list">${cwdOptions(target ? target.id : "")}</datalist></div>
       <div class="nfield"><label>CLI</label><select id="nf-cli">${cliOptions(null, preferredCli)}</select></div>
+      <div class="nfield"><label>Provision repo — optional</label><select id="nf-repo"><option value="" selected>(none — use working dir or spawn-from)</option></select></div>
+      <div class="nfield" id="nf-branch-row" style="display:none"><label>Branch</label><input id="nf-branch" list="nf-branch-list" placeholder="(repo default) — pick one, or type a new name to create it" spellcheck="false" autocapitalize="off" /><datalist id="nf-branch-list"></datalist><div class="lhint" id="nf-branch-hint" style="display:none"></div></div>
       <div class="nfield"><label>Spawn from — optional</label><input id="nf-from" placeholder="github URL / owner/repo@branch — provisions a worktree" spellcheck="false" autocapitalize="off" /></div>
       <div class="nfield"><label>Prompt — optional</label><textarea id="nf-prompt" rows="3" placeholder="initial message to send the agent…"></textarea></div>
       <div class="lrow">
@@ -8122,8 +8125,95 @@ my.translate = async (text, lang) => {
           const dl = $("nf-cwd-list");
           if (dl) dl.innerHTML = cwdOptions(ev.target.value);
           showHook(sources.get(ev.target.value));
+          loadRepoPicker(sources.get(ev.target.value));
+        });
+        $("nf-repo")?.addEventListener("change", () => {
+          const repo = $("nf-repo").value;
+          const row = $("nf-branch-row");
+          if (row) row.style.display = repo ? "" : "none";
+          if (repo) loadBranchPicker(spawnTarget($("newform").dataset.room), repo);
+          else nfRemoteBranches = null;
+        });
+        $("nf-branch-row")?.addEventListener("input", (ev) => {
+          if (ev.target.id === "nf-branch") updateBranchHint();
         });
         showHook(target);
+        loadRepoPicker(target);
+      }
+
+      // ---- provisioning picker (repo → branch) for the New-agent form -------
+      // Data comes from the target host's /api/ws/repos and /api/ws/branches.
+      // Both are best-effort on the server (gh may be unauthenticated); here a
+      // fetch failure just leaves the pickers empty — the free-text "Spawn
+      // from" field still works.
+      let nfRemoteBranches = null; // Set of remote branch names for the picked repo
+      function loadRepoPicker(target) {
+        const selEl = $("nf-repo");
+        if (!selEl || !target?.tx?.fetchJSON) return;
+        const forId = target.id;
+        target.tx
+          .fetchJSON("/api/ws/repos")
+          .then((d) => {
+            // a slow answer for a host the user switched away from must not
+            // paint the new host's repo list (same guard as showHook)
+            if ($("newform").dataset.room !== forId) return;
+            const cur = selEl.value;
+            const repos = (d && d.repos) || [];
+            selEl.innerHTML =
+              `<option value="">(none — use working dir or spawn-from)</option>` +
+              repos
+                .map((r) => {
+                  const full = `${r.owner}/${r.repo}`;
+                  return `<option value="${esc(full)}"${full === cur ? " selected" : ""}>${esc(full)}${r.local ? "" : " (gh)"}</option>`;
+                })
+                .join("");
+          })
+          .catch(() => {});
+      }
+      function loadBranchPicker(target, repo) {
+        const dl = $("nf-branch-list");
+        const hint = $("nf-branch-hint");
+        nfRemoteBranches = null;
+        if (dl) dl.innerHTML = "";
+        if (hint) {
+          hint.textContent = "fetching branches…";
+          hint.style.display = "";
+        }
+        if (!target?.tx?.fetchJSON) return;
+        const want = repo;
+        target.tx
+          .fetchJSON("/api/ws/branches?repo=" + encodeURIComponent(repo))
+          .then((d) => {
+            if ($("nf-repo")?.value !== want) return; // user picked another repo meanwhile
+            const branches = (d && d.branches) || [];
+            nfRemoteBranches = new Set(branches.filter((b) => b.remote).map((b) => b.name));
+            if (dl)
+              dl.innerHTML = branches
+                .map(
+                  (b) =>
+                    `<option value="${esc(b.name)}">${b.provisioned ? "provisioned" : b.remote ? "remote" : "local"}</option>`,
+                )
+                .join("");
+            updateBranchHint(d && d.error);
+          })
+          .catch(() => {
+            if (hint) hint.textContent = "branch list unavailable — type a branch name";
+          });
+      }
+      function updateBranchHint(fetchError) {
+        const hint = $("nf-branch-hint");
+        if (!hint) return;
+        const br = ($("nf-branch")?.value || "").trim();
+        if (nfRemoteBranches == null) {
+          if (fetchError) hint.textContent = `branch list unavailable (${fetchError})`;
+          return;
+        }
+        if (br && !nfRemoteBranches.has(br)) {
+          hint.textContent = `“${br}” is not on the remote — a new branch will be created off the default`;
+        } else {
+          hint.textContent = `${nfRemoteBranches.size} remote branches — empty = repo default; a new name creates a branch`;
+        }
+        hint.style.display = "";
       }
 
       // Surface whether the target host runs a spawn hook (a trusted local command
@@ -8168,10 +8258,26 @@ my.translate = async (text, lang) => {
         try {
           localStorage.setItem(LAST_CLI_KEY, cli);
         } catch {}
+        // The repo/branch pickers win over the free-text "Spawn from" field:
+        // picked repo [+ branch] → a `from` spec; a branch name that isn't on
+        // the remote asks the server to create it (create:true, ws new --create).
+        let from = $("nf-from")?.value.trim() || "";
+        let create = false;
+        const pickedRepo = $("nf-repo")?.value || "";
+        if (pickedRepo) {
+          const br = ($("nf-branch")?.value || "").trim();
+          from = br ? `${pickedRepo}@${br}` : pickedRepo;
+          // Unknown remote list (fetch failed) → still send create: the server
+          // only uses it after the branch turns out missing, so it's harmless
+          // for existing branches and saves an un-actionable 502 for new ones.
+          create = !!(br && (!nfRemoteBranches || !nfRemoteBranches.has(br)));
+        }
         const spec = {
           cli,
-          from: $("nf-from")?.value.trim() || "",
-          cwd: $("nf-cwd").value.trim(),
+          from,
+          create,
+          // a provision spec decides the cwd server-side — don't send a stale one
+          cwd: from ? "" : $("nf-cwd").value.trim(),
           prompt: $("nf-prompt").value,
         };
         const room = $("newform").dataset.room || undefined;

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -452,6 +452,59 @@ describe("console DOM behaviour", () => {
     }
   });
 
+  it("New-agent form provisions from a picked repo/branch (create for new names)", async () => {
+    // The + New agent form's repo picker (GET /api/ws/repos) and branch picker
+    // (GET /api/ws/branches) compose a `from` spec: an existing remote branch
+    // spawns plain {from}; a branch name NOT on the remote adds create:true so
+    // the host branches it off the default (ws new --create semantics).
+    const { ctx, page } = await openConsole(browser, url);
+    const spawns: any[] = [];
+    page.on("request", (r) => {
+      if (r.method() === "POST" && new URL(r.url()).pathname === "/api/spawn") {
+        try {
+          spawns.push(r.postDataJSON());
+        } catch {}
+      }
+    });
+    try {
+      await page.click("#newbtn");
+      // repo picker fills async from /api/ws/repos — placeholder + 3 repos
+      await expect.poll(() => page.locator("#nf-repo option").count()).toBe(4);
+      expect(await page.locator("#nf-repo").innerText()).toContain("acme/newrepo (gh)");
+
+      // pick a repo → branch row appears, datalist fills from /api/ws/branches
+      await page.selectOption("#nf-repo", "acme/widgets");
+      await expect.poll(() => page.locator("#nf-branch-row").isVisible()).toBe(true);
+      await expect.poll(() => page.locator("#nf-branch-list option").count()).toBe(2);
+
+      // a NEW branch name → hint flags the create, spawn carries create:true
+      await page.fill("#nf-branch", "feat-x");
+      await expect
+        .poll(() => page.locator("#nf-branch-hint").innerText())
+        .toContain("new branch will be created");
+      await page.selectOption("#nf-cli", "claude");
+      await page.click("#nf-go");
+      await expect.poll(() => spawns.length).toBe(1);
+      expect(spawns[0].from).toBe("acme/widgets@feat-x");
+      expect(spawns[0].create).toBe(true);
+      expect(spawns[0].cwd).toBeUndefined();
+
+      // an EXISTING remote branch → plain {from}, no create
+      await page.click("#newbtn");
+      await expect.poll(() => page.locator("#nf-repo option").count()).toBe(4);
+      await page.selectOption("#nf-repo", "acme/widgets");
+      await expect.poll(() => page.locator("#nf-branch-list option").count()).toBe(2);
+      await page.fill("#nf-branch", "main");
+      await page.selectOption("#nf-cli", "claude");
+      await page.click("#nf-go");
+      await expect.poll(() => spawns.length).toBe(2);
+      expect(spawns[1].from).toBe("acme/widgets@main");
+      expect(spawns[1].create).toBeUndefined();
+    } finally {
+      await ctx.close();
+    }
+  });
+
   it("key bar + composer apply sticky Ctrl/Alt and never leak the modifier", async () => {
     const { ctx, page } = await openConsole(
       browser,

--- a/tests/ui-dom/server.ts
+++ b/tests/ui-dom/server.ts
@@ -18,6 +18,8 @@
  *   POST /api/restart           → { ok: true }  (Cmd+K /restart, ⋯ Restart)
  *   GET  /api/ws                → WORKSPACES fixture  (Cmd+K /ws browser)
  *   GET  /api/ws/status?path=   → one workspace + a fixed dirty git state
+ *   GET  /api/ws/repos          → provisionable repos  (New-agent repo picker)
+ *   GET  /api/ws/branches?repo= → a repo's branch list (New-agent branch picker)
  *   POST /api/spawn             → { ok: true }  (Enter on a /ws row)
  */
 import http from "http";
@@ -176,6 +178,41 @@ export async function startServer(
               hasUpstream: true,
             },
           },
+        }),
+      );
+    }
+    // New-agent form provisioning pickers: the repos this host can provision
+    // from (local checkouts + gh-visible) and a repo's branch list.
+    if (req.method === "GET" && p === "/api/ws/repos") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(
+        JSON.stringify({
+          schema: "ay-ws/v1",
+          wsRoot: "/home/u/ws",
+          repos: [
+            { owner: "snomiao", repo: "agent-yes", local: true, branches: [{ name: "main", path: WORKSPACES[0]!.path }] },
+            { owner: "acme", repo: "widgets", local: true, branches: [{ name: "dev", path: WORKSPACES[1]!.path }] },
+            { owner: "acme", repo: "newrepo", local: false, branches: [] },
+          ],
+          gh: { ok: true },
+        }),
+      );
+    }
+    if (req.method === "GET" && p === "/api/ws/branches") {
+      const repo = url.searchParams.get("repo");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      return res.end(
+        JSON.stringify({
+          schema: "ay-ws/v1",
+          repo,
+          source: "ls-remote",
+          branches:
+            repo === "acme/widgets"
+              ? [
+                  { name: "dev", remote: true, provisioned: true, path: WORKSPACES[1]!.path },
+                  { name: "main", remote: true, provisioned: false },
+                ]
+              : [],
         }),
       );
     }

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -532,6 +532,43 @@ function originOwnerRepo(cwd: string): { owner: string; repo: string } | null {
   }
 }
 
+// Run a host command and capture its output — used by the /api/ws/repos and
+// /api/ws/branches listing endpoints (git ls-remote / gh). Runs under the
+// recovered login-shell env (freshAgentEnv) because the oxmgr/launchd daemon's
+// raw PATH lacks Homebrew/bun, so `git`/`gh` would otherwise be missing — the
+// same reason runProvisionHook does this. Never throws; a timeout kills the
+// child and reports ok:false.
+async function runCapture(
+  argv: string[],
+  opts?: { cwd?: string; timeoutMs?: number },
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  try {
+    const child = Bun.spawn(argv, {
+      cwd: opts?.cwd,
+      env: freshAgentEnv(),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timeoutMs = opts?.timeoutMs ?? 15_000;
+    const code = await Promise.race([
+      child.exited,
+      new Promise<number>((r) => setTimeout(() => r(124), timeoutMs)),
+    ]);
+    if (code === 124) child.kill();
+    const [stdout, stderr] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    return { ok: code === 0, stdout, stderr };
+  } catch (e) {
+    return { ok: false, stdout: "", stderr: (e as Error).message };
+  }
+}
+
+// 60s memo for /api/ws/repos' gh side (see the endpoint for why).
+let ghRepoListMemo: { t: number; ok: boolean; repos: string[]; error?: string } | null = null;
+
 type ProvisionHookResult =
   | { ran: false }
   | { ran: true; ok: boolean; code: number | null; detail: string };
@@ -3062,6 +3099,159 @@ export async function cmdServe(rest: string[]): Promise<number> {
       }
     }
 
+    // GET /api/ws/repos — the repos this host can provision from: every
+    // owner/repo already present under the workspace layout (with its
+    // provisioned branches), plus — best-effort — the repos `gh repo list` can
+    // see with this host's auth. gh being missing/unauthenticated must never
+    // fail the endpoint (two-account gh setups break routinely); the UI gets
+    // `gh.ok=false` + a short reason and still renders the local repos.
+    if (req.method === "GET" && p === "/api/ws/repos") {
+      const ws = await import("./ws.ts");
+      try {
+        await ws.loadProvision();
+      } catch (e) {
+        return new Response((e as Error).message, { status: 501 });
+      }
+      let wsRoot: string;
+      let workspaces: Awaited<ReturnType<typeof ws.collectWorkspaces>>["workspaces"];
+      try {
+        ({ wsRoot, workspaces } = await ws.collectWorkspaces());
+      } catch (e) {
+        return new Response(`workspace walk failed: ${(e as Error).message}`, { status: 500 });
+      }
+      const byRepo = new Map<
+        string,
+        { owner: string; repo: string; local: boolean; branches: { name: string; path: string }[] }
+      >();
+      for (const w of workspaces) {
+        const key = `${w.owner}/${w.repo}`;
+        const entry = byRepo.get(key) ?? { owner: w.owner, repo: w.repo, local: true, branches: [] };
+        entry.branches.push({ name: w.branch, path: w.path });
+        byRepo.set(key, entry);
+      }
+      // gh repo list is slow (network + up to 10s timeout) and the UI hits this
+      // endpoint on every form open / host switch — memoize the gh side briefly.
+      const gh: { ok: boolean; error?: string } = { ok: false };
+      let ghRepos: string[] = [];
+      const memo = ghRepoListMemo;
+      if (memo && performance.now() - memo.t < 60_000) {
+        gh.ok = memo.ok;
+        if (memo.error) gh.error = memo.error;
+        ghRepos = memo.repos;
+      } else {
+        const r = await runCapture(
+          ["gh", "repo", "list", "--limit", "200", "--json", "nameWithOwner"],
+          { timeoutMs: 10_000 },
+        );
+        if (r.ok) {
+          try {
+            ghRepos = (JSON.parse(r.stdout) as { nameWithOwner: string }[]).map(
+              (x) => x.nameWithOwner,
+            );
+            gh.ok = true;
+          } catch {
+            gh.error = "gh returned unparseable JSON";
+          }
+        } else {
+          gh.error = (r.stderr.trim() || "gh unavailable").slice(0, 200);
+        }
+        ghRepoListMemo = { t: performance.now(), ok: gh.ok, repos: ghRepos, error: gh.error };
+      }
+      for (const nameWithOwner of ghRepos) {
+        const [owner, repo] = nameWithOwner.split("/");
+        if (owner && repo && !byRepo.has(nameWithOwner))
+          byRepo.set(nameWithOwner, { owner, repo, local: false, branches: [] });
+      }
+      const repos = [...byRepo.values()].sort((a, b) =>
+        // provisioned repos first, then alphabetical — the picker's natural order
+        a.local !== b.local
+          ? a.local
+            ? -1
+            : 1
+          : `${a.owner}/${a.repo}`.localeCompare(`${b.owner}/${b.repo}`),
+      );
+      return Response.json({ schema: ws.WS_JSON_SCHEMA, wsRoot, repos, gh });
+    }
+
+    // GET /api/ws/branches?repo=<owner>/<repo> — the branches a provision of
+    // that repo could target. Remote branches come from `git ls-remote --heads
+    // origin` run inside an existing local checkout (uses that checkout's
+    // credentials), falling back to `gh api .../branches` when the repo has no
+    // local checkout yet. Local-only branches (provisioned but never pushed)
+    // are merged in. The repo param is strictly validated and passed as argv —
+    // these endpoints are reachable with just a share token.
+    if (req.method === "GET" && p === "/api/ws/branches") {
+      const repoParam = url.searchParams.get("repo") ?? "";
+      const m = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(repoParam);
+      // "." / ".." pass the charset but would traverse the `gh api repos/…` URL
+      if (!m || m[1] === "." || m[1] === ".." || m[2] === "." || m[2] === "..")
+        return new Response("missing/invalid ?repo=<owner>/<repo>", { status: 400 });
+      const [, owner, repo] = m as unknown as [string, string, string];
+      const ws = await import("./ws.ts");
+      let prov: Awaited<ReturnType<typeof ws.loadProvision>>;
+      try {
+        prov = await ws.loadProvision();
+      } catch (e) {
+        return new Response((e as Error).message, { status: 501 });
+      }
+      const wsRoot = prov.resolveWsRoot(getProvisionRoot());
+      // Provisioned local checkouts of this repo (branch → path).
+      const localByBranch = new Map<string, string>();
+      try {
+        for (const w of await ws.walkWorkspaces(wsRoot)) {
+          if (w.owner === owner && w.repo === repo) localByBranch.set(w.branch, w.path);
+        }
+      } catch {
+        /* no local checkouts is fine */
+      }
+      let remote: string[] = [];
+      let source = "";
+      let error: string | undefined;
+      const anchor = localByBranch.values().next().value as string | undefined;
+      if (anchor) {
+        const r = await runCapture(["git", "-C", anchor, "ls-remote", "--heads", "origin"]);
+        if (r.ok) {
+          remote = [...r.stdout.matchAll(/\trefs\/heads\/(.+)/g)].map((x) => x[1]!.trim());
+          source = "ls-remote";
+        } else {
+          error = (r.stderr.trim() || "git ls-remote failed").slice(0, 200);
+        }
+      }
+      if (!source) {
+        const r = await runCapture([
+          "gh",
+          "api",
+          `repos/${owner}/${repo}/branches`,
+          "--paginate",
+          "--jq",
+          ".[].name",
+        ]);
+        if (r.ok) {
+          remote = r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+          source = "gh";
+          error = undefined;
+        } else if (!error) {
+          error = (r.stderr.trim() || "gh unavailable").slice(0, 200);
+        }
+      }
+      const names = [...new Set([...remote, ...localByBranch.keys()])].sort((a, b) =>
+        a.localeCompare(b),
+      );
+      const branches = names.map((name) => ({
+        name,
+        remote: remote.includes(name),
+        provisioned: localByBranch.has(name),
+        ...(localByBranch.has(name) ? { path: localByBranch.get(name)! } : {}),
+      }));
+      return Response.json({
+        schema: ws.WS_JSON_SCHEMA,
+        repo: `${owner}/${repo}`,
+        source: source || "local-only",
+        branches,
+        ...(error ? { error } : {}),
+      });
+    }
+
     // GET /api/notes
     if (req.method === "GET" && p === "/api/notes") {
       const notes = await readNotes();
@@ -3833,6 +4023,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         from?: string;
         prompt?: string;
         yes?: boolean;
+        create?: boolean;
         fork?: { fromCwd?: string; branch?: string };
       };
       try {
@@ -3978,7 +4169,11 @@ export async function cmdServe(rest: string[]): Promise<number> {
           provision: (
             spec: Spec,
             opts?: { wsRoot?: string },
-          ) => Promise<{ ok: boolean; folder: string; action: string; error?: string }>;
+          ) => Promise<{ ok: boolean; folder: string; action: string; error?: string; reason?: string }>;
+          createBranch?: (
+            spec: Spec,
+            opts?: { wsRoot?: string },
+          ) => Promise<{ ok: boolean; folder: string; action: string; error?: string; reason?: string }>;
         };
         try {
           prov = (await importProvisionModule()) as typeof prov;
@@ -4029,14 +4224,32 @@ export async function cmdServe(rest: string[]): Promise<number> {
             { status: 403 },
           );
         }
-        let result: { ok: boolean; folder: string; action: string; error?: string };
+        let result: { ok: boolean; folder: string; action: string; error?: string; reason?: string };
         try {
           const wsRoot = getProvisionRoot();
           result = await prov.provision(spec, wsRoot ? { wsRoot } : undefined);
+          // `create:true` = the "ay ws new --create" semantics: when the branch
+          // doesn't exist on the remote, branch it off the default locally.
+          // Runs INSIDE the hook/allowlist gate above — same repo, same risk.
+          if (
+            !result?.ok &&
+            body.create === true &&
+            result?.reason === "branch-not-found" &&
+            typeof prov.createBranch === "function"
+          ) {
+            result = await prov.createBranch(spec, wsRoot ? { wsRoot } : undefined);
+          }
         } catch (e) {
           return new Response(`provision failed: ${(e as Error).message}`, { status: 502 });
         }
-        if (!result?.ok) return new Response(result?.error ?? "provision failed", { status: 502 });
+        if (!result?.ok)
+          return new Response(
+            (result?.error ?? "provision failed") +
+              (result?.reason === "branch-not-found" && body.create !== true
+                ? "\n(branch missing on the remote — retry with create:true to branch off the default)"
+                : ""),
+            { status: 502 },
+          );
         cwd = result.folder;
         provisioned = { action: result.action, folder: result.folder };
       } else {


### PR DESCRIPTION
## 概要

console の spawn フォームは working dir の自由入力しか無く、ホスト上のどの repo / branch から worktree を provision できるかが見えなかった。`ay ws` の provisioning 能力 (from-branch / new-branch) を frontend から使えるようにする。

## 変更点

**サーバ (ts/serve.ts)**
- `GET /api/ws/repos` — workspace レイアウト配下の repo (provisioned branch 付き) + best-effort で `gh repo list` をマージ。gh 未認証/不在でも 200 (`gh.ok=false` + 理由)。gh 側は 60s メモ化
- `GET /api/ws/branches?repo=<owner>/<repo>` — ローカル checkout での `git ls-remote --heads origin` (fallback: `gh api repos/…/branches`) + provisioned ローカル branch の統合一覧。repo パラメータは厳格検証 (`.`/`..` セグメント拒否、argv 渡し)
- `POST /api/spawn` に `create:true` — branch が remote に無い場合は `ay ws new --create` と同じく default から新 branch を作成 (既存の provision hook / allowlist ゲートの内側で実行)

**UI (lab/ui/index.html)**
- New-agent フォームに「Provision repo」セレクタ + 「Branch」datalist を追加 (host 切替で再取得、遅延応答ガード付き)
- 既存 branch → `{from: "owner/repo@branch"}`、remote に無い名前 → `{from, create:true}` (hint で新規作成を明示)。branch 一覧が取れない時も create を送り、un-actionable な 502 を回避
- provision spec がある時は stale な cwd を送らない

**テスト (tests/ui-dom)**
- スタブサーバに `/api/ws/repos` `/api/ws/branches` を追加、フォーム provisioning の E2E DOM テスト 2 ケース (既存 branch / 新 branch)

## 検証

- `bun run test:ui-dom` 26/26 green
- 実機 smoke: `/api/ws/repos` `/api/ws/branches` の実応答確認、`?repo=../evil` → 400
- tsc の既存エラーは本変更の行範囲外 (main も tsc-clean ではない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)