### PR TITLE
feat(ay): 引数なしの `ay` は help を表示する（claude を spawn しない）

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ bun add -g agent-yes      # or: npm install -g agent-yes
 
 Then: `ay claude` (run an agent with auto-yes) · `ay serve --share` (web console + shareable link) · live console at https://agent-yes.com
 
+`ay` on its own prints the command list — `ay` **is** agent-yes, the fleet manager, so
+starting an agent names a CLI (`ay claude`, `ay codex`, …). `cy` remains the one-word
+shortcut that launches claude with no arguments.
+
 For the local web console, install [Portless](https://portless.sh/) once with `npm install -g portless`, then run `ay serve`. It assigns a free internal port and serves the console at `https://agent-yes.localhost/`. `ay serve --port N` remains available for a fixed-port API listener.
 
 ## Features

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -71,6 +71,16 @@ fn should_delegate(first_arg: &str, exe_base: &str) -> bool {
     is_subcommand(first_arg, manager_commands)
 }
 
+/// Pure decision: is this a completely bare MANAGER invocation (`agent-yes` /
+/// `ay` with no user args)? Those print help instead of launching claude — `ay`
+/// means agent-yes, the fleet manager, so a zero-argument run is "what can this
+/// do?", not "start an agent". Mirrors `isBareManagerInvocation` in
+/// ts/subcommands.ts. A cli-bound alias is excluded: bare `cy` / `claude-yes`
+/// still spawns claude.
+fn is_bare_manager_invocation(has_args: bool, exe_base: &str) -> bool {
+    !has_args && invoked_cli_name(exe_base).is_none()
+}
+
 /// If this binary was invoked with a leading management subcommand, re-exec the
 /// JS launcher and return `Some(exit_code)` for the caller to exit with;
 /// otherwise return `None` so the normal agent-run proceeds.
@@ -79,11 +89,16 @@ fn should_delegate(first_arg: &str, exe_base: &str) -> bool {
 /// off `process.argv[2]` alone (a subcommand buried after flags is not one).
 pub fn maybe_delegate_subcommand() -> Option<i32> {
     let raw: Vec<String> = env::args().collect();
-    let first = raw.get(1)?; // raw[0] is the binary itself
     let exe_base = env::current_exe()
         .ok()
         .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
         .unwrap_or_default();
+    // raw[0] is the binary itself, so raw[1] is the first user arg.
+    let Some(first) = raw.get(1) else {
+        // No args at all: the manager entry shows help; a cli-bound alias runs.
+        return is_bare_manager_invocation(false, &exe_base)
+            .then(|| delegate_to_js(&["help".to_string()]));
+    };
     if !should_delegate(first, &exe_base) {
         return None;
     }
@@ -541,6 +556,20 @@ mod tests {
         assert!(!should_delegate("claude", "agent-yes"));
         assert!(!should_delegate("-p", "agent-yes"));
         assert!(!should_delegate("fix", "agent-yes"));
+    }
+
+    #[test]
+    fn test_is_bare_manager_invocation() {
+        // Bare manager entry → help (delegated to the JS CLI).
+        assert!(is_bare_manager_invocation(false, "agent-yes"));
+        assert!(is_bare_manager_invocation(false, "ay"));
+        // Bare cli-bound alias → still spawns its agent.
+        assert!(!is_bare_manager_invocation(false, "cy"));
+        assert!(!is_bare_manager_invocation(false, "claude-yes"));
+        assert!(!is_bare_manager_invocation(false, "codex-yes"));
+        // With args, nothing is "bare" — normal dispatch decides.
+        assert!(!is_bare_manager_invocation(true, "agent-yes"));
+        assert!(!is_bare_manager_invocation(true, "cy"));
     }
 
     #[test]

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -28,9 +28,17 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   const managerCommands = !invokedCliName(process.argv);
   // Intercept bare -h/--help so we show TS subcommands, not just Rust agent-runner options.
   const isHelpFlag = rawArg === "-h" || rawArg === "--help";
-  const { isSubcommand, runSubcommand, cmdHelp, isUnknownManagerToken } =
+  const { isSubcommand, runSubcommand, cmdHelp, isUnknownManagerToken, isBareManagerInvocation } =
     await import("./subcommands.ts");
   if (isHelpFlag && process.argv.length === 3) {
+    await cmdHelp(managerCommands);
+    process.exit(0);
+  }
+  // Bare `ay` / `agent-yes`: show help. `ay` is the fleet manager, so a
+  // zero-argument run is someone asking "what can this do?", not "launch an
+  // agent" — launching names a CLI (`ay claude …`), and `cy` remains the
+  // no-argument shortcut for claude. Mirrored in rs/src/cli.rs.
+  if (isBareManagerInvocation(process.argv, managerCommands)) {
     await cmdHelp(managerCommands);
     process.exit(0);
   }

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -162,6 +162,24 @@ describe("subcommands.isUnknownManagerToken (footgun guard)", () => {
   });
 });
 
+describe("subcommands.isBareManagerInvocation", () => {
+  it("fires for a bare manager entry (`ay` with no args) → help, not a spawn", async () => {
+    const { isBareManagerInvocation } = await loadModule();
+    expect(isBareManagerInvocation(["bun", "/x/dist/agent-yes.js"], true)).toBe(true);
+  });
+  it("never fires for a cli-bound alias (bare `cy` still spawns claude)", async () => {
+    const { isBareManagerInvocation } = await loadModule();
+    expect(isBareManagerInvocation(["bun", "/x/dist/cy.js"], false)).toBe(false);
+  });
+  it("does not fire once any arg is present, including a flags-only run", async () => {
+    const { isBareManagerInvocation } = await loadModule();
+    // `ay claude`, `ay ls`, `ay --continue` each asked for something specific.
+    expect(isBareManagerInvocation(["bun", "/x/agent-yes.js", "claude"], true)).toBe(false);
+    expect(isBareManagerInvocation(["bun", "/x/agent-yes.js", "ls"], true)).toBe(false);
+    expect(isBareManagerInvocation(["bun", "/x/agent-yes.js", "--continue"], true)).toBe(false);
+  });
+});
+
 describe("subcommands.cmdHelp", () => {
   const capture = async (managerCommands?: boolean) => {
     const { cmdHelp } = await loadModule();
@@ -2746,7 +2764,9 @@ describe("subcommands.cmdSend double-envelope warning", () => {
         const buf = Buffer.alloc(8192);
         const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
         const received = buf.subarray(0, n).toString();
-        expect(received).toMatch(/^<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/repo\/beta#900001 — /);
+        expect(received).toMatch(
+          /^<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/repo\/beta#900001 — /,
+        );
         expect(received).toContain("<ay-msg deadbeef");
         fs.closeSync(rdwrFd);
       } finally {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -513,6 +513,22 @@ export function isUnknownManagerToken(
 }
 
 /**
+ * True for a completely bare MANAGER invocation — `ay` / `agent-yes` with no
+ * args at all. `ay` means agent-yes (the fleet manager), so it prints help
+ * instead of silently launching an agent; naming a CLI is what launches one
+ * (`ay claude`), and `cy` stays the zero-argument way to start claude.
+ *
+ * Never fires for a cli-bound alias (managerCommands=false): bare `cy` /
+ * `claude-yes` / `codex-yes` must keep spawning their agent.
+ *
+ * `argv` is process.argv, so length 2 = [runtime, script] with no user args;
+ * a flags-only run like `ay --continue` still launches (it asked for a run).
+ */
+export function isBareManagerInvocation(argv: string[], managerCommands: boolean): boolean {
+  return managerCommands && argv.length <= 2;
+}
+
+/**
  * Write to stdout and wait until it has actually been handed off.
  *
  * The CLI ends with `process.exit()`, which DISCARDS bytes still sitting in the
@@ -839,9 +855,10 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `  ay ls   <token>@<host>:<port>       connect inline (no alias needed)\n` +
       `  ay send <token>@<host>:<port>:<kw> <msg>\n` +
       `\n` +
-      `Run an agent:\n` +
-      `  ay [claude|codex|gemini|...] [options] -- [prompt]\n` +
+      `Run an agent (naming a CLI is what launches one — bare 'ay' shows this help):\n` +
+      `  ay <claude|codex|gemini|...> [options] -- [prompt]\n` +
       `  ay claude -- "fix the bug in auth.ts"\n` +
+      `  cy [options] -- [prompt]            shortcut for 'ay claude' (bare 'cy' starts claude)\n` +
       `  ay claude --help                    full agent-runner options\n` +
       `\n` +
       `Labs (examples at https://github.com/snomiao/agent-yes/tree/main/lab):\n` +


### PR DESCRIPTION
## 背景

`ay` は agent-yes（フリート管理側）そのものの名前だが、これまでは引数なしの `ay` が既定で claude を spawn していた。「何ができるのか」を見たいだけの実行が、意図しないエージェント起動になっていた。

`claude-yes` のために作られたのが agent-yes であり、引数なしで claude を起動する用途は `cy` が引き続き担う。`ay` は agent-yes を意味する、という整理。

## 変更

- 引数ゼロの **manager entry**（`ay` / `agent-yes`）は help を表示して exit 0
- エージェント起動は CLI 名を伴う形に統一（`ay claude …` / `ay --cli claude …`）
- **cli 紐付きエイリアスは不変**: 引数なしの `cy` / `claude-yes` / `codex-yes` は従来どおりエージェントを起動する
- help 本文にも `cy` が `ay claude` のショートカットである旨を明記

## スコープ（明示的な前提）

変わるのは **引数が完全にゼロ** の実行のみ。`ay --continue` のようなフラグだけの実行は明示的に実行を指示しているため、従来どおり起動する。`ay -h` / `ay help` も従来どおり。

## 実装

両ランタイムに実装（片方だけだと Rust バイナリを直接叩いた場合に挙動がずれるため）:

- TS: `ts/cli.ts` の subcommand fast path → `isBareManagerInvocation()` で判定し `cmdHelp()`
- Rust: `rs/src/cli.rs` `maybe_delegate_subcommand()` → 引数ゼロかつ manager 名なら JS 側の `help` へ委譲

判定はいずれも純関数に切り出し、TS / Rust 双方で単体テスト済み。

## 検証

- `bun ts/cli.ts`（引数なし = 素の `ay` 相当）→ help を表示して exit 0
- `vitest ts/subcommands.spec.ts` 126 passed（`isBareManagerInvocation` の 3 ケース含む）
- `cargo test --bin agent-yes cli::` 37 passed（`test_is_bare_manager_invocation` 含む）
- `tsgo --noEmit` の差分ゼロ（残るエラーは origin/main 由来の既存分のみ、stash して確認済み）
- `cargo fmt --check` で `cli.rs` の指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)