### PR TITLE
docs(cwd): エージェント起動の案内を `cd <dir> && ay …` に統一する

### DIFF
--- a/examples/spawn-notify.sh
+++ b/examples/spawn-notify.sh
@@ -31,9 +31,12 @@ task="$*"
 
 # 1) Fire-and-forget. nohup+disown so the agent outlives this waiter; agent-yes
 #    keeps its own PTY log under ~/.agent-yes, so /dev/null here loses nothing.
+#    `cd` in a subshell rather than `--cwd`: that flag is deprecated on an agent
+#    run, and anything in AY_FLAGS would sit before it, so agent-yes never parses
+#    it — it lands in the trailing args and the CLI dies on the unknown option.
 mkdir -p "$cwd"
 # shellcheck disable=SC2086
-nohup ay "$cli" ${AY_FLAGS:-} --cwd "$cwd" -- "$task" >/dev/null 2>&1 &
+( cd "$cwd" && exec nohup ay "$cli" ${AY_FLAGS:-} -- "$task" >/dev/null 2>&1 ) &
 disown || true
 
 # 2) Resolve the agent we just spawned to an EXACT pid (newest match in this cwd),

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -529,7 +529,12 @@ async function cmdWsFork(args: string[]): Promise<number> {
     return 1;
   }
   process.stdout.write(`${res.action}  ${res.folder}\n`);
-  process.stderr.write(`\n  ay claude --cwd ${res.folder} -- "<prompt>"   # work there\n`);
+  // `cd <dir> && ay …`, never `ay … --cwd <dir>`: --cwd is deprecated on an agent
+  // run, and a CLI-specific flag placed before it (`ay claude --model X --cwd D`)
+  // is swallowed into clap's trailing args and forwarded to the target CLI, which
+  // dies on the unknown option. cd has neither problem and puts every relative
+  // path in the command in the same place as the agent.
+  process.stderr.write(`\n  cd ${res.folder} && ay claude -- "<prompt>"   # work there\n`);
   return 0;
 }
 


### PR DESCRIPTION
## 背景

`--cwd` はエージェント起動時には非推奨だが、**agent-yes 自身がまだ非推奨の形を案内していた**。
案内を読んだエージェントが実際に踏むのは次の不具合である。

```
ay claude --model opus --cwd DIR -- "..."
```

CLI 固有のフラグ (`--model`) が `--cwd` より前にあると、clap の `trailing_var_arg` が
`--model` 以降をすべて後続引数として扱うため `--cwd` が agent-yes に解析されず、
対象 CLI にそのまま転送される。

再現結果 (v1.262.0):

| | 結果 |
|---|---|
| 子プロセスのログ | `error: unknown option '--cwd'` |
| 子プロセスの終了 | exit 1 / fatal |
| 親プロセスの表示 | `Spawned pid N` を表示して **exit 0** |
| 登録される cwd | `--cwd` の値ではなく**起動元ディレクトリ** |

つまり起動失敗が呼び出し側にまったく伝わらない。
`--cwd` を前に置いた `ay claude --cwd DIR -- "pwd"` は正常に動作するため、
フラグの並び順にのみ依存する。

## 変更

- `ts/ws.ts` — `ay ws fork` 成功時の案内を `cd <folder> && ay claude -- "<prompt>"` に変更
- `examples/spawn-notify.sh` — `--cwd` をやめてサブシェルの `cd` に変更。
  ここは `${AY_FLAGS}` が必ず `--cwd` の前に入るため、上記の転送不具合を確実に踏む形になっていた

## 変更しないもの

別のフラグであり非推奨ではないため、そのままにする。

- `ay ls / attach / status --cwd` — 絞り込みフィルタ
- `ay schedule / spawn --cwd` — それぞれのサブコマンド自身のフラグ
- `ts/schedule.ts:141` の `--cwd` — oxmgr 側のフラグ。組み立てる `agentCmd` に
  `--cwd` を含めていないので、既に `cd してから ay` と同じ正しい形になっている

## 追加調査 (本 PR では未修正)

今回の調査で判明した、別途対応すべき事項:

1. **起動失敗が握り潰される** — 子が fatal で死んでも親は `Spawned pid N` / exit 0 を返す
2. **wrapper 自身が chdir しない** — どのランタイムも `set_current_dir` / `process.chdir` を
   呼ばず `cwd` 文字列を引き回しているだけなので、`current_dir()` / `process.cwd()` を
   読む箇所 (`rs/src/config_loader.rs:430,463`、`rs/src/serve/http.rs:56`、
   `ts/channels.ts`、`ts/configLoader.ts` など) は `--cwd` 指定時に食い違う。
   これが `--cwd` を非推奨にした元々の理由 (agent-yes.com の表示・検索の不整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)