### PR TITLE
fix(cwd): --cwd を agent-yes のフラグから外し、CLI へそのまま渡す

### DIFF
--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -202,8 +202,6 @@ pub struct CliArgs {
     pub queue: bool,
     pub use_skills: bool,
     pub skip_permissions: bool,
-    /// Working directory to run the agent in. None = use process current_dir.
-    pub cwd: Option<String>,
     /// Force raw TUI passthrough even when stdout is not a TTY.
     pub force_tty: bool,
     /// Force plain rendered text output even when stdout is a TTY.
@@ -281,10 +279,6 @@ struct Args {
     /// Pass --dangerously-skip-permissions to the CLI
     #[arg(short = 'y', long = "yes", default_value = "false")]
     yes: bool,
-
-    /// Deprecated: working directory for the agent. Prefer `cd <dir> && <command>`.
-    #[arg(long)]
-    cwd: Option<String>,
 
     /// Force raw TUI passthrough even when stdout is not a TTY (piped/redirected)
     #[arg(long = "force-tty", default_value = "false")]
@@ -399,7 +393,6 @@ fn resolve_args(args: Args, exe_name: &str) -> Result<CliArgs> {
         queue: args.queue,
         use_skills: args.use_skills,
         skip_permissions: args.yes,
-        cwd: args.cwd,
         force_tty: args.force_tty,
         no_tty: args.no_tty,
         swarm,
@@ -765,7 +758,6 @@ mod tests {
             queue: false,
             use_skills: false,
             yes: false,
-            cwd: None,
             force_tty: false,
             no_tty: false,
             swarm: None,
@@ -913,17 +905,16 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_args_cwd_default_none() {
-        let result = resolve_args(default_args(), "agent-yes").unwrap();
-        assert!(result.cwd.is_none());
-    }
-
-    #[test]
-    fn test_resolve_args_cwd_explicit() {
+    fn test_resolve_args_cwd_is_forwarded_to_the_cli() {
+        // `--cwd` is not an agent-yes flag: it rides along to the target CLI like
+        // any other unknown option, so agent-yes never has a cwd but its own.
         let mut args = default_args();
-        args.cwd = Some("/tmp".into());
+        args.args = vec!["--cwd".into(), "/tmp".into()];
         let result = resolve_args(args, "agent-yes").unwrap();
-        assert_eq!(result.cwd, Some("/tmp".into()));
+        assert_eq!(
+            result.cli_args,
+            vec!["--cwd".to_string(), "/tmp".to_string()]
+        );
     }
 
     #[test]

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -65,17 +65,25 @@ fn shell_display_quote(s: &str) -> String {
     }
 }
 
-/// Build the `--cwd` deprecation warning from a program name and its user args
-/// (everything after argv[0]). Strips `--cwd <dir>` / `--cwd=<dir>` and rebuilds
-/// the copy-pasteable `cd <dir> && <same command>` hint. Pure so it can be unit
-/// tested. Mirrors detectCwdDeprecation in ts/cwdDeprecation.ts.
-fn build_cwd_migration(prog: &str, user_args: &[String]) -> String {
+/// Build the `--cwd` hint from a program name and its user args (everything after
+/// argv[0]). Strips `--cwd <dir>` / `--cwd=<dir>` and rebuilds the copy-pasteable
+/// `cd <dir> && <same command>` line. Returns None when no `--cwd` appears before
+/// the `--` separator — past it the token belongs to the CLI or the prompt, and
+/// agent-yes has no business reading it. Pure so it can be unit tested. Mirrors
+/// detectCwdDeprecation in ts/cwdDeprecation.ts.
+fn build_cwd_migration(prog: &str, user_args: &[String]) -> Option<String> {
+    let end = user_args
+        .iter()
+        .position(|a| a == "--")
+        .unwrap_or(user_args.len());
     let mut dir: Option<String> = None;
     let mut rest: Vec<String> = Vec::new();
+    let mut saw = false;
     let mut i = 0;
     while i < user_args.len() {
         let arg = &user_args[i];
-        if arg == "--cwd" {
+        if i < end && arg == "--cwd" {
+            saw = true;
             // `--cwd DIR` — consume the value unless the next token is a flag.
             if let Some(next) = user_args.get(i + 1) {
                 if !next.starts_with('-') {
@@ -87,13 +95,19 @@ fn build_cwd_migration(prog: &str, user_args: &[String]) -> String {
             i += 1;
             continue;
         }
-        if let Some(v) = arg.strip_prefix("--cwd=") {
-            dir = Some(v.to_string());
-            i += 1;
-            continue;
+        if i < end {
+            if let Some(v) = arg.strip_prefix("--cwd=") {
+                saw = true;
+                dir = Some(v.to_string());
+                i += 1;
+                continue;
+            }
         }
         rest.push(arg.clone());
         i += 1;
+    }
+    if !saw {
+        return None;
     }
 
     let mut cmd = shell_display_quote(prog);
@@ -106,18 +120,18 @@ fn build_cwd_migration(prog: &str, user_args: &[String]) -> String {
         Some(ref d) => shell_display_quote(d),
         None => "<dir>".to_string(),
     };
-    format!(
-        "\x1b[33m⚠ --cwd is deprecated.\x1b[0m Run the command in the target directory instead:\n\n    cd {dir_disp} && {cmd}"
-    )
+    Some(format!(
+        "\x1b[33m⚠ --cwd is not an agent-yes flag\x1b[0m — it is passed straight through to the CLI. To run the agent somewhere else:\n\n    cd {dir_disp} && {cmd}"
+    ))
 }
 
-/// `--cwd <dir>` on an agent run is deprecated: `cd <dir> && <same command>`
-/// does the same thing without an agent-yes-specific flag. Print the migration
-/// hint before continuing (the flag still works). The JS launcher prints its own
-/// (more faithful, it knows the `cy`/`ay` name the user typed) copy and sets
-/// AGENT_YES_SUPPRESS_CWD_WARN so this mirror only fires on a direct
-/// `agent-yes … --cwd` invocation that bypassed the launcher.
-fn warn_cwd_deprecated() {
+/// `--cwd <dir>` is not an agent-yes flag: it rides along to the target CLI like
+/// any other unknown option, so the agent runs wherever `ay` was invoked. Print
+/// the `cd <dir> && <same command>` hint so that's not a surprise, then continue.
+/// The JS launcher prints its own (more faithful — it knows the `cy`/`ay` name the
+/// user typed) copy and sets AGENT_YES_SUPPRESS_CWD_WARN, so this mirror only
+/// fires on a direct `agent-yes … --cwd` invocation that bypassed the launcher.
+fn warn_cwd_passthrough() {
     if std::env::var_os("AGENT_YES_SUPPRESS_CWD_WARN").is_some() {
         return;
     }
@@ -131,7 +145,9 @@ fn warn_cwd_deprecated() {
                 .to_string()
         })
         .unwrap_or_else(|| "agent-yes".to_string());
-    eprintln!("{}", build_cwd_migration(&prog, &raw[1..]));
+    if let Some(msg) = build_cwd_migration(&prog, &raw[1..]) {
+        eprintln!("{msg}");
+    }
 }
 
 #[tokio::main]
@@ -143,6 +159,12 @@ async fn main() -> Result<()> {
     if let Some(code) = cli::maybe_delegate_subcommand() {
         std::process::exit(code);
     }
+
+    // `--cwd` reads like an agent-yes flag but isn't one — it is forwarded to the
+    // target CLI, so the agent runs wherever `ay` was invoked. Point at `cd` before
+    // that surprises anyone. Runs AFTER the subcommand delegation above, so the
+    // `--cwd` FILTER on `ay ls/status/spawn/schedule` never reaches this.
+    warn_cwd_passthrough();
 
     // Parse CLI arguments
     let args = cli::parse_args()?;
@@ -157,55 +179,15 @@ async fn main() -> Result<()> {
         install_method
     );
 
-    // Resolve working directory: --cwd flag overrides, else use process current_dir.
-    // Canonicalise to an absolute path so downstream consumers (pid_store, lock keys,
-    // webhooks) see a stable identifier regardless of how the user typed it.
-    let cwd = if let Some(ref requested) = args.cwd {
-        warn_cwd_deprecated();
-        // Expand leading `~` / `~/` because shells (zsh, bash) do NOT expand a tilde
-        // that appears after `=` (e.g. `--cwd=~/foo` arrives literally). Only the
-        // user's own `~` is supported; `~user` is not.
-        let expanded = if requested == "~" {
-            dirs::home_dir()
-                .map(|h| h.to_string_lossy().to_string())
-                .ok_or_else(|| {
-                    anyhow::anyhow!("Invalid --cwd \"~\": cannot resolve home directory")
-                })?
-        } else if let Some(rest) = requested.strip_prefix("~/") {
-            let home = dirs::home_dir().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Invalid --cwd {:?}: cannot resolve home directory",
-                    requested
-                )
-            })?;
-            home.join(rest).to_string_lossy().to_string()
-        } else {
-            requested.clone()
-        };
-        let path = std::path::PathBuf::from(&expanded);
-        let canonical = path
-            .canonicalize()
-            .map_err(|e| anyhow::anyhow!("Invalid --cwd {:?}: {}", requested, e))?;
-        if !canonical.is_dir() {
-            return Err(anyhow::anyhow!("--cwd {:?} is not a directory", requested));
-        }
-        // Move the wrapper itself, not just the string we thread downstream. Every
-        // consumer that reads `std::env::current_dir()` instead of taking `cwd` as a
-        // parameter — config_loader's project-config lookup, serve, swarm — would
-        // otherwise resolve against the launch directory while the agent runs
-        // somewhere else, which is precisely the display/search divergence that got
-        // `--cwd` deprecated. Doing it here, before the config load and before either
-        // run path, makes wrapper cwd == agent cwd == recorded cwd by construction —
-        // the same state `cd <dir> && ay …` produces.
-        std::env::set_current_dir(&canonical)
-            .map_err(|e| anyhow::anyhow!("Failed to enter --cwd {:?}: {}", requested, e))?;
-        canonical.to_string_lossy().to_string()
-    } else {
-        std::env::current_dir()
-            .map_err(|e| anyhow::anyhow!("Failed to get current working directory: {}", e))?
-            .to_string_lossy()
-            .to_string()
-    };
+    // The agent always runs where the wrapper runs. There is no flag that moves it
+    // (`--cwd` is forwarded to the CLI, see warn_cwd_passthrough), so the wrapper's
+    // own cwd, the agent's cwd and the recorded cwd cannot drift apart — the
+    // divergence that used to break display and search on agent-yes.com is
+    // unreachable rather than merely fixed. To run elsewhere: `cd <dir> && ay …`.
+    let cwd = std::env::current_dir()
+        .map_err(|e| anyhow::anyhow!("Failed to get current working directory: {}", e))?
+        .to_string_lossy()
+        .to_string();
 
     // Check for swarm mode (new --swarm flag or deprecated --experimental-swarm)
     if args.swarm.is_some() {
@@ -719,7 +701,7 @@ async fn run_swarm_mode(args: CliArgs, cwd: &str) -> Result<i32> {
 }
 
 #[cfg(test)]
-mod cwd_deprecation_tests {
+mod cwd_passthrough_tests {
     use super::{build_cwd_migration, shell_display_quote};
 
     fn args(parts: &[&str]) -> Vec<String> {
@@ -740,29 +722,45 @@ mod cwd_deprecation_tests {
         let msg = build_cwd_migration(
             "agent-yes",
             &args(&["--cli", "claude", "--cwd", "/ws/app", "-p", "fix"]),
-        );
+        )
+        .expect("--cwd before `--` should produce a hint");
         assert!(
             msg.contains("cd /ws/app && agent-yes --cli claude -p fix"),
             "{msg}"
         );
-        assert!(msg.contains("--cwd is deprecated"));
+        assert!(msg.contains("--cwd is not an agent-yes flag"));
     }
 
     #[test]
     fn strips_cwd_equals_form() {
-        let msg = build_cwd_migration("agent-yes", &args(&["--cwd=/tmp/x", "codex"]));
+        let msg = build_cwd_migration("agent-yes", &args(&["--cwd=/tmp/x", "codex"])).unwrap();
         assert!(msg.contains("cd /tmp/x && agent-yes codex"), "{msg}");
     }
 
     #[test]
     fn keeps_home_relative_dir_bare() {
-        let msg = build_cwd_migration("agent-yes", &args(&["--cwd", "~/ws/product"]));
+        let msg = build_cwd_migration("agent-yes", &args(&["--cwd", "~/ws/product"])).unwrap();
         assert!(msg.contains("cd ~/ws/product && agent-yes"), "{msg}");
     }
 
     #[test]
     fn placeholder_when_value_missing() {
-        let msg = build_cwd_migration("agent-yes", &args(&["--cli", "claude", "--cwd"]));
+        let msg = build_cwd_migration("agent-yes", &args(&["--cli", "claude", "--cwd"])).unwrap();
         assert!(msg.contains("cd <dir> && agent-yes --cli claude"), "{msg}");
+    }
+
+    #[test]
+    fn no_hint_when_cwd_is_absent() {
+        assert!(build_cwd_migration("agent-yes", &args(&["claude", "-p", "fix"])).is_none());
+    }
+
+    #[test]
+    fn no_hint_for_cwd_after_the_separator() {
+        // Past `--` the token is the CLI's or the prompt's, not a misplaced flag —
+        // and it is forwarded verbatim either way, so there is nothing to suggest.
+        assert!(
+            build_cwd_migration("agent-yes", &args(&["claude", "--", "--cwd", "/ws/app"]))
+                .is_none()
+        );
     }
 }

--- a/rs/tests/integration_tests.rs
+++ b/rs/tests/integration_tests.rs
@@ -458,94 +458,6 @@ fn test_cwd_is_preserved() {
     );
 }
 
-#[cfg(unix)] // relies on a bash mock CLI (chmod +x, `:` PATH separator)
-#[test]
-fn test_cwd_flag_overrides_current_dir() {
-    // Verify that --cwd <path> makes the agent run in <path>, even when
-    // agent-yes itself was invoked from a different directory.
-    let temp_dir = tempdir().unwrap();
-    let invocation_dir = temp_dir.path().join("invocation");
-    let target_dir = temp_dir.path().join("target_workspace");
-    fs::create_dir(&invocation_dir).unwrap();
-    fs::create_dir(&target_dir).unwrap();
-
-    let bin_dir = temp_dir.path().join("bin");
-    fs::create_dir(&bin_dir).unwrap();
-    let _mock_cli_path = create_cwd_printing_cli(&bin_dir, "claude");
-
-    let original_path = std::env::var("PATH").unwrap_or_default();
-    let new_path = format!("{}:{}", bin_dir.display(), original_path);
-
-    let home_dir = temp_dir.path().join("home");
-    fs::create_dir_all(&home_dir).unwrap();
-
-    let mut cmd = cargo_bin_cmd!("agent-yes");
-    cmd.current_dir(&invocation_dir)
-        .env("PATH", new_path)
-        .env("HOME", &home_dir)
-        .arg("--cli")
-        .arg("claude")
-        .arg("--cwd")
-        .arg(&target_dir)
-        .arg("--timeout")
-        .arg("5s")
-        .arg("-p")
-        .arg("test");
-
-    let output = cmd.output().unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    let expected_pwd = target_dir.canonicalize().unwrap();
-    let unexpected_pwd = invocation_dir.canonicalize().unwrap();
-
-    assert!(
-        stdout.contains(&format!("PWD: {}", expected_pwd.display()))
-            || stderr.contains(&format!("PWD: {}", expected_pwd.display())),
-        "Expected PWD: {} but got stdout:\n{}\nstderr:\n{}",
-        expected_pwd.display(),
-        stdout,
-        stderr
-    );
-
-    // And make sure it's NOT the invocation dir
-    assert!(
-        !stdout.contains(&format!("PWD: {}", unexpected_pwd.display()))
-            && !stderr.contains(&format!("PWD: {}", unexpected_pwd.display())),
-        "Expected PWD to differ from invocation dir {}",
-        unexpected_pwd.display(),
-    );
-}
-
-#[cfg(unix)] // relies on a bash mock CLI (chmod +x, `:` PATH separator)
-#[test]
-fn test_cwd_flag_rejects_missing_directory() {
-    // --cwd pointing at a nonexistent path should make agent-yes fail fast.
-    let temp_dir = tempdir().unwrap();
-    let missing = temp_dir.path().join("does-not-exist");
-
-    let bin_dir = temp_dir.path().join("bin");
-    fs::create_dir(&bin_dir).unwrap();
-    let _mock_cli_path = create_cwd_printing_cli(&bin_dir, "claude");
-
-    let original_path = std::env::var("PATH").unwrap_or_default();
-    let new_path = format!("{}:{}", bin_dir.display(), original_path);
-    let home_dir = temp_dir.path().join("home");
-    fs::create_dir_all(&home_dir).unwrap();
-
-    let mut cmd = cargo_bin_cmd!("agent-yes");
-    cmd.env("PATH", new_path)
-        .env("HOME", &home_dir)
-        .arg("--cli")
-        .arg("claude")
-        .arg("--cwd")
-        .arg(&missing)
-        .arg("-p")
-        .arg("test");
-
-    cmd.assert().failure();
-}
-
 /// Integration test: `agent-yes` creates project-local logs, a per-pid
 /// global FIFO, and registers both absolute paths in `~/.agent-yes/pids.jsonl`
 /// populated. End-to-end byte flow through the FIFO is covered by the
@@ -670,4 +582,80 @@ exit 0
             "expected raw log to be removed after render, still present at {raw_log}"
         );
     }
+}
+
+/// Mock CLI that echoes the argv it was handed, so a test can assert exactly
+/// what agent-yes forwarded to the target CLI.
+#[cfg(unix)]
+fn create_arg_printing_cli(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let script_path = dir.join(name);
+    let mut file = File::create(&script_path).unwrap();
+    writeln!(
+        file,
+        r#"#!/usr/bin/env bash
+echo "ARGV: $*"
+# Print ready pattern so agent-yes doesn't timeout
+echo "? for shortcuts"
+sleep 1
+exit 0
+"#
+    )
+    .unwrap();
+
+    let mut perms = fs::metadata(&script_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script_path, perms).unwrap();
+
+    script_path
+}
+
+#[cfg(unix)] // relies on a bash mock CLI (chmod +x, `:` PATH separator)
+#[test]
+fn test_cwd_flag_is_forwarded_to_the_cli() {
+    // `--cwd` is NOT an agent-yes flag. It rides along to the target CLI like any
+    // other unknown option, and the agent runs where the wrapper runs — so the
+    // wrapper cwd, the agent cwd and the recorded cwd can never drift apart.
+    // To run somewhere else: `cd <dir> && ay …`.
+    let temp_dir = tempdir().unwrap();
+    let invocation_dir = temp_dir.path().join("invocation");
+    let other_dir = temp_dir.path().join("other_workspace");
+    fs::create_dir(&invocation_dir).unwrap();
+    fs::create_dir(&other_dir).unwrap();
+
+    let bin_dir = temp_dir.path().join("bin");
+    fs::create_dir(&bin_dir).unwrap();
+    let _mock_cli_path = create_arg_printing_cli(&bin_dir, "claude");
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), original_path);
+    let home_dir = temp_dir.path().join("home");
+    fs::create_dir_all(&home_dir).unwrap();
+
+    let mut cmd = cargo_bin_cmd!("agent-yes");
+    cmd.current_dir(&invocation_dir)
+        .env("PATH", new_path)
+        .env("HOME", &home_dir)
+        .arg("--cli")
+        .arg("claude")
+        .arg("--timeout")
+        .arg("5s")
+        .arg("--cwd")
+        .arg(&other_dir);
+
+    let output = cmd.output().expect("failed to run agent-yes");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.contains("--cwd"),
+        "--cwd should reach the CLI verbatim.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    // And the hint should point at the shell equivalent instead.
+    assert!(
+        stderr.contains("--cwd is not an agent-yes flag"),
+        "expected the cd hint.\nstderr: {}",
+        stderr
+    );
 }

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -63,11 +63,12 @@ import { buildRustArgs } from "./buildRustArgs.ts";
   }
 }
 
-// Deprecation: `--cwd <dir>` on an agent run. Runs AFTER the subcommand fast
+// `--cwd <dir>` on an agent run reads like an agent-yes flag but isn't one — it
+// is forwarded to the target CLI, so the agent runs wherever `ay` was invoked.
+// Point at `cd <dir> && …` once, then continue. Runs AFTER the subcommand fast
 // path above, so subcommand `--cwd` FILTERS (ay ls/status/spawn/schedule) are
-// untouched — only a real agent launch reaches here. Warn once, then continue
-// (the flag still works); suppress the Rust runner's mirror of this warning so
-// it isn't printed twice when we spawn the Rust binary below.
+// untouched — only a real agent launch reaches here. Suppress the Rust runner's
+// mirror of this hint so it isn't printed twice when we spawn the binary below.
 {
   const { detectCwdDeprecation, SUPPRESS_CWD_WARN_ENV } = await import("./cwdDeprecation.ts");
   const dep = detectCwdDeprecation(process.argv);

--- a/ts/cwdDeprecation.spec.ts
+++ b/ts/cwdDeprecation.spec.ts
@@ -55,9 +55,20 @@ describe("detectCwdDeprecation", () => {
     expect(dep!.suggestion).toBe("cd <dir> && cy claude");
   });
 
-  it("includes the deprecation notice in the message", () => {
+  it("says the flag is passed through, not handled", () => {
     const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/ws"));
-    expect(dep!.message).toContain("--cwd is deprecated");
+    expect(dep!.message).toContain("--cwd is not an agent-yes flag");
     expect(dep!.message).toContain("cd /ws && cy");
+  });
+
+  it("ignores a --cwd that appears after `--`", () => {
+    // Past the separator the token belongs to the CLI or the prompt. It is
+    // forwarded verbatim either way, so there is nothing to suggest.
+    expect(
+      detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--", "--cwd", "/ws/app")),
+    ).toBeNull();
+    expect(
+      detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--", "run with --cwd=/ws")),
+    ).toBeNull();
   });
 });

--- a/ts/cwdDeprecation.ts
+++ b/ts/cwdDeprecation.ts
@@ -1,25 +1,31 @@
 /**
- * `--cwd <dir>` on an agent run is deprecated.
+ * `--cwd <dir>` on an agent run is NOT an agent-yes flag.
  *
- * It used to pick the directory the agent runs in. The shell already does this
- * better: `cd <dir> && <same command>` puts the agent AND every relative path in
- * the command in the same place, with no agent-yes-specific flag to remember.
- * This module detects the flag on a raw argv and builds the copy-pasteable
- * migration hint we print before continuing (the flag still works for now).
+ * It once selected the directory the agent runs in. It no longer does: agent-yes
+ * forwards it to the target CLI like any other unknown option, so the agent runs
+ * wherever `ay` was invoked and the CLI decides what `--cwd` means (usually:
+ * rejects it). Because agent-yes never handles a cwd but its own process cwd, the
+ * wrapper cwd / agent cwd / recorded cwd cannot drift apart.
  *
- * Scope: the agent-run path only (ts/cli.ts). Management subcommands that take a
- * `--cwd` FILTER (`ay ls/status/spawn/schedule …`) are a different flag and are
- * not deprecated — they never reach this code because subcommands are dispatched
- * earlier. The Rust runner mirrors this warning in rs/src/main.rs for direct
- * `agent-yes` invocations that bypass this launcher.
+ * The shell does this job better anyway: `cd <dir> && <same command>` puts the
+ * agent AND every relative path in the command in the same place, with no
+ * agent-yes-specific flag to remember. This module detects the flag on a raw argv
+ * and builds the copy-pasteable hint we print before continuing.
+ *
+ * Scope: the agent-run path only (ts/cli.ts), and only tokens BEFORE `--` —
+ * past the separator the token belongs to the CLI or the prompt. Management
+ * subcommands that take a `--cwd` FILTER (`ay ls/status/spawn/schedule …`) are a
+ * different flag and are unaffected — they never reach this code because
+ * subcommands are dispatched earlier. The Rust runner mirrors this hint in
+ * rs/src/main.rs for direct `agent-yes` invocations that bypass this launcher.
  */
 
-/** Env var the JS launcher sets on the spawned Rust child so the warning, once
+/** Env var the JS launcher sets on the spawned Rust child so the hint, once
  * printed here, is not printed a second time by the Rust runner. Mirrored in
  * rs/src/main.rs. */
 export const SUPPRESS_CWD_WARN_ENV = "AGENT_YES_SUPPRESS_CWD_WARN";
 
-export interface CwdDeprecation {
+export interface CwdPassthroughHint {
   /** The directory value the user passed to --cwd (undefined if the flag had no value). */
   dir: string | undefined;
   /** The suggested replacement command line, e.g. `cd ~/foo && cy claude -- fix`. */
@@ -49,20 +55,24 @@ function programName(scriptPath: string | undefined): string {
 }
 
 /**
- * Detect a deprecated `--cwd <dir>` / `--cwd=<dir>` flag on a full process.argv
- * (`[exec, script, ...userArgs]`). Returns the migration hint, or null when no
- * `--cwd` flag is present.
+ * Detect a `--cwd <dir>` / `--cwd=<dir>` token on a full process.argv
+ * (`[exec, script, ...userArgs]`). Returns the hint, or null when no `--cwd`
+ * appears before the `--` separator.
  */
-export function detectCwdDeprecation(argv: string[]): CwdDeprecation | null {
+export function detectCwdDeprecation(argv: string[]): CwdPassthroughHint | null {
   const prog = programName(argv[1]);
   const userArgs = argv.slice(2);
+  // Past `--` the token is the CLI's or the prompt's — forwarded verbatim either
+  // way, so there is nothing to suggest and nothing to strip.
+  const sepIndex = userArgs.indexOf("--");
+  const optionEnd = sepIndex === -1 ? userArgs.length : sepIndex;
 
   let sawCwd = false;
   let dir: string | undefined;
   const rest: string[] = [];
   for (let i = 0; i < userArgs.length; i++) {
     const arg = userArgs[i]!;
-    if (arg === "--cwd") {
+    if (i < optionEnd && arg === "--cwd") {
       sawCwd = true;
       const next = userArgs[i + 1];
       // `--cwd DIR` — consume the value; a following flag means the value is missing.
@@ -72,7 +82,7 @@ export function detectCwdDeprecation(argv: string[]): CwdDeprecation | null {
       }
       continue;
     }
-    if (arg.startsWith("--cwd=")) {
+    if (i < optionEnd && arg.startsWith("--cwd=")) {
       sawCwd = true;
       dir = arg.slice("--cwd=".length);
       continue;
@@ -86,7 +96,8 @@ export function detectCwdDeprecation(argv: string[]): CwdDeprecation | null {
   const dirDisplay = dir === undefined ? "<dir>" : shellDisplayQuote(dir);
   const suggestion = `cd ${dirDisplay} && ${cmd}`;
   const message =
-    `\x1b[33m⚠ --cwd is deprecated.\x1b[0m Run the command in the target directory instead:\n\n` +
+    `\x1b[33m⚠ --cwd is not an agent-yes flag\x1b[0m — it is passed straight through to the CLI. ` +
+    `To run the agent somewhere else:\n\n` +
     `    ${suggestion}`;
   return { dir, suggestion, message };
 }


### PR DESCRIPTION
`--cwd` を agent-yes 側で特別扱いするのをやめ、`--model` など他の未知のオプションと
同様に対象 CLI へ転送する。エージェントは常に `ay` を起動したディレクトリで動く。
別のディレクトリで動かすには `cd <dir> && ay …`。

## 経緯

`--cwd` は非推奨 (#386) だったが、「引数の並び順が正しければ動く」状態が残っていた。

| コマンド | これまでの挙動 |
|---|---|
| `ay claude --cwd D -- "p"` | agent-yes が解析して**動く** |
| `ay claude --model X --cwd D -- "p"` | clap の `trailing_var_arg` が `--model` 以降を後続引数として扱い CLI へ転送 → CLI が落ちる |

同じフラグが並び順だけで挙動を変えるのは非推奨として中途半端であり、
「たまに動く」ぶん誤用を誘発していた。特別扱いをやめれば並び順に関係なく挙動は一つになる。

## 変更

- **`rs/src/cli.rs`** — clap の `--cwd` 定義と `CliArgs::cwd` を削除。
  `--cwd` は `trailing_var_arg` / `allow_hyphen_values` の後続引数に収集され、
  **位置に関係なく** CLI へ転送される
- **`rs/src/main.rs`** — cwd 解決分岐 (`~` 展開・canonicalize・`is_dir` 検査・
  `set_current_dir`) を削除。cwd は常に `current_dir()`。
  ヒントは分岐の中から呼んでいたため、起動直後の raw argv 走査へ移す
- **文言** — 「非推奨」から「agent-yes のフラグではない (CLI へ転送される)」へ。
  agent-yes がこのフラグを所有していない以上「非推奨」は不正確
- **検出範囲** — `--` より前のトークンに限定 (両ランタイム)。
  区切りより後ろは CLI ないしプロンプトのものであり、いずれにせよ逐語転送される

```
⚠ --cwd is not an agent-yes flag — it is passed straight through to the CLI.
  To run the agent somewhere else:

    cd /ws/api && ay claude --model sonnet -- pwd
```

## #389 との関係

**#389 (#388) で入れた `set_current_dir` は本 PR で削除する。**

wrapper の cwd と CLI の cwd の食い違いを *修正した* のが #389 だが、
本 PR では agent-yes が自プロセスの cwd 以外を扱わなくなるため、
食い違いは修正済みではなく **発生し得ない** 状態になる。

## 挙動変更 ⚠

これまで動いていた `ay <cli> --cwd <dir> -- "<prompt>"` (フラグが先頭側にある形) は
**動かなくなり**、CLI がこのオプションを拒否して失敗する。
失敗は #387 の修正により非ゼロ終了で報告される。

## 確認

両方の並び順で挙動が一致することを確認した:

```
$ cd /tmp && ay claude --cwd <D> -- "pwd"
$ cd /tmp && ay claude --model sonnet --cwd <D> -- "pwd"
# どちらも: ヒント表示 → CLI へ転送 → CLI が拒否 → exit 1
```

## 変更しないもの

- `ay ls / attach / status --cwd` — 絞り込みフィルタ
- `ay schedule / spawn --cwd` — 各サブコマンド自身のフラグ
- console / remote spawn — `Bun.spawn(argv, { cwd })` でプロセスの cwd を直接指定しており
  `--cwd` に依存していないため影響しない

## テスト

- **Rust**: unit 172 passed、integration 9 passed。
  `test_cwd_flag_overrides_current_dir` と `test_cwd_flag_rejects_missing_directory` は
  削除した挙動の検証だったため、転送を検証する `test_cwd_flag_is_forwarded_to_the_cli` に置き換え。
  `test_cwd_is_preserved` は素の実行時の cwd 保持を見るものなのでそのまま維持
- **TS**: 1400 passed / 1 skipped、カバレッジ閾値通過

関連: #386 (ドキュメント側の統一)、#387 / #388 / #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)