### PR TITLE
fix(serve): daemon 起動の agent に login+interactive shell の env を継承させる

### DIFF
--- a/rs/src/bin/ayrs.rs
+++ b/rs/src/bin/ayrs.rs
@@ -79,6 +79,11 @@ async fn main() -> anyhow::Result<()> {
                 Some(ServeAction::Status) => return serve::service::status(),
                 None => {}
             }
+            // Recover the login-shell env in the background now, so the first
+            // /api/spawn doesn't pay the shell's rc-file startup cost (see
+            // serve/shell_env.rs — launchd hands us a bare PATH).
+            serve::shell_env::warm();
+
             // --port and --webrtc are independent transports over the SAME API
             // surface; running both is the normal local+remote setup.
             let http = port.map(|p| tokio::spawn(serve::http::run(p)));

--- a/rs/src/serve/control.rs
+++ b/rs/src/serve/control.rs
@@ -64,6 +64,17 @@ fn spawn_detached(bin: &std::path::Path, args: &[String], cwd: &str) -> std::io:
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
+    // A launchd/systemd daemon carries the bare service env (PATH without
+    // ~/.bun/bin, ~/.cargo/bin, Homebrew, …) and would pass it verbatim to
+    // every agent — inside which bun/user CLIs are then "command not found".
+    // Overlay the recovered login-shell env instead: recovered values win,
+    // daemon-only vars pass through, and on recovery failure the daemon env is
+    // inherited unchanged. Mirrors freshAgentEnv in ts/serve.ts.
+    if let Some(env) = super::shell_env::login_shell_env() {
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+    }
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;

--- a/rs/src/serve/mod.rs
+++ b/rs/src/serve/mod.rs
@@ -15,4 +15,5 @@ pub mod meta;
 pub mod nego;
 pub mod service;
 pub mod share;
+pub mod shell_env;
 pub mod widget;

--- a/rs/src/serve/shell_env.rs
+++ b/rs/src/serve/shell_env.rs
@@ -1,0 +1,258 @@
+//! Recover the user's login+interactive shell environment for daemon-spawned
+//! agents.
+//!
+//! An `ayrs serve` started by launchd/systemd inherits the bare service PATH
+//! (`/usr/bin:/bin:/usr/sbin:/sbin`) — none of the user's shell config is ever
+//! read by the init system — and `spawn_detached` used to pass that
+//! environment verbatim to every agent it spawned, so `bun`/`cargo`/user CLIs
+//! were "command not found" inside them. The user's config is fine; it was
+//! never consulted.
+//!
+//! Fix: once per daemon lifetime, run the user's shell as a login+interactive
+//! (`-lic`) one-shot that prints its environment fenced by sentinels, and use
+//! that as the base env for spawned agents. `-i` matters: PATH exports are
+//! commonly scattered across `.zshenv`/`.zprofile`/`.zshrc`, and a plain
+//! login shell (`-lc`) never reads `.zshrc`, silently dropping entries.
+//! Mirrors (and strengthens) `loginShellEnv` in ts/serve.ts.
+//!
+//! Best-effort by design: sentinel extraction survives rc-file banners, a
+//! timeout guards against an rc file that blocks, and every failure path
+//! falls back to "inherit the daemon env unchanged" — spawning must never
+//! break because env recovery did.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tracing::{debug, info};
+
+const DELIM: &str = "_AYRS_SHELL_ENV_DELIM_";
+const TIMEOUT_MS: u64 = 8_000;
+
+static CACHE: OnceLock<Option<HashMap<String, String>>> = OnceLock::new();
+
+/// Resolve (and cache) the recovered login-shell environment. `None` when
+/// recovery failed or is unsupported (Windows) — callers then inherit the
+/// daemon env unchanged.
+pub fn login_shell_env() -> Option<&'static HashMap<String, String>> {
+    CACHE.get_or_init(compute).as_ref()
+}
+
+/// Kick off recovery in the background at daemon startup so the first
+/// /api/spawn doesn't pay the shell's rc-file startup cost.
+pub fn warm() {
+    std::thread::spawn(|| {
+        let n = login_shell_env().map(|e| e.len());
+        match n {
+            Some(n) => info!("shell_env: recovered {} vars from login shell", n),
+            None => info!("shell_env: recovery unavailable — spawns inherit the daemon env"),
+        }
+    });
+}
+
+fn compute() -> Option<HashMap<String, String>> {
+    if cfg!(windows) {
+        return None; // different PATH model; the launchd/systemd disease is unix
+    }
+    let shell = pick_shell()?;
+    let out = run_env_dump(&shell, TIMEOUT_MS)?;
+    let mut env = parse_delimited_env(&out)?;
+    // A usable PATH is the whole point — refuse a dump without one.
+    let path = env.get("PATH")?.clone();
+    env.insert("PATH".into(), dedup_path(&path));
+    debug!("shell_env: recovered via {}", shell);
+    Some(env)
+}
+
+/// The shell whose rc files own the user's PATH. $SHELL when the daemon has
+/// one; under launchd it usually doesn't, so fall back through the common
+/// defaults (zsh first — it is the macOS default since Catalina).
+fn pick_shell() -> Option<String> {
+    if let Ok(sh) = std::env::var("SHELL") {
+        if !sh.trim().is_empty() && Path::new(&sh).exists() {
+            return Some(sh);
+        }
+    }
+    ["/bin/zsh", "/bin/bash", "/bin/sh"]
+        .iter()
+        .find(|p| Path::new(p).exists())
+        .map(|p| p.to_string())
+}
+
+/// `<shell> -lic '<sentinel>; env -0; <sentinel>'` with a hard timeout.
+/// stdout is drained on a separate thread while we poll for exit — an env
+/// dump can exceed the pipe buffer, and a blocked pipe would deadlock the
+/// timeout loop.
+fn run_env_dump(shell: &str, timeout_ms: u64) -> Option<Vec<u8>> {
+    let script = format!(r#"printf %s "{DELIM}"; env -0; printf %s "{DELIM}""#);
+    let mut child = std::process::Command::new(shell)
+        .args(["-lic", &script])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let mut stdout = child.stdout.take()?;
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        buf
+    });
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = reader.join().ok()?;
+                return status.success().then_some(out);
+            }
+            Ok(None) => {
+                if started.elapsed() >= Duration::from_millis(timeout_ms) {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    // Do NOT join the reader: a grandchild of the killed shell
+                    // (an rc file's `sleep`/spinner) can keep the pipe's write
+                    // end open long after the shell is dead, and read_to_end
+                    // only returns when the last writer closes. Abandon the
+                    // thread — it exits by itself once the pipe drains.
+                    debug!("shell_env: {} timed out after {}ms", shell, timeout_ms);
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                return None;
+            }
+        }
+    }
+}
+
+/// Extract the NUL-separated `env -0` dump fenced between the first and last
+/// sentinel — anything an rc file printed outside the fence is ignored.
+fn parse_delimited_env(out: &[u8]) -> Option<HashMap<String, String>> {
+    let delim = DELIM.as_bytes();
+    let start = find(out, delim)? + delim.len();
+    let end = rfind(out, delim)?;
+    if end <= start {
+        return None;
+    }
+    let mut env = HashMap::new();
+    for pair in out[start..end].split(|&b| b == 0) {
+        if pair.is_empty() {
+            continue;
+        }
+        let Ok(pair) = std::str::from_utf8(pair) else { continue };
+        let Some(eq) = pair.find('=') else { continue };
+        if eq == 0 {
+            continue;
+        }
+        env.insert(pair[..eq].to_string(), pair[eq + 1..].to_string());
+    }
+    (!env.is_empty()).then_some(env)
+}
+
+/// Order-preserving dedup: rc files commonly re-prepend the same directories
+/// (`.zshenv`/`.zprofile`/`.zshrc` each adding `~/.bun/bin` again).
+fn dedup_path(path: &str) -> String {
+    let mut seen = std::collections::HashSet::new();
+    path.split(':')
+        .filter(|p| !p.is_empty() && seen.insert(p.to_string()))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn rfind(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).rposition(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dump(inner: &str) -> Vec<u8> {
+        format!("{DELIM}{inner}{DELIM}").into_bytes()
+    }
+
+    #[test]
+    fn parses_a_clean_dump() {
+        let env = parse_delimited_env(&dump("PATH=/a:/b\0HOME=/Users/x\0")).unwrap();
+        assert_eq!(env["PATH"], "/a:/b");
+        assert_eq!(env["HOME"], "/Users/x");
+    }
+
+    #[test]
+    fn ignores_banner_noise_outside_the_fence() {
+        let mut out = b"welcome banner from .zshrc\n".to_vec();
+        out.extend_from_slice(&dump("PATH=/a\0"));
+        out.extend_from_slice(b"\ntrailing plugin output");
+        assert_eq!(parse_delimited_env(&out).unwrap()["PATH"], "/a");
+    }
+
+    #[test]
+    fn survives_values_with_newlines() {
+        let env = parse_delimited_env(&dump("MULTI=line1\nline2\0PATH=/a\0")).unwrap();
+        assert_eq!(env["MULTI"], "line1\nline2");
+    }
+
+    #[test]
+    fn rejects_missing_or_lone_delimiters() {
+        assert!(parse_delimited_env(b"no delims at all").is_none());
+        assert!(parse_delimited_env(format!("{DELIM}PATH=/a").as_bytes()).is_none());
+        assert!(parse_delimited_env(&dump("")).is_none());
+    }
+
+    #[test]
+    fn dedups_path_preserving_order() {
+        assert_eq!(dedup_path("/a:/b:/a:/c:/b"), "/a:/b:/c");
+        assert_eq!(dedup_path("/a::/b"), "/a:/b");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovers_env_through_a_real_shell_pipeline() {
+        // A stand-in "shell" that ignores -lic and emits a fenced dump — proves
+        // spawn → drain → timeout-poll → parse end to end without depending on
+        // the CI user's rc files.
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fake-shell");
+        let mut f = std::fs::File::create(&script).unwrap();
+        writeln!(
+            f,
+            "#!/bin/sh\nprintf %s \"{DELIM}\"; printf 'PATH=/x:/y:/x\\0FOO=bar\\0'; printf %s \"{DELIM}\""
+        )
+        .unwrap();
+        drop(f);
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let out = run_env_dump(script.to_str().unwrap(), 5_000).unwrap();
+        let mut env = parse_delimited_env(&out).unwrap();
+        let path = env.remove("PATH").unwrap();
+        assert_eq!(dedup_path(&path), "/x:/y");
+        assert_eq!(env["FOO"], "bar");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn times_out_a_hung_shell() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("hung-shell");
+        let mut f = std::fs::File::create(&script).unwrap();
+        writeln!(f, "#!/bin/sh\nsleep 60").unwrap();
+        drop(f);
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let started = Instant::now();
+        assert!(run_env_dump(script.to_str().unwrap(), 300).is_none());
+        assert!(started.elapsed() < Duration::from_secs(10));
+    }
+}

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -464,12 +464,21 @@ function loginShellEnv(): Record<string, string> | null {
   loginShellEnvCache = null;
   if (process.platform === "win32") return loginShellEnvCache;
   try {
-    const shell = process.env.SHELL || "/bin/sh";
+    // $SHELL when the daemon has one; a launchd/systemd env usually doesn't,
+    // so fall back through the common defaults (zsh first — the macOS default).
+    const shell =
+      [process.env.SHELL, "/bin/zsh", "/bin/bash", "/bin/sh"].find(
+        (s): s is string => Boolean(s && existsSync(s)),
+      ) ?? "/bin/sh";
     // Delimiters fence off the env dump from any banner/prompt noise the rc files
     // print to stdout; `env -0` is NUL-separated so values with newlines survive.
+    // `-i` (interactive) on top of `-l`: PATH exports are commonly scattered
+    // across .zshenv/.zprofile/.zshrc, and a plain login shell never reads
+    // .zshrc — silently dropping those entries. The timeout guards against an
+    // rc file that blocks under -i.
     const delim = "_AY_SHELL_ENV_DELIM_";
     const res = Bun.spawnSync(
-      [shell, "-lc", `printf %s "${delim}"; env -0; printf %s "${delim}"`],
+      [shell, "-lic", `printf %s "${delim}"; env -0; printf %s "${delim}"`],
       {
         stdin: "ignore",
         stderr: "ignore",
@@ -490,7 +499,15 @@ function loginShellEnv(): Record<string, string> | null {
       env[pair.slice(0, eq)] = pair.slice(eq + 1);
     }
     // Require a usable result — a PATH carrying ~/.bun/bin is the whole point.
-    if (env.PATH) loginShellEnvCache = env;
+    if (env.PATH) {
+      // Order-preserving dedup: rc files re-prepend the same dirs on every
+      // nesting level (.zshenv/.zprofile/.zshrc each adding ~/.bun/bin again).
+      const seen = new Set<string>();
+      env.PATH = env.PATH.split(":")
+        .filter((p) => p && !seen.has(p) && (seen.add(p), true))
+        .join(":");
+      loginShellEnvCache = env;
+    }
   } catch {
     // best-effort; fall back to process.env
   }


### PR DESCRIPTION
## 背景 (rechrome lane の実測報告)

launchd 起動の `ayrs serve` は素の service PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) しか持たない — launchd はユーザの zsh 設定を一切読まない。`/api/spawn`・`/api/restart` はその env をそのまま子 agent に渡すため、agent の Bash 内で `bun` / `oxmgr` / ユーザ CLI が全部 "command not found" になっていた。ユーザの設定は正しいが、一度も読まれていなかった。

## 変更点

**rs/src/serve/shell_env.rs (新規)** — daemon 生涯に一度、ユーザ shell の `-lic` one-shot で `env -0` dump を回収し、spawn する agent の base env にする:

- **`-i` が重要**: PATH export は `.zshenv`/`.zprofile`/`.zshrc` に散在し、login only (`zsh -lc`) は `.zshrc` を読まないため `~/.local/node/bin` 等を取りこぼす (報告者の実測)
- sentinel (`printf %s "<delim>"; env -0; printf %s "<delim>"`) で rc の banner / plugin 出力を無害化。PATH は保序 dedup (rc が同じ dir を三重に prepend していた実測あり)
- 8s timeout + 全失敗経路は「daemon env をそのまま継承」へ回落。spawn が env 回収のせいで壊れることはない
- timeout 時 reader thread は **join しない**: kill した shell の孫プロセスが pipe の write 端を握り続けると `read_to_end` が返らない (テストが実際に 60s 吊って発見)
- `SHELL` 不在 (launchd では通常そう) は `/bin/zsh` → `/bin/bash` → `/bin/sh` に回落
- `ayrs serve` 起動時に background thread で warm — 初回 spawn が rc 起動コストを払わない

**control.rs spawn_detached**: 回収 env を overlay (回収値優先、daemon 専用変数は素通し)。spawn / restart の両経路がこの一点を通る。

**ts/serve.ts loginShellEnv**: 既存の回収機構を強化 — `-lc` → `-lic`、SHELL fallback、PATH 保序 dedup。Rust 実装と同一意味論。

plist への `EnvironmentVariables` 書き込みは不採用: spawn 側解決なら plist が再生成されても退化しない (報告者と合意済み)。**daemon の再起動はこの PR ではしない** — 稼働中 agent が全部道連れになるため、タイミングは taku の判断。

## テスト

- shell_env 単体 7 件: sentinel 抽出 (banner 混入 / 改行入り値 / delimiter 欠落)、PATH dedup、fake-shell での end-to-end 回収、hung-shell の timeout (60s 吊り回帰の再現テスト)
- cargo test 全 464 件 pass、TS build/lint pass、tsc は main 基線と同一集合

🤖 Generated with [Claude Code](https://claude.com/claude-code)