### PR TITLE
fix(rs): Rust 側 SUBCOMMANDS の TS からのドリフトを解消し、ミラー検証テストを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.test.local
 .env.production.local
 .env.local
+# generated CODEX_HOME for `ay deepseek` (scripts/deepseek-codex.ts) — holds a
+# config pointing at the DeepSeek endpoint, never commit it
+.codex-deepseek/
 
 # caches
 .eslintcache

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -21,8 +21,9 @@ use std::env;
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "whoami", "result", "notify", "notifyd", "read", "cat", "tail",
-    "head", "send", "msgs", "spawn", "attach", "stop", "exit", "restart", "note", "ch", "channels",
-    "term", "widget", "mint", "serve", "schedule", "remote", "expose", "callback", "reap", "help",
+    "head", "send", "key", "select", "msgs", "spawn", "attach", "stop", "exit", "restart", "note",
+    "todo", "ch", "channels", "term", "widget", "mint", "serve", "tray", "schedule", "remote",
+    "expose", "callback", "reap", "deepseek", "ds", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, rm, utimes, writeFile } from "fs/promises";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "fs/promises";
 import { appendFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
@@ -121,6 +121,8 @@ describe("subcommands.isSubcommand", () => {
     expect(isSubcommand("stop")).toBe(true);
     expect(isSubcommand("tail")).toBe(true);
     expect(isSubcommand("send")).toBe(true);
+    expect(isSubcommand("deepseek")).toBe(true);
+    expect(isSubcommand("ds")).toBe(true);
     expect(isSubcommand("not-a-command")).toBe(false);
     expect(isSubcommand(undefined)).toBe(false);
   });
@@ -136,6 +138,35 @@ describe("subcommands.isSubcommand", () => {
     // Inspection subcommands stay universal — `cy ls` / `cy send` still work.
     expect(isSubcommand("ls", false)).toBe(true);
     expect(isSubcommand("send", false)).toBe(true);
+  });
+});
+
+describe("subcommands ↔ rs/src/cli.rs subcommand mirror", () => {
+  // The Rust runner keeps its OWN hardcoded copy of both lists (it must decide
+  // whether to re-exec the JS launcher before clap swallows the word as prompt
+  // text). Nothing enforced that copy, so it silently drifted: `key`, `select`,
+  // `todo`, `tray`, `deepseek` and `ds` existed only on the TS side, and running
+  // them on the Rust binary directly launched an agent with the subcommand as
+  // its prompt. Parse both sources and require them to stay identical.
+  const names = (src: string, re: RegExp): string[] =>
+    [...(src.match(re)?.[1] ?? "").matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
+
+  it("keeps SUBCOMMANDS and MANAGER_SUBCOMMANDS identical in both runtimes", async () => {
+    const ts = await readFile(new URL("./subcommands.ts", import.meta.url), "utf8");
+    const rs = await readFile(new URL("../rs/src/cli.rs", import.meta.url), "utf8");
+    expect(names(rs, /pub const SUBCOMMANDS: &\[&str\] = &\[([\s\S]*?)\];/)).toEqual(
+      names(ts, /const SUBCOMMANDS = new Set\(\[([\s\S]*?)\]\)/),
+    );
+    expect(names(rs, /pub const MANAGER_SUBCOMMANDS: &\[&str\] = &\[([\s\S]*?)\];/)).toEqual(
+      names(ts, /const MANAGER_SUBCOMMANDS = new Set\(\[([\s\S]*?)\]\)/),
+    );
+  });
+
+  it("actually parsed something (guards against a regex that silently matches nothing)", async () => {
+    const rs = await readFile(new URL("../rs/src/cli.rs", import.meta.url), "utf8");
+    expect(names(rs, /pub const SUBCOMMANDS: &\[&str\] = &\[([\s\S]*?)\];/).length).toBeGreaterThan(
+      20,
+    );
   });
 });
 


### PR DESCRIPTION
## 問題

`rs/src/cli.rs` は「clap が prompt として飲み込む前に JS ランチャへ re-exec するか」を判断するため、`SUBCOMMANDS` 一覧を**独自にハードコードで**持っている（コメント上も "MUST mirror ts/subcommands.ts" と書かれている）。しかしこの写しを強制する仕組みが無く、実際にドリフトしていた。

TS にしか無かったもの **6 件**:

```
key, select, todo, tray, deepseek, ds
```

### 影響（潜在的）

JS shim を経由しない Rust バイナリ直接実行では委譲されず、サブコマンド名がそのまま prompt 扱いになる。

```
agent-yes deepseek   # → 「deepseek」を prompt にした claude が起動してしまう
```

`ay` / `cy` 経由では TS 側が先に受けるため表面化していなかった（= 潜在バグ）。

## 変更

1. `rs/src/cli.rs` の `SUBCOMMANDS` を `ts/subcommands.ts` と一致させる（38 件）
2. **ミラー検証テストを追加** — 両ファイルを実際に読んでリストを突き合わせる。ドリフトしたら落ちる
3. `ay deepseek` / `ds` の `isSubcommand` アサーションを追加
4. `.codex-deepseek/`（`scripts/deepseek-codex.ts` が生成する CODEX_HOME、DeepSeek エンドポイント設定を含む）を `.gitignore` に追加

`MANAGER_SUBCOMMANDS`（`setup` / `ws`）は元から一致していたが、同じテストで併せて検証する。

## 検証

- `vitest ts/subcommands.spec.ts` 128 passed
- **ミラーテストが実際に落ちることを確認**: Rust 側から `"ds"` を 1 件消す → 該当テストのみ fail、戻すと pass（落ちないテストは無意味なため）
- `cargo test --bin agent-yes cli::` 37 passed
- `cargo fmt --check` で `cli.rs` の指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)