### PR TITLE
ship: tree/main に滞留していた 3 commit を main へ (ls --json 截断 / deepseek-codex / send guard)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+DEEPSEEK_API_KEY=replace-me
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+# DEEPSEEK_MODEL=deepseek-v4-pro

--- a/docs/deepseek-codex.md
+++ b/docs/deepseek-codex.md
@@ -1,0 +1,73 @@
+# Codex with DeepSeek
+
+A local-only adapter that lets Codex CLI use DeepSeek's Chat Completions API.
+It does not modify `~/.codex/config.toml`, global Codex authentication, or the
+globally linked `agent-yes` package. Codex is launched through the agent-yes
+wrapper, so the session is a first-class agent (`ay ls`, `ay tail`, resume, …).
+
+## Setup
+
+Create `.env.local` in the repository root:
+
+```dotenv
+DEEPSEEK_API_KEY=your-key
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_MODEL=deepseek-v4-pro
+```
+
+For a machine-global token (works from any working directory), put the same
+keys in `~/.agent-yes/.env.local` instead. Precedence is: ambient env → repo
+`.env.local` → `~/.agent-yes/.env.local`.
+
+`.env.local` and `.codex-deepseek/` are ignored by Git. The latter is an
+isolated `CODEX_HOME`, so DeepSeek sessions and Codex state stay inside this
+clone.
+
+## Run
+
+Interactive Codex:
+
+```bash
+ay ds
+```
+
+With a prompt:
+
+```bash
+ay ds "explain this codebase"
+```
+
+Non-interactive Codex:
+
+```bash
+ay ds exec --skip-git-repo-check "Inspect this repository"
+```
+
+All arguments after `ds`/`deepseek` are forwarded to Codex. The launcher starts
+a loopback-only Responses-to-Chat-Completions adapter, runs Codex against it via
+the agent-yes wrapper, and stops the adapter when Codex exits. When launched
+from a nested non-TTY context (e.g. another agent), the inner `ay codex` detaches
+the session; the adapter keeps serving until that orphaned session exits.
+
+`exec` invocations spawn Codex directly instead of via the agent-yes wrapper
+(the wrapper's `defaultArgs` would inject `--search`, which `exec` rejects).
+
+## Debugging
+
+Set `DEEPSEEK_DEBUG=1` to log each upstream request's status (and the request
+body on failure) to stderr:
+
+```bash
+DEEPSEEK_DEBUG=1 ay ds "explain this codebase"
+```
+
+Transient upstream 5xx (e.g. DeepSeek gateway 502s) are absorbed by Codex's
+built-in retries (`request_max_retries`/`stream_max_retries` are set to 3).
+`DEEPSEEK_SERVER_ONLY=1` runs just the adapter (no Codex) for driving it with
+an external client.
+
+## Compatibility
+
+The adapter translates text, function calls, custom tool calls, tool results,
+and streaming SSE events. It has been smoke-tested with Codex CLI 0.146.0 and
+`deepseek-v4-pro`, including a real shell-tool round trip.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
+    "deepseek": "bun scripts/deepseek-codex.ts",
     "build": "tsdown",
     "check:e2e": "bun scripts/check-e2e.ts",
     "cf": "bun scripts/cf.ts",

--- a/scripts/deepseek-codex.ts
+++ b/scripts/deepseek-codex.ts
@@ -1,0 +1,580 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+type Json = Record<string, any>;
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Load .env.local ourselves (bun only auto-loads it from the *current working
+// directory*, so `ay ds` from an unrelated cwd would miss the token). Sources,
+// in ascending precedence: ~/.agent-yes/.env.local (global) → <repo-root>/.env.local
+// (local checkout) → the ambient environment, which always wins.
+function loadLocalEnv(): void {
+  const paths = [join(homedir(), ".agent-yes", ".env.local"), join(root, ".env.local")];
+  for (const path of paths) {
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      const value = trimmed
+        .slice(eq + 1)
+        .trim()
+        .replace(/^["']|["']$/g, "");
+      if (key && process.env[key] === undefined) process.env[key] = value;
+    }
+  }
+}
+loadLocalEnv();
+
+const apiKey = process.env.DEEPSEEK_API_KEY;
+const upstream = (process.env.DEEPSEEK_BASE_URL || "https://api.deepseek.com").replace(/\/$/, "");
+const model = process.env.DEEPSEEK_MODEL || "deepseek-v4-pro";
+
+if (!apiKey) {
+  console.error("DEEPSEEK_API_KEY is missing from .env.local");
+  process.exit(2);
+}
+
+function textContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part?.type === "input_text" || part?.type === "output_text" || part?.type === "text") {
+        return part.text || "";
+      }
+      return "";
+    })
+    .join("");
+}
+
+// DeepSeek reasoning models require that any reasoning_content emitted in a
+// prior assistant turn be echoed back verbatim on the next request, but the
+// Responses<->Chat translation here rebuilds assistant turns from Codex's
+// history and has nowhere to carry that field. Stash it out-of-band, keyed
+// by the item/call id we handed back to Codex, and reattach on replay.
+const reasoningStore = new Map<string, string>();
+
+function toChat(body: Json) {
+  const messages: Json[] = [];
+  if (body.instructions) messages.push({ role: "system", content: String(body.instructions) });
+  const input =
+    typeof body.input === "string" ? [{ role: "user", content: body.input }] : body.input || [];
+
+  // Codex can fire several tool calls in one turn (parallel shell commands).
+  // OpenAI-compatible endpoints (incl. DeepSeek) require all concurrent calls
+  // to live in ONE assistant message, with every tool_call_id answered by the
+  // immediately following tool messages. So buffer consecutive call items and
+  // flush them as a single assistant message before any non-call item.
+  let pendingCalls: Array<{
+    id: string;
+    name: string;
+    arguments: string;
+    reasoning_content?: string;
+  }> = [];
+  const flushCalls = () => {
+    if (!pendingCalls.length) return;
+    const reasoning_content = pendingCalls.find((c) => c.reasoning_content)?.reasoning_content;
+    messages.push({
+      role: "assistant",
+      content: null,
+      ...(reasoning_content ? { reasoning_content } : {}),
+      tool_calls: pendingCalls.map(({ id, name, arguments: args }) => ({
+        id,
+        type: "function",
+        function: { name, arguments: args },
+      })),
+    });
+    pendingCalls = [];
+  };
+
+  for (const item of input) {
+    if (item.type === "message" || item.role) {
+      flushCalls();
+      const content = textContent(item.content);
+      const role = item.role === "developer" ? "system" : item.role || "user";
+      if (content) {
+        const msg: Json = { role, content };
+        const reasoning_content = item.id && reasoningStore.get(item.id);
+        if (reasoning_content) msg.reasoning_content = reasoning_content;
+        messages.push(msg);
+      }
+    } else if (item.type === "function_call") {
+      const reasoning_content = reasoningStore.get(item.call_id || item.id);
+      pendingCalls.push({
+        id: item.call_id || item.id,
+        name: item.name,
+        arguments: item.arguments || "{}",
+        ...(reasoning_content ? { reasoning_content } : {}),
+      });
+    } else if (item.type === "function_call_output") {
+      flushCalls();
+      messages.push({
+        role: "tool",
+        tool_call_id: item.call_id,
+        content: textContent(item.output) || String(item.output || ""),
+      });
+    } else if (item.type === "custom_tool_call") {
+      const reasoning_content = reasoningStore.get(item.call_id || item.id);
+      pendingCalls.push({
+        id: item.call_id || item.id,
+        name: item.name,
+        arguments: JSON.stringify({ input: item.input || "" }),
+        ...(reasoning_content ? { reasoning_content } : {}),
+      });
+    } else if (item.type === "custom_tool_call_output") {
+      flushCalls();
+      messages.push({
+        role: "tool",
+        tool_call_id: item.call_id,
+        content: textContent(item.output) || String(item.output || ""),
+      });
+    }
+  }
+  flushCalls();
+
+  const custom = new Set<string>();
+  const tools = (body.tools || []).flatMap((tool: Json) => {
+    if (tool.type === "function") {
+      const fn = tool.function || tool;
+      return [
+        {
+          type: "function",
+          function: {
+            name: fn.name,
+            description: fn.description || "",
+            parameters: fn.parameters || { type: "object", properties: {} },
+          },
+        },
+      ];
+    }
+    if (tool.type === "custom" && tool.name) {
+      custom.add(tool.name);
+      return [
+        {
+          type: "function",
+          function: {
+            name: tool.name,
+            description: `${tool.description || ""}\nReturn the custom tool input in the input field.`,
+            parameters: {
+              type: "object",
+              properties: { input: { type: "string" } },
+              required: ["input"],
+            },
+          },
+        },
+      ];
+    }
+    return [];
+  });
+
+  return {
+    request: {
+      model,
+      messages,
+      ...(tools.length ? { tools } : {}),
+      stream: true,
+      stream_options: { include_usage: true },
+      max_tokens: body.max_output_tokens,
+    },
+    custom,
+  };
+}
+
+function sse(data: Json | "[DONE]"): string {
+  return `data: ${data === "[DONE]" ? data : JSON.stringify(data)}\n\n`;
+}
+
+async function responses(request: Request): Promise<Response> {
+  let body: Json;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: { message: "invalid JSON" } }, { status: 400 });
+  }
+  const { request: chat, custom } = toChat(body);
+  const requestBody = JSON.stringify(chat);
+  const upstreamResponse = await fetch(`${upstream}/chat/completions`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: requestBody,
+  });
+  if (process.env.DEEPSEEK_DEBUG) {
+    console.error(
+      `[deepseek-adapter] upstream ${upstreamResponse.status} ${upstreamResponse.statusText}`,
+    );
+  }
+  if (!upstreamResponse.ok || !upstreamResponse.body) {
+    const upstreamBody = await upstreamResponse.text();
+    if (process.env.DEEPSEEK_DEBUG) {
+      console.error(`[deepseek-adapter] request: ${requestBody.slice(0, 3000)}`);
+      console.error(`[deepseek-adapter] upstream error body: ${upstreamBody.slice(0, 3000)}`);
+    }
+    return new Response(upstreamBody, {
+      status: upstreamResponse.status,
+      headers: {
+        "Content-Type": upstreamResponse.headers.get("content-type") || "application/json",
+      },
+    });
+  }
+
+  const responseId = `resp_deepseek_${crypto.randomUUID().replaceAll("-", "")}`;
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const emit = (event: Json | "[DONE]") => controller.enqueue(encoder.encode(sse(event)));
+      const responseBase = {
+        id: responseId,
+        object: "response",
+        model,
+        status: "in_progress",
+        output: [],
+      };
+      emit({ type: "response.created", response: responseBase });
+      emit({ type: "response.in_progress", response: responseBase });
+      let buffer = "";
+      let textStarted = false;
+      let text = "";
+      let reasoning = "";
+      let usage: Json = {};
+      const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
+      const reader = upstreamResponse.body!.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+          for (const raw of lines) {
+            const line = raw.trim();
+            if (!line.startsWith("data:")) continue;
+            const payload = line.slice(5).trim();
+            if (!payload || payload === "[DONE]") continue;
+            const chunk = JSON.parse(payload);
+            if (chunk.usage) usage = chunk.usage;
+            const delta = chunk.choices?.[0]?.delta || {};
+            if (delta.reasoning_content) reasoning += delta.reasoning_content;
+            if (delta.content) {
+              if (!textStarted) {
+                textStarted = true;
+                emit({
+                  type: "response.output_item.added",
+                  output_index: 0,
+                  item: {
+                    id: `${responseId}_msg`,
+                    type: "message",
+                    role: "assistant",
+                    status: "in_progress",
+                    content: [],
+                  },
+                });
+                emit({
+                  type: "response.content_part.added",
+                  item_id: `${responseId}_msg`,
+                  output_index: 0,
+                  content_index: 0,
+                  part: { type: "output_text", text: "", annotations: [] },
+                });
+              }
+              text += delta.content;
+              emit({
+                type: "response.output_text.delta",
+                item_id: `${responseId}_msg`,
+                output_index: 0,
+                content_index: 0,
+                delta: delta.content,
+              });
+            }
+            for (const call of delta.tool_calls || []) {
+              const index = call.index || 0;
+              const current = toolCalls.get(index) || {
+                id: call.id || `call_${crypto.randomUUID()}`,
+                name: "",
+                arguments: "",
+              };
+              if (call.id) current.id = call.id;
+              if (call.function?.name) current.name += call.function.name;
+              if (call.function?.arguments) current.arguments += call.function.arguments;
+              toolCalls.set(index, current);
+            }
+          }
+        }
+        const output: Json[] = [];
+        if (textStarted) {
+          const item = {
+            id: `${responseId}_msg`,
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text, annotations: [] }],
+          };
+          emit({
+            type: "response.output_text.done",
+            item_id: item.id,
+            output_index: 0,
+            content_index: 0,
+            text,
+          });
+          emit({
+            type: "response.content_part.done",
+            item_id: item.id,
+            output_index: 0,
+            content_index: 0,
+            part: item.content[0],
+          });
+          emit({ type: "response.output_item.done", output_index: 0, item });
+          output.push(item);
+          if (reasoning) reasoningStore.set(item.id, reasoning);
+        }
+        for (const [, call] of [...toolCalls].sort(([a], [b]) => a - b)) {
+          if (reasoning) reasoningStore.set(call.id, reasoning);
+          const outputIndex = output.length;
+          if (custom.has(call.name)) {
+            let input = call.arguments;
+            try {
+              input = JSON.parse(call.arguments).input ?? call.arguments;
+            } catch {}
+            const item = {
+              id: `${responseId}_tool_${outputIndex}`,
+              type: "custom_tool_call",
+              status: "completed",
+              call_id: call.id,
+              name: call.name,
+              input,
+            };
+            emit({
+              type: "response.output_item.added",
+              output_index: outputIndex,
+              item: { ...item, status: "in_progress", input: "" },
+            });
+            emit({
+              type: "response.custom_tool_call_input.delta",
+              item_id: item.id,
+              output_index: outputIndex,
+              delta: input,
+            });
+            emit({
+              type: "response.custom_tool_call_input.done",
+              item_id: item.id,
+              output_index: outputIndex,
+              input,
+            });
+            emit({ type: "response.output_item.done", output_index: outputIndex, item });
+            output.push(item);
+          } else {
+            const item = {
+              id: `${responseId}_tool_${outputIndex}`,
+              type: "function_call",
+              status: "completed",
+              call_id: call.id,
+              name: call.name,
+              arguments: call.arguments,
+            };
+            emit({
+              type: "response.output_item.added",
+              output_index: outputIndex,
+              item: { ...item, status: "in_progress", arguments: "" },
+            });
+            emit({
+              type: "response.function_call_arguments.delta",
+              item_id: item.id,
+              output_index: outputIndex,
+              delta: call.arguments,
+            });
+            emit({
+              type: "response.function_call_arguments.done",
+              item_id: item.id,
+              output_index: outputIndex,
+              arguments: call.arguments,
+            });
+            emit({ type: "response.output_item.done", output_index: outputIndex, item });
+            output.push(item);
+          }
+        }
+        emit({
+          type: "response.completed",
+          response: {
+            ...responseBase,
+            status: "completed",
+            output,
+            usage: {
+              input_tokens: usage.prompt_tokens || 0,
+              output_tokens: usage.completion_tokens || 0,
+              total_tokens: usage.total_tokens || 0,
+            },
+          },
+        });
+        emit("[DONE]");
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      } finally {
+        reader.releaseLock();
+      }
+    },
+  });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+  });
+}
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url);
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/v1/responses" || url.pathname === "/responses")
+    )
+      return responses(request);
+    if (url.pathname === "/health") return Response.json({ ok: true, model });
+    return Response.json({ error: { message: "not found" } }, { status: 404 });
+  },
+});
+
+const codexHome = join(root, ".codex-deepseek");
+mkdirSync(codexHome, { recursive: true });
+
+// The DeepSeek provider config that used to be injected as codex `-c` flags.
+// Now written to CODEX_HOME/config.toml instead, because codex is spawned
+// through the agent-yes wrapper (`ay codex`) whose yargs parser would swallow
+// `-c` (alias of --continue) before it ever reached codex.
+const configToml = [
+  `model_provider = "deepseek"`,
+  `model = "${model}"`,
+  `model_supports_reasoning_summaries = false`,
+  `model_context_window = 1000000`,
+  ``,
+  `[model_providers.deepseek]`,
+  `name = "DeepSeek local adapter"`,
+  `base_url = "http://127.0.0.1:${server.port}/v1"`,
+  `env_key = "DEEPSEEK_PROXY_KEY"`,
+  `wire_api = "responses"`,
+  // Let codex absorb transient upstream 5xx (e.g. DeepSeek gateway 502s) with
+  // its built-in exponential backoff instead of surfacing them to the user.
+  `request_max_retries = 3`,
+  `stream_max_retries = 3`,
+].join("\n");
+writeFileSync(join(codexHome, "config.toml"), configToml);
+
+if (process.env.DEEPSEEK_SERVER_ONLY) {
+  // Debug mode: run the adapter without spawning codex so the upstream request
+  // can be driven by an external codex/curl invocation. Serve until signalled.
+  await new Promise<void>((resolve) => {
+    for (const signal of ["SIGINT", "SIGTERM"] as const) process.once(signal, resolve);
+  });
+  server.stop(true);
+  process.exit(0);
+}
+
+// Spawn codex THROUGH the agent-yes wrapper so the session is a first-class
+// agent: registered in `ay ls`, tail-able, resumable, auto-yes, etc. AGENT_YES_BIN
+// is injected by `ay ds`; fall back to `ay` on PATH for a bare `bun run deepseek`.
+// Exception: `exec` subcommand, whose non-interactive one-shot runs don't need
+// agent registration, and which the wrapper's codex `defaultArgs` (`--search`)
+// would break (`codex --search exec` is an unknown-argument error).
+const args = process.argv.slice(2);
+const ayBin = process.env.AGENT_YES_BIN || "ay";
+const isExec = args[0] === "exec";
+const spawnedAt = Date.now();
+const child = Bun.spawn(isExec ? ["codex", ...args] : [ayBin, "codex", ...args], {
+  cwd: process.cwd(),
+  env: { ...process.env, CODEX_HOME: codexHome, DEEPSEEK_PROXY_KEY: "local-adapter" },
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => child.kill(signal));
+}
+const exitCode = await child.exited;
+
+// When `ay codex` is launched from a nested non-TTY context (AGENT_YES_PID set
+// + stdout piped) the wrapper detaches the codex agent and returns immediately
+// (see cli.ts shouldForkNested). That orphaned agent still talks to THIS
+// adapter, so tearing the server down here would break it mid-stream. Keep
+// serving until every codex agent this invocation spawned has exited.
+await waitForOrphanedCodex(spawnedAt);
+
+server.stop(true);
+process.exit(exitCode);
+
+// ---------------------------------------------------------------------------
+// orphan-aware server teardown
+// ---------------------------------------------------------------------------
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Last-wins-per-pid view of the agent registry (~/.agent-yes/pids.jsonl). */
+function readAgentRegistry(): Array<{
+  pid: number;
+  cli?: string;
+  cwd?: string;
+  status?: string;
+  started_at?: number;
+}> {
+  const pidsPath = join(homedir(), ".agent-yes", "pids.jsonl");
+  let raw: string;
+  try {
+    raw = readFileSync(pidsPath, "utf-8");
+  } catch {
+    return [];
+  }
+  const merged = new Map<number, any>();
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const doc = JSON.parse(trimmed);
+      if (typeof doc.pid === "number") {
+        const prev = merged.get(doc.pid);
+        merged.set(doc.pid, prev ? { ...prev, ...doc } : doc);
+      }
+    } catch {
+      /* skip corrupt */
+    }
+  }
+  return [...merged.values()];
+}
+
+async function waitForOrphanedCodex(spawnedAt: number): Promise<void> {
+  const MAX_WAIT_MS = 24 * 60 * 60 * 1000;
+  const deadline = Date.now() + MAX_WAIT_MS;
+  while (Date.now() < deadline) {
+    const orphan = readAgentRegistry().find(
+      (r) =>
+        r.cli === "codex" &&
+        r.cwd === process.cwd() &&
+        typeof r.started_at === "number" &&
+        r.started_at >= spawnedAt - 5000 &&
+        r.status !== "exited" &&
+        isPidAlive(r.pid),
+    );
+    if (!orphan) return;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+}

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -3222,6 +3222,15 @@ async function cmdSend(rest: string[]): Promise<number> {
     })
     .help(false)
     .version(false)
+    // An UNKNOWN flag must be an error, never a silent reinterpretation of the
+    // message. yargs otherwise swallows `--body-file /tmp/x` as an ad-hoc option
+    // whose VALUE is the next token — which removes the positional entirely and
+    // sends an EMPTY body. That failure is invisible from both ends: the sender
+    // sees a normal exit, the recipient sees a blank message and reads it as an
+    // idle lane. Observed 2026-07-30: four consecutive replies vanished this way,
+    // and the receiving lane concluded the sender had stopped working and began
+    // taking over the work.
+    .strictOptions()
     .exitProcess(false);
 
   const argv = await y.parseAsync();
@@ -3237,6 +3246,17 @@ async function cmdSend(rest: string[]): Promise<number> {
 
   if (!keyword)
     throw new Error("usage: ay send <keyword> <msg|-> [--code=enter|esc|ctrl-c|ctrl-y|tab|none]");
+
+  // Second line of defence, independent of how the message went missing: never
+  // deliver nothing. Sending an empty body is never what anyone meant, and its
+  // whole cost is paid by the RECIPIENT, who cannot tell "no message" from
+  // "nothing to say". `-` is exempt here and validated after stdin is read.
+  if (rawMessage !== "-" && rawMessage.trim() === "") {
+    throw new Error(
+      "ay send: refusing to send an empty message. Pass the text as a single argument, " +
+        "or use `-` to read the body from stdin (e.g. `ay send <keyword> - < file.txt`).",
+    );
+  }
 
   const codeName = argv.code.toLowerCase();
   {
@@ -3271,6 +3291,9 @@ async function cmdSend(rest: string[]): Promise<number> {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
     body = Buffer.concat(chunks).toString("utf-8").trimEnd();
+    if (body.trim() === "") {
+      throw new Error("ay send: refusing to send an empty message (stdin was empty).");
+    }
   } else {
     body = rawMessage;
   }

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -12,7 +12,9 @@
  */
 
 import { randomBytes } from "crypto";
+import { spawn } from "child_process";
 import { appendFile, mkdir, open, readFile, stat, writeFile } from "fs/promises";
+import { fileURLToPath } from "node:url";
 import ms from "ms";
 import { homedir } from "os";
 import path from "path";
@@ -442,6 +444,8 @@ const SUBCOMMANDS = new Set([
   "expose",
   "callback",
   "reap",
+  "deepseek",
+  "ds",
   "help",
 ]);
 
@@ -510,6 +514,42 @@ export function isUnknownManagerToken(
   if (!managerCommands || !rawArg || rawArg.startsWith("-")) return false;
   if (isSubcommand(rawArg, managerCommands)) return false;
   return !supportedClis.includes(rawArg);
+}
+
+/**
+ * Write to stdout and wait until it has actually been handed off.
+ *
+ * The CLI ends with `process.exit()`, which DISCARDS bytes still sitting in the
+ * pipe buffer. Writing to a file completes synchronously so this never showed
+ * there, but any consumer that PIPES us silently lost everything past 64KiB.
+ * Measured on `ay ls --json` with a large fleet (symval CTO, 2026-08-05):
+ *
+ *     ay ls --json > file    118055 bytes, valid JSON
+ *     ay ls --json | consumer 65536 bytes, cut mid-multibyte — will not parse
+ *
+ * The truncation is invisible to the caller: it looks exactly like a small
+ * fleet, and an orchestrator that parses this reported 27 of 71 agents.
+ *
+ * Only capturing the REAL write's completion works. Probing afterwards with an
+ * empty `write("")` — by return value, by drain event, or by callback — reports
+ * ready while the big write is still queued (all three verified failing), so do
+ * not "simplify" this into a flush helper at the exit site.
+ */
+async function writeStdoutFlushed(text: string): Promise<void> {
+  // Use the WRITE'S OWN RETURN VALUE, not a probe afterwards. `false` means the
+  // pipe buffer is full and bytes are still queued; only then do we wait.
+  //
+  // Deliberately `=== false`: a stubbed/mocked stdout (tests, embedders) returns
+  // undefined, and treating that as backpressure made this await forever — it
+  // broke 5 specs before the strict compare went in. The timeout is a second
+  // guarantee that a stuck consumer can never hang the CLI.
+  const flushed = process.stdout.write(text);
+  if (flushed === false) {
+    await Promise.race([
+      new Promise<void>((resolve) => process.stdout.once("drain", () => resolve())),
+      new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+    ]);
+  }
 }
 
 /**
@@ -629,6 +669,9 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         await reaper.sweep();
         return 0;
       }
+      case "deepseek":
+      case "ds":
+        return cmdDeepseek(rest);
       case "help":
         return cmdHelp(managerCommands);
       default:
@@ -639,6 +682,47 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
     process.stderr.write(`ay ${sub}: ${msg}\n`);
     return 1;
   }
+}
+
+// ---------------------------------------------------------------------------
+// ay deepseek / ay ds
+// ---------------------------------------------------------------------------
+
+/**
+ * `ay deepseek [-- <args>…]` / `ay ds …`: run the local DeepSeek adapter that
+ * bridges Codex's Responses API to DeepSeek's chat completions, then spawn
+ * `codex` pointed at it. The adapter script lives in this package's
+ * `scripts/deepseek-codex.ts` and is Bun-only (Bun.serve / Bun.spawn), so it is
+ * re-exec'd via the same bun runtime that's running us — never imported into
+ * this process. Extra args are forwarded verbatim to `codex`.
+ */
+export function cmdDeepseek(rest: string[]): Promise<number> {
+  const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const script = path.join(root, "scripts", "deepseek-codex.ts");
+  const bunBin = process.execPath.split(/[/\\]/).at(-1)?.startsWith("bun")
+    ? process.execPath
+    : "bun";
+  const child = spawn(bunBin, [script, ...rest], {
+    cwd: process.cwd(),
+    env: { ...process.env, AGENT_YES_BIN: process.argv[1] },
+    stdio: "inherit",
+  });
+  return new Promise((resolve) => {
+    child.on("error", (err) => {
+      process.stderr.write(`ay deepseek: failed to start: ${err.message}\n`);
+      resolve(1);
+    });
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        resolve(128 + (signal === "SIGINT" ? 2 : signal === "SIGTERM" ? 15 : 1));
+      } else {
+        resolve(code ?? 1);
+      }
+    });
+    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+      process.on(signal, () => child.kill(signal));
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -747,6 +831,7 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay result <keyword> [--wait]        pull an agent's structured result envelope\n` +
       `  ay result set '<json>'              (inside an agent) deposit your result envelope\n` +
       `  ay reap                             kill process groups leaked by dead agents\n` +
+      `  ay deepseek|ds [-- <codex args>]    run codex via the local DeepSeek adapter (DEEPSEEK_API_KEY)\n` +
       wsLines +
       `\n` +
       `Remote:\n` +
@@ -1849,7 +1934,7 @@ async function cmdLs(rest: string[]): Promise<number> {
     const enriched = await Promise.all(
       records.map(async (r) => ({ ...r, ...(await deriveLiveState(r)) })),
     );
-    process.stdout.write(JSON.stringify(enriched, null, 2) + "\n");
+    await writeStdoutFlushed(JSON.stringify(enriched, null, 2) + "\n");
     return 0;
   }
 


### PR DESCRIPTION
## 経緯

shared worktree (tree/main) の `fix/stdout-flush-before-exit` branch 上に、完成済みだが push されないまま滞留していた 3 commit を origin/main に cherry-pick して出荷する。branch 上の未 commit WIP (stdout-flush 本体) には触れていない。

- `fix(ls)`: `ay ls --json` が pipe 時に 64KiB で切れる問題の修正
- `feat(deepseek)`: deepseek-codex adapter script + docs + .env.local.example
- `fix(send)`: unknown flag / 空 body で無言配送しないガード

ts/subcommands.spec.ts 127 件 local pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)