### PR TITLE
feat(identity): 標準 identity 形式 + 端末 title 捕捉、role 概念は撤去

### DIFF
--- a/docs/cy-subcommands.md
+++ b/docs/cy-subcommands.md
@@ -14,7 +14,6 @@ cy cat  <keyword>                       # read の全文エイリアス（窓指
 cy tail <keyword> [-f] [-n N] [--latest]  # 末尾 N 行（既定 96）、-f で追従
 cy head <keyword> [-n N] [--latest]     # 既定 N=96
 cy send <keyword> <msg> [--code=enter|esc|ctrl-c|ctrl-y|ctrl-d|ctrl-\|tab|none|raw:0xNN]
-cy role [name] | cy role <keyword> <name> [--clear]   # 送信 envelope に載る lane/role 名
 cy attach <keyword> [--escape ctrl-\] [--latest] [--cwd <dir>]
 cy stop <keyword> [--method=auto|graceful|double-ctrl-c]
 ```
@@ -102,21 +101,35 @@ Rust 側はパイプを **自プロセスで O_RDWR で開いたまま** にし�
 ユーザの stdin と同じ `stdin_tx` チャンネルへ流すため、`/auto` 検出・
 `Ctrl+C` 処理・`stdin_ready` ゲートはそのまま適用される。
 
-### 送信 envelope と role 名
+### 送信 envelope と標準 identity
 
 エージェントからの `ay send` は本文を
-`<ay-msg <nonce> from <cli> #<pid> [(role)] @ <cwd> — reply: ay send <agent_id> "...">`
-で包んで届ける。`role` はエージェントが自己申告する lane 名
-（`pm` / `crm` など)で、受信側が cwd/pid から役割を推測する手間を省く。
-設定方法は 2 通り:
+`<ay-msg <nonce> from <cli> <identity> — reply: ay send <agent_id> "...">`
+で包んで届ける。`<identity>` は全 surface 共通の標準形式:
 
-- 起動時に環境変数 `AGENT_YES_ROLE=pm ay claude`(登録後に子プロセス env
-  からは strip されるので、subagent には継承されない)
-- 起動後に `ay role pm`(自分)/ `ay role <keyword> pm`(他エージェント)。
-  `--clear` で削除。
+```
+<username>@<hostname>:<path>:<branch>#<pid>
+例: sno@Mac:~/ws/symval/symval/tree/crm:main#30402
+```
 
-役割名は `[A-Za-z0-9._-]{1,32}` に制限する(envelope の開きタグは nonce
-保護されないため、空白や `>` を含む値はヘッダ構造の偽造に使えてしまう)。
+- `branch` は cwd の git checkout から純 file read で解決する
+  (worktree の `gitdir:` 間接参照も辿る。detached HEAD は短縮 commit id、
+  repo 外ではセグメントごと省略)。worktree 運用では branch 名がそのまま
+  lane の役割を表すことが多い(`crm-yamamoto-wifi` / `fix/t173-tone-core`)。
+- パースは右端から: `#<pid>` を末尾から、`branch` は最後の `:` の後
+  (git の ref 名は `:` を含めない)、`username` は先頭の `@` まで。
+  途中の `path` は `:` や `@` を含み得るため、両端アンカーで読む。
+- 各セグメントは header-safe な文字集合に clamp される(envelope の開き
+  タグは nonce 保護されないため、空白や `>` はヘッダ偽造に使えてしまう)。
+
+### 端末 title の捕捉
+
+wrapper は子 CLI の PTY 出力から端末 title (OSC 0/2) を拾い、pid registry
+の `title` に保持する。claude / opencode は作業内容の要約を title に流し
+続けるので、`ay whoami` / `ay ls --json` で「そのエージェントが今なにを
+しているか」を画面を読まずに確認できる。書き込みは変化時のみ +
+2 秒スロットルで、定常状態のレジストリ書き込みはゼロ。
+
 なお、送受信の全文は `ay msgs` で双方の `.agent-yes/{inbox,outbox}.jsonl`
 から後追いできる(`ay cat` は端末描画のみで注入テキストを含まない)。
 

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -21,8 +21,7 @@ use std::env;
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "whoami", "result", "notify", "notifyd", "read", "cat", "tail",
-    "head", "send", "msgs", "role", "spawn", "attach", "stop", "exit", "restart", "note", "ch",
-    "channels",
+    "head", "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
     "term", "widget", "mint", "serve", "schedule", "remote", "expose", "callback", "reap", "help",
 ];
 

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -340,6 +340,16 @@ pub struct AgentContext {
     // unresponsive flag) from inside the loop.
     pid: u32,
 
+    // Terminal-title capture (see title_scanner.rs). `latest_title` is what the
+    // child CLI most recently set; `written_title`/`title_written_at` throttle
+    // the pid_store rewrite (registry writes take the cross-runtime lock, and
+    // claude refreshes its title every few seconds — write only on change and
+    // at most every TITLE_WRITE_MIN_MS).
+    title_scanner: crate::title_scanner::TitleScanner,
+    latest_title: Option<String>,
+    written_title: Option<String>,
+    title_written_at: Option<Instant>,
+
     // Liveness tracking. `last_stdin_at` is stamped whenever we send a
     // high-signal poke (user/FIFO input, auto-Enter, auto-retry, typing
     // response, idle action); `last_output_at` advances on every PTY chunk.
@@ -421,6 +431,10 @@ impl AgentContext {
             last_checked_screen_hash: None,
             used_alt_screen: false,
             pid,
+            title_scanner: crate::title_scanner::TitleScanner::new(),
+            latest_title: None,
+            written_title: None,
+            title_written_at: None,
             last_stdin_at: None,
             last_output_at: Instant::now(),
             poke_unresponsive: false,
@@ -920,6 +934,10 @@ impl AgentContext {
                     // check (so a clean exit never flashes "unresponsive").
                     self.check_responsiveness();
 
+                    // A title change that arrived during the write-throttle
+                    // window flushes here even if the CLI goes quiet after it.
+                    self.maybe_flush_title();
+
                     // Check for idle timeout
                     if let Some(timeout) = timeout_ms {
                         let idle = self.idle_waiter.idle_time_ms();
@@ -1018,6 +1036,13 @@ impl AgentContext {
         // wolf), which is the intended conservative behaviour. See
         // check_responsiveness.
         self.last_output_at = Instant::now();
+
+        // Track the child's terminal title (OSC 0/2) — the flush to the pid
+        // store is throttled separately in maybe_flush_title().
+        if let Some(title) = self.title_scanner.feed(output) {
+            self.latest_title = Some(title);
+        }
+        self.maybe_flush_title();
 
         // Forward raw PTY bytes to stdout only in TTY passthrough mode. In
         // plain (non-TTY) mode we suppress the raw stream and emit rendered
@@ -1445,6 +1470,28 @@ impl AgentContext {
     /// Updates this detector's sub-state and republishes the unified flag. No-op
     /// when the timeout is 0 (this detector disabled for the CLI) — the other
     /// detector can still publish.
+    /// Publish the latest captured terminal title to the pid store. Change-
+    /// gated AND rate-limited: registry writes take the cross-runtime lock and
+    /// rewrite the file, while claude retitles every few seconds — steady state
+    /// must cost zero writes, and a burst of retitles collapses to one write
+    /// per window (the tick loop calls this again, so the final title always
+    /// lands within the window).
+    fn maybe_flush_title(&mut self) {
+        const TITLE_WRITE_MIN_MS: u64 = 2_000;
+        let Some(latest) = self.latest_title.clone() else { return };
+        if self.written_title.as_deref() == Some(latest.as_str()) {
+            return;
+        }
+        if let Some(at) = self.title_written_at {
+            if at.elapsed().as_millis() < TITLE_WRITE_MIN_MS as u128 {
+                return;
+            }
+        }
+        crate::pid_store::PidStore::new().update_title(self.pid, &latest);
+        self.written_title = Some(latest);
+        self.title_written_at = Some(Instant::now());
+    }
+
     fn check_responsiveness(&mut self) {
         let timeout_ms = self.cli_config.unresponsive_timeout_ms;
         if timeout_ms == 0 {

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -17,6 +17,7 @@ mod ready_manager;
 mod reaper;
 mod running_lock;
 mod swarm;
+mod title_scanner;
 mod utils;
 mod vterm;
 mod webhook;

--- a/rs/src/pid_store.rs
+++ b/rs/src/pid_store.rs
@@ -58,12 +58,13 @@ pub struct PidRecord {
     /// follow-up (see docs/agent-sharing.md). Mirrors the TS `agent_id`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
-    /// Self-declared lane/role name (e.g. "pm", "crm") rendered into the
-    /// `ay send` envelope header. From $AGENT_YES_ROLE at registration or set
-    /// later via `ay role` (TS side). Mirrors the TS `role`. Kept as a real
-    /// field (not dropped on rewrite) so compaction preserves TS-set roles.
+    /// The child CLI's most recent terminal title (OSC 0/2 from its PTY
+    /// stream — claude/opencode continuously set it to a task summary), so
+    /// `ay whoami` / `ay ls --json` answer "what is this agent doing" without
+    /// reading its screen. Mirrors the TS `title`. A real field (not dropped
+    /// on rewrite) so compaction preserves it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub role: Option<String>,
+    pub title: Option<String>,
     /// The permission posture this agent was SPAWNED with (yolo flag + the
     /// wrapper's robust/auto-continue flags). Stamped at registration because
     /// neither the CLI argv nor the wrapper flags survive into the index
@@ -93,20 +94,6 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
-/// A caller-set AGENT_YES_ROLE names the lane this agent plays ("pm", "crm", …)
-/// for the `ay send` envelope. It renders into the envelope's open tag, which is
-/// not nonce-protected, so clamp to a safe charset here (mirrors sanitizeRole in
-/// ts/globalPidIndex.ts). pty_spawner strips the var from the wrapped CLI's env
-/// so subagents don't inherit the parent's role.
-fn role_from_env() -> Option<String> {
-    let raw = std::env::var("AGENT_YES_ROLE").ok()?;
-    let trimmed = raw.trim();
-    let ok = (1..=32).contains(&trimmed.len())
-        && trimmed
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-');
-    ok.then(|| trimmed.to_string())
-}
 
 pub struct PidStore {
     path: PathBuf,
@@ -178,7 +165,7 @@ impl PidStore {
                 .ok()
                 .and_then(|s| s.parse::<u32>().ok()),
             agent_id: Some(new_agent_id()),
-            role: role_from_env(),
+            title: None,
             permissions,
         };
         // Hold the cross-runtime lock across the append so a concurrent rewrite
@@ -223,6 +210,32 @@ impl PidStore {
         })();
         if let Err(e) = result {
             warn!("PidStore: failed to update status: {}", e);
+        }
+    }
+
+    /// Record the child CLI's latest terminal title. Callers (context.rs's
+    /// maybe_flush_title) are change-gated and rate-limited, so this can take
+    /// the full lock + rewrite without hurting the steady state. Skips the
+    /// rewrite when the stored value already matches (a restart replays the
+    /// same title).
+    pub fn update_title(&self, pid: u32, title: &str) {
+        let _lock = acquire_lock(&self.path);
+        let result = (|| -> Result<()> {
+            let mut records = self.read_all()?;
+            let mut changed = false;
+            for r in &mut records {
+                if r.pid == pid && r.title.as_deref() != Some(title) {
+                    r.title = Some(title.to_string());
+                    changed = true;
+                }
+            }
+            if changed {
+                self.write_all(&records)?;
+            }
+            Ok(())
+        })();
+        if let Err(e) = result {
+            warn!("PidStore: failed to update title: {}", e);
         }
     }
 
@@ -620,7 +633,7 @@ mod tests {
             wrapper_pid: None,
             parent_pid: None,
             agent_id: None,
-            role: None,
+            title: None,
             permissions: None,
         }];
         store.write_all(&records).unwrap();
@@ -659,7 +672,7 @@ mod tests {
                 wrapper_pid: None,
                 parent_pid: None,
                 agent_id: None,
-                role: None,
+                title: None,
                 permissions: None,
             }])
             .unwrap();

--- a/rs/src/pty_spawner.rs
+++ b/rs/src/pty_spawner.rs
@@ -539,11 +539,6 @@ pub async fn spawn_agent(
     // ambiguous. Our own process env still carries it for new_agent_id().
     cmd.env_remove("AGENT_YES_AGENT_ID");
 
-    // Same reasoning for AGENT_YES_ROLE: it names THIS agent's lane (pid_store
-    // reads it from our env at registration). A subagent is its own lane, so
-    // don't let it inherit the parent's role. Mirrors ts/index.ts.
-    cmd.env_remove("AGENT_YES_ROLE");
-
     // Strip the parent Claude Code session markers so the wrapped CLI is a CLEAN
     // top-level session. Without this, an `ay claude` launched from inside another
     // Claude Code session inherits CLAUDE_CODE_CHILD_SESSION — the child claude then

--- a/rs/src/title_scanner.rs
+++ b/rs/src/title_scanner.rs
@@ -1,0 +1,186 @@
+//! Incremental scanner for terminal-title escapes in the child CLI's PTY
+//! stream.
+//!
+//! Coding-agent CLIs (claude, opencode, codex) continuously set the terminal
+//! title to a summary of what they are doing via `OSC 0`/`OSC 2`
+//! (`ESC ] 0 ; <title> BEL`, also terminated by `ESC \`). The wrapper sits on
+//! the PTY anyway, so scanning the stream gives a live "what is this agent
+//! doing" label for free — surfaced as `title` in the pid registry and shown
+//! by `ay whoami` / `ay ls --json`.
+//!
+//! The scanner is a tiny state machine fed arbitrary chunk boundaries: a title
+//! sequence split across two reads must still parse, and everything that is
+//! not a title sequence must pass through untouched (the scanner never
+//! modifies the stream — it only observes).
+
+/// Titles longer than this are junk (a runaway OSC without a terminator);
+/// discard the sequence instead of buffering unboundedly.
+const MAX_TITLE_LEN: usize = 512;
+/// What we store/display: enough for a task summary, short enough for a table.
+const STORED_TITLE_LEN: usize = 256;
+
+#[derive(Default)]
+enum State {
+    #[default]
+    Ground,
+    Esc,          // saw ESC
+    OscParam,     // saw ESC ] — collecting the numeric param
+    OscTitle,     // param was 0/2 and ';' consumed — collecting title chars
+    OscOther,     // some other OSC — skip to terminator
+    OscTitleEsc,  // inside title, saw ESC (maybe ST `ESC \`)
+    OscOtherEsc,  // inside other OSC, saw ESC
+}
+
+#[derive(Default)]
+pub struct TitleScanner {
+    state: State,
+    param: String,
+    title: String,
+}
+
+impl TitleScanner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one output chunk; returns the LAST complete title in it, if any.
+    pub fn feed(&mut self, chunk: &str) -> Option<String> {
+        let mut found: Option<String> = None;
+        for c in chunk.chars() {
+            match self.state {
+                State::Ground => {
+                    if c == '\x1b' {
+                        self.state = State::Esc;
+                    }
+                }
+                State::Esc => {
+                    if c == ']' {
+                        self.param.clear();
+                        self.state = State::OscParam;
+                    } else if c == '\x1b' {
+                        // stay: ESC ESC ] … still starts an OSC
+                    } else {
+                        self.state = State::Ground;
+                    }
+                }
+                State::OscParam => match c {
+                    '0'..='9' if self.param.len() < 4 => self.param.push(c),
+                    ';' => {
+                        // OSC 0 (icon+title) and OSC 2 (title) carry the window
+                        // title; OSC 1 is icon-only and everything else (8, 52,
+                        // 133, …) is unrelated.
+                        if self.param == "0" || self.param == "2" {
+                            self.title.clear();
+                            self.state = State::OscTitle;
+                        } else {
+                            self.state = State::OscOther;
+                        }
+                    }
+                    '\x07' => self.state = State::Ground,
+                    '\x1b' => self.state = State::OscOtherEsc,
+                    _ => self.state = State::OscOther,
+                },
+                State::OscTitle => match c {
+                    '\x07' => {
+                        found = Some(clean_title(&self.title));
+                        self.state = State::Ground;
+                    }
+                    '\x1b' => self.state = State::OscTitleEsc,
+                    _ => {
+                        if self.title.len() >= MAX_TITLE_LEN {
+                            // Runaway sequence — drop it and resync.
+                            self.state = State::OscOther;
+                        } else {
+                            self.title.push(c);
+                        }
+                    }
+                },
+                State::OscTitleEsc => {
+                    if c == '\\' {
+                        found = Some(clean_title(&self.title));
+                    }
+                    // Either way the OSC is over (a bare ESC aborts it).
+                    self.state = State::Ground;
+                }
+                State::OscOther => {
+                    if c == '\x07' {
+                        self.state = State::Ground;
+                    } else if c == '\x1b' {
+                        self.state = State::OscOtherEsc;
+                    }
+                }
+                State::OscOtherEsc => {
+                    self.state = State::Ground;
+                }
+            }
+        }
+        found.filter(|t| !t.is_empty())
+    }
+}
+
+/// Control chars can't be typed into a title bar, and the stored value ends up
+/// in JSONL + terminal tables — strip them and clamp.
+fn clean_title(raw: &str) -> String {
+    let cleaned: String = raw.chars().filter(|c| !c.is_control()).collect();
+    let trimmed = cleaned.trim();
+    trimmed.chars().take(STORED_TITLE_LEN).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_osc0_bel() {
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("\x1b]0;✳ fixing tests\x07"), Some("✳ fixing tests".into()));
+    }
+
+    #[test]
+    fn parses_osc2_st() {
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("\x1b]2;my task\x1b\\"), Some("my task".into()));
+    }
+
+    #[test]
+    fn survives_chunk_split_mid_sequence() {
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("text \x1b]0;ha"), None);
+        assert_eq!(s.feed("lf done\x07 more"), Some("half done".into()));
+    }
+
+    #[test]
+    fn last_title_in_chunk_wins() {
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("\x1b]0;one\x07\x1b]2;two\x07"), Some("two".into()));
+    }
+
+    #[test]
+    fn ignores_icon_only_and_unrelated_osc() {
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("\x1b]1;icon\x07\x1b]52;c;YWJj\x07\x1b]133;A\x07"), None);
+    }
+
+    #[test]
+    fn ignores_non_osc_escapes_and_plain_text(){
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("plain \x1b[31mred\x1b[0m text"), None);
+    }
+
+    #[test]
+    fn caps_runaway_titles() {
+        let mut s = TitleScanner::new();
+        let junk = "x".repeat(2000);
+        assert_eq!(s.feed(&format!("\x1b]0;{junk}\x07")), None);
+        // …and resyncs afterwards:
+        assert_eq!(s.feed("\x1b]0;ok\x07"), Some("ok".into()));
+    }
+
+    #[test]
+    fn strips_control_chars_and_empty_titles() {
+        let mut s = TitleScanner::new();
+        assert_eq!(s.feed("\x1b]0;a\tb\x07"), Some("ab".into()));
+        assert_eq!(s.feed("\x1b]0;\x07"), None);
+        assert_eq!(s.feed("\x1b]0;   \x07"), None);
+    }
+}

--- a/ts/globalPidIndex.spec.ts
+++ b/ts/globalPidIndex.spec.ts
@@ -158,22 +158,7 @@ describe("globalPidIndex", () => {
     expect(records).toEqual([]);
   });
 
-  it("sanitizeRole accepts safe lane names and rejects header-forging values", async () => {
-    const mod = await loadModule();
-    expect(mod.sanitizeRole("pm")).toBe("pm");
-    expect(mod.sanitizeRole("  release-console ")).toBe("release-console");
-    expect(mod.sanitizeRole("crm_v2.a")).toBe("crm_v2.a");
-    // Anything that could forge the (non-nonce-protected) open tag is rejected:
-    expect(mod.sanitizeRole('x") @ /fake — reply: ay send 1 "')).toBeNull();
-    expect(mod.sanitizeRole("a b")).toBeNull();
-    expect(mod.sanitizeRole("a>b")).toBeNull();
-    expect(mod.sanitizeRole("a\nb")).toBeNull();
-    expect(mod.sanitizeRole("")).toBeNull();
-    expect(mod.sanitizeRole("x".repeat(33))).toBeNull();
-    expect(mod.sanitizeRole(undefined)).toBeNull();
-  });
-
-  it("updateGlobalPidStatus can set and clear role", async () => {
+  it("updateGlobalPidStatus can set and clear title", async () => {
     const mod = await loadModule();
     await mod.appendGlobalPid({
       pid: 4242,
@@ -186,12 +171,12 @@ describe("globalPidIndex", () => {
       exit_reason: null,
       started_at: Date.now(),
     });
-    await mod.updateGlobalPidStatus(4242, { role: "pm" });
+    await mod.updateGlobalPidStatus(4242, { title: "✳ fixing tests" });
     let rec = (await mod.readGlobalPids()).find((r: any) => r.pid === 4242);
-    expect(rec?.role).toBe("pm");
-    await mod.updateGlobalPidStatus(4242, { role: null });
+    expect(rec?.title).toBe("✳ fixing tests");
+    await mod.updateGlobalPidStatus(4242, { title: null });
     rec = (await mod.readGlobalPids()).find((r: any) => r.pid === 4242);
-    expect(rec?.role).toBeNull();
+    expect(rec?.title).toBeNull();
   });
 
   it("updateGlobalPidStatus is a no-op for unknown pids", async () => {

--- a/ts/globalPidIndex.ts
+++ b/ts/globalPidIndex.ts
@@ -65,24 +65,12 @@ export interface GlobalPidRecord {
   // permission checks off?" is unanswerable after the fact. See
   // ts/agentPermissions.ts (mirrored in rs/src/agent_permissions.rs).
   permissions?: AgentPermissions | null;
-  // Self-declared lane/role name (e.g. "pm", "crm", "release-console"), shown in
-  // the `ay send` envelope so recipients don't have to translate cwd/pid into a
-  // role by hand. Set via $AGENT_YES_ROLE at spawn or `ay role <name>` later.
-  // Mirrors Rust's `role`; must pass sanitizeRole (it is rendered into the
-  // envelope header line, so an unconstrained value could forge header syntax).
-  role?: string | null;
-}
-
-// Roles render verbatim into the `<ay-msg …>` header line, whose OPEN tag is not
-// nonce-protected (only the close tag is) — whitespace, ">", or control chars in
-// a role could forge header structure. Clamp at every entry point (env pickup,
-// `ay role`), not at render time, so stored records stay clean.
-const ROLE_RE = /^[A-Za-z0-9._-]{1,32}$/;
-
-/** Validate a role name; returns the trimmed role or null when unusable. */
-export function sanitizeRole(raw: string | undefined | null): string | null {
-  const trimmed = raw?.trim();
-  return trimmed && ROLE_RE.test(trimmed) ? trimmed : null;
+  // The child CLI's most recent terminal title (OSC 0/2 from its PTY stream —
+  // claude/opencode continuously set it to a task summary). The wrapper's
+  // title scanner keeps this fresh so `ay whoami` / `ay ls --json` can answer
+  // "what is this agent doing" without reading its screen. Mirrors Rust's
+  // `title`.
+  title?: string | null;
 }
 
 /**
@@ -136,7 +124,9 @@ export async function appendGlobalPid(record: GlobalPidRecord): Promise<void> {
 /** Append a partial update by pid (status, exit_code, exit_reason, log_file). */
 export async function updateGlobalPidStatus(
   pid: number,
-  patch: Partial<Pick<GlobalPidRecord, "status" | "exit_code" | "exit_reason" | "log_file" | "role">>,
+  patch: Partial<
+    Pick<GlobalPidRecord, "status" | "exit_code" | "exit_reason" | "log_file" | "title">
+  >,
 ): Promise<void> {
   const file = resolveGlobalFile(); // capture at call time (see withLock)
   try {

--- a/ts/identity.spec.ts
+++ b/ts/identity.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { formatIdentity, localHost, localUser, readGitBranch, tildify } from "./identity.ts";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "ay-ident-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true }).catch(() => null);
+});
+
+async function gitFixture(rel: string, head: string): Promise<string> {
+  const repo = path.join(root, rel);
+  await mkdir(path.join(repo, ".git"), { recursive: true });
+  await writeFile(path.join(repo, ".git", "HEAD"), head);
+  return repo;
+}
+
+describe("readGitBranch", () => {
+  it("reads the branch from a normal checkout", async () => {
+    const repo = await gitFixture("repo", "ref: refs/heads/main\n");
+    expect(readGitBranch(repo)).toBe("main");
+  });
+
+  it("walks up from a subdirectory", async () => {
+    const repo = await gitFixture("repo2", "ref: refs/heads/feat/x-1.2\n");
+    const sub = path.join(repo, "a", "b");
+    await mkdir(sub, { recursive: true });
+    expect(readGitBranch(sub)).toBe("feat/x-1.2");
+  });
+
+  it("follows a worktree's gitdir indirection file", async () => {
+    const gitdir = path.join(root, "main-repo", ".git", "worktrees", "wt1");
+    await mkdir(gitdir, { recursive: true });
+    await writeFile(path.join(gitdir, "HEAD"), "ref: refs/heads/crm-yamamoto-wifi\n");
+    const wt = path.join(root, "wt-checkout");
+    await mkdir(wt, { recursive: true });
+    await writeFile(path.join(wt, ".git"), `gitdir: ${gitdir}\n`);
+    expect(readGitBranch(wt)).toBe("crm-yamamoto-wifi");
+  });
+
+  it("resolves a RELATIVE gitdir against the checkout", async () => {
+    const gitdir = path.join(root, "gd");
+    await mkdir(gitdir, { recursive: true });
+    await writeFile(path.join(gitdir, "HEAD"), "ref: refs/heads/rel\n");
+    const wt = path.join(root, "rel-checkout");
+    await mkdir(wt, { recursive: true });
+    await writeFile(path.join(wt, ".git"), "gitdir: ../gd\n");
+    expect(readGitBranch(wt)).toBe("rel");
+  });
+
+  it("returns a short commit id for a detached HEAD", async () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    const repo = await gitFixture("det", sha + "\n");
+    expect(readGitBranch(repo)).toBe(sha.slice(0, 12));
+  });
+
+  it("returns null outside any git checkout", async () => {
+    const plain = path.join(root, "plain");
+    await mkdir(plain, { recursive: true });
+    expect(readGitBranch(plain)).toBeNull();
+  });
+
+  it("returns null on an unreadable/garbled HEAD", async () => {
+    const repo = await gitFixture("bad", "something else entirely\n");
+    expect(readGitBranch(repo)).toBeNull();
+  });
+});
+
+describe("formatIdentity", () => {
+  it("renders user@host:path:branch#pid", async () => {
+    const repo = await gitFixture("fmt", "ref: refs/heads/main\n");
+    const id = formatIdentity({ user: "sno", host: "Mac", cwd: repo, pid: 30402 });
+    expect(id).toBe(`sno@Mac:${repo}:main#30402`);
+  });
+
+  it("omits the branch segment outside a repo", async () => {
+    const plain = path.join(root, "nofmt");
+    await mkdir(plain, { recursive: true });
+    const id = formatIdentity({ user: "sno", host: "Mac", cwd: plain, pid: 7 });
+    expect(id).toBe(`sno@Mac:${plain}#7`);
+  });
+
+  it("accepts an explicit branch (and null to suppress detection)", () => {
+    expect(formatIdentity({ user: "u", host: "h", cwd: "/x", branch: "b", pid: 1 })).toBe(
+      "u@h:/x:b#1",
+    );
+    expect(formatIdentity({ user: "u", host: "h", cwd: "/x", branch: null, pid: 1 })).toBe(
+      "u@h:/x#1",
+    );
+  });
+
+  it("defaults user/host to header-safe local values", () => {
+    const id = formatIdentity({ cwd: "/x", branch: null, pid: 1 });
+    expect(id).toMatch(/^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/x#1$/);
+    expect(id).toContain(`${localUser()}@${localHost()}`);
+  });
+
+  it("tildifies the home directory like ay ls does", () => {
+    expect(tildify(path.join(require("os").homedir(), "ws"))).toBe("~/ws");
+    expect(tildify("/opt/x")).toBe("/opt/x");
+  });
+});

--- a/ts/identity.spec.ts
+++ b/ts/identity.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import { formatIdentity, localHost, localUser, readGitBranch, tildify } from "./identity.ts";
 
@@ -102,7 +102,7 @@ describe("formatIdentity", () => {
   });
 
   it("tildifies the home directory like ay ls does", () => {
-    expect(tildify(path.join(require("os").homedir(), "ws"))).toBe("~/ws");
+    expect(tildify(path.join(homedir(), "ws"))).toBe(`~${path.sep}ws`);
     expect(tildify("/opt/x")).toBe("/opt/x");
   });
 });

--- a/ts/identity.ts
+++ b/ts/identity.ts
@@ -1,0 +1,124 @@
+/**
+ * The standardized agent identity string:
+ *
+ *   <username>@<hostname>:<path>:<branch>#<pid>
+ *   e.g.  sno@Mac:~/ws/symval/symval/tree/crm:main#30402
+ *
+ * One line answers "who is this agent" across every surface that names one —
+ * the `ay send` envelope header, `ay whoami`, logs. The branch segment usually
+ * carries the lane name for free (worktree checkouts like `crm-yamamoto-wifi`
+ * or `fix/t173-tone-core` name their purpose), which is why there is no
+ * separate role concept.
+ *
+ * Parsing (right-to-left, for consumers that need it): `#<pid>` from the end;
+ * the branch is after the last `:` (git forbids `:` in ref names); the
+ * username is before the first `@`; the hostname is between that `@` and the
+ * next `:` (hostnames contain no `:`). The path in the middle may itself
+ * contain `@`/`:` (Windows drives), which is why parsing anchors on the ends.
+ *
+ * Every token is clamped before rendering: the identity is embedded in the
+ * `<ay-msg …>` envelope's OPEN tag, which is not nonce-protected — whitespace
+ * or `>` in a token could forge header structure.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir, hostname, userInfo } from "node:os";
+import path from "node:path";
+
+/** Replace anything outside a conservative charset so a token can never break
+ * out of the envelope header line. Collapses runs to a single `-`. */
+function safeToken(raw: string, max: number): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned.slice(0, max);
+}
+
+/** The local username, header-safe ("John Smith" → "John-Smith"). */
+export function localUser(): string {
+  try {
+    return safeToken(userInfo().username, 32) || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/** The local hostname's first label ("Macs-MBP.local" → "Macs-MBP"). */
+export function localHost(): string {
+  const first = hostname().split(".")[0] ?? "";
+  return safeToken(first, 32) || "unknown";
+}
+
+/**
+ * The checked-out branch of the git repo containing `cwd`, or a short commit
+ * id when detached, or null when `cwd` is not inside a git checkout. Pure
+ * file reads — never spawns git — so it is cheap enough to run on every send:
+ * walk up to the nearest `.git`, follow a worktree's `gitdir:` indirection
+ * file, then parse `HEAD`.
+ */
+export function readGitBranch(cwd: string): string | null {
+  let dir = path.resolve(cwd);
+  for (let depth = 0; depth < 32; depth++) {
+    const dotGit = path.join(dir, ".git");
+    let gitDir: string | null = null;
+    try {
+      const content = readFileSync(dotGit, "utf8");
+      // A worktree/submodule checkout: `.git` is a FILE containing
+      // `gitdir: <path>` (absolute, or relative to the checkout).
+      const m = /^gitdir:\s*(.+)\s*$/m.exec(content);
+      gitDir = m ? path.resolve(dir, m[1]!.trim()) : null;
+    } catch (err: any) {
+      if (err?.code === "EISDIR") gitDir = dotGit;
+      // ENOENT/EACCES: no .git here — walk up.
+    }
+    if (gitDir) {
+      try {
+        const head = readFileSync(path.join(gitDir, "HEAD"), "utf8").trim();
+        const ref = /^ref:\s*refs\/heads\/(.+)$/.exec(head);
+        if (ref) return safeBranch(ref[1]!);
+        if (/^[0-9a-f]{40}$/i.test(head)) return head.slice(0, 12); // detached
+        return null; // unrecognized HEAD — don't guess
+      } catch {
+        return null; // .git exists but HEAD unreadable
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+/** Branch names never contain `:`/space/`~`/`^` (git forbids them), but they
+ * DO allow `/` and `#` — keep `/` (readable, unambiguous: parsing anchors on
+ * `#<pid>` at the end) and clamp everything else defensively. */
+function safeBranch(raw: string): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9._/#-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned.slice(0, 64);
+}
+
+/** Abbreviate the home directory to `~`, mirroring how `ay ls` prints cwds. */
+export function tildify(p: string): string {
+  const home = homedir();
+  return p.startsWith(home) ? "~" + p.slice(home.length) : p;
+}
+
+export interface IdentityParts {
+  user?: string;
+  host?: string;
+  cwd: string;
+  /** Pass null to omit the branch segment; omit the key to auto-detect. */
+  branch?: string | null;
+  pid: number;
+}
+
+/**
+ * Render the standardized identity for an agent. `user`/`host` default to the
+ * local machine (correct for the envelope: the sending wrapper runs on the
+ * agent's own host), `branch` auto-detects from `cwd` unless given.
+ */
+export function formatIdentity(parts: IdentityParts): string {
+  const user = parts.user ?? localUser();
+  const host = parts.host ?? localHost();
+  const branch = parts.branch === undefined ? readGitBranch(parts.cwd) : parts.branch;
+  const where = tildify(parts.cwd);
+  return `${user}@${host}:${where}${branch ? `:${branch}` : ""}#${parts.pid}`;
+}

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -18,6 +18,7 @@ import { acquireLock, releaseLock, shouldUseLock } from "./runningLock.ts";
 import { logger } from "./logger.ts";
 import { createFifoStream } from "./beta/fifo.ts";
 import { PidStore } from "./pidStore.ts";
+import { TitlePublisher, TitleScanner } from "./titleScanner.ts";
 import { sendEnter, sendMessage } from "./core/messaging.ts";
 import {
   AUTO_RETRY_GIVE_UP_MS,
@@ -460,10 +461,6 @@ export default async function agentYes({
   // `ay`) don't inherit it and register under the same id (which would make that
   // id ambiguous). The wrapper's own process.env still carries it for pidStore.
   delete ptyEnv.AGENT_YES_AGENT_ID;
-  // Same reasoning for AGENT_YES_ROLE: it names THIS agent's lane (pidStore
-  // reads it from our own env at registration). A subagent is its own lane, so
-  // don't let it inherit the parent's role.
-  delete ptyEnv.AGENT_YES_ROLE;
   // Strip the parent Claude Code session markers so the wrapped CLI is a CLEAN
   // top-level session. Without this, an `ay claude` launched from inside another
   // Claude Code session (or this claude's Bash tool) inherits
@@ -524,12 +521,23 @@ export default async function agentYes({
   // Wire up the xterm proxy to write back to the PTY
   shellWrite = (data: string) => shell.write(data);
 
+  // Capture the child CLI's terminal title (OSC 0/2) into the registry so
+  // `ay whoami` / `ay ls --json` can answer "what is this agent doing".
+  // TitlePublisher change-gates + rate-limits the registry writes.
+  const titleScanner = new TitleScanner();
+  const titlePublisher = new TitlePublisher((title) => {
+    pidStore.updateTitle(shell.pid, title).catch(() => null);
+  });
+
   // Attach data handler IMMEDIATELY after spawn to avoid losing early PTY output.
   // node-pty emits 'data' events eagerly — if no listener is attached, events are lost.
   function onData(data: string) {
     const currentPid = shell.pid;
     xtermProxy.write(data);
     globalAgentRegistry.appendStdout(currentPid, data);
+    const title = titleScanner.feed(data);
+    if (title) titlePublisher.observe(title);
+    else titlePublisher.poll();
   }
   shell.onData(onData);
 

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -25,8 +25,6 @@ export interface MailParty {
   cli: string;
   cwd: string;
   agent_id?: string | null;
-  /** Self-declared lane/role name at send time, when the party had one set. */
-  role?: string;
 }
 
 /** A single delivered inter-agent message, stored verbatim in both mailboxes. */

--- a/ts/pidStore.spec.ts
+++ b/ts/pidStore.spec.ts
@@ -63,30 +63,20 @@ describe("PidStore", () => {
       expect(rec._id).toBeTypeOf("string");
     });
 
-    it("picks up a sane AGENT_YES_ROLE and ignores a forgeable one", async () => {
-      const saved = process.env.AGENT_YES_ROLE;
-      try {
-        process.env.AGENT_YES_ROLE = "pm";
-        const rec = await store.registerProcess({
-          pid: 12346,
-          cli: "claude",
-          args: [],
-          cwd: "/tmp",
-        });
-        expect(rec.role).toBe("pm");
-
-        process.env.AGENT_YES_ROLE = "a b > forged";
-        const rec2 = await store.registerProcess({
-          pid: 12347,
-          cli: "claude",
-          args: [],
-          cwd: "/tmp",
-        });
-        expect(rec2.role).toBeUndefined();
-      } finally {
-        if (saved === undefined) delete process.env.AGENT_YES_ROLE;
-        else process.env.AGENT_YES_ROLE = saved;
-      }
+    it("updateTitle stores the latest terminal title and dedupes", async () => {
+      await store.registerProcess({
+        pid: 12346,
+        cli: "claude",
+        args: [],
+        cwd: "/tmp",
+      });
+      await store.updateTitle(12346, "✳ fixing tests");
+      let rec = store.getAllRecords().find((r) => r.pid === 12346);
+      expect(rec?.title).toBe("✳ fixing tests");
+      await store.updateTitle(12346, "✳ fixing tests"); // unchanged — no-op
+      await store.updateTitle(12346, "done");
+      rec = store.getAllRecords().find((r) => r.pid === 12346);
+      expect(rec?.title).toBe("done");
     });
 
     it("should upsert when registering same pid", async () => {

--- a/ts/pidStore.ts
+++ b/ts/pidStore.ts
@@ -9,7 +9,6 @@ import {
   appendGlobalPid,
   maybeCompactGlobalPids,
   pruneOldLogs,
-  sanitizeRole,
   updateGlobalPidStatus,
 } from "./globalPidIndex.ts";
 
@@ -30,8 +29,8 @@ export interface PidRecord {
   agentId?: string;
   /** Permission posture at spawn time; mirrored to the global index. */
   permissions?: AgentPermissions;
-  /** Self-declared lane/role name; mirrored to the global index as `role`. */
-  role?: string;
+  /** The child CLI's latest terminal title (OSC 0/2); mirrored as `title`. */
+  title?: string;
 }
 
 export class PidStore {
@@ -95,11 +94,6 @@ export class PidStore {
       existing?.agentId ??
       (injected && /^[0-9a-f]{6,32}$/i.test(injected) ? injected : randomBytes(6).toString("hex"));
 
-    // A caller-set AGENT_YES_ROLE names the lane this agent plays ("pm", "crm",
-    // …) for the `ay send` envelope. Picked up once at registration; index.ts
-    // strips it from the wrapped CLI's env so subagents don't inherit it.
-    const role = sanitizeRole(process.env.AGENT_YES_ROLE) ?? existing?.role;
-
     const record: Omit<PidRecord, "_id"> = {
       pid,
       cli,
@@ -113,7 +107,6 @@ export class PidStore {
       exitReason: "",
       startedAt: now,
       agentId,
-      ...(role ? { role } : {}),
     };
 
     if (existing) {
@@ -149,7 +142,6 @@ export class PidStore {
       parent_pid: parentPid ?? null,
       agent_id: agentId,
       permissions: permissions ?? null,
-      role: role ?? null,
     })
       .then(() => maybeCompactGlobalPids())
       .catch(() => null);
@@ -178,6 +170,17 @@ export class PidStore {
       exit_code: extra?.exitCode ?? null,
       exit_reason: extra?.exitReason ?? null,
     }).catch(() => null);
+  }
+
+  /** Record the child CLI's latest terminal title (see ts/titleScanner.ts —
+   * callers are change-gated + rate-limited, so each call may write). */
+  async updateTitle(pid: number, title: string): Promise<void> {
+    const existing = this.store.findOne((doc) => doc.pid === pid);
+    if (existing && existing.title !== title) {
+      await this.store.updateById(existing._id!, { title });
+    }
+    // Mirror to global index. Same fire-and-forget policy as updateStatus.
+    updateGlobalPidStatus(pid, { title }).catch(() => null);
   }
 
   getAllRecords(): PidRecord[] {

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -2670,121 +2670,8 @@ describe("subcommands.cmdWhoami", () => {
     expect(text).toMatch(/agent {5}claude #\d+ {2}\(agent_id aaaa0000bbbb\)/);
     expect(text).toMatch(/reply {5}ay send aaaa0000bbbb/);
     expect(text).toMatch(
-      /<ay-msg from claude #\d+ @ \/repo\/alpha — reply: ay send aaaa0000bbbb "\.\.\.">/,
+      /<ay-msg from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/repo\/alpha#\d+ — reply: ay send aaaa0000bbbb "\.\.\.">/,
     );
-  });
-});
-
-describe("subcommands.cmdRole", () => {
-  async function registerAgent(over: Record<string, unknown> = {}) {
-    const { appendGlobalPid } = await import("./globalPidIndex.ts");
-    await appendGlobalPid({
-      pid: 910001,
-      cli: "claude",
-      prompt: null,
-      cwd: "/repo/lane",
-      log_file: null,
-      status: "active",
-      exit_code: null,
-      exit_reason: null,
-      started_at: Date.now(),
-      wrapper_pid: 515151,
-      agent_id: "eeee0000ffff",
-      ...over,
-    } as any);
-  }
-
-  function capture() {
-    const out: string[] = [];
-    const err: string[] = [];
-    const origOut = process.stdout.write.bind(process.stdout);
-    const origErr = process.stderr.write.bind(process.stderr);
-    (process.stdout as any).write = (s: any) => (out.push(String(s)), true);
-    (process.stderr as any).write = (s: any) => (err.push(String(s)), true);
-    return {
-      out,
-      err,
-      restore() {
-        process.stdout.write = origOut;
-        process.stderr.write = origErr;
-      },
-    };
-  }
-
-  async function withAgentEnv<T>(fn: () => Promise<T>): Promise<T> {
-    const saved = process.env.AGENT_YES_PID;
-    process.env.AGENT_YES_PID = "515151";
-    try {
-      return await fn();
-    } finally {
-      if (saved === undefined) delete process.env.AGENT_YES_PID;
-      else process.env.AGENT_YES_PID = saved;
-    }
-  }
-
-  it("self get/set/clear round-trips via agent context", async () => {
-    const { runSubcommand } = await loadModule();
-    await registerAgent();
-    await withAgentEnv(async () => {
-      let cap = capture();
-      try {
-        expect(await runSubcommand(["bun", "cli.js", "role", "pm"])).toBe(0);
-        expect(cap.out.join("")).toContain('role set to "pm"');
-      } finally {
-        cap.restore();
-      }
-      cap = capture();
-      try {
-        expect(await runSubcommand(["bun", "cli.js", "role"])).toBe(0);
-        expect(cap.out.join("")).toBe("pm\n");
-        expect(await runSubcommand(["bun", "cli.js", "role", "--clear"])).toBe(0);
-        expect(await runSubcommand(["bun", "cli.js", "role"])).toBe(0);
-        expect(cap.out.join("")).toContain("role cleared");
-      } finally {
-        cap.restore();
-      }
-    });
-  });
-
-  it("keyword set and keyword clear work from a human shell", async () => {
-    const { runSubcommand } = await loadModule();
-    await registerAgent();
-    let cap = capture();
-    try {
-      expect(await runSubcommand(["bun", "cli.js", "role", "910001", "crm"])).toBe(0);
-      expect(cap.out.join("")).toContain('role set to "crm"');
-      expect(await runSubcommand(["bun", "cli.js", "role", "910001", "--clear"])).toBe(0);
-      expect(cap.out.join("")).toContain("role cleared");
-    } finally {
-      cap.restore();
-    }
-  });
-
-  it("rejects header-forging role values", async () => {
-    const { runSubcommand } = await loadModule();
-    await registerAgent();
-    const cap = capture();
-    try {
-      expect(await runSubcommand(["bun", "cli.js", "role", "910001", "a b>"])).toBe(1);
-      expect(cap.err.join("")).toContain("invalid role");
-    } finally {
-      cap.restore();
-    }
-  });
-
-  it("errors without agent context when no keyword is given", async () => {
-    const { runSubcommand } = await loadModule();
-    const saved = process.env.AGENT_YES_PID;
-    delete process.env.AGENT_YES_PID;
-    const cap = capture();
-    try {
-      expect(await runSubcommand(["bun", "cli.js", "role"])).toBe(1);
-      expect(await runSubcommand(["bun", "cli.js", "role", "somename"])).toBe(1);
-      expect(cap.err.join("")).toContain("no agent context");
-    } finally {
-      cap.restore();
-      if (saved !== undefined) process.env.AGENT_YES_PID = saved;
-    }
   });
 });
 
@@ -2859,7 +2746,7 @@ describe("subcommands.cmdSend double-envelope warning", () => {
         const buf = Buffer.alloc(8192);
         const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
         const received = buf.subarray(0, n).toString();
-        expect(received).toMatch(/^<ay-msg [0-9a-f]{8} from claude #900001 @ /);
+        expect(received).toMatch(/^<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/repo\/beta#900001 — /);
         expect(received).toContain("<ay-msg deadbeef");
         fs.closeSync(rdwrFd);
       } finally {
@@ -2933,16 +2820,20 @@ describe("subcommands.cmdSend double-envelope warning", () => {
     }
   });
 
-  it.skipIf(!itUnix)("a sender with a role gets it rendered into the envelope header", async () => {
+  it.skipIf(!itUnix)("the envelope header carries the standardized identity", async () => {
     const { runSubcommand } = await loadModule();
     const { appendGlobalPid } = await import("./globalPidIndex.ts");
     const { spawnSync } = await import("child_process");
     const tmp = await mkdtemp(path.join(tmpdir(), "ay-fifo-"));
     try {
-      const fifo = path.join(tmp, "role.fifo");
+      const fifo = path.join(tmp, "ident.fifo");
       if (spawnSync("mkfifo", [fifo]).status !== 0) return;
       const fs = await import("fs");
       const rdwrFd = fs.openSync(fifo, fs.constants.O_RDWR);
+      // Sender cwd IS a git checkout, so the identity carries its branch.
+      const senderCwd = path.join(tmp, "sender-repo");
+      await mkdir(path.join(senderCwd, ".git"), { recursive: true });
+      await writeFile(path.join(senderCwd, ".git", "HEAD"), "ref: refs/heads/crm-lane\n");
       await appendGlobalPid({
         pid: process.pid,
         cli: "claude",
@@ -2959,7 +2850,7 @@ describe("subcommands.cmdSend double-envelope warning", () => {
         pid: 900001,
         cli: "claude",
         prompt: null,
-        cwd: "/repo/beta",
+        cwd: senderCwd,
         log_file: null,
         status: "active",
         exit_code: null,
@@ -2967,7 +2858,6 @@ describe("subcommands.cmdSend double-envelope warning", () => {
         started_at: Date.now(),
         wrapper_pid: 424242,
         agent_id: "cccc0000dddd",
-        role: "crm",
       });
       const savedAyPid = process.env.AGENT_YES_PID;
       process.env.AGENT_YES_PID = "424242";
@@ -2991,8 +2881,9 @@ describe("subcommands.cmdSend double-envelope warning", () => {
       const buf = Buffer.alloc(4096);
       const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
       const received = buf.subarray(0, n).toString();
+      // <user>@<host>:<path>:<branch>#<pid> — reply targets the agent_id.
       expect(received).toMatch(
-        /^<ay-msg [0-9a-f]{8} from claude #900001 \(crm\) @ \/repo\/beta — reply: ay send cccc0000dddd "\.\.\.">/,
+        /^<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:.+:crm-lane#900001 — reply: ay send cccc0000dddd "\.\.\.">/,
       );
       fs.closeSync(rdwrFd);
     } finally {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -18,12 +18,8 @@ import { fileURLToPath } from "node:url";
 import ms from "ms";
 import { homedir } from "os";
 import path from "path";
-import {
-  type GlobalPidRecord,
-  readGlobalPids,
-  sanitizeRole,
-  updateGlobalPidStatus,
-} from "./globalPidIndex.ts";
+import { type GlobalPidRecord, readGlobalPids, updateGlobalPidStatus } from "./globalPidIndex.ts";
+import { formatIdentity } from "./identity.ts";
 import { buildAgentForest, flattenForest } from "./agentTree.ts";
 import { parseTaskCounts, type TaskCounts } from "./todoParse.ts";
 import { agentYesHome } from "./agentYesHome.ts";
@@ -328,7 +324,8 @@ async function cmdWhoami(rest: string[]): Promise<number> {
   const ageMin = Math.max(0, Math.round((Date.now() - self.started_at) / 60_000));
   const lines = [
     `agent     ${self.cli} #${self.pid}${self.agent_id ? `  (agent_id ${self.agent_id})` : ""}`,
-    `role      ${self.role ?? "-  (set with: ay role <name>)"}`,
+    `identity  ${formatIdentity({ cwd: self.cwd, pid: self.pid })}`,
+    `title     ${self.title ?? "-"}`,
     `state     ${state}${question ? ` — ${question}` : ""}`,
     `cwd       ${self.cwd}`,
     `started   ${new Date(self.started_at).toISOString()}  (${ageMin}m ago)`,
@@ -336,7 +333,7 @@ async function cmdWhoami(rest: string[]): Promise<number> {
     `log       ${self.log_file ?? "-"}`,
     `fifo      ${self.fifo_file ?? "-"}`,
     `reply     ${reply} "..."`,
-    `envelope  <ay-msg from ${self.cli} #${self.pid}${self.role ? ` (${self.role})` : ""} @ ${self.cwd} — reply: ${reply} "...">…</ay-msg>`,
+    `envelope  <ay-msg from ${self.cli} ${formatIdentity({ cwd: self.cwd, pid: self.pid })} — reply: ${reply} "...">…</ay-msg>`,
   ];
   process.stdout.write(lines.join("\n") + "\n");
   return 0;
@@ -387,7 +384,7 @@ async function readLocalTsPids(cwd: string): Promise<GlobalPidRecord[]> {
     exit_code: d.exitCode ?? null,
     exit_reason: d.exitReason ?? null,
     started_at: d.startedAt ?? 0,
-    role: d.role ?? null,
+    title: d.title ?? null,
   }));
 }
 
@@ -422,7 +419,6 @@ const SUBCOMMANDS = new Set([
   "head",
   "send",
   "msgs",
-  "role",
   "key",
   "select",
   "spawn",
@@ -593,8 +589,6 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdSend(rest);
       case "msgs":
         return await cmdMsgs(rest);
-      case "role":
-        return await cmdRole(rest);
       case "key":
         return await cmdKey(rest);
       case "select":
@@ -815,7 +809,6 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay head <keyword>                   first N lines\n` +
       `  ay send <keyword> <msg>             send a message (keyword '.' = agent in this cwd)\n` +
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
-      `  ay role [name] | ay role <kw> <name>  lane/role name shown in the send envelope\n` +
       `  ay ch mk|join|send|read|tail <topic>  local-first E2E channels: AI ↔ humans on a topic (ay ch help)\n` +
       `  ay term embed <pid>                 <script> to embed a live read-only agent terminal in a page (ay term help)\n` +
       `  ay widget ls | read selection|dom   read an opted-in page widget's context (selection/DOM) (ay widget help)\n` +
@@ -3429,13 +3422,13 @@ async function cmdSend(rest: string[]): Promise<number> {
   let nonce: string | undefined;
   if (sender.agent && !isSlashCommand(body) && !raw) {
     nonce = randomBytes(4).toString("hex");
-    // The sender's self-declared role ("pm", "crm", …) rides along when set —
-    // recipients read dozens of these a day and a pid/cwd doesn't carry the
-    // lane name (cwd → role isn't always derivable). sanitizeRole guarantees
-    // the value can't forge header syntax.
-    const senderRole = sanitizeRole(sender.agent.role);
-    const roleTag = senderRole ? ` (${senderRole})` : "";
-    prefix = `<ay-msg ${nonce} from ${sender.agent.cli} #${sender.agent.pid}${roleTag} @ ${shortenPath(sender.agent.cwd)} — reply: ay send ${replyTarget} "...">\n`;
+    // The standardized identity (<user>@<host>:<path>:<branch>#<pid>) names the
+    // sender in one token: the branch usually carries the lane name for free
+    // (worktree checkouts name their purpose), so recipients don't translate
+    // cwd/pid into a role by hand. Every segment is clamped to a header-safe
+    // charset in identity.ts — the open tag is not nonce-protected.
+    const identity = formatIdentity({ cwd: sender.agent.cwd, pid: sender.agent.pid });
+    prefix = `<ay-msg ${nonce} from ${sender.agent.cli} ${identity} — reply: ay send ${replyTarget} "...">\n`;
     suffix = `\n</ay-msg ${nonce}>`;
     // A body that itself starts with an <ay-msg …> header is usually an agent
     // hand-wrapping what this send is about to wrap again — the recipient then
@@ -3516,7 +3509,6 @@ async function cmdSend(rest: string[]): Promise<number> {
             cli: sender.agent.cli,
             cwd: sender.agent.cwd,
             agent_id: sender.agent.agent_id,
-            role: sender.agent.role ?? undefined,
           }
         : null,
       to: {
@@ -3524,7 +3516,6 @@ async function cmdSend(rest: string[]): Promise<number> {
         cli: record.cli,
         cwd: record.cwd,
         agent_id: record.agent_id,
-        role: record.role ?? undefined,
       },
       body,
       code: trailing === "\r" ? undefined : codeName,
@@ -3693,87 +3684,6 @@ async function cmdMsgs(rest: string[]): Promise<number> {
     const line = tag + truncate(rec.body.replace(/\s+/g, " "), 100);
     process.stdout.write(`${when}  ${peer.padEnd(20)}${via}${flag}  ${line}\n`);
   }
-  return 0;
-}
-
-/**
- * `ay role [name]` / `ay role <keyword> <name>` — read or set an agent's
- * self-declared lane/role name ("pm", "crm", …). The role rides in the
- * `ay send` envelope header (`from claude #123 (pm) @ …`) so recipients don't
- * translate cwd/pid into a lane by hand — the emergent `[pm→qa]` body prefixes
- * exist exactly because the envelope lacked this. With no args: print the
- * calling agent's role. With one arg: set the calling agent's role (requires
- * agent context). With two args: resolve the keyword and set that agent's role.
- * `--clear` removes it. Roles are clamped by sanitizeRole (they render into the
- * non-nonce-protected open tag).
- */
-const ROLE_RESOLVE_OPTS: CommonOpts = {
-  all: false,
-  active: false,
-  cwdScope: null,
-  latest: false,
-  json: false,
-};
-
-async function cmdRole(rest: string[]): Promise<number> {
-  const y = yargs(rest)
-    .usage('Usage: ay role [name] | ay role <keyword> <name> | ay role [keyword] --clear')
-    .option("clear", { type: "boolean", default: false, description: "Remove the role" })
-    .help(false)
-    .version(false)
-    .exitProcess(false);
-  const argv = await y.parseAsync();
-  const args = argv._.slice(0).map(String);
-
-  // Figure out target + new value from arity: 0 args = self get (or self clear),
-  // 1 arg = self set (or keyword clear), 2 args = keyword set.
-  let target: GlobalPidRecord | null = null;
-  let newRole: string | undefined;
-  if (args.length === 2) {
-    target = await resolveOne(args[0]!, ROLE_RESOLVE_OPTS);
-    newRole = args[1]!;
-  } else if (args.length === 1 && argv.clear) {
-    target = await resolveOne(args[0]!, ROLE_RESOLVE_OPTS);
-  } else if (args.length === 1) {
-    target = await resolveSender();
-    if (!target) {
-      process.stderr.write(
-        "ay role: no agent context (AGENT_YES_PID unset or unregistered) — from a human shell, name the agent: ay role <keyword> <name>\n",
-      );
-      return 1;
-    }
-    newRole = args[0]!;
-  } else {
-    target = await resolveSender();
-    if (!target) {
-      process.stderr.write(
-        "ay role: no agent context — from a human shell, name the agent: ay role <keyword> [<name>|--clear]\n",
-      );
-      return 1;
-    }
-  }
-
-  if (newRole === undefined && !argv.clear) {
-    process.stdout.write(`${target.role ?? ""}\n`);
-    return 0;
-  }
-
-  let role: string | null = null;
-  if (!argv.clear) {
-    role = sanitizeRole(newRole);
-    if (!role) {
-      process.stderr.write(
-        `ay role: invalid role ${JSON.stringify(newRole)} — use 1-32 chars of [A-Za-z0-9._-]\n`,
-      );
-      return 1;
-    }
-  }
-  await updateGlobalPidStatus(target.pid, { role });
-  process.stdout.write(
-    role
-      ? `pid ${target.pid} (${target.cli}): role set to "${role}" — envelopes now read: from ${target.cli} #${target.pid} (${role}) @ ${shortenPath(target.cwd)}\n`
-      : `pid ${target.pid} (${target.cli}): role cleared\n`,
-  );
   return 0;
 }
 

--- a/ts/titleScanner.spec.ts
+++ b/ts/titleScanner.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { TitlePublisher, TitleScanner } from "./titleScanner.ts";
+
+describe("TitleScanner", () => {
+  it("parses OSC 0 terminated by BEL", () => {
+    const s = new TitleScanner();
+    expect(s.feed("\x1b]0;✳ fixing tests\x07")).toBe("✳ fixing tests");
+  });
+
+  it("parses OSC 2 terminated by ST (ESC \\)", () => {
+    const s = new TitleScanner();
+    expect(s.feed("\x1b]2;my task\x1b\\")).toBe("my task");
+  });
+
+  it("survives a chunk split mid-sequence", () => {
+    const s = new TitleScanner();
+    expect(s.feed("text \x1b]0;ha")).toBeNull();
+    expect(s.feed("lf done\x07 more")).toBe("half done");
+  });
+
+  it("returns the last title when a chunk has several", () => {
+    const s = new TitleScanner();
+    expect(s.feed("\x1b]0;one\x07\x1b]2;two\x07")).toBe("two");
+  });
+
+  it("ignores icon-only and unrelated OSC sequences", () => {
+    const s = new TitleScanner();
+    expect(s.feed("\x1b]1;icon\x07\x1b]52;c;YWJj\x07\x1b]133;A\x07")).toBeNull();
+  });
+
+  it("ignores CSI colors and plain text", () => {
+    const s = new TitleScanner();
+    expect(s.feed("plain \x1b[31mred\x1b[0m text")).toBeNull();
+  });
+
+  it("caps runaway titles and resyncs", () => {
+    const s = new TitleScanner();
+    expect(s.feed(`\x1b]0;${"x".repeat(2000)}\x07`)).toBeNull();
+    expect(s.feed("\x1b]0;ok\x07")).toBe("ok");
+  });
+
+  it("strips control chars and rejects empty titles", () => {
+    const s = new TitleScanner();
+    expect(s.feed("\x1b]0;a\tb\x07")).toBe("ab");
+    expect(s.feed("\x1b]0;\x07")).toBeNull();
+    expect(s.feed("\x1b]0;   \x07")).toBeNull();
+  });
+});
+
+describe("TitlePublisher", () => {
+  it("writes on change, dedupes, and rate-limits within the window", () => {
+    const writes: string[] = [];
+    const p = new TitlePublisher((t) => writes.push(t), 2000);
+    p.observe("a");
+    expect(writes).toEqual(["a"]); // first write is immediate
+    p.observe("a");
+    expect(writes).toEqual(["a"]); // unchanged — no write
+    p.observe("b");
+    expect(writes).toEqual(["a"]); // changed but throttled
+    p.poll(Date.now() + 2500); // window elapsed — pending title lands
+    expect(writes).toEqual(["a", "b"]);
+    p.poll(Date.now() + 5000);
+    expect(writes).toEqual(["a", "b"]); // nothing pending — no write
+  });
+});

--- a/ts/titleScanner.ts
+++ b/ts/titleScanner.ts
@@ -1,0 +1,137 @@
+/**
+ * Incremental scanner for terminal-title escapes (OSC 0/2) in the child CLI's
+ * PTY stream — the TS-runtime mirror of rs/src/title_scanner.rs; keep the two
+ * in sync.
+ *
+ * Coding-agent CLIs (claude, opencode, codex) continuously set the terminal
+ * title to a summary of what they are doing (`ESC ] 0 ; <title> BEL`, also
+ * terminated by `ESC \`). The wrapper observes the stream anyway, so scanning
+ * it yields a live "what is this agent doing" label for free — surfaced as
+ * `title` in the pid registry and shown by `ay whoami` / `ay ls --json`.
+ *
+ * Fed arbitrary chunk boundaries: a sequence split across reads still parses.
+ * The scanner only observes — it never modifies the stream.
+ */
+
+/** A title longer than this is a runaway OSC without terminator — discard. */
+const MAX_TITLE_LEN = 512;
+/** What we store/display. */
+const STORED_TITLE_LEN = 256;
+
+const enum State {
+  Ground,
+  Esc,
+  OscParam,
+  OscTitle,
+  OscOther,
+  OscTitleEsc,
+  OscOtherEsc,
+}
+
+export class TitleScanner {
+  private state = State.Ground;
+  private param = "";
+  private title = "";
+
+  /** Feed one output chunk; returns the LAST complete title in it, if any. */
+  feed(chunk: string): string | null {
+    let found: string | null = null;
+    for (const c of chunk) {
+      switch (this.state) {
+        case State.Ground:
+          if (c === "\x1b") this.state = State.Esc;
+          break;
+        case State.Esc:
+          if (c === "]") {
+            this.param = "";
+            this.state = State.OscParam;
+          } else if (c !== "\x1b") {
+            this.state = State.Ground;
+          }
+          break;
+        case State.OscParam:
+          if (c >= "0" && c <= "9" && this.param.length < 4) {
+            this.param += c;
+          } else if (c === ";") {
+            // OSC 0 (icon+title) and 2 (title) carry the window title; OSC 1
+            // is icon-only and everything else (8, 52, 133, …) is unrelated.
+            if (this.param === "0" || this.param === "2") {
+              this.title = "";
+              this.state = State.OscTitle;
+            } else {
+              this.state = State.OscOther;
+            }
+          } else if (c === "\x07") {
+            this.state = State.Ground;
+          } else if (c === "\x1b") {
+            this.state = State.OscOtherEsc;
+          } else {
+            this.state = State.OscOther;
+          }
+          break;
+        case State.OscTitle:
+          if (c === "\x07") {
+            found = cleanTitle(this.title);
+            this.state = State.Ground;
+          } else if (c === "\x1b") {
+            this.state = State.OscTitleEsc;
+          } else if (this.title.length >= MAX_TITLE_LEN) {
+            this.state = State.OscOther; // runaway — drop and resync
+          } else {
+            this.title += c;
+          }
+          break;
+        case State.OscTitleEsc:
+          if (c === "\\") found = cleanTitle(this.title);
+          this.state = State.Ground; // a bare ESC aborts the OSC either way
+          break;
+        case State.OscOther:
+          if (c === "\x07") this.state = State.Ground;
+          else if (c === "\x1b") this.state = State.OscOtherEsc;
+          break;
+        case State.OscOtherEsc:
+          this.state = State.Ground;
+          break;
+      }
+    }
+    return found || null;
+  }
+}
+
+/** Strip control chars (they can't be typed into a title bar) and clamp. */
+function cleanTitle(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  const trimmed = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  return trimmed.slice(0, STORED_TITLE_LEN);
+}
+
+/**
+ * Change-gated + rate-limited publisher: registry writes take the
+ * cross-runtime lock, while claude retitles every few seconds — the steady
+ * state must cost zero writes, and a retitle burst collapses to one write per
+ * window. Call `poll()` from any recurring point in the run loop so the final
+ * title still lands within a window after the CLI goes quiet.
+ */
+export class TitlePublisher {
+  private latest: string | null = null;
+  private written: string | null = null;
+  private writtenAt = 0;
+
+  constructor(
+    private readonly write: (title: string) => void,
+    private readonly minIntervalMs = 2_000,
+  ) {}
+
+  observe(title: string): void {
+    this.latest = title;
+    this.poll();
+  }
+
+  poll(now: number = Date.now()): void {
+    if (this.latest === null || this.latest === this.written) return;
+    if (now - this.writtenAt < this.minIntervalMs) return;
+    this.write(this.latest);
+    this.written = this.latest;
+    this.writtenAt = now;
+  }
+}


### PR DESCRIPTION
## 背景

#373 の role 概念 (ay role / AGENT_YES_ROLE) に対して「branch 名が lane を表すので、この収益に概念を 1 つ増やす価値はない」という判断が出た。代わりにエージェントの自己紹介を標準 identity 形式に統一し、子 CLI が自分で宣言する端末 title を捕捉する。

## 変更点

**標準 identity 形式** (envelope / whoami 共通):

```
<username>@<hostname>:<path>:<branch>#<pid>
例: sno@Mac:~/ws/symval/symval/tree/crm:main#30402
```

- `ts/identity.ts`: formatIdentity + readGitBranch。branch は純 file read で解決 (git を spawn しない): 最寄りの `.git` まで walk up → worktree の `gitdir:` 間接参照を辿る → HEAD をパース。detached は短縮 commit id、repo 外はセグメント省略
- パースは両端アンカー (右端 `#<pid>`、branch は最後の `:` の後 — git ref は `:` を含めない)。途中の path は `:` `@` を含み得る (Windows drive)
- 各セグメントは header-safe 文字集合に clamp — envelope の開きタグは nonce 保護されないため
- envelope: `<ay-msg <nonce> from claude sno@Mac:~/ws/…:main#30402 — reply: ay send <agent_id> "...">`

**端末 title 捕捉** (OSC 0/2):

- claude / opencode は作業要約を端末 title に流し続ける。wrapper は PTY を経由しているので、両 runtime の出力経路で incremental scan して `record.title` に保持 (`rs/src/title_scanner.rs` + `ts/titleScanner.ts`、実装は同一の state machine)
- chunk 分割耐性・512B 暴走 cap・icon-only (OSC 1) と無関係 OSC (52/133 等) は無視・control 文字 strip
- 書き込みは変化時のみ + 2s throttle (レジストリ書き込みは cross-runtime lock を取るため、定常状態はゼロ書き込み)。`ay whoami` の `title` 行と `ay ls --json` で参照

**role 撤去**: cmdRole / AGENT_YES_ROLE / role field (TS+rs) / docs。#373 で追加した coverage テスト (cmdHist 等) は残す。

## テスト

- 新規: identity.spec (12 — worktree 間接参照 / relative gitdir / detached / 非 repo)、titleScanner.spec (9 — chunk split / runaway cap / throttle)、rust title_scanner 8 件
- 更新: envelope regex を identity 形式に、role テストは title テストへ置換
- TS 88 files pass (coverage gate 通過)、cargo test 457 件 pass、tsc --noEmit は main 基線 38 エラーと同一集合 (新規ゼロ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)