### PR TITLE
fix(hist): `ay hist` を CLI に配線する

### DIFF
--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -21,9 +21,9 @@ use std::env;
 /// MUST mirror `SUBCOMMANDS` in ts/subcommands.ts — keep the two in sync.
 pub const SUBCOMMANDS: &[&str] = &[
     "ls", "list", "ps", "status", "whoami", "result", "notify", "notifyd", "read", "cat", "tail",
-    "head", "send", "key", "select", "msgs", "spawn", "attach", "stop", "exit", "restart", "note",
-    "todo", "ch", "channels", "term", "widget", "mint", "serve", "tray", "schedule", "remote",
-    "expose", "callback", "reap", "deepseek", "ds", "help",
+    "head", "hist", "history", "send", "key", "select", "msgs", "spawn", "attach", "stop", "exit",
+    "restart", "note", "todo", "ch", "channels", "term", "widget", "mint", "serve", "tray",
+    "schedule", "remote", "expose", "callback", "reap", "deepseek", "ds", "help",
 ];
 
 /// Subcommands reserved for the generic manager entry (`ay`/`agent-yes`), not a

--- a/rs/src/log_files.rs
+++ b/rs/src/log_files.rs
@@ -190,7 +190,6 @@ mod tests {
 
     #[test]
     fn test_compact_tail_keeps_trailing_bytes_in_place() {
-        use std::os::unix::fs::MetadataExt;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("big.raw.log");
         // 300 KiB of distinct lines; compact to the last 64 KiB.
@@ -198,7 +197,15 @@ mod tests {
             .flat_map(|i| format!("{:015}\n", i).into_bytes())
             .collect();
         fs::write(&path, &body).unwrap();
-        let ino_before = fs::metadata(&path).unwrap().ino();
+        // Unix-only: `MetadataExt::ino` does not exist on Windows, and importing it
+        // unconditionally made the whole test binary fail to COMPILE there — so no
+        // cargo test could run on Windows at all. Gate just the inode check; every
+        // byte-level assertion below stays live on all platforms.
+        #[cfg(unix)]
+        let ino_before = {
+            use std::os::unix::fs::MetadataExt;
+            fs::metadata(&path).unwrap().ino()
+        };
         let keep = 64 * 1024;
         let len = compact_tail(&path, keep).unwrap();
         assert_eq!(len, keep);
@@ -207,7 +214,11 @@ mod tests {
         // The kept bytes are the file's true tail.
         assert_eq!(&on_disk[..], &body[body.len() - keep as usize..]);
         // Same inode — in-place, so live-tail followers keep their fd valid.
-        assert_eq!(fs::metadata(&path).unwrap().ino(), ino_before);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(fs::metadata(&path).unwrap().ino(), ino_before);
+        }
     }
 
     #[test]
@@ -226,7 +237,11 @@ mod tests {
         let size = fs::metadata(&path).unwrap().len();
         // File was compacted, not left to grow past the trigger.
         assert!(size <= COMPACT_TRIGGER_BYTES, "size {} not capped", size);
-        assert!(size >= COMPACT_KEEP_BYTES, "size {} unexpectedly tiny", size);
+        assert!(
+            size >= COMPACT_KEEP_BYTES,
+            "size {} unexpectedly tiny",
+            size
+        );
         // Most recent output is retained.
         let mut tail = vec![0u8; 32];
         let mut f = fs::File::open(&path).unwrap();

--- a/ts/hist.spec.ts
+++ b/ts/hist.spec.ts
@@ -54,9 +54,9 @@ describe("snippet", () => {
 describe("renderRecord", () => {
   it("labels the human as user and the agent by its source", () => {
     expect(renderRecord(rec, { color: false, max: 0 })).toContain("user");
-    expect(
-      renderRecord({ ...rec, role: "assistant" }, { color: false, max: 0 }),
-    ).toContain("claude");
+    expect(renderRecord({ ...rec, role: "assistant" }, { color: false, max: 0 })).toContain(
+      "claude",
+    );
     expect(
       renderRecord({ ...rec, role: "assistant", source: "codex" }, { color: false, max: 0 }),
     ).toContain("codex");
@@ -66,6 +66,21 @@ describe("renderRecord", () => {
     const out = renderRecord(rec, { color: false, max: 0 });
     // eslint-disable-next-line no-control-regex
     expect(/\x1b\[/.test(out)).toBe(false);
+  });
+
+  it("stays ANSI-free when color is off AND the turn is truncated", () => {
+    // The truncation note carried hardcoded dim/reset, so `ay hist | cat` leaked
+    // escapes on exactly the turns long enough to be shortened. The max:0 case
+    // above never truncates, so it cannot catch this.
+    const out = renderRecord({ ...rec, text: "x".repeat(900) }, { color: false, max: 600 });
+    expect(out).toContain("(+300 chars");
+    // eslint-disable-next-line no-control-regex
+    expect(/\x1b\[/.test(out)).toBe(false);
+  });
+
+  it("still tints the truncation note when color is on", () => {
+    const out = renderRecord({ ...rec, text: "x".repeat(900) }, { color: true, max: 600 });
+    expect(out).toContain(`${"\x1b[2m"}(+300 chars`);
   });
 
   it("colors user and agent turns differently when color is on", () => {

--- a/ts/hist.ts
+++ b/ts/hist.ts
@@ -28,13 +28,22 @@ function shortTime(ts: string | null): string {
   return sameDay ? hhmm : `${d.toISOString().slice(5, 10)} ${hhmm}`;
 }
 
-/** Collapse a turn to `max` chars, noting how much was withheld. */
-export function snippet(text: string, max: number): string {
+/**
+ * Collapse a turn to `max` chars, noting how much was withheld.
+ *
+ * `color` gates the dim tint on that note. Everything else in the renderer
+ * already honours it, but this note hardcoded the escapes — so `ay hist | cat`
+ * stayed clean only until a turn was long enough to truncate, i.e. the common
+ * case. Defaults true so a direct `snippet()` call keeps its old look.
+ */
+export function snippet(text: string, max: number, color = true): string {
   const trimmed = text.trim();
   if (max <= 0 || trimmed.length <= max) return trimmed;
   const head = trimmed.slice(0, max);
   const hiddenLines = trimmed.slice(max).split("\n").length;
-  return `${head}… ${DIM}(+${trimmed.length - max} chars, ${hiddenLines} more lines)${RESET}`;
+  const dim = color ? DIM : "";
+  const off = color ? RESET : "";
+  return `${head}… ${dim}(+${trimmed.length - max} chars, ${hiddenLines} more lines)${off}`;
 }
 
 export function renderRecord(r: HistRecord, opts: { color: boolean; max: number }): string {
@@ -42,7 +51,7 @@ export function renderRecord(r: HistRecord, opts: { color: boolean; max: number 
   const tint = opts.color ? (r.role === "user" ? CYAN : GREEN) : "";
   const dim = opts.color ? DIM : "";
   const off = opts.color ? RESET : "";
-  const body = snippet(r.text, opts.max)
+  const body = snippet(r.text, opts.max, opts.color)
     .split("\n")
     .map((l) => `  ${l}`)
     .join("\n");

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -417,6 +417,8 @@ const SUBCOMMANDS = new Set([
   "cat",
   "tail",
   "head",
+  "hist",
+  "history",
   "send",
   "msgs",
   "key",
@@ -601,6 +603,9 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
         return await cmdRead(rest, { mode: "tail" });
       case "head":
         return await cmdRead(rest, { mode: "head" });
+      case "hist":
+      case "history":
+        return await (await import("./hist.ts")).cmdHist(rest);
       case "send":
         return await cmdSend(rest);
       case "msgs":
@@ -823,6 +828,9 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `                                        --before-line L [--limit N]\n` +
       `  ay cat <keyword>                    full log\n` +
       `  ay head <keyword>                   first N lines\n` +
+      `  ay hist [-n 6] [--all] [--json]     past agent conversations (claude/codex\n` +
+      `                                        transcripts, incl. exited sessions);\n` +
+      `                                        this cwd unless --all\n` +
       `  ay send <keyword> <msg>             send a message (keyword '.' = agent in this cwd)\n` +
       `  ay msgs [keyword] [--in|--out]      inter-agent message log (sent + received)\n` +
       `  ay ch mk|join|send|read|tail <topic>  local-first E2E channels: AI ↔ humans on a topic (ay ch help)\n` +


### PR DESCRIPTION
`ts/hist.ts` と `ts/histStore.ts`、および 42 件のテストは main に入っているが、
**dispatch が入っていない**。`hist` は `SUBCOMMANDS` にも `runSubcommand` の switch にも
`ay help` にも無く、実装済みだが到達不能な状態だった。

```
$ ay hist --help
ay: unknown subcommand or CLI 'hist'.
```

## 変更

- **`ts/subcommands.ts`** — `SUBCOMMANDS` に `hist` / `history` を追加、switch に dispatch を追加、
  `ay help` に 1 項目追加
- **`rs/src/cli.rs`** — Rust 側の `SUBCOMMANDS` にも同じ 2 件を追加。
  未登録の先頭語を Rust runner は「起動すべき agent CLI」とみなすため、片側だけだと
  `agent-yes hist` が `hist` という名のプログラムを探しに行く。
  #390 の mirror テストがこの同期を自動検証する

併せて、検証中に見つかった 2 件:

- **`ts/hist.ts`** — `snippet()` が dim/reset のエスケープを直書きしていたため、
  `ay hist | cat` は**切り詰めが起きるほど長いターンだけ** ANSI が漏れていた。
  つまり実際にはよくある方が壊れていた。`color` を渡すようにする。
  既存の「color off で ANSI を出さない」テストは `max:0` で切り詰めが発生しないため、
  これを検出できなかった
- **`rs/src/log_files.rs`** — Unix 専用の `MetadataExt::ino` を無条件に import していたため、
  Windows ではテストバイナリ全体がコンパイルできなかった。inode の assertion だけを
  `cfg(unix)` で囲む。バイト単位の assertion は全プラットフォームで有効なまま。
  (CI は現状どのプラットフォームでも `cargo test` を実行していないため、
  これは顕在化していない潜在的な問題である)

## #378 との関係

**#378 と同じ意図だが、#378 はそのまま merge できない。**
あちらのブランチは main から大きく遅れており、main に対する差分が **3937 行の削除**になる。
また #378 が含んでいた TS/Rust mirror の同期と mirror テストは **#390 で既に main に入っている**。
残っていた差分のみを main の上に適用し直した。

本 PR が入れば #378 は superseded として close できる。

## 確認

```
$ ay hist -n 2
no agent conversation history for <cwd> (scanned 0 transcripts).
try: ay hist --all              # 従来は unknown subcommand
$ ay history -n 1               # alias も配線されている
$ ay hist --all -n 3 | cat
# 実データで描画。切り詰め注記あり・ANSI エスケープ 0 件
```

TS 1404 passed / 1 skipped、カバレッジ閾値通過 (`hist.ts` 100% statements)。Rust unit 172 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)