### PR TITLE
fix: 起動直後に死んだエージェントを握り潰さない / --cwd 指定時に wrapper も chdir する

### DIFF
--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -55,9 +55,9 @@ fn shell_display_quote(s: &str) -> String {
     if s.is_empty() {
         return "''".to_string();
     }
-    let safe = s.chars().all(|c| {
-        c.is_ascii_alphanumeric() || "_@%+=:,./~-".contains(c)
-    });
+    let safe = s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "_@%+=:,./~-".contains(c));
     if safe {
         s.to_string()
     } else {
@@ -124,7 +124,12 @@ fn warn_cwd_deprecated() {
     let raw: Vec<String> = std::env::args().collect();
     let prog = raw
         .first()
-        .map(|p| p.rsplit(['/', '\\']).next().unwrap_or(p.as_str()).to_string())
+        .map(|p| {
+            p.rsplit(['/', '\\'])
+                .next()
+                .unwrap_or(p.as_str())
+                .to_string()
+        })
         .unwrap_or_else(|| "agent-yes".to_string());
     eprintln!("{}", build_cwd_migration(&prog, &raw[1..]));
 }
@@ -184,6 +189,16 @@ async fn main() -> Result<()> {
         if !canonical.is_dir() {
             return Err(anyhow::anyhow!("--cwd {:?} is not a directory", requested));
         }
+        // Move the wrapper itself, not just the string we thread downstream. Every
+        // consumer that reads `std::env::current_dir()` instead of taking `cwd` as a
+        // parameter — config_loader's project-config lookup, serve, swarm — would
+        // otherwise resolve against the launch directory while the agent runs
+        // somewhere else, which is precisely the display/search divergence that got
+        // `--cwd` deprecated. Doing it here, before the config load and before either
+        // run path, makes wrapper cwd == agent cwd == recorded cwd by construction —
+        // the same state `cd <dir> && ay …` produces.
+        std::env::set_current_dir(&canonical)
+            .map_err(|e| anyhow::anyhow!("Failed to enter --cwd {:?}: {}", requested, e))?;
         canonical.to_string_lossy().to_string()
     } else {
         std::env::current_dir()
@@ -726,7 +741,10 @@ mod cwd_deprecation_tests {
             "agent-yes",
             &args(&["--cli", "claude", "--cwd", "/ws/app", "-p", "fix"]),
         );
-        assert!(msg.contains("cd /ws/app && agent-yes --cli claude -p fix"), "{msg}");
+        assert!(
+            msg.contains("cd /ws/app && agent-yes --cli claude -p fix"),
+            "{msg}"
+        );
         assert!(msg.contains("--cwd is deprecated"));
     }
 

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -157,8 +157,13 @@ if (config.useRust) {
     // agent so we don't block the parent's tool call for the whole session, then
     // print how to drive it and exit. `--attach`/AGENT_YES_ATTACH=1 opts out.
     const attach = config.attach || process.env.AGENT_YES_ATTACH === "1";
-    const { shouldForkNested, buildSpawnTutorial, waitForRegistration, predictedLogPath } =
-      await import("./forkNested.ts");
+    const {
+      shouldForkNested,
+      buildSpawnTutorial,
+      waitForRegistration,
+      confirmAgentStarted,
+      predictedLogPath,
+    } = await import("./forkNested.ts");
     if (
       shouldForkNested({
         isTTY: Boolean(process.stdout.isTTY),
@@ -196,13 +201,23 @@ if (config.useRust) {
         console.error(deathMsg);
         process.exit(1);
       }
-      forked.unref();
       if (!registered) {
+        forked.unref();
         console.error(
           `Agent pid ${forkedPid} spawned but never became addressable (ay tail/ay send) within 5s.\n` +
             `Log (if written yet): ${predictedLogPath(process.cwd(), forkedPid)}\n` +
             `It may still be starting up — retry: ay tail ${forkedPid}`,
         );
+        process.exit(1);
+      }
+      // Registration only proves the wrapper got far enough to write its record —
+      // the CLI can still die immediately after. Confirm it actually started before
+      // claiming success, or a caller fanning out reads "Spawned pid N" + exit 0 for
+      // a dead agent (#387). Keep the exit/error listeners live until this resolves.
+      const started = await confirmAgentStarted(forkedPid, 1500, () => deathMsg !== null);
+      forked.unref();
+      if (!started.ok) {
+        console.error(deathMsg ?? started.reason);
         process.exit(1);
       }
       console.log(buildSpawnTutorial(config.cli || "agent", forkedPid));

--- a/ts/forkNested.spec.ts
+++ b/ts/forkNested.spec.ts
@@ -1,9 +1,10 @@
-import { appendFileSync, mkdtempSync, rmSync } from "fs";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildSpawnTutorial,
+  confirmAgentStarted,
   predictedLogPath,
   shouldForkNested,
   waitForRegistration,
@@ -91,6 +92,106 @@ describe("waitForRegistration", () => {
     const start = Date.now();
     await expect(waitForRegistration(444, 5000, () => true)).resolves.toBe(false);
     expect(Date.now() - start).toBeLessThan(1000); // no full-timeout wait
+  });
+});
+
+describe("confirmAgentStarted", () => {
+  let home: string;
+  let proj: string;
+  let prevHome: string | undefined;
+
+  const appendPid = (record: Record<string, unknown>) =>
+    appendFileSync(path.join(home, "pids.jsonl"), JSON.stringify(record) + "\n");
+
+  const live = (pid: number, over: Record<string, unknown> = {}) => ({
+    pid,
+    cli: "claude",
+    prompt: null,
+    cwd: proj,
+    log_file: null,
+    status: "active",
+    exit_code: null,
+    exit_reason: null,
+    started_at: Date.now(),
+    ...over,
+  });
+
+  /** Write the raw log the wrapper produces once the CLI is really up. */
+  const writeRawLog = (pid: number, body = "\x1b[?25l hello") => {
+    mkdirSync(path.join(proj, ".agent-yes"), { recursive: true });
+    writeFileSync(predictedLogPath(proj, pid), body);
+  };
+
+  beforeEach(() => {
+    home = mkdtempSync(path.join(tmpdir(), "ay-confirm-home-"));
+    proj = mkdtempSync(path.join(tmpdir(), "ay-confirm-proj-"));
+    prevHome = process.env.AGENT_YES_HOME;
+    process.env.AGENT_YES_HOME = home;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(proj, { recursive: true, force: true });
+  });
+
+  it("fails when the agent flips to exited inside the grace window — the #387 race", async () => {
+    appendPid(live(501));
+    setTimeout(
+      () => appendPid(live(501, { status: "exited", exit_code: 1, exit_reason: "fatal" })),
+      60,
+    );
+    const res = await confirmAgentStarted(501, 2000);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toContain("exited during startup");
+      expect(res.reason).toContain("fatal");
+      expect(res.reason).toContain("ay tail 501");
+    }
+  });
+
+  it("puts the agent's own error output in the failure message", async () => {
+    const errLog = path.join(proj, "boom.log");
+    writeFileSync(errLog, "error: unknown option '--cwd'\n");
+    appendPid(
+      live(502, { status: "exited", exit_code: 1, exit_reason: "fatal", log_file: errLog }),
+    );
+    const res = await confirmAgentStarted(502, 300);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("error: unknown option '--cwd'");
+  });
+
+  it("reports death even when the agent produced output before dying", async () => {
+    writeRawLog(503);
+    appendPid(live(503, { status: "exited", exit_code: 1, exit_reason: "fatal" }));
+    // Liveness must never outrank the failure check within a tick.
+    await expect(confirmAgentStarted(503, 300)).resolves.toMatchObject({ ok: false });
+  });
+
+  it("returns early once the raw log proves the CLI is up", async () => {
+    appendPid(live(504));
+    writeRawLog(504);
+    const start = Date.now();
+    await expect(confirmAgentStarted(504, 5000)).resolves.toEqual({ ok: true });
+    expect(Date.now() - start).toBeLessThan(1000); // did not pay the whole grace
+  });
+
+  it("succeeds at the deadline when the agent is alive but quiet", async () => {
+    appendPid(live(505));
+    await expect(confirmAgentStarted(505, 250)).resolves.toEqual({ ok: true });
+  });
+
+  it("fails when aborted() reports the wrapper already died", async () => {
+    appendPid(live(506));
+    const res = await confirmAgentStarted(506, 5000, () => true);
+    expect(res.ok).toBe(false);
+  });
+
+  it("fails when the record vanished — compaction drops dead+exited agents", async () => {
+    const res = await confirmAgentStarted(507, 300);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("disappeared from the registry");
   });
 });
 

--- a/ts/forkNested.ts
+++ b/ts/forkNested.ts
@@ -76,3 +76,83 @@ export async function waitForRegistration(
 export function predictedLogPath(cwd: string, pid: number): string {
   return path.join(cwd, ".agent-yes", `${pid}.raw.log`);
 }
+
+/** Outcome of {@link confirmAgentStarted}: started, or died with a reason to print. */
+export type StartConfirmation = { ok: true } | { ok: false; reason: string };
+
+/** Last `max` bytes of a file as text, or "" if it can't be read. Used to put the
+ *  agent's own error (e.g. `error: unknown option '--cwd'`) in the failure message
+ *  instead of making the caller go dig for it. */
+async function tailFile(file: string | null | undefined, max = 400): Promise<string> {
+  if (!file) return "";
+  try {
+    const { readFile } = await import("fs/promises");
+    const text = (await readFile(file, "utf8")).trim();
+    return text.length > max ? `…${text.slice(-max)}` : text;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Confirm a just-registered agent actually STARTED, rather than registering and
+ * dying a moment later.
+ *
+ * `waitForRegistration` is necessary but not sufficient: the wrapper writes its
+ * pid record before the target CLI has proven it can run, so a CLI that dies on
+ * startup (bad flag, missing binary) registers as `active` and only flips to
+ * `exited` afterwards. Returning as soon as the record appears therefore printed
+ * a success tutorial and exit 0 for an agent that was already dead — a fan-out
+ * could collapse in silence (#387).
+ *
+ * So after registration we hold a short grace window and watch for death. Failure
+ * is checked BEFORE liveness each tick: an agent that produced output and *then*
+ * died must still be reported dead. The raw-log check is only an early-exit
+ * optimisation — real PTY output means the CLI is up, so healthy spawns usually
+ * return in well under the grace instead of paying all of it. Timing out is
+ * success, keeping the previous behaviour for anything this can't decide.
+ */
+export async function confirmAgentStarted(
+  pid: number,
+  graceMs = 1500,
+  aborted?: () => boolean,
+): Promise<StartConfirmation> {
+  const { readGlobalPids } = await import("./globalPidIndex.ts");
+  const { stat } = await import("fs/promises");
+  const deadline = Date.now() + graceMs;
+
+  while (Date.now() < deadline) {
+    if (aborted?.()) return { ok: false, reason: `Agent pid ${pid} died during startup.` };
+
+    const record = (await readGlobalPids()).find((r) => r.pid === pid);
+    // Gone entirely: compaction drops records that are both dead and exited, so a
+    // vanished record is a death we merely failed to observe — not "keep waiting".
+    if (!record) {
+      return {
+        ok: false,
+        reason: `Agent pid ${pid} disappeared from the registry during startup.`,
+      };
+    }
+    if (record.status === "exited" || record.exit_code !== null) {
+      const why = record.exit_reason ?? `exit code ${record.exit_code}`;
+      const tail = await tailFile(record.log_file);
+      return {
+        ok: false,
+        reason:
+          `Agent pid ${pid} exited during startup (${why}).` +
+          (tail ? `\n${tail}` : "") +
+          `\nSee: ay tail ${pid}`,
+      };
+    }
+    // Positive proof of life: the wrapper only has PTY bytes to write once the CLI
+    // is actually running. Built from the RECORD's cwd, not ours — under `--cwd`
+    // they differ, and that divergence is exactly what this path gets wrong.
+    try {
+      if ((await stat(predictedLogPath(record.cwd, pid))).size > 0) return { ok: true };
+    } catch {
+      // No raw log yet — normal this early; keep watching for death instead.
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
`Fixes #387`, `Fixes #388`。#386 のドキュメント修正で拾いきれなかった、
コード側に残っていた 2 件を直す。

---

## 1. 起動失敗の握り潰し (#387)

detach spawn は pid 登録を確認した時点で成功の tutorial を出していた。
しかし wrapper は**対象 CLI が起動できたことを確認する前に** pid record を書く。
起動時に落ちる CLI は `active` として登録され、その直後に `exited` へ変わる。

子の即死を検出する既存の `deathMsg` 経路 (#151) はあるが、
これは**登録と死亡の競合**であり、登録が先に見えた場合はすり抜ける。
すり抜けると呼び出し側には `Spawned pid N` と exit 0 しか見えないため、
fan-out 全体が無言で空振りする。

### 変更

`ts/forkNested.ts` に `confirmAgentStarted` を追加し、
`waitForRegistration` の後に短い猶予時間だけ死亡を監視する。

| 判定 | 挙動 |
|---|---|
| `aborted()` (wrapper 死亡) | 失敗 |
| `status === "exited"` または `exit_code !== null` | 失敗 |
| record が消えた | 失敗 (compaction は dead かつ exited の record を落とすので、消失 = 観測し損ねた死亡) |
| `.raw.log` に出力あり | **即座に成功** |
| 猶予時間切れ | 成功 (従来どおり) |

- 各 tick で**生存確認より先に失敗を判定する**。出力を出してから死んだ
  エージェントも死亡として報告する
- `.raw.log` の判定は早期脱出の最適化であり、正しさは失敗判定側が担保する。
  健全な spawn は猶予時間を待たずに返る (実測 442ms)
- raw log のパスは `process.cwd()` ではなく **record の cwd** から組み立てる。
  `--cwd` 指定時に両者は食い違い、その食い違いこそがこの経路の不具合そのもの

失敗時は `exit_reason` と `log_file` の末尾 (対象 CLI 自身のエラー文言が
出ている場所) を添えて非ゼロ終了する。

### 確認

再現コマンドが非ゼロ終了で失敗を報告するようになった:

```
$ cd /tmp && ay claude --model sonnet --cwd <D> -- "pwd"
Agent exited immediately (code 1). See: ay tail 19004
$ echo $?
1
```

競合そのもの (登録が先に見えるケース) は timing 依存で e2e では
再現が安定しないため、`forkNested.spec.ts` に 7 件の決定的なテストを追加した。

---

## 2. wrapper が chdir しない (#388)

`--cwd <dir>` は解決した cwd を**文字列として下流に引き回すだけ**で、
wrapper プロセス自身は起動元ディレクトリに留まっていた。

そのため `cwd` を引数で受け取らず `std::env::current_dir()` を直接読む箇所は、
エージェントの実際の作業ディレクトリではなく `ay` を起動したディレクトリを見る
(`config_loader`、`serve`、`swarm` など)。`config_loader` が該当する影響は特に大きく、
`--cwd` 指定時に**別ディレクトリのプロジェクト設定を読んでしまう**。

### 変更

canonicalize と `is_dir` 検査の直後、設定読み込みより前、
`swarm`/`run_agent` のいずれの経路に入るより前に `set_current_dir` を呼ぶ。
wrapper の cwd == エージェントの cwd == 登録される cwd が構造的に一致し、
`cd <dir> && ay …` と同じ状態になる。

### 確認

```
$ cd /tmp && ay claude --cwd <D> -- "pwd"
$ lsof -a -p <wrapper_pid> -d cwd
agent-yes 22967 sno cwd DIR ... <D>      # 従来は /tmp
```

---

## 方針についての注記

**`--cwd` は非推奨のまま**であり、非推奨警告もそのまま維持する。
本 PR は `--cwd` を一等市民に戻すものではなく、
フラグがコードに残っている限り踏める不具合を潰すもの (#386 の方針は変更なし)。

clap の `trailing_var_arg` による `--cwd` の転送 (`ay claude --model X --cwd D`) も
issue 化しておらず、ドキュメント側で解決済みのため触っていない。
ただし #387 の修正により、この形は**無言で失敗せず、非ゼロ終了で失敗を報告する**ようになる。

## テスト

- TS: 1399 passed / 1 skipped、カバレッジ閾値 (90%) 通過。`forkNested.ts` は 97.82%
- Rust: unit 172 passed、integration 10 passed
  (`test_cwd_flag_overrides_current_dir` / `test_cwd_is_preserved` /
  `test_cwd_flag_rejects_missing_directory` を含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)