### PR TITLE
docs(CLAUDE.md): timeout 付き子プロセス stdout 読みの reader-join 罠を恒久化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,15 @@ not found`), install rustup first, then re-source the env:
 curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 . "$HOME/.cargo/env"
 ```
+
+## Reading a child process's stdout with a timeout: never join the reader
+
+When you kill a timed-out child whose stdout you are draining on another
+thread, do NOT `join` that reader thread (Rust) / `await` that read promise
+(TS) on the timeout path. Killing the child does not close the pipe: any
+**grandchild** it spawned (an rc file's `sleep`, a spinner, a forked helper)
+inherits the pipe's write end and keeps it open, so `read_to_end` only returns
+when the grandchild eventually exits — a test hung 60 s on exactly this in
+`rs/src/serve/shell_env.rs`. Abandon the reader instead; it exits by itself
+once the last writer closes. This applies to every "spawn a child, read its
+output, enforce a deadline" site, not just shell_env.


### PR DESCRIPTION
#382 の shell_env 実装で実際に踏んだ罠の恒久化 (rechrome lane の提案):

kill した子プロセスの stdout を別スレッドで drain している場合、timeout 経路でその reader を join してはいけない。kill しても pipe は閉じない — 子の**孫プロセス** (rc ファイルの sleep / spinner / forked helper) が write 端を継承して開いたままにするため、`read_to_end` は孫が終わるまで返らない (実際にテストが 60s 吊った)。reader は遺棄する — 最後の writer が閉じれば自力で終わる。

これは shell_env 固有ではなく「子プロセスを spawn して出力を読み、deadline を課す」全箇所に適用される罠なので、repo の CLAUDE.md に留める。doc-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)