### PR TITLE
docs(cwd): #391 で古くなった --cwd の説明とモジュール名を直す

### DIFF
--- a/examples/spawn-notify.sh
+++ b/examples/spawn-notify.sh
@@ -31,9 +31,9 @@ task="$*"
 
 # 1) Fire-and-forget. nohup+disown so the agent outlives this waiter; agent-yes
 #    keeps its own PTY log under ~/.agent-yes, so /dev/null here loses nothing.
-#    `cd` in a subshell rather than `--cwd`: that flag is deprecated on an agent
-#    run, and anything in AY_FLAGS would sit before it, so agent-yes never parses
-#    it — it lands in the trailing args and the CLI dies on the unknown option.
+#    `cd` in a subshell rather than `--cwd`: on an agent run that flag is not an
+#    agent-yes flag at all — it is forwarded to the CLI, which dies on the unknown
+#    option. The subshell keeps this script's own cwd untouched for step 2.
 mkdir -p "$cwd"
 # shellcheck disable=SC2086
 ( cd "$cwd" && exec nohup ay "$cli" ${AY_FLAGS:-} -- "$task" >/dev/null 2>&1 ) &

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -50,7 +50,7 @@ fn detect_install_method() -> &'static str {
 /// Quote one argv token for display in a copy-pasteable shell command. Leaves
 /// shell-safe tokens (including a leading `~`/`~/path`, so `cd ~/foo` still
 /// expands) bare; single-quotes anything else. Mirrors `shellDisplayQuote` in
-/// ts/cwdDeprecation.ts.
+/// ts/cwdPassthroughHint.ts.
 fn shell_display_quote(s: &str) -> String {
     if s.is_empty() {
         return "''".to_string();
@@ -70,7 +70,7 @@ fn shell_display_quote(s: &str) -> String {
 /// `cd <dir> && <same command>` line. Returns None when no `--cwd` appears before
 /// the `--` separator — past it the token belongs to the CLI or the prompt, and
 /// agent-yes has no business reading it. Pure so it can be unit tested. Mirrors
-/// detectCwdDeprecation in ts/cwdDeprecation.ts.
+/// detectCwdPassthrough in ts/cwdPassthroughHint.ts.
 fn build_cwd_migration(prog: &str, user_args: &[String]) -> Option<String> {
     let end = user_args
         .iter()

--- a/ts/cli.ts
+++ b/ts/cli.ts
@@ -70,8 +70,8 @@ import { buildRustArgs } from "./buildRustArgs.ts";
 // untouched — only a real agent launch reaches here. Suppress the Rust runner's
 // mirror of this hint so it isn't printed twice when we spawn the binary below.
 {
-  const { detectCwdDeprecation, SUPPRESS_CWD_WARN_ENV } = await import("./cwdDeprecation.ts");
-  const dep = detectCwdDeprecation(process.argv);
+  const { detectCwdPassthrough, SUPPRESS_CWD_WARN_ENV } = await import("./cwdPassthroughHint.ts");
+  const dep = detectCwdPassthrough(process.argv);
   if (dep) {
     console.warn(dep.message);
     process.env[SUPPRESS_CWD_WARN_ENV] = "1";

--- a/ts/cwdPassthroughHint.spec.ts
+++ b/ts/cwdPassthroughHint.spec.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { detectCwdDeprecation } from "./cwdDeprecation.ts";
+import { detectCwdPassthrough } from "./cwdPassthroughHint.ts";
 
 // argv shape is [exec, script, ...userArgs]; the script's basename is the
 // program name the user typed (cy/ay/claude-yes/…).
 const argv = (script: string, ...user: string[]) => ["/usr/bin/bun", script, ...user];
 
-describe("detectCwdDeprecation", () => {
+describe("detectCwdPassthrough", () => {
   it("returns null when --cwd is absent", () => {
-    expect(detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "-p", "hi"))).toBeNull();
+    expect(detectCwdPassthrough(argv("/x/dist/cy.js", "claude", "-p", "hi"))).toBeNull();
   });
 
   it("detects `--cwd DIR` and rebuilds the command without it", () => {
-    const dep = detectCwdDeprecation(
+    const dep = detectCwdPassthrough(
       argv("/x/dist/cy.js", "claude", "--cwd", "/ws/app", "-p", "fix"),
     );
     expect(dep).not.toBeNull();
@@ -20,23 +20,23 @@ describe("detectCwdDeprecation", () => {
   });
 
   it("detects `--cwd=DIR` form", () => {
-    const dep = detectCwdDeprecation(argv("/x/dist/agent-yes.js", "codex", "--cwd=/tmp/x"));
+    const dep = detectCwdPassthrough(argv("/x/dist/agent-yes.js", "codex", "--cwd=/tmp/x"));
     expect(dep!.dir).toBe("/tmp/x");
     expect(dep!.suggestion).toBe("cd /tmp/x && agent-yes codex");
   });
 
   it("keeps a home-relative dir bare so the shell still expands ~", () => {
-    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "~/ws/product"));
+    const dep = detectCwdPassthrough(argv("/x/dist/cy.js", "--cwd", "~/ws/product"));
     expect(dep!.suggestion).toBe("cd ~/ws/product && cy");
   });
 
   it("preserves the prompt after `--` and quotes tokens with spaces", () => {
     // The shell splits `-- solve all todos` into one argv token per word.
-    const dep = detectCwdDeprecation(
+    const dep = detectCwdPassthrough(
       argv("/x/dist/claude-yes.js", "--cwd", "/ws/app", "--", "solve", "all", "todos"),
     );
     // A single already-quoted token keeping its space is re-quoted for display.
-    const dep2 = detectCwdDeprecation(
+    const dep2 = detectCwdPassthrough(
       argv("/x/dist/claude-yes.js", "--cwd", "/ws/app", "--", "a b"),
     );
     expect(dep!.suggestion).toBe("cd /ws/app && claude-yes -- solve all todos");
@@ -44,19 +44,19 @@ describe("detectCwdDeprecation", () => {
   });
 
   it("quotes a dir containing spaces", () => {
-    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/my ws/app"));
+    const dep = detectCwdPassthrough(argv("/x/dist/cy.js", "--cwd", "/my ws/app"));
     expect(dep!.suggestion).toBe("cd '/my ws/app' && cy");
   });
 
   it("handles `--cwd` given as the last token with no value", () => {
-    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--cwd"));
+    const dep = detectCwdPassthrough(argv("/x/dist/cy.js", "claude", "--cwd"));
     expect(dep).not.toBeNull();
     expect(dep!.dir).toBeUndefined();
     expect(dep!.suggestion).toBe("cd <dir> && cy claude");
   });
 
   it("says the flag is passed through, not handled", () => {
-    const dep = detectCwdDeprecation(argv("/x/dist/cy.js", "--cwd", "/ws"));
+    const dep = detectCwdPassthrough(argv("/x/dist/cy.js", "--cwd", "/ws"));
     expect(dep!.message).toContain("--cwd is not an agent-yes flag");
     expect(dep!.message).toContain("cd /ws && cy");
   });
@@ -65,10 +65,10 @@ describe("detectCwdDeprecation", () => {
     // Past the separator the token belongs to the CLI or the prompt. It is
     // forwarded verbatim either way, so there is nothing to suggest.
     expect(
-      detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--", "--cwd", "/ws/app")),
+      detectCwdPassthrough(argv("/x/dist/cy.js", "claude", "--", "--cwd", "/ws/app")),
     ).toBeNull();
     expect(
-      detectCwdDeprecation(argv("/x/dist/cy.js", "claude", "--", "run with --cwd=/ws")),
+      detectCwdPassthrough(argv("/x/dist/cy.js", "claude", "--", "run with --cwd=/ws")),
     ).toBeNull();
   });
 });

--- a/ts/cwdPassthroughHint.ts
+++ b/ts/cwdPassthroughHint.ts
@@ -59,7 +59,7 @@ function programName(scriptPath: string | undefined): string {
  * (`[exec, script, ...userArgs]`). Returns the hint, or null when no `--cwd`
  * appears before the `--` separator.
  */
-export function detectCwdDeprecation(argv: string[]): CwdPassthroughHint | null {
+export function detectCwdPassthrough(argv: string[]): CwdPassthroughHint | null {
   const prog = programName(argv[1]);
   const userArgs = argv.slice(2);
   // Past `--` the token is the CLI's or the prompt's — forwarded verbatim either

--- a/ts/ws.ts
+++ b/ts/ws.ts
@@ -529,11 +529,10 @@ async function cmdWsFork(args: string[]): Promise<number> {
     return 1;
   }
   process.stdout.write(`${res.action}  ${res.folder}\n`);
-  // `cd <dir> && ay …`, never `ay … --cwd <dir>`: --cwd is deprecated on an agent
-  // run, and a CLI-specific flag placed before it (`ay claude --model X --cwd D`)
-  // is swallowed into clap's trailing args and forwarded to the target CLI, which
-  // dies on the unknown option. cd has neither problem and puts every relative
-  // path in the command in the same place as the agent.
+  // `cd <dir> && ay …`, never `ay … --cwd <dir>`: on an agent run `--cwd` is not
+  // an agent-yes flag at all — it is forwarded to the target CLI, which dies on
+  // the unknown option. cd has no such problem and puts every relative path in
+  // the command in the same place as the agent.
   process.stderr.write(`\n  cd ${res.folder} && ay claude -- "<prompt>"   # work there\n`);
   return 0;
 }


### PR DESCRIPTION
#391 で `--cwd` は agent-yes のフラグではなくなり、**位置に関係なく** CLI へ転送される
ようになった。コード自体は正しいが、説明と名前が #391 以前の状態を指したまま残っていた。
読んだ人が「並び順によっては動く」と誤解するため直す。

**挙動の変更はない。**

## 古くなっていた説明 (#386 で入れたもの)

`ts/ws.ts` と `examples/spawn-notify.sh` のコメントが、いずれも

- 「`--cwd` は**非推奨**」→ 非推奨ではなく、**そもそも agent-yes のフラグではない**
- 「**前に別のフラグがあると**吞まれて転送される」→ 位置に関係なく**常に**転送される

と書いたままだった。前者は「非推奨だが動く」、後者は「並び順を直せば動く」と
読めてしまい、どちらも #391 以降は誤り。

`spawn-notify.sh` のサブシェルの理由も書き直した。`AY_FLAGS` が `--cwd` の前に来るから
ではなく、**step 2 のためにこのスクリプト自身の cwd を汚さないため**である。

## 名前

| 旧 | 新 |
|---|---|
| `ts/cwdDeprecation.ts` | `ts/cwdPassthroughHint.ts` |
| `ts/cwdDeprecation.spec.ts` | `ts/cwdPassthroughHint.spec.ts` |
| `detectCwdDeprecation` | `detectCwdPassthrough` |

非推奨ではないので実態に合わせる。`rs/src/main.rs` の doc コメントにある参照先も更新した。

`SUPPRESS_CWD_WARN_ENV` (`AGENT_YES_SUPPRESS_CWD_WARN`) は
両ランタイムをまたぐ契約なので値・名前ともに変更しない。

## テスト

TS 1402 passed / 1 skipped、カバレッジ閾値通過。`bash -n examples/spawn-notify.sh` も通る。

関連: #386 (元のコメント)、#391 (挙動変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)