### PR TITLE
fix(docker): mini イメージの node-pty ビルドが散発的に落ちるのを直す

### DIFF
--- a/docker/Dockerfile.mini
+++ b/docker/Dockerfile.mini
@@ -2,7 +2,11 @@
 # Size: ~200-400MB vs 2.2GB for full image
 
 # Build stage - includes all build tools and dependencies
-FROM node:alpine AS builder
+# Pin the node MAJOR: a bare `node:alpine` floats to whatever is newest, so the
+# node/npm/node-gyp that builds node-pty below can change under us and break the
+# image with zero repo changes. Same major that was floating in (26) — this only
+# stops the silent jump to the next one.
+FROM node:26-alpine AS builder
 
 # Install build tools and bun
 RUN apk add --no-cache \
@@ -25,7 +29,7 @@ COPY . .
 RUN bun run build
 
 # Runtime stage - minimal runtime environment
-FROM node:alpine
+FROM node:26-alpine
 
 # Install runtime dependencies and temporary build tools
 RUN apk add --no-cache \
@@ -43,8 +47,31 @@ COPY --from=builder /src/agent-yes/dist ./dist
 COPY --from=builder /src/agent-yes/package.json ./
 COPY --from=builder /src/agent-yes/bun.lock ./
 
-# Install only production dependencies and build native modules
-RUN bun install --production --ignore-scripts && npm rebuild node-pty && bun pm cache clean
+# Install only production dependencies and build native modules.
+#
+# node-pty must be COMPILED here: the ENTRYPOINT below runs under node (not bun),
+# so ts/pty.ts loads node-pty rather than bun-pty — and node-pty ships prebuilds
+# for darwin/win32 only, never linux. So every build runs node-gyp, which first
+# downloads the node headers over the network. That download is the flakiest step
+# in the whole image, and when it fails the error looks like a compile error:
+#
+#   gyp http 200 https://nodejs.org/download/release/vX/node-vX-headers.tar.gz
+#   gyp ERR! UNCAUGHT EXCEPTION
+#   gyp ERR! stack AssertionError: assert(!this.paused)
+#   gyp ERR! stack   at Parser.finish (.../npm/node_modules/undici/...client-h1.js)
+#
+# i.e. npm's bundled undici crashing mid-body on a response it already got a 200
+# for — transient, and only on the slower emulated arm64 leg. Retry instead of
+# failing the build: the same commit passed on a re-run with no changes.
+RUN bun install --production --ignore-scripts \
+    && for i in 1 2 3; do \
+         npm rebuild node-pty && break; \
+         echo "node-pty rebuild failed (attempt $i/3), retrying in $((i * 10))s"; \
+         rm -rf /root/.cache/node-gyp; \
+         sleep $((i * 10)); \
+       done \
+    && node -e "require('node-pty')" \
+    && bun pm cache clean
 
 # Remove build tools to save space
 RUN apk del build-base python3


### PR DESCRIPTION
## 症状

`build-and-push-mini` が仕組み上フレーク。**同一コミットで結果が反転**した:

| 実行 | 結果 |
|---|---|
| PR #390 の head（merge 前） | **FAILURE** |
| main `dcab30f`（= その commit が入った直後） | **success** |

差分ゼロで結果が変わる = 非決定的失敗。required check ではないため merge は止まらないが、赤が常態化すると本物の失敗を見落とす。

## 原因

ENTRYPOINT は `node` で起動するため `ts/pty.ts` は bun-pty ではなく **node-pty** を読む。その node-pty は **darwin/win32 の prebuild しか同梱していない**（npm tarball を展開して確認済み: `prebuilds/` は `darwin-arm64` `darwin-x64` `win32-arm64` `win32-x64` の 4 つのみ）。

つまり linux では毎回 node-gyp でソースからコンパイルされる。node-gyp はまず node headers をネットワーク取得するが、**この取得が全ビルド中で最も不安定**で、しかも失敗時の見た目がコンパイルエラーになる:

```
gyp http 200 https://nodejs.org/download/release/v26.7.0/node-v26.7.0-headers.tar.gz
gyp ERR! UNCAUGHT EXCEPTION
gyp ERR! stack AssertionError [ERR_ASSERTION]: assert(!this.paused)
gyp ERR! stack   at Parser.finish (.../npm/node_modules/undici/lib/dispatcher/client-h1.js:305:5)
```

**200 を受け取った後に** npm 同梱 undici がボディ処理中に落ちている。エミュレーションで遅い **linux/arm64 レグでのみ**再現する典型的な transient で、コード側の問題ではない。

## 変更

1. **リトライ** — node-pty の rebuild を最大 3 回（間隔 10/20s、リトライ前に node-gyp キャッシュを破棄）
2. **検証ゲート** — リトライ後に `node -e "require('node-pty')"` で native module が実際に読めることを確認
3. **ベースイメージ固定** — `node:alpine` → `node:26-alpine`

### 2 が必要な理由（重要）

`for` ループの終了ステータスは最後のコマンドのものになるため、**3 回とも失敗しても 0 で通過し `&&` チェーンが続いてしまう**。ゲートが無いと壊れたイメージが publish されうる。

- POSIX sh で挙動を確認: 全失敗時も `ALLFAIL_EXIT=0`（＝ゲートは必須）
- ゲート自体も確認: native binding を消した状態で `node -e "require('node-pty')"` → **exit 1**。`require` 時に `unixTerminal.js:27` の `loadNativeModule('pty')` がトップレベルで走るため確実に落ちる

## 検証について（正直に）

- `docker buildx build --check` は警告ゼロ、`node:26-alpine` の解決も確認
- リトライ/ゲートのシェル挙動、node-pty の prebuild 有無、ゲートの exit code は上記のとおり個別に実証済み
- **ただしイメージのフルビルド自体はローカルで再現できていない**（この環境の docker build はネットワーク不通で `apk add` の時点で落ちる）。最終確認は CI に委ねる
- 元がフレークのため「1 回緑」は証明にならない。リトライが効いているかは今後の再発頻度で判断する

🤖 Generated with [Claude Code](https://claude.com/claude-code)