### PR TITLE
feat(console): Provision repo を combobox 化、非 GitHub git URL の raw clone に対応

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -7982,6 +7982,7 @@ my.translate = async (text, lang) => {
         const res = await target.tx.post("/api/spawn", {
           cli: spec.cli || "claude",
           from: spec.from || undefined,
+          branch: spec.branch || undefined,
           create: spec.create || undefined,
           fork: spec.fork || undefined,
           cwd: spec.cwd || undefined,
@@ -8104,11 +8105,10 @@ my.translate = async (text, lang) => {
         $("newform").innerHTML = `<div class="lcard">
       <div class="ltitle">New agent · ${esc(sourceLabel(target) || "local")}</div>
       ${hostRow}
-      <div class="nfield"><label>Working dir</label><input id="nf-cwd" list="nf-cwd-list" value="${esc(cwd)}" placeholder="(host default — ignored when Spawn from is set)" spellcheck="false" autocapitalize="off" /><datalist id="nf-cwd-list">${cwdOptions(target ? target.id : "")}</datalist></div>
+      <div class="nfield"><label>Working dir</label><input id="nf-cwd" list="nf-cwd-list" value="${esc(cwd)}" placeholder="(host default — ignored when a Provision repo is set)" spellcheck="false" autocapitalize="off" /><datalist id="nf-cwd-list">${cwdOptions(target ? target.id : "")}</datalist></div>
       <div class="nfield"><label>CLI</label><select id="nf-cli">${cliOptions(null, preferredCli)}</select></div>
-      <div class="nfield"><label>Provision repo — optional</label><select id="nf-repo"><option value="" selected>(none — use working dir or spawn-from)</option></select></div>
+      <div class="nfield"><label>Provision repo — optional</label><input id="nf-repo" list="nf-repo-list" placeholder="owner/repo · github URL · git URL (gitlab etc.) — provisions a worktree" spellcheck="false" autocapitalize="off" /><datalist id="nf-repo-list"></datalist><div class="lhint" id="nf-repo-hint" style="display:none"></div></div>
       <div class="nfield" id="nf-branch-row" style="display:none"><label>Branch</label><input id="nf-branch" list="nf-branch-list" placeholder="(repo default) — pick one, or type a new name to create it" spellcheck="false" autocapitalize="off" /><datalist id="nf-branch-list"></datalist><div class="lhint" id="nf-branch-hint" style="display:none"></div></div>
-      <div class="nfield"><label>Spawn from — optional</label><input id="nf-from" placeholder="github URL / owner/repo@branch — provisions a worktree" spellcheck="false" autocapitalize="off" /></div>
       <div class="nfield"><label>Prompt — optional</label><textarea id="nf-prompt" rows="3" placeholder="initial message to send the agent…"></textarea></div>
       <div class="lrow">
         <button class="lfleet" id="nf-go">▷ Launch</button>
@@ -8127,13 +8127,7 @@ my.translate = async (text, lang) => {
           showHook(sources.get(ev.target.value));
           loadRepoPicker(sources.get(ev.target.value));
         });
-        $("nf-repo")?.addEventListener("change", () => {
-          const repo = $("nf-repo").value;
-          const row = $("nf-branch-row");
-          if (row) row.style.display = repo ? "" : "none";
-          if (repo) loadBranchPicker(spawnTarget($("newform").dataset.room), repo);
-          else nfRemoteBranches = null;
-        });
+        $("nf-repo")?.addEventListener("change", onRepoChange);
         $("nf-branch-row")?.addEventListener("input", (ev) => {
           if (ev.target.id === "nf-branch") updateBranchHint();
         });
@@ -8141,15 +8135,39 @@ my.translate = async (text, lang) => {
         loadRepoPicker(target);
       }
 
-      // ---- provisioning picker (repo → branch) for the New-agent form -------
-      // Data comes from the target host's /api/ws/repos and /api/ws/branches.
-      // Both are best-effort on the server (gh may be unauthenticated); here a
-      // fetch failure just leaves the pickers empty — the free-text "Spawn
-      // from" field still works.
+      // ---- provisioning picker (repo combobox → branch) for the New-agent form
+      // The repo field is a COMBOBOX: a datalist filled from the target host's
+      // /api/ws/repos (local checkouts + gh-visible repos), but free text always
+      // works — owner/repo, a full github URL (repo or /tree/<branch> URL), or
+      // any other git URL (gitlab etc. — the host raw-`git clone`s those).
+      // The listing endpoints are best-effort; a fetch failure just leaves the
+      // datalist empty and shows a short hint, manual input still provisions.
       let nfRemoteBranches = null; // Set of remote branch names for the picked repo
+
+      // What the repo field's text means. github-first: bare owner/repo IS a
+      // github repo; only scheme/git@ inputs on other hosts become raw git URLs.
+      function parseRepoInput(v) {
+        v = (v || "").trim();
+        if (!v) return null;
+        let m =
+          /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?(?:\/tree\/([^\s?#]+))?\/?$/i.exec(
+            v,
+          );
+        if (m) return { kind: "github", owner: m[1], repo: m[2], branch: m[3] || "" };
+        m = /^git@github\.com:([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i.exec(v);
+        if (m) return { kind: "github", owner: m[1], repo: m[2], branch: "" };
+        m = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(v);
+        if (m && m[1] !== "." && m[1] !== "..")
+          return { kind: "github", owner: m[1], repo: m[2], branch: "" };
+        if (/^(git@[^:\s]+:|ssh:\/\/|git:\/\/|https?:\/\/)\S+$/.test(v))
+          return { kind: "git", url: v.replace(/\/+$/, "") };
+        return null;
+      }
       function loadRepoPicker(target) {
-        const selEl = $("nf-repo");
-        if (!selEl || !target?.tx?.fetchJSON) return;
+        const dl = $("nf-repo-list");
+        const hint = $("nf-repo-hint");
+        if (!dl) return;
+        if (!target?.tx?.fetchJSON) return;
         const forId = target.id;
         target.tx
           .fetchJSON("/api/ws/repos")
@@ -8157,18 +8175,49 @@ my.translate = async (text, lang) => {
             // a slow answer for a host the user switched away from must not
             // paint the new host's repo list (same guard as showHook)
             if ($("newform").dataset.room !== forId) return;
-            const cur = selEl.value;
             const repos = (d && d.repos) || [];
-            selEl.innerHTML =
-              `<option value="">(none — use working dir or spawn-from)</option>` +
-              repos
-                .map((r) => {
-                  const full = `${r.owner}/${r.repo}`;
-                  return `<option value="${esc(full)}"${full === cur ? " selected" : ""}>${esc(full)}${r.local ? "" : " (gh)"}</option>`;
-                })
-                .join("");
+            dl.innerHTML = repos
+              .map(
+                (r) =>
+                  `<option value="${esc(`${r.owner}/${r.repo}`)}">${r.local ? "provisioned" : "gh"}</option>`,
+              )
+              .join("");
+            if (hint && d && d.gh && !d.gh.ok && d.gh.error) {
+              hint.textContent = `gh listing unavailable (${d.gh.error}) — type a repo or URL`;
+              hint.style.display = "";
+            } else if (hint) hint.style.display = "none";
           })
-          .catch(() => {});
+          .catch(() => {
+            if ($("newform").dataset.room !== forId) return;
+            if (hint) {
+              hint.textContent =
+                "repo list unavailable on this host — type owner/repo or a git URL";
+              hint.style.display = "";
+            }
+          });
+      }
+      function onRepoChange() {
+        const parsed = parseRepoInput($("nf-repo")?.value || "");
+        const row = $("nf-branch-row");
+        const hint = $("nf-branch-hint");
+        nfRemoteBranches = null;
+        if (row) row.style.display = parsed ? "" : "none";
+        if (!parsed) return;
+        if (parsed.kind === "github") {
+          if (parsed.branch && $("nf-branch")) $("nf-branch").value = parsed.branch;
+          loadBranchPicker(
+            spawnTarget($("newform").dataset.room),
+            `${parsed.owner}/${parsed.repo}`,
+          );
+        } else {
+          const dl = $("nf-branch-list");
+          if (dl) dl.innerHTML = "";
+          if (hint) {
+            hint.textContent =
+              "non-GitHub git URL — the host runs a raw `git clone`; branch optional (a new name creates it)";
+            hint.style.display = "";
+          }
+        }
       }
       function loadBranchPicker(target, repo) {
         const dl = $("nf-branch-list");
@@ -8184,7 +8233,9 @@ my.translate = async (text, lang) => {
         target.tx
           .fetchJSON("/api/ws/branches?repo=" + encodeURIComponent(repo))
           .then((d) => {
-            if ($("nf-repo")?.value !== want) return; // user picked another repo meanwhile
+            // user picked another repo meanwhile (value may be a URL — normalize)
+            const cur = parseRepoInput($("nf-repo")?.value || "");
+            if (!cur || cur.kind !== "github" || `${cur.owner}/${cur.repo}` !== want) return;
             const branches = (d && d.branches) || [];
             nfRemoteBranches = new Set(branches.filter((b) => b.remote).map((b) => b.name));
             if (dl)
@@ -8258,23 +8309,37 @@ my.translate = async (text, lang) => {
         try {
           localStorage.setItem(LAST_CLI_KEY, cli);
         } catch {}
-        // The repo/branch pickers win over the free-text "Spawn from" field:
-        // picked repo [+ branch] → a `from` spec; a branch name that isn't on
-        // the remote asks the server to create it (create:true, ws new --create).
-        let from = $("nf-from")?.value.trim() || "";
+        // The repo combobox decides provisioning: a github repo [+ branch]
+        // becomes a `from` spec (a branch name that isn't on the remote asks
+        // the server to create it — create:true, ws new --create); any other
+        // git URL is sent as-is with the branch alongside (raw clone path).
+        let from = "";
+        let branch = "";
         let create = false;
-        const pickedRepo = $("nf-repo")?.value || "";
-        if (pickedRepo) {
-          const br = ($("nf-branch")?.value || "").trim();
-          from = br ? `${pickedRepo}@${br}` : pickedRepo;
+        const parsed = parseRepoInput($("nf-repo")?.value || "");
+        const br = ($("nf-branch")?.value || "").trim();
+        if (parsed && parsed.kind === "github") {
+          from = br ? `${parsed.owner}/${parsed.repo}@${br}` : `${parsed.owner}/${parsed.repo}`;
           // Unknown remote list (fetch failed) → still send create: the server
           // only uses it after the branch turns out missing, so it's harmless
           // for existing branches and saves an un-actionable 502 for new ones.
           create = !!(br && (!nfRemoteBranches || !nfRemoteBranches.has(br)));
+        } else if (parsed && parsed.kind === "git") {
+          from = parsed.url;
+          branch = br;
+          create = !!br;
+        } else if ($("nf-repo")?.value.trim()) {
+          // unparseable text must not silently fall through to a plain-cwd spawn
+          $("nf-repo").focus();
+          alert(
+            "Provision repo not recognized — use owner/repo, a github URL, or a git URL (git@… / https://…)",
+          );
+          return;
         }
         const spec = {
           cli,
           from,
+          branch,
           create,
           // a provision spec decides the cwd server-side — don't send a stale one
           cwd: from ? "" : $("nf-cwd").value.trim(),

--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -466,14 +466,22 @@ describe("console DOM behaviour", () => {
         } catch {}
       }
     });
+    // the combobox fires its logic on `change` — fill() then commit like a user
+    const setRepo = async (v: string) => {
+      await page.fill("#nf-repo", v);
+      await page.dispatchEvent("#nf-repo", "change");
+    };
     try {
       await page.click("#newbtn");
-      // repo picker fills async from /api/ws/repos — placeholder + 3 repos
-      await expect.poll(() => page.locator("#nf-repo option").count()).toBe(4);
-      expect(await page.locator("#nf-repo").innerText()).toContain("acme/newrepo (gh)");
+      // repo combobox datalist fills async from /api/ws/repos — 3 repos
+      await expect.poll(() => page.locator("#nf-repo-list option").count()).toBe(3);
+      const values = await page
+        .locator("#nf-repo-list option")
+        .evaluateAll((os) => os.map((o) => (o as HTMLOptionElement).value));
+      expect(values).toContain("acme/newrepo");
 
       // pick a repo → branch row appears, datalist fills from /api/ws/branches
-      await page.selectOption("#nf-repo", "acme/widgets");
+      await setRepo("acme/widgets");
       await expect.poll(() => page.locator("#nf-branch-row").isVisible()).toBe(true);
       await expect.poll(() => page.locator("#nf-branch-list option").count()).toBe(2);
 
@@ -489,17 +497,29 @@ describe("console DOM behaviour", () => {
       expect(spawns[0].create).toBe(true);
       expect(spawns[0].cwd).toBeUndefined();
 
-      // an EXISTING remote branch → plain {from}, no create
+      // a github /tree/<branch> URL → normalized spec, branch prefilled
       await page.click("#newbtn");
-      await expect.poll(() => page.locator("#nf-repo option").count()).toBe(4);
-      await page.selectOption("#nf-repo", "acme/widgets");
+      await setRepo("https://github.com/acme/widgets/tree/main");
+      await expect.poll(() => page.locator("#nf-branch").inputValue()).toBe("main");
       await expect.poll(() => page.locator("#nf-branch-list option").count()).toBe(2);
-      await page.fill("#nf-branch", "main");
       await page.selectOption("#nf-cli", "claude");
       await page.click("#nf-go");
       await expect.poll(() => spawns.length).toBe(2);
       expect(spawns[1].from).toBe("acme/widgets@main");
       expect(spawns[1].create).toBeUndefined();
+      expect(spawns[1].branch).toBeUndefined();
+
+      // a non-GitHub git URL → sent raw with the branch alongside (raw clone)
+      await page.click("#newbtn");
+      await setRepo("https://gitlab.com/acme/tools.git");
+      await expect.poll(() => page.locator("#nf-branch-hint").innerText()).toContain("git clone");
+      await page.fill("#nf-branch", "dev");
+      await page.selectOption("#nf-cli", "claude");
+      await page.click("#nf-go");
+      await expect.poll(() => spawns.length).toBe(3);
+      expect(spawns[2].from).toBe("https://gitlab.com/acme/tools.git");
+      expect(spawns[2].branch).toBe("dev");
+      expect(spawns[2].create).toBe(true);
     } finally {
       await ctx.close();
     }

--- a/ts/serve.spec.ts
+++ b/ts/serve.spec.ts
@@ -4,6 +4,7 @@ import {
   installerArgv,
   isNoNodeExecError,
   oxmgrVersionHasWindowsFix,
+  parseGitUrl,
   portlessConsoleUrl,
 } from "./serve.ts";
 
@@ -126,5 +127,40 @@ describe("installerArgv", () => {
 
   it("returns null with neither installer", () => {
     expect(installerArgv("pm2", null, null)).toBeNull();
+  });
+});
+
+// The raw-clone spawn path only handles NON-github git sources; github (and
+// bare owner/repo, which never reaches this parser) goes through the provision
+// module. Owner/repo come from the URL's last two path segments so the checkout
+// lands in the standard <wsRoot>/<owner>/<repo>/tree/<branch> layout.
+describe("parseGitUrl", () => {
+  it("parses scp-style, ssh and https non-github URLs", () => {
+    expect(parseGitUrl("git@gitlab.com:acme/tools.git")).toEqual({
+      url: "git@gitlab.com:acme/tools.git",
+      owner: "acme",
+      repo: "tools",
+    });
+    expect(parseGitUrl("ssh://git@git.corp.io/team/app.git")).toEqual({
+      url: "ssh://git@git.corp.io/team/app.git",
+      owner: "team",
+      repo: "app",
+    });
+    expect(parseGitUrl("https://gitlab.com/acme/tools")).toEqual({
+      url: "https://gitlab.com/acme/tools",
+      owner: "acme",
+      repo: "tools",
+    });
+    // subgrouped gitlab paths use the LAST two segments
+    expect(parseGitUrl("https://gitlab.com/org/group/proj.git")?.owner).toBe("group");
+  });
+
+  it("rejects github, bare specs, and traversal-looking segments", () => {
+    expect(parseGitUrl("https://github.com/acme/tools")).toBeNull();
+    expect(parseGitUrl("git@github.com:acme/tools.git")).toBeNull();
+    expect(parseGitUrl("acme/tools")).toBeNull();
+    expect(parseGitUrl("https://gitlab.com/tools")).toBeNull();
+    expect(parseGitUrl("https://gitlab.com/../evil")).toBeNull();
+    expect(parseGitUrl("file:///etc/passwd")).toBeNull();
   });
 });

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -1,4 +1,15 @@
-import { appendFile, mkdir, open, readdir, readFile, stat, unlink, writeFile } from "fs/promises";
+import {
+  appendFile,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "fs/promises";
 import { existsSync, renameSync, watch, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -564,6 +575,38 @@ async function runCapture(
   } catch (e) {
     return { ok: false, stdout: "", stderr: (e as Error).message };
   }
+}
+
+// A non-GitHub git source (gitlab, self-hosted, …) for /api/spawn's raw-clone
+// path. github.com inputs return null — those go through the provision module
+// (gh auth, setup-repo.sh). Accepts scp-style git@host:path, ssh://, git://,
+// http(s):// — bare owner/repo is github-first and never lands here.
+export function parseGitUrl(s: string): { url: string; owner: string; repo: string } | null {
+  let host = "";
+  let pathPart = "";
+  const scp = /^git@([^:/\s]+):([^\s]+?)(?:\.git)?\/?$/.exec(s);
+  if (scp) {
+    host = scp[1]!;
+    pathPart = scp[2]!;
+  } else {
+    let u: URL;
+    try {
+      u = new URL(s);
+    } catch {
+      return null;
+    }
+    if (!/^(https?|ssh|git)$/.test(u.protocol.replace(":", ""))) return null;
+    host = u.hostname;
+    pathPart = u.pathname.replace(/^\/+|\/+$/g, "").replace(/\.git$/, "");
+  }
+  if (/(^|\.)github\.com$/i.test(host)) return null;
+  const segs = pathPart.split("/").filter(Boolean);
+  if (segs.length < 2) return null;
+  const owner = segs[segs.length - 2]!;
+  const repo = segs[segs.length - 1]!.replace(/\.git$/, "");
+  if (!owner || !repo || owner === "." || owner === ".." || repo === "." || repo === "..")
+    return null;
+  return { url: s.replace(/\/+$/, ""), owner, repo };
 }
 
 // 60s memo for /api/ws/repos' gh side (see the endpoint for why).
@@ -4024,6 +4067,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
         prompt?: string;
         yes?: boolean;
         create?: boolean;
+        branch?: string; // raw-clone path only (github specs embed the branch in `from`)
         fork?: { fromCwd?: string; branch?: string };
       };
       try {
@@ -4161,6 +4205,105 @@ export async function cmdServe(rest: string[]): Promise<number> {
           );
         cwd = result.folder;
         provisioned = { action: result.action, folder: result.folder };
+      } else if (from && parseGitUrl(from)) {
+        // Non-GitHub git URL (gitlab, self-hosted, …): raw `git clone` into the
+        // standard layout <wsRoot>/<owner>/<repo>/tree/<branch> — no provision
+        // module, no setup-repo.sh. Same admission gates as the github path:
+        // provision hook first (it may select credentials), else the allowlist.
+        const gitSrc = parseGitUrl(from)!;
+        const branch = typeof body.branch === "string" ? body.branch.trim() : "";
+        // the branch lands in a filesystem path (tree/<branch>) — no empty/./..
+        // segments, no option-looking names
+        const badBranch = (b: string) =>
+          b.startsWith("-") || b.split("/").some((s) => !s || s === "." || s === "..");
+        if (branch && badBranch(branch))
+          return new Response(`invalid branch name: ${branch}`, { status: 400 });
+        const gitHook = await runProvisionHook(getProvisionRoot() ?? homedir(), {
+          KOHO_ACTION: "from",
+          KOHO_SOURCE: from,
+          KOHO_OWNER: gitSrc.owner,
+          KOHO_REPO: gitSrc.repo,
+          KOHO_BRANCH: branch,
+          KOHO_WS_ROOT: getProvisionRoot() ?? "",
+        });
+        if (gitHook.ran) {
+          if (!gitHook.ok)
+            return new Response(
+              `provision hook denied '${gitSrc.owner}/${gitSrc.repo}' (exit ${gitHook.code})` +
+                (gitHook.detail ? `:\n${gitHook.detail}` : ""),
+              { status: 403 },
+            );
+        } else if (!isProvisionAllowed(gitSrc.owner, gitSrc.repo)) {
+          return new Response(
+            `provisioning '${gitSrc.owner}/${gitSrc.repo}' is not allowed — add the owner to ` +
+              `provisionAllowlist in ~/.agent-yes/config.json (or "*" to allow all), ` +
+              `or set a provisionHook to gate it yourself`,
+            { status: 403 },
+          );
+        }
+        const wsRootDir = getProvisionRoot() ?? path.join(homedir(), "ws");
+        const base = path.join(wsRootDir, gitSrc.owner, gitSrc.repo, "tree");
+        const destFor = (b: string) => path.join(base, b);
+        if (branch && existsSync(path.join(destFor(branch), ".git"))) {
+          // already provisioned — reuse; a fetch/pull is the agent's business
+          cwd = destFor(branch);
+          provisioned = { action: "existing", folder: cwd };
+        } else {
+          const tmp = path.join(base, `.clone-${process.pid}-${Date.now().toString(36)}`);
+          try {
+            await mkdir(base, { recursive: true });
+          } catch (e) {
+            return new Response(`cannot create ${base}: ${(e as Error).message}`, { status: 500 });
+          }
+          const cloneMs = 300_000;
+          let created = false;
+          let r = await runCapture(
+            branch
+              ? ["git", "clone", "--branch", branch, "--", gitSrc.url, tmp]
+              : ["git", "clone", "--", gitSrc.url, tmp],
+            { timeoutMs: cloneMs },
+          );
+          if (!r.ok && branch && body.create === true) {
+            // branch may not exist yet — clone the default and branch off it
+            await rm(tmp, { recursive: true, force: true }).catch(() => {});
+            r = await runCapture(["git", "clone", "--", gitSrc.url, tmp], { timeoutMs: cloneMs });
+            if (r.ok) {
+              const co = await runCapture(["git", "-C", tmp, "checkout", "-b", branch]);
+              if (!co.ok) r = co;
+              else created = true;
+            }
+          }
+          if (!r.ok) {
+            await rm(tmp, { recursive: true, force: true }).catch(() => {});
+            return new Response(
+              `git clone failed: ${(r.stderr.trim() || "unknown").slice(0, 500)}` +
+                (branch && body.create !== true
+                  ? "\n(if the branch doesn't exist yet, retry with create:true)"
+                  : ""),
+              { status: 502 },
+            );
+          }
+          const head = await runCapture(["git", "-C", tmp, "rev-parse", "--abbrev-ref", "HEAD"]);
+          let actual = branch || (head.ok ? head.stdout.trim() : "") || "main";
+          if (badBranch(actual)) actual = "main";
+          const dest = destFor(actual);
+          if (existsSync(dest)) {
+            // raced/already there — keep the existing checkout, drop ours
+            await rm(tmp, { recursive: true, force: true }).catch(() => {});
+          } else {
+            try {
+              await mkdir(path.dirname(dest), { recursive: true });
+              await rename(tmp, dest);
+            } catch (e) {
+              await rm(tmp, { recursive: true, force: true }).catch(() => {});
+              return new Response(`cannot place checkout at ${dest}: ${(e as Error).message}`, {
+                status: 500,
+              });
+            }
+          }
+          cwd = dest;
+          provisioned = { action: created ? "cloned+new-branch" : "cloned", folder: dest };
+        }
       } else if (from) {
         type Spec = { owner: string; repo: string; branch: string };
         let prov: {


### PR DESCRIPTION
## 背景

#374 の「Provision repo」は `<select>` で、`/api/ws/repos` が取得できない環境 (旧 daemon 等) では "(none)" しか表示されず、手入力の口も無かった。

## 変更点

**UI (lab/ui/index.html)**
- repo 欄を **datalist combobox** に変更。候補は `/api/ws/repos` (local checkout + gh 可視 repo) から充填しつつ、自由入力を常に受け付ける:
  - `owner/repo` (github-first)
  - github URL — repo URL / `/tree/<branch>` URL (branch は自動プリフィル) / `git@github.com:` 形式
  - それ以外の git URL (gitlab・self-hosted 等) → サーバが raw `git clone`
- 一覧取得失敗時は hint を表示して手入力で続行可能。解釈できない入力は plain-cwd spawn に落ちず alert で明示

**サーバ (ts/serve.ts)**
- `POST /api/spawn` に raw-clone パスを追加: `from` が非 GitHub git URL (scp / ssh / git / http(s)) の場合、provision module を使わず `git clone` で `<wsRoot>/<owner>/<repo>/tree/<branch>` に配置 (owner/repo は URL 末尾 2 セグメント)。`body.branch` で `--branch` clone、`create:true` なら default から新 branch 作成。既存の provision hook / allowlist ゲートの内側で実行
- branch 名は path に埋まるため検証 (空/`.`/`..` セグメント・先頭 `-` を拒否)、URL は `--` 区切りで argv 渡し
- `parseGitUrl` を export + 単体テスト

**テスト**
- ts/serve.spec.ts: parseGitUrl 8 アサーション
- tests/ui-dom: combobox 操作に更新 + github `/tree/` URL・gitlab URL の 2 ケース追加 (26/26 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)