### PR TITLE
feat(ps): ay ps — エージェント単位のリソース使用量をプロセスツリーで集計する

### DIFF
--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatSystemLine,
+  isSelfTree,
+  readPpidSync,
+  renderTable,
+  repoLabel,
+  type PsRow,
+} from "./cmdPs.ts";
+import type { SystemStats, TreeStats } from "./procStats.ts";
+
+const stats = (over: Partial<TreeStats> = {}): TreeStats => ({
+  pid: 1,
+  rss: 0,
+  cpuPercent: 0,
+  procs: 1,
+  ...over,
+});
+
+const row = (over: Partial<PsRow> = {}): PsRow => ({
+  pid: 100,
+  cli: "claude",
+  status: "idle",
+  cwd: "/code/snomiao/foo/tree/main",
+  repo: "foo",
+  stats: stats(),
+  self: false,
+  ...over,
+});
+
+const sys = (over: Partial<SystemStats> = {}): SystemStats => ({
+  load: [15.23, 12.52, 9.86],
+  ncpu: 8,
+  memTotalBytes: 16 * 1024 ** 3,
+  memAvailableBytes: 2 * 1024 ** 3,
+  swapTotalBytes: 5 * 1024 ** 3,
+  swapFreeBytes: 1 * 1024 ** 3,
+  zombies: 0,
+  ...over,
+});
+
+describe("repoLabel", () => {
+  it("names the repo, not the branch dir every worktree shares", () => {
+    expect(repoLabel("/code/snomiao/agent-yes/tree/main")).toBe("agent-yes");
+    expect(repoLabel("/code/snomiao/agent-yes/tree/feat/x")).toBe("agent-yes");
+  });
+
+  it("falls back to the last segment outside a tree layout", () => {
+    expect(repoLabel("/srv/plain-checkout")).toBe("plain-checkout");
+  });
+
+  it("does not index out of bounds on a root-level tree dir", () => {
+    expect(repoLabel("/tree/main")).toBe("main");
+  });
+});
+
+describe("formatSystemLine", () => {
+  it("puts the oversubscription ratio next to the raw load", () => {
+    // "15.23" is meaningless without the core count beside it.
+    expect(formatSystemLine(sys())).toContain("load 15.23 12.52 9.86 (8 cpu, 1.9x)");
+  });
+
+  it("reports mem as used/total", () => {
+    expect(formatSystemLine(sys())).toContain("mem 14.0Gi/16.0Gi");
+  });
+
+  it("calls out an exhausted swap in words", () => {
+    // Full swap is the line between "loaded" and "one alloc from the OOM killer".
+    expect(formatSystemLine(sys({ swapFreeBytes: 0 }))).toContain("FULL");
+    expect(formatSystemLine(sys())).not.toContain("FULL");
+  });
+
+  it("omits swap entirely when the box has none", () => {
+    expect(formatSystemLine(sys({ swapTotalBytes: 0 }))).not.toContain("swap");
+  });
+
+  it("mentions zombies only when there are some", () => {
+    expect(formatSystemLine(sys({ zombies: 1440 }))).toContain("zombies 1440");
+    expect(formatSystemLine(sys())).not.toContain("zombies");
+  });
+
+  it("degrades to whatever it could read", () => {
+    const line = formatSystemLine(
+      sys({ load: null, memTotalBytes: null, memAvailableBytes: null, swapTotalBytes: null }),
+    );
+    expect(line).toBe("");
+  });
+});
+
+describe("renderTable", () => {
+  const rows = [
+    row({ pid: 1, repo: "big", stats: stats({ rss: 1024 ** 3, cpuPercent: 53.8, procs: 17 }) }),
+    row({ pid: 22222, repo: "self", self: true, stats: stats({ rss: 1024 ** 2 }) }),
+  ];
+
+  it("marks the tree the command is running in", () => {
+    const out = renderTable(rows, null);
+    const selfLine = out.split("\n").find((l) => l.startsWith("22222")) as string;
+    expect(selfLine).toContain("← this session");
+    expect(out.split("\n").find((l) => l.startsWith("1 "))).not.toContain("← this session");
+  });
+
+  it("keeps every column aligned once the wide unmanaged row is present", () => {
+    // "unmanaged" is wider than any real CLI name — sizing without it knocked
+    // the whole table out of line.
+    const out = renderTable(rows, stats({ pid: 0, rss: 2 * 1024 ** 3, procs: 1359 }));
+    const lines = out.split("\n");
+    const rssCol = (l: string) => l.indexOf("RSS");
+    const header = lines[0] as string;
+    expect(lines.some((l) => l.includes("unmanaged"))).toBe(true);
+    // Every row's PROCS value must end at the same column as the header's.
+    const procsEnd = header.indexOf("PROCS") + "PROCS".length;
+    for (const l of lines.slice(1)) {
+      expect(l.slice(0, procsEnd).trimEnd().length).toBeLessThanOrEqual(procsEnd);
+    }
+    expect(rssCol(header)).toBeGreaterThan(0);
+  });
+
+  it("omits the unmanaged row when the box is fully accounted for", () => {
+    expect(renderTable(rows, stats({ procs: 0 }))).not.toContain("unmanaged");
+  });
+});
+
+describe("cmdPs", () => {
+  const rec = (over: Record<string, unknown> = {}) => ({
+    pid: 100,
+    cli: "claude",
+    prompt: null,
+    cwd: "/code/snomiao/foo/tree/main",
+    log_file: null,
+    status: "active",
+    exit_code: null,
+    exit_reason: null,
+    started_at: 0,
+    ...over,
+  });
+
+  /** Swap in fake dependencies, run cmdPs with a fresh module graph, capture output. */
+  async function run(
+    rest: string[],
+    opts: {
+      records?: ReturnType<typeof rec>[];
+      trees?: Map<number, TreeStats>;
+      unattributed?: TreeStats;
+      system?: SystemStats | null;
+    } = {},
+  ) {
+    const records = opts.records ?? [rec()];
+    vi.resetModules();
+    vi.doMock("./subcommands.ts", () => ({
+      listRecords: vi.fn(async () => records),
+      deriveLiveState: vi.fn(async (r: { status: string }) => ({ state: r.status })),
+    }));
+    vi.doMock("./procStats.ts", async () => {
+      const actual = await vi.importActual<typeof import("./procStats.ts")>("./procStats.ts");
+      return {
+        ...actual,
+        snapshotProcs: vi.fn(async () => []),
+        systemStats: vi.fn(async () => opts.system ?? sys()),
+        sampleTrees: vi.fn(async () => ({
+          trees: opts.trees ?? new Map<number, TreeStats>(),
+          unattributed: opts.unattributed ?? stats({ procs: 0 }),
+        })),
+      };
+    });
+    const out: string[] = [];
+    const err: string[] = [];
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    (process.stdout as any).write = (s: any) => (out.push(String(s)), true);
+    (process.stderr as any).write = (s: any) => (err.push(String(s)), true);
+    try {
+      const { cmdPs } = await import("./cmdPs.ts");
+      const code = await cmdPs(rest);
+      return { code, out: out.join(""), err: err.join("") };
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+      vi.doUnmock("./subcommands.ts");
+      vi.doUnmock("./procStats.ts");
+      vi.resetModules();
+    }
+  }
+
+  it("prints the box vitals header and a row per agent", async () => {
+    const r = await run([], {
+      trees: new Map([[100, stats({ pid: 100, rss: 1024 ** 2, procs: 3 })]]),
+    });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("load 15.23");
+    expect(r.out).toContain("PID");
+    expect(r.out).toContain("100");
+    expect(r.out).toContain("foo");
+  });
+
+  it("says so and still exits 0 when nothing is running", async () => {
+    const r = await run([], { records: [] });
+    expect(r.code).toBe(0);
+    expect(r.err).toContain("no running agents");
+    expect(r.out).toBe("");
+  });
+
+  it("names the keyword that matched nothing", async () => {
+    const r = await run(["nope"], { records: [] });
+    expect(r.err).toContain('no agents matched "nope"');
+  });
+
+  it("--json emits the rollup with system, agents and unattributed", async () => {
+    const r = await run(["--json"], {
+      trees: new Map([[100, stats({ pid: 100, rss: 4096, cpuPercent: 12.345, procs: 2 })]]),
+      unattributed: stats({ pid: 0, rss: 512, cpuPercent: 1.5, procs: 9 }),
+    });
+    expect(r.code).toBe(0);
+    const parsed = JSON.parse(r.out);
+    expect(parsed.system.ncpu).toBe(8);
+    expect(parsed.agents).toHaveLength(1);
+    expect(parsed.agents[0]).toMatchObject({ pid: 100, cli: "claude", rssBytes: 4096, procs: 2 });
+    // Rounded to 2dp on the way out, so consumers get a stable number.
+    expect(parsed.agents[0].cpuPercent).toBe(12.35);
+    expect(parsed.unattributed).toMatchObject({ rssBytes: 512, procs: 9 });
+  });
+
+  it("--sort orders by the chosen resource, and --tree keeps forest order", async () => {
+    const records = [rec({ pid: 1 }), rec({ pid: 2 }), rec({ pid: 3 })];
+    const trees = new Map([
+      [1, stats({ pid: 1, rss: 10, cpuPercent: 90, procs: 1 })],
+      [2, stats({ pid: 2, rss: 30, cpuPercent: 10, procs: 7 })],
+      [3, stats({ pid: 3, rss: 20, cpuPercent: 50, procs: 3 })],
+    ]);
+    const pids = (out: string) =>
+      out
+        .split("\n")
+        .slice(1)
+        .map((l) => l.trim().split(/\s+/)[0])
+        .filter((p) => /^\d+$/.test(p));
+
+    expect(pids((await run(["--json"], { records, trees })).out.length ? "" : "")).toEqual([]);
+    // rss is the default: biggest first.
+    expect(pids((await run([], { records, trees })).out)).toEqual(["2", "3", "1"]);
+    expect(pids((await run(["--sort", "cpu"], { records, trees })).out)).toEqual(["1", "3", "2"]);
+    expect(pids((await run(["--sort", "procs"], { records, trees })).out)).toEqual(["2", "3", "1"]);
+    expect(pids((await run(["--sort", "pid"], { records, trees })).out)).toEqual(["1", "2", "3"]);
+    // --tree opts out of sorting entirely, keeping ay ls's forest order.
+    expect(pids((await run(["--tree"], { records, trees })).out)).toEqual(["1", "2", "3"]);
+  });
+
+  it("renders a 0-usage row rather than dropping an agent the sampler missed", async () => {
+    const r = await run([], { trees: new Map() });
+    expect(r.out).toContain("100");
+    expect(r.out).toMatch(/100\s+claude\s+active\s+0\.0/);
+  });
+
+  it("--cwd scopes the listing to that directory", async () => {
+    // The scope is resolved to an absolute path before it reaches listRecords,
+    // so a relative --cwd can't silently match nothing.
+    const r = await run(["--cwd", "."], { trees: new Map() });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("PID");
+  });
+
+  it("clamps a nonsense --interval up to the 100ms floor instead of sampling for 0s", async () => {
+    // A 0/NaN window would make every CPU% a divide-by-nothing artefact.
+    for (const bad of ["0", "-5", "not-a-number"]) {
+      const r = await run(["--interval", bad], { trees: new Map() });
+      expect(r.code).toBe(0);
+    }
+  });
+
+  it("--all asks for exited agents too", async () => {
+    const r = await run(["--all"], { trees: new Map() });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("PID");
+  });
+
+  it("--help prints usage without doing any work", async () => {
+    const r = await run(["--help"]);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Usage: ay ps");
+    expect(r.out).not.toContain("PID  CLI");
+  });
+
+  it("omits the header entirely when no box stat could be read", async () => {
+    // formatSystemLine returns "" in that case; printing a bare blank line above
+    // the table would look like a rendering bug.
+    const r = await run([], {
+      system: sys({
+        load: null,
+        memTotalBytes: null,
+        memAvailableBytes: null,
+        swapTotalBytes: null,
+      }),
+    });
+    expect(r.out.startsWith("PID")).toBe(true);
+  });
+});
+
+describe("isSelfTree", () => {
+  // The `← this session` marker: anything that later grows a kill affordance
+  // must not let you shoot the session issuing the command, so the ancestry walk
+  // has to be right. It reads /proc, but the walk itself is platform-independent.
+  const chain = (links: Record<number, number>) => (pid: number) => links[pid] ?? null;
+
+  it("finds the root several hops up the ancestry", () => {
+    expect(isSelfTree(10, 40, chain({ 40: 30, 30: 20, 20: 10 }), "linux")).toBe(true);
+  });
+
+  it("is true for the wrapper pid itself", () => {
+    expect(isSelfTree(10, 10, chain({}), "linux")).toBe(true);
+  });
+
+  it("is false for an unrelated tree", () => {
+    expect(isSelfTree(99, 40, chain({ 40: 30, 30: 1 }), "linux")).toBe(false);
+  });
+
+  it("gives up when the ancestry is unreadable rather than guessing", () => {
+    expect(isSelfTree(10, 40, () => null, "linux")).toBe(false);
+  });
+
+  it("terminates on a cycle instead of spinning", () => {
+    expect(isSelfTree(999, 40, chain({ 40: 41, 41: 40 }), "linux")).toBe(false);
+  });
+
+  it("returns false off Linux, where /proc does not exist", () => {
+    expect(isSelfTree(10, 40, chain({ 40: 10 }), "darwin")).toBe(false);
+  });
+
+  it("readPpidSync returns null for a pid that cannot be read", () => {
+    expect(readPpidSync(-1)).toBeNull();
+  });
+});

--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -49,6 +49,13 @@ describe("repoLabel", () => {
     expect(repoLabel("/srv/plain-checkout")).toBe("plain-checkout");
   });
 
+  it("handles Windows-style separators too", () => {
+    // The registry stores whatever the wrapper recorded, so both shapes reach
+    // here regardless of the host we are rendering on.
+    expect(repoLabel("C:\\code\\snomiao\\agent-yes\\tree\\main")).toBe("agent-yes");
+    expect(repoLabel("C:\\srv\\plain-checkout")).toBe("plain-checkout");
+  });
+
   it("does not index out of bounds on a root-level tree dir", () => {
     expect(repoLabel("/tree/main")).toBe("main");
   });
@@ -121,6 +128,40 @@ describe("renderTable", () => {
   });
 });
 
+// Hoisted mocks with a mutable fixture. The earlier version re-mocked inside a
+// helper with vi.resetModules() per call; when a reset raced, the REAL
+// listRecords ran and returned whatever agents happened to be on the box — which
+// looks like a pass locally (rows appear) and an empty table on CI (no agents).
+const fixture: {
+  records: Record<string, unknown>[];
+  trees: Map<number, TreeStats>;
+  unattributed: TreeStats;
+  system: SystemStats;
+} = {
+  records: [],
+  trees: new Map(),
+  unattributed: { pid: 0, rss: 0, cpuPercent: 0, procs: 0 },
+  system: sys(),
+};
+
+vi.mock("./subcommands.ts", () => ({
+  listRecords: vi.fn(async () => fixture.records),
+  deriveLiveState: vi.fn(async (r: { status: string }) => ({ state: r.status })),
+}));
+
+vi.mock("./procStats.ts", async () => {
+  const actual = await vi.importActual<typeof import("./procStats.ts")>("./procStats.ts");
+  return {
+    ...actual,
+    snapshotProcs: vi.fn(async () => new Map()),
+    systemStats: vi.fn(async () => fixture.system),
+    sampleTrees: vi.fn(async () => ({
+      trees: fixture.trees,
+      unattributed: fixture.unattributed,
+    })),
+  };
+});
+
 describe("cmdPs", () => {
   const rec = (over: Record<string, unknown> = {}) => ({
     pid: 100,
@@ -135,34 +176,20 @@ describe("cmdPs", () => {
     ...over,
   });
 
-  /** Swap in fake dependencies, run cmdPs with a fresh module graph, capture output. */
   async function run(
     rest: string[],
     opts: {
-      records?: ReturnType<typeof rec>[];
+      records?: Record<string, unknown>[];
       trees?: Map<number, TreeStats>;
       unattributed?: TreeStats;
-      system?: SystemStats | null;
+      system?: SystemStats;
     } = {},
   ) {
-    const records = opts.records ?? [rec()];
-    vi.resetModules();
-    vi.doMock("./subcommands.ts", () => ({
-      listRecords: vi.fn(async () => records),
-      deriveLiveState: vi.fn(async (r: { status: string }) => ({ state: r.status })),
-    }));
-    vi.doMock("./procStats.ts", async () => {
-      const actual = await vi.importActual<typeof import("./procStats.ts")>("./procStats.ts");
-      return {
-        ...actual,
-        snapshotProcs: vi.fn(async () => []),
-        systemStats: vi.fn(async () => opts.system ?? sys()),
-        sampleTrees: vi.fn(async () => ({
-          trees: opts.trees ?? new Map<number, TreeStats>(),
-          unattributed: opts.unattributed ?? stats({ procs: 0 }),
-        })),
-      };
-    });
+    fixture.records = opts.records ?? [rec()];
+    fixture.trees = opts.trees ?? new Map();
+    fixture.unattributed = opts.unattributed ?? stats({ pid: 0, procs: 0 });
+    fixture.system = opts.system ?? sys();
+
     const out: string[] = [];
     const err: string[] = [];
     const origOut = process.stdout.write.bind(process.stdout);
@@ -176,11 +203,15 @@ describe("cmdPs", () => {
     } finally {
       process.stdout.write = origOut;
       process.stderr.write = origErr;
-      vi.doUnmock("./subcommands.ts");
-      vi.doUnmock("./procStats.ts");
-      vi.resetModules();
     }
   }
+
+  /** pids in render order, from the table body. */
+  const pids = (out: string) =>
+    out
+      .split("\n")
+      .map((l) => l.trim().split(/\s+/)[0])
+      .filter((p) => /^\d+$/.test(p ?? ""));
 
   it("prints the box vitals header and a row per agent", async () => {
     const r = await run([], {
@@ -189,7 +220,7 @@ describe("cmdPs", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("load 15.23");
     expect(r.out).toContain("PID");
-    expect(r.out).toContain("100");
+    expect(pids(r.out)).toEqual(["100"]);
     expect(r.out).toContain("foo");
   });
 
@@ -227,14 +258,6 @@ describe("cmdPs", () => {
       [2, stats({ pid: 2, rss: 30, cpuPercent: 10, procs: 7 })],
       [3, stats({ pid: 3, rss: 20, cpuPercent: 50, procs: 3 })],
     ]);
-    const pids = (out: string) =>
-      out
-        .split("\n")
-        .slice(1)
-        .map((l) => l.trim().split(/\s+/)[0])
-        .filter((p) => /^\d+$/.test(p));
-
-    expect(pids((await run(["--json"], { records, trees })).out.length ? "" : "")).toEqual([]);
     // rss is the default: biggest first.
     expect(pids((await run([], { records, trees })).out)).toEqual(["2", "3", "1"]);
     expect(pids((await run(["--sort", "cpu"], { records, trees })).out)).toEqual(["1", "3", "2"]);
@@ -246,7 +269,7 @@ describe("cmdPs", () => {
 
   it("renders a 0-usage row rather than dropping an agent the sampler missed", async () => {
     const r = await run([], { trees: new Map() });
-    expect(r.out).toContain("100");
+    expect(pids(r.out)).toEqual(["100"]);
     expect(r.out).toMatch(/100\s+claude\s+active\s+0\.0/);
   });
 
@@ -255,7 +278,7 @@ describe("cmdPs", () => {
     // so a relative --cwd can't silently match nothing.
     const r = await run(["--cwd", "."], { trees: new Map() });
     expect(r.code).toBe(0);
-    expect(r.out).toContain("PID");
+    expect(pids(r.out)).toEqual(["100"]);
   });
 
   it("clamps a nonsense --interval up to the 100ms floor instead of sampling for 0s", async () => {
@@ -269,14 +292,14 @@ describe("cmdPs", () => {
   it("--all asks for exited agents too", async () => {
     const r = await run(["--all"], { trees: new Map() });
     expect(r.code).toBe(0);
-    expect(r.out).toContain("PID");
+    expect(pids(r.out)).toEqual(["100"]);
   });
 
   it("--help prints usage without doing any work", async () => {
     const r = await run(["--help"]);
     expect(r.code).toBe(0);
     expect(r.out).toContain("Usage: ay ps");
-    expect(r.out).not.toContain("PID  CLI");
+    expect(pids(r.out)).toEqual([]);
   });
 
   it("omits the header entirely when no box stat could be read", async () => {

--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -1,7 +1,10 @@
+import { homedir } from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   formatSystemLine,
   isSelfTree,
+  parsePpidFromStat,
   readPpidSync,
   renderTable,
   repoLabel,
@@ -47,6 +50,17 @@ describe("repoLabel", () => {
 
   it("falls back to the last segment outside a tree layout", () => {
     expect(repoLabel("/srv/plain-checkout")).toBe("plain-checkout");
+  });
+
+  it("falls back to the shortened path when there is no segment at all", () => {
+    // `/` and "" split into no segments; without the fallback the REPO column
+    // would print "undefined".
+    expect(repoLabel("/")).toBe("/");
+    expect(repoLabel("")).toBe("");
+  });
+
+  it("abbreviates a home-relative fallback with ~", () => {
+    expect(repoLabel(homedir())).toBe(path.basename(homedir()));
   });
 
   it("handles Windows-style separators too", () => {
@@ -349,5 +363,27 @@ describe("isSelfTree", () => {
 
   it("readPpidSync returns null for a pid that cannot be read", () => {
     expect(readPpidSync(-1)).toBeNull();
+  });
+});
+
+describe("parsePpidFromStat", () => {
+  // /proc/<pid>/stat field 2 is the process name in parens, UNESCAPED. Splitting
+  // on whitespace or the first ")" mis-reads every process whose name contains
+  // either, so the fields after comm can only be located from the LAST ")".
+  it("reads the ppid of an ordinary line", () => {
+    expect(parsePpidFromStat("1234 (bash) S 1200 1234 1234 0 -1 4194304")).toBe(1200);
+  });
+
+  it("survives a process name containing spaces and parens", () => {
+    expect(parsePpidFromStat("1234 (foo) bar (baz) S 999 1234 0")).toBe(999);
+  });
+
+  it("returns null when there is no comm field to anchor on", () => {
+    expect(parsePpidFromStat("garbage without parens")).toBeNull();
+  });
+
+  it("returns null when the ppid field is missing or not a number", () => {
+    expect(parsePpidFromStat("1234 (bash) S")).toBeNull();
+    expect(parsePpidFromStat("1234 (bash) S notanumber 1234")).toBeNull();
   });
 });

--- a/ts/cmdPs.ts
+++ b/ts/cmdPs.ts
@@ -1,0 +1,327 @@
+/**
+ * `ay ps` — what each agent COSTS, rolled up per process tree.
+ *
+ * The split from `ay ls`: `ls` answers "what is running and what is it doing"
+ * (prompt, git, badges, forest); `ps` answers "what is this box spending on
+ * each agent, and is any of it safe to reclaim". Same rows, different question.
+ *
+ * `ps` used to be a plain alias for `ls`. It is now its own command, because the
+ * number you actually want is not in any `ps`/`htop` output: one agent is a
+ * whole subtree of wrapper + CLI + pty hosts + subagents, and only ay knows
+ * which pids collapse into which session.
+ *
+ * Deliberately local-only. Resource numbers are per-machine and there is nothing
+ * meaningful to sum across remotes; `ay ls` remains the fleet-wide view.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import yargs from "yargs";
+import { buildAgentForest, flattenForest } from "./agentTree.ts";
+import {
+  humanBytes,
+  sampleTrees,
+  snapshotProcs,
+  systemStats,
+  type SystemStats,
+  type TreeStats,
+} from "./procStats.ts";
+import { deriveLiveState, listRecords } from "./subcommands.ts";
+
+/** Default CPU sampling window. Long enough to be meaningful, short enough to feel instant. */
+const DEFAULT_WINDOW_MS = 1000;
+
+function shortenPath(p: string): string {
+  const home = homedir();
+  return p.startsWith(home) ? "~" + p.slice(home.length) : p;
+}
+
+/** Trailing path segment that identifies a worktree — `/code/x/foo/tree/main` → `foo`. */
+export function repoLabel(cwd: string): string {
+  const parts = cwd.split(path.sep).filter(Boolean);
+  const treeAt = parts.lastIndexOf("tree");
+  // The repo's own name is more useful than the branch dir every checkout shares.
+  if (treeAt > 0) return parts[treeAt - 1] as string;
+  return parts[parts.length - 1] ?? shortenPath(cwd);
+}
+
+/** `15.23 12.52 9.86 (8 cpu, 1.9x)  mem 13.0/15Gi  swap 4.8/4.8Gi FULL  zombies 1440` */
+export function formatSystemLine(sys: SystemStats): string {
+  const bits: string[] = [];
+  if (sys.load) {
+    const [one, five, fifteen] = sys.load;
+    const ratio = one / Math.max(1, sys.ncpu);
+    // Flag oversubscription explicitly — "15.23" means nothing without the core
+    // count beside it, and that ratio is the whole point of the number.
+    bits.push(
+      `load ${one.toFixed(2)} ${five.toFixed(2)} ${fifteen.toFixed(2)} ` +
+        `(${sys.ncpu} cpu, ${ratio.toFixed(1)}x)`,
+    );
+  }
+  if (sys.memTotalBytes !== null) {
+    const used = sys.memAvailableBytes !== null ? sys.memTotalBytes - sys.memAvailableBytes : null;
+    bits.push(`mem ${humanBytes(used)}/${humanBytes(sys.memTotalBytes)}`);
+  }
+  if (sys.swapTotalBytes !== null && sys.swapTotalBytes > 0) {
+    const usedSwap = sys.swapFreeBytes !== null ? sys.swapTotalBytes - sys.swapFreeBytes : null;
+    // A full swap is the difference between "loaded" and "one allocation away
+    // from the OOM killer", so it gets a word rather than just a ratio.
+    const full = sys.swapFreeBytes !== null && sys.swapFreeBytes <= 0 ? " FULL" : "";
+    bits.push(`swap ${humanBytes(usedSwap)}/${humanBytes(sys.swapTotalBytes)}${full}`);
+  }
+  if (sys.zombies > 0) bits.push(`zombies ${sys.zombies}`);
+  return bits.join("   ");
+}
+
+export interface PsRow {
+  pid: number;
+  cli: string;
+  status: string;
+  cwd: string;
+  repo: string;
+  stats: TreeStats;
+  self: boolean;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+function padStart(s: string, n: number): string {
+  return s.length >= n ? s : " ".repeat(n - s.length) + s;
+}
+
+export function renderTable(rows: PsRow[], unattributed: TreeStats | null): string {
+  const cells = rows.map((r) => ({
+    pid: String(r.pid),
+    cli: r.cli,
+    status: r.status,
+    cpu: r.stats.cpuPercent.toFixed(1),
+    rss: humanBytes(r.stats.rss),
+    procs: String(r.stats.procs),
+    repo: r.repo,
+    self: r.self,
+  }));
+  // The unmanaged row participates in the width pass — "unmanaged" is wider than
+  // any real CLI name, so sizing without it knocks the whole table out of line.
+  if (unattributed && unattributed.procs > 0) {
+    cells.push({
+      pid: "-",
+      cli: "unmanaged",
+      status: "-",
+      cpu: unattributed.cpuPercent.toFixed(1),
+      rss: humanBytes(unattributed.rss),
+      procs: String(unattributed.procs),
+      repo: "-",
+      self: false,
+    });
+  }
+  const w = {
+    pid: Math.max(3, ...cells.map((c) => c.pid.length)),
+    cli: Math.max(3, ...cells.map((c) => c.cli.length)),
+    status: Math.max(6, ...cells.map((c) => c.status.length)),
+    cpu: Math.max(5, ...cells.map((c) => c.cpu.length)),
+    rss: Math.max(5, ...cells.map((c) => c.rss.length)),
+    procs: Math.max(5, ...cells.map((c) => c.procs.length)),
+    repo: Math.max(4, ...cells.map((c) => c.repo.length)),
+  };
+  const line = (
+    pid: string,
+    cli: string,
+    status: string,
+    cpu: string,
+    rss: string,
+    procs: string,
+    repo: string,
+    tail = "",
+  ) =>
+    `${pad(pid, w.pid)}  ${pad(cli, w.cli)}  ${pad(status, w.status)}  ` +
+    `${padStart(cpu, w.cpu)}  ${padStart(rss, w.rss)}  ${padStart(procs, w.procs)}  ` +
+    `${pad(repo, w.repo)}${tail}`;
+
+  const out: string[] = [line("PID", "CLI", "STATUS", "CPU%", "RSS", "PROCS", "REPO")];
+  for (const c of cells) {
+    out.push(
+      line(c.pid, c.cli, c.status, c.cpu, c.rss, c.procs, c.repo, c.self ? "  ← this session" : ""),
+    );
+  }
+  return out.join("\n");
+}
+
+export async function cmdPs(rest: string[]): Promise<number> {
+  const y = yargs(rest)
+    .usage(
+      "Usage: ay ps [keyword] [options]\n\n" +
+        "Per-agent resource usage, rolled up across each agent's whole process tree\n" +
+        "(wrapper + CLI + pty hosts + subagents). Local-only; use `ay ls` for the\n" +
+        "fleet view and per-agent prompts.",
+    )
+    .option("all", {
+      type: "boolean",
+      default: false,
+      description: "Include exited agents",
+    })
+    .option("json", { type: "boolean", default: false, description: "Output as JSON" })
+    .option("sort", {
+      type: "string",
+      choices: ["rss", "cpu", "procs", "pid"],
+      default: "rss",
+      description: "Sort rows by resource usage (default: rss, biggest first)",
+    })
+    .option("tree", {
+      type: "boolean",
+      default: false,
+      description: "Keep ay ls's parent>child forest order instead of sorting",
+    })
+    .option("interval", {
+      type: "number",
+      default: DEFAULT_WINDOW_MS / 1000,
+      description: "CPU sampling window in seconds — CPU% is a live delta, not a lifetime average",
+    })
+    .option("cwd", { type: "string", description: "Restrict to agents whose cwd starts with dir" })
+    .option("help", { alias: "h", type: "boolean", default: false, description: "Show this help" })
+    .example("ay ps", "biggest agents first, with box vitals")
+    .example("ay ps --sort cpu", "who is actually burning CPU right now")
+    .example("ay ps --json", "machine-readable rollup")
+    .help(false)
+    .version(false)
+    .exitProcess(false);
+
+  const argv = await y.parseAsync();
+  if (argv.help || argv.h) {
+    process.stdout.write((await y.getHelp()) + "\n");
+    return 0;
+  }
+
+  const keyword = argv._[0] !== undefined ? String(argv._[0]) : undefined;
+  const records = await listRecords(keyword, {
+    all: argv.all,
+    active: false,
+    json: false,
+    latest: false,
+    cwdScope: typeof argv.cwd === "string" ? path.resolve(argv.cwd) : null,
+  });
+
+  if (records.length === 0) {
+    process.stderr.write(keyword ? `no agents matched "${keyword}"\n` : "no running agents\n");
+    return 0;
+  }
+
+  // `flattenForest` yields parents before children; sampleTrees attributes
+  // first-come, so sampling in that order would let a parent absorb a nested
+  // agent's whole subtree and render the child as a bogus 0-proc row. Reverse to
+  // claim deepest-first, then display in forest order.
+  const ordered = flattenForest(buildAgentForest(records)).map((r) => r.record);
+  const windowMs = Math.max(100, (Number.isFinite(argv.interval) ? argv.interval : 1) * 1000);
+  const { trees, unattributed } = await sampleTrees(
+    [...ordered].reverse().map((r) => r.pid),
+    { windowMs },
+  );
+
+  const states = new Map(
+    await Promise.all(ordered.map(async (r) => [r.pid, (await deriveLiveState(r)).state] as const)),
+  );
+  const selfPid = process.pid;
+  const rows: PsRow[] = ordered.map((r) => ({
+    pid: r.pid,
+    cli: r.cli,
+    status: states.get(r.pid) ?? r.status,
+    cwd: r.cwd,
+    repo: repoLabel(r.cwd),
+    stats: trees.get(r.pid) ?? { pid: r.pid, rss: 0, cpuPercent: 0, procs: 0 },
+    // Mark the tree we are standing in — anything that later grows a kill
+    // affordance must not let you shoot the session issuing the command.
+    self: trees.get(r.pid) !== undefined && isSelfTree(r.pid, selfPid),
+  }));
+
+  if (!argv.tree) {
+    const key = String(argv.sort);
+    rows.sort((a, b) => {
+      if (key === "cpu") return b.stats.cpuPercent - a.stats.cpuPercent;
+      if (key === "procs") return b.stats.procs - a.stats.procs;
+      if (key === "pid") return a.pid - b.pid;
+      return b.stats.rss - a.stats.rss;
+    });
+  }
+
+  const sys = await systemStats(await snapshotProcs());
+
+  if (argv.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          system: sys,
+          agents: rows.map((r) => ({
+            pid: r.pid,
+            cli: r.cli,
+            status: r.status,
+            cwd: r.cwd,
+            rssBytes: r.stats.rss,
+            cpuPercent: Number(r.stats.cpuPercent.toFixed(2)),
+            procs: r.stats.procs,
+            self: r.self,
+          })),
+          unattributed: {
+            rssBytes: unattributed.rss,
+            cpuPercent: Number(unattributed.cpuPercent.toFixed(2)),
+            procs: unattributed.procs,
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return 0;
+  }
+
+  const header = formatSystemLine(sys);
+  if (header) process.stdout.write(` ${header}\n\n`);
+  process.stdout.write(renderTable(rows, unattributed) + "\n");
+  return 0;
+}
+
+/**
+ * Is `rootPid` the wrapper of the tree this very process lives in?
+ *
+ * Walks our own ancestry rather than the snapshot: cheap, and correct even when
+ * the snapshot raced. Linux-only detail (reads /proc), returns false elsewhere —
+ * mislabelling the self row is cosmetic.
+ */
+export function isSelfTree(
+  rootPid: number,
+  selfPid: number,
+  // Injectable so the ancestry walk itself is testable off Linux — the real
+  // reader is /proc-only, but the hop/cycle logic is platform-independent and
+  // is the part that can actually be wrong.
+  readPpid: (pid: number) => number | null = readPpidSync,
+  platform: string = process.platform,
+): boolean {
+  if (platform !== "linux") return false;
+  let pid = selfPid;
+  // Bounded: a /proc that reports a cycle (or a pid1 that is its own parent)
+  // must not spin here.
+  for (let hops = 0; hops < 64 && pid > 1; hops++) {
+    if (pid === rootPid) return true;
+    const ppid = readPpid(pid);
+    if (ppid === null) return false;
+    pid = ppid;
+  }
+  return false;
+}
+
+export function readPpidSync(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const close = stat.lastIndexOf(")");
+    if (close < 0) return null;
+    const ppid = Number(
+      stat
+        .slice(close + 1)
+        .trim()
+        .split(/\s+/)[1],
+    );
+    return Number.isFinite(ppid) ? ppid : null;
+  } catch {
+    return null;
+  }
+}

--- a/ts/cmdPs.ts
+++ b/ts/cmdPs.ts
@@ -39,7 +39,12 @@ function shortenPath(p: string): string {
 
 /** Trailing path segment that identifies a worktree — `/code/x/foo/tree/main` → `foo`. */
 export function repoLabel(cwd: string): string {
-  const parts = cwd.split(path.sep).filter(Boolean);
+  // Split on BOTH separators, not `path.sep`. Agent cwds come off the registry,
+  // which stores whatever the wrapper recorded — a posix path is perfectly
+  // normal on a Windows host (msys/WSL shells, or a record synced from another
+  // box). Keying on path.sep left the whole path unsplit there, so the REPO
+  // column printed the full path instead of the repo name.
+  const parts = cwd.split(/[\\/]+/).filter(Boolean);
   const treeAt = parts.lastIndexOf("tree");
   // The repo's own name is more useful than the branch dir every checkout shares.
   if (treeAt > 0) return parts[treeAt - 1] as string;

--- a/ts/cmdPs.ts
+++ b/ts/cmdPs.ts
@@ -314,18 +314,29 @@ export function isSelfTree(
   return false;
 }
 
+/**
+ * ppid out of one `/proc/<pid>/stat` line.
+ *
+ * Split from the read so the parsing — the part that can actually be wrong — is
+ * testable on hosts without /proc. Field 2 is `comm`, wrapped in parens and NOT
+ * escaped: a process named `foo) bar (baz` is legal, so the fields after it can
+ * only be found from the LAST `)`, never by splitting on whitespace.
+ */
+export function parsePpidFromStat(stat: string): number | null {
+  const close = stat.lastIndexOf(")");
+  if (close < 0) return null;
+  const ppid = Number(
+    stat
+      .slice(close + 1)
+      .trim()
+      .split(/\s+/)[1],
+  );
+  return Number.isFinite(ppid) ? ppid : null;
+}
+
 export function readPpidSync(pid: number): number | null {
   try {
-    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-    const close = stat.lastIndexOf(")");
-    if (close < 0) return null;
-    const ppid = Number(
-      stat
-        .slice(close + 1)
-        .trim()
-        .split(/\s+/)[1],
-    );
-    return Number.isFinite(ppid) ? ppid : null;
+    return parsePpidFromStat(readFileSync(`/proc/${pid}/stat`, "utf8"));
   } catch {
     return null;
   }

--- a/ts/procStats.spec.ts
+++ b/ts/procStats.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildChildIndex,
+  defaultListPids,
+  defaultReadPsTable,
+  defaultReadStat,
+  defaultReadSys,
   derivePageSize,
   descendantsOf,
   humanBytes,
@@ -406,5 +410,97 @@ describe("real host adapters", () => {
     expect(mine.procs).toBe(0);
     expect(mine.rss).toBe(0);
     expect(unattributed.procs).toBe(0);
+  });
+});
+
+describe("systemStats degradation", () => {
+  // Injected readers, so every branch runs on every platform — the real-adapter
+  // block above can only exercise whichever shape the host happens to have.
+  const noProcs = new Map<number, ProcSample>();
+  const proc = (over: Partial<ProcSample> = {}): ProcSample => ({
+    pid: 1,
+    ppid: 0,
+    rss: 0,
+    utime: 0,
+    stime: 0,
+    state: "S",
+    ...over,
+  });
+
+  it("prefers /proc loadavg and meminfo when both parse", async () => {
+    const sys = await systemStats(noProcs, {
+      readSys: async (name) =>
+        name === "loadavg"
+          ? "1.50 2.50 3.50 2/1234 5678"
+          : "MemTotal: 16000 kB\nMemAvailable: 4000 kB\nSwapTotal: 2000 kB\nSwapFree: 500 kB\n",
+    });
+    expect(sys.load).toEqual([1.5, 2.5, 3.5]);
+    expect(sys.memTotalBytes).toBe(16000 * 1024);
+    expect(sys.memAvailableBytes).toBe(4000 * 1024);
+    expect(sys.swapTotalBytes).toBe(2000 * 1024);
+    expect(sys.swapFreeBytes).toBe(500 * 1024);
+  });
+
+  it("falls back to node:os when /proc is unreadable", async () => {
+    const sys = await systemStats(noProcs, { readSys: async () => null });
+    // No /proc means no swap breakdown anywhere — the header just omits it.
+    expect(sys.swapTotalBytes).toBeNull();
+    expect(sys.swapFreeBytes).toBeNull();
+    expect(sys.memTotalBytes).toBeGreaterThan(0);
+    expect(sys.ncpu).toBeGreaterThan(0);
+  });
+
+  it("rejects a truncated loadavg rather than reporting NaN", async () => {
+    const sys = await systemStats(noProcs, {
+      readSys: async (name) => (name === "loadavg" ? "1.50 2.50" : null),
+    });
+    // Two fields is not a load average; it must not become [1.5, 2.5, NaN].
+    expect(sys.load === null || sys.load.every(Number.isFinite)).toBe(true);
+  });
+
+  it("rejects a non-numeric loadavg", async () => {
+    const sys = await systemStats(noProcs, {
+      readSys: async (name) => (name === "loadavg" ? "x y z" : null),
+    });
+    expect(sys.load === null || sys.load.every(Number.isFinite)).toBe(true);
+  });
+
+  it("counts zombies from the snapshot, not from /proc", async () => {
+    const procs = new Map<number, ProcSample>([
+      [1, proc({ pid: 1, state: "Z" })],
+      [2, proc({ pid: 2, state: "S" })],
+      [3, proc({ pid: 3, state: "Z" })],
+    ]);
+    const sys = await systemStats(procs, { readSys: async () => null });
+    expect(sys.zombies).toBe(2);
+  });
+});
+
+describe("default adapter failure paths", () => {
+  // Each adapter has a catch that turns "this host has no such thing" into an
+  // empty result instead of an exception — that is what lets `ay ps` degrade
+  // rather than crash off Linux. Reachable on every platform by asking for
+  // something that cannot exist.
+  it("defaultReadStat returns null for an impossible pid", async () => {
+    await expect(defaultReadStat(-1)).resolves.toBeNull();
+  });
+
+  it("defaultReadSys returns null for a file that is not there", async () => {
+    await expect(defaultReadSys("definitely-not-a-proc-file")).resolves.toBeNull();
+  });
+
+  it("defaultListPids returns a list or an empty array, never throws", async () => {
+    // Linux: the real pid list. Elsewhere: readdir("/proc") fails and the catch
+    // hands back [] so snapshotProcs can fall through to the `ps` path.
+    const pids = await defaultListPids();
+    expect(Array.isArray(pids)).toBe(true);
+    if (process.platform === "linux") expect(pids.length).toBeGreaterThan(0);
+    else expect(pids).toEqual([]);
+  });
+
+  it("defaultReadPsTable returns text where ps exists and null where it does not", async () => {
+    const table = await defaultReadPsTable();
+    if (process.platform === "win32") expect(table).toBeNull();
+    else expect(typeof table).toBe("string");
   });
 });

--- a/ts/procStats.spec.ts
+++ b/ts/procStats.spec.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChildIndex,
+  derivePageSize,
+  descendantsOf,
+  humanBytes,
+  parseMeminfo,
+  parseProcStat,
+  parsePsTable,
+  parsePsTime,
+  sampleTrees,
+  snapshotProcs,
+  systemStats,
+  type ProcSample,
+} from "./procStats.ts";
+
+/**
+ * Build the post-comm portion of a /proc/<pid>/stat line. Fields 3.. are:
+ * state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt cmajflt
+ * utime stime cutime cstime priority nice num_threads itrealvalue starttime
+ * vsize rss — so state=0, ppid=1, utime=11, stime=12, starttime=19, rss=21.
+ */
+function statLine(opts: {
+  pid: number;
+  ppid: number;
+  utime?: number;
+  stime?: number;
+  rssPages?: number;
+  state?: string;
+  comm?: string;
+  startTime?: string;
+}): string {
+  const f = Array(22).fill("0");
+  f[0] = opts.state ?? "S";
+  f[1] = String(opts.ppid);
+  f[11] = String(opts.utime ?? 0);
+  f[12] = String(opts.stime ?? 0);
+  f[19] = opts.startTime ?? "5000";
+  f[21] = String(opts.rssPages ?? 0);
+  return `${opts.pid} (${opts.comm ?? "claude"}) ${f.join(" ")}`;
+}
+
+describe("parseProcStat", () => {
+  it("reads ppid, cpu and rss from a normal stat line", () => {
+    const s = parseProcStat(
+      42,
+      statLine({ pid: 42, ppid: 7, utime: 150, stime: 50, rssPages: 10 }),
+    );
+    expect(s).toEqual({
+      pid: 42,
+      ppid: 7,
+      rss: 10 * 4096,
+      cpuSeconds: 2, // (150 + 50) ticks / 100 USER_HZ
+      state: "S",
+      startToken: "5000",
+    });
+  });
+
+  it("scales rss by the measured page size, not a hardcoded 4 KiB", () => {
+    const s = parseProcStat(1, statLine({ pid: 1, ppid: 0, rssPages: 10 }), 16384);
+    expect(s?.rss).toBe(10 * 16384);
+  });
+
+  it("survives a comm containing spaces and parentheses", () => {
+    // The reason we parse after the LAST ')': naive splitting mis-indexes every
+    // field past the comm.
+    const s = parseProcStat(9, statLine({ pid: 9, ppid: 3, comm: "my prog (v2)", rssPages: 2 }));
+    expect(s?.ppid).toBe(3);
+    expect(s?.rss).toBe(2 * 4096);
+  });
+
+  it("returns null on a line with no comm terminator", () => {
+    expect(parseProcStat(1, "garbage without paren")).toBeNull();
+  });
+
+  it("returns null when the numeric fields are unparseable", () => {
+    expect(parseProcStat(1, "1 (x) S notanumber")).toBeNull();
+  });
+});
+
+describe("parsePsTime", () => {
+  it("parses mm:ss", () => {
+    expect(parsePsTime("01:30")).toBe(90);
+  });
+  it("parses hh:mm:ss", () => {
+    expect(parsePsTime("02:00:00")).toBe(7200);
+  });
+  it("parses dd-hh:mm:ss", () => {
+    expect(parsePsTime("1-00:00:00")).toBe(86400);
+  });
+  it("returns 0 for junk", () => {
+    expect(parsePsTime("-")).toBe(0);
+  });
+});
+
+describe("parsePsTable", () => {
+  it("normalizes ps KiB into bytes so both backends agree", () => {
+    const procs = parsePsTable("  10  1  2048  00:10 S\n  11 10   512  00:00 Z\n");
+    expect(procs.get(10)).toEqual({
+      pid: 10,
+      ppid: 1,
+      rss: 2048 * 1024,
+      cpuSeconds: 10,
+      state: "S",
+      // No usable start token from `ps` — the pid-reuse guard is Linux-only.
+      startToken: "",
+    });
+    expect(procs.get(11)?.state).toBe("Z");
+  });
+
+  it("skips short/garbage lines", () => {
+    expect(parsePsTable("\nnonsense\n  1 2 3 4 S\n").size).toBe(1);
+  });
+});
+
+describe("descendantsOf", () => {
+  const procs = new Map<number, ProcSample>(
+    (
+      [
+        [1, 0],
+        [10, 1],
+        [11, 10],
+        [12, 11], // depth 3 under 10
+        [20, 1],
+      ] as [number, number][]
+    ).map(([pid, ppid]) => [
+      pid,
+      { pid, ppid, rss: 0, cpuSeconds: 0, state: "S", startToken: `t${pid}` },
+    ]),
+  );
+  const kids = buildChildIndex(procs);
+
+  it("walks the FULL closure, not just direct children", () => {
+    expect([...descendantsOf(10, kids)].sort((a, b) => a - b)).toEqual([10, 11, 12]);
+  });
+
+  it("excludes pids already claimed by an earlier root", () => {
+    expect([...descendantsOf(10, kids, new Set([11]))].sort((a, b) => a - b)).toEqual([10]);
+  });
+
+  it("terminates on a parent cycle instead of blowing the stack", () => {
+    const cyclic = new Map<number, ProcSample>([
+      [1, { pid: 1, ppid: 2, rss: 0, cpuSeconds: 0, state: "S", startToken: "t1" }],
+      [2, { pid: 2, ppid: 1, rss: 0, cpuSeconds: 0, state: "S", startToken: "t2" }],
+    ]);
+    expect(descendantsOf(1, buildChildIndex(cyclic)).size).toBe(2);
+  });
+});
+
+/** Two scripted /proc snapshots, returned on successive calls. */
+function scriptedDeps(rounds: string[][]) {
+  let call = 0;
+  const pidsOf = (lines: string[]) => lines.map((l) => Number(l.split(" ")[0]));
+  return {
+    platform: "linux",
+    listPids: async () => {
+      const r = rounds[Math.min(call, rounds.length - 1)] as string[];
+      return pidsOf(r);
+    },
+    readStat: async (pid: number) => {
+      const r = rounds[Math.min(call, rounds.length - 1)] as string[];
+      const hit = r.find((l) => Number(l.split(" ")[0]) === pid) ?? null;
+      // Advance only after the last pid of a round has been read.
+      if (pid === pidsOf(r)[r.length - 1]) call++;
+      return hit;
+    },
+  };
+}
+
+describe("sampleTrees", () => {
+  it("rolls a subtree up and derives CPU% from the delta, not lifetime total", async () => {
+    // Root 10 has child 11. Between samples the pair burns 0.5s of CPU over a
+    // 0.5s window => 100% of one core, even though lifetime CPU is far larger.
+    const first = [
+      statLine({ pid: 10, ppid: 1, utime: 10000, rssPages: 100 }),
+      statLine({ pid: 11, ppid: 10, utime: 10000, rssPages: 100 }),
+    ];
+    const second = [
+      statLine({ pid: 10, ppid: 1, utime: 10025, rssPages: 100 }),
+      statLine({ pid: 11, ppid: 10, utime: 10025, rssPages: 100 }),
+    ];
+    const { trees } = await sampleTrees([10], {
+      windowMs: 500,
+      deps: scriptedDeps([first, second]),
+    });
+    const t = trees.get(10);
+    expect(t?.procs).toBe(2);
+    expect(t?.rss).toBe(200 * 4096);
+    // 0.5 CPU-seconds over ~0.5s wall. Generous bound: the sleep can overshoot
+    // on a loaded box, which only ever lowers the percentage.
+    expect(t?.cpuPercent).toBeGreaterThan(60);
+    expect(t?.cpuPercent).toBeLessThanOrEqual(110);
+  });
+
+  it("does not credit a process that appeared mid-window with its whole history", async () => {
+    // 11 shows up only in the second sample carrying 100s of cumulative CPU.
+    // Counting that would spike the row to nonsense.
+    const first = [statLine({ pid: 10, ppid: 1 })];
+    const second = [statLine({ pid: 10, ppid: 1 }), statLine({ pid: 11, ppid: 10, utime: 10000 })];
+    const { trees } = await sampleTrees([10], {
+      windowMs: 100,
+      deps: scriptedDeps([first, second]),
+    });
+    expect(trees.get(10)?.procs).toBe(2);
+    expect(trees.get(10)?.cpuPercent).toBe(0);
+  });
+
+  it("ignores the baseline when a pid was REUSED between samples", async () => {
+    // Same pid, different process (start time changed) carrying a much smaller
+    // counter. Subtracting across the two is meaningless; Math.max would clamp
+    // to 0 here, but the reverse case (reused pid with a LARGER counter) would
+    // otherwise report a huge bogus spike.
+    const first = [statLine({ pid: 10, ppid: 1, utime: 100, startTime: "1000" })];
+    const second = [statLine({ pid: 10, ppid: 1, utime: 9999, startTime: "8888" })];
+    const { trees } = await sampleTrees([10], {
+      windowMs: 100,
+      deps: scriptedDeps([first, second]),
+    });
+    expect(trees.get(10)?.cpuPercent).toBe(0);
+  });
+
+  it("still uses the baseline when the start token is unavailable", async () => {
+    // The ps fallback yields "" for both samples — "no opinion" must not be
+    // treated as a mismatch, or CPU% would be permanently 0 off Linux.
+    let call = 0;
+    const deps = {
+      platform: "darwin",
+      readPsTable: async () => (call++ === 0 ? "10 1 100 00:00 S\n" : "10 1 100 00:01 S\n"),
+    };
+    const { trees } = await sampleTrees([10], { windowMs: 100, deps });
+    expect(trees.get(10)?.cpuPercent).toBeGreaterThan(0);
+  });
+
+  it("gives a nested root its own subtree when claimed deepest-first", async () => {
+    // 10 -> 11 -> 12, with both 10 and 11 listed as agent roots.
+    const snap = [
+      statLine({ pid: 10, ppid: 1, rssPages: 10 }),
+      statLine({ pid: 11, ppid: 10, rssPages: 10 }),
+      statLine({ pid: 12, ppid: 11, rssPages: 10 }),
+    ];
+    const { trees } = await sampleTrees([11, 10], {
+      windowMs: 100,
+      deps: scriptedDeps([snap, snap]),
+    });
+    // Child claims 11+12; parent keeps only itself — no double counting, and
+    // crucially the child is not rendered as an empty 0-proc row.
+    expect(trees.get(11)?.procs).toBe(2);
+    expect(trees.get(10)?.procs).toBe(1);
+  });
+
+  it("reports everything unclaimed as the unattributed row", async () => {
+    const snap = [
+      statLine({ pid: 10, ppid: 1, rssPages: 10 }),
+      statLine({ pid: 99, ppid: 1, rssPages: 5 }),
+    ];
+    const { unattributed } = await sampleTrees([10], {
+      windowMs: 100,
+      deps: scriptedDeps([snap, snap]),
+    });
+    expect(unattributed.procs).toBe(1);
+    expect(unattributed.rss).toBe(5 * 4096);
+  });
+});
+
+describe("snapshotProcs", () => {
+  it("skips pids that vanish between listing and reading", async () => {
+    const procs = await snapshotProcs({
+      platform: "linux",
+      listPids: async () => [1, 2],
+      readStat: async (pid) => (pid === 1 ? statLine({ pid: 1, ppid: 0 }) : null),
+    });
+    expect([...procs.keys()]).toEqual([1]);
+  });
+
+  it("falls back to the ps table off Linux", async () => {
+    const procs = await snapshotProcs({
+      platform: "darwin",
+      readPsTable: async () => "  5  1  1024  00:02 S\n",
+    });
+    expect(procs.get(5)?.rss).toBe(1024 * 1024);
+  });
+});
+
+describe("derivePageSize", () => {
+  it("recovers a 16 KiB page size from our own VmRSS vs rss-in-pages", () => {
+    // 100 pages reported as 1600 kB => 16384 bytes per page.
+    expect(derivePageSize(statLine({ pid: 1, ppid: 0, rssPages: 100 }), "VmRSS:  1600 kB")).toBe(
+      16384,
+    );
+  });
+
+  it("recovers the ordinary 4 KiB case", () => {
+    expect(derivePageSize(statLine({ pid: 1, ppid: 0, rssPages: 100 }), "VmRSS:   400 kB")).toBe(
+      4096,
+    );
+  });
+
+  it("falls back to 4 KiB when either side is missing or zero", () => {
+    expect(derivePageSize(statLine({ pid: 1, ppid: 0, rssPages: 0 }), "VmRSS: 400 kB")).toBe(4096);
+    expect(derivePageSize(statLine({ pid: 1, ppid: 0, rssPages: 100 }), "no vmrss here")).toBe(
+      4096,
+    );
+    expect(derivePageSize("garbage", "VmRSS: 400 kB")).toBe(4096);
+  });
+});
+
+describe("parseMeminfo", () => {
+  it("converts kB entries to bytes", () => {
+    const m = parseMeminfo("MemTotal:       16316360 kB\nMemAvailable:    2500000 kB\n");
+    expect(m.get("MemTotal")).toBe(16316360 * 1024);
+    expect(m.get("MemAvailable")).toBe(2500000 * 1024);
+  });
+});
+
+describe("systemStats", () => {
+  it("reads load/mem and counts zombies from the snapshot", async () => {
+    const procs = new Map<number, ProcSample>([
+      [1, { pid: 1, ppid: 0, rss: 0, cpuSeconds: 0, state: "S", startToken: "t1" }],
+      [2, { pid: 2, ppid: 1, rss: 0, cpuSeconds: 0, state: "Z", startToken: "t2" }],
+      [3, { pid: 3, ppid: 1, rss: 0, cpuSeconds: 0, state: "Z", startToken: "t3" }],
+    ]);
+    const sys = await systemStats(procs, {
+      readSys: async (name) =>
+        name === "loadavg"
+          ? "15.23 12.52 9.86 5/2000 12345\n"
+          : "MemTotal: 100 kB\nMemAvailable: 40 kB\nSwapTotal: 50 kB\nSwapFree: 0 kB\n",
+    });
+    expect(sys.load).toEqual([15.23, 12.52, 9.86]);
+    expect(sys.zombies).toBe(2);
+    expect(sys.memAvailableBytes).toBe(40 * 1024);
+    expect(sys.swapFreeBytes).toBe(0);
+  });
+
+  it("falls back to node:os when /proc is unreadable, so the header is not blank", async () => {
+    // Off Linux there is no /proc at all; without this fallback macOS/BSD would
+    // render an empty system line.
+    const sys = await systemStats(new Map(), { readSys: async () => null });
+    expect(sys.memTotalBytes).toBeGreaterThan(0);
+    expect(sys.memAvailableBytes).toBeGreaterThan(0);
+    // node:os has no swap breakdown — that stays unknown rather than guessed.
+    expect(sys.swapTotalBytes).toBeNull();
+    if (process.platform !== "win32") expect(sys.load).not.toBeNull();
+  });
+});
+
+describe("humanBytes", () => {
+  it("keeps a decimal below 100 so Gi totals match free -h", () => {
+    expect(humanBytes(15.6 * 1024 ** 3)).toBe("15.6Gi");
+  });
+  it("rounds at three significant digits", () => {
+    expect(humanBytes(376 * 1024 ** 2)).toBe("376Mi");
+  });
+  it("renders unknown as a dash", () => {
+    expect(humanBytes(null)).toBe("-");
+  });
+});
+
+describe("real host adapters", () => {
+  // Every other test here injects fake readers, so the DEFAULT ones — /proc on
+  // Linux, the `ps` fallback everywhere else — were never executed. These call
+  // them for real: read-only, and the only check that the adapters actually work
+  // on the machine the code ships to.
+  it("snapshotProcs sees this very process on the real host", async () => {
+    const procs = await snapshotProcs();
+    expect(procs.size).toBeGreaterThan(0);
+    const self = procs.get(process.pid);
+    expect(self).toBeDefined();
+    expect(self!.rss).toBeGreaterThan(0);
+  });
+
+  it("systemStats reads the box vitals on the real host", async () => {
+    const sys = await systemStats(await snapshotProcs());
+    // load is unavailable on some sandboxes; memory should always be readable.
+    expect(sys.memTotalBytes === null || sys.memTotalBytes > 0).toBe(true);
+    expect(sys.ncpu === null || sys.ncpu > 0).toBe(true);
+    expect(sys.zombies).toBeGreaterThanOrEqual(0);
+  });
+
+  it("sampleTrees attributes this process's own tree", async () => {
+    const { trees, unattributed } = await sampleTrees([process.pid], { windowMs: 100 });
+    const mine = trees.get(process.pid);
+    expect(mine).toBeDefined();
+    expect(mine!.procs).toBeGreaterThanOrEqual(1);
+    expect(unattributed.procs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/ts/procStats.spec.ts
+++ b/ts/procStats.spec.ts
@@ -357,10 +357,17 @@ describe("humanBytes", () => {
 
 describe("real host adapters", () => {
   // Every other test here injects fake readers, so the DEFAULT ones — /proc on
-  // Linux, the `ps` fallback everywhere else — were never executed. These call
-  // them for real: read-only, and the only check that the adapters actually work
-  // on the machine the code ships to.
-  it("snapshotProcs sees this very process on the real host", async () => {
+  // Linux, the `ps` fallback elsewhere — were never executed. These call them for
+  // real (read-only): the only check that the adapters work on the machine the
+  // code ships to.
+  //
+  // Windows has neither /proc nor a POSIX `ps`, so there is nothing to read
+  // there. The contract on that platform is "degrade to empty", not "throw", and
+  // that is what the win32 branch asserts — `ay ps` must stay a no-op rather
+  // than a crash.
+  const posix = process.platform !== "win32";
+
+  it.runIf(posix)("snapshotProcs sees this very process on the real host", async () => {
     const procs = await snapshotProcs();
     expect(procs.size).toBeGreaterThan(0);
     const self = procs.get(process.pid);
@@ -368,19 +375,30 @@ describe("real host adapters", () => {
     expect(self!.rss).toBeGreaterThan(0);
   });
 
-  it("systemStats reads the box vitals on the real host", async () => {
+  it.runIf(!posix)("snapshotProcs degrades to empty on Windows instead of throwing", async () => {
+    await expect(snapshotProcs()).resolves.toBeInstanceOf(Map);
+  });
+
+  it("systemStats reads whatever the real host exposes, without throwing", async () => {
     const sys = await systemStats(await snapshotProcs());
-    // load is unavailable on some sandboxes; memory should always be readable.
+    // Any single field can be unreadable depending on platform/sandbox; the
+    // contract is that it returns a well-formed record either way.
     expect(sys.memTotalBytes === null || sys.memTotalBytes > 0).toBe(true);
     expect(sys.ncpu === null || sys.ncpu > 0).toBe(true);
     expect(sys.zombies).toBeGreaterThanOrEqual(0);
   });
 
-  it("sampleTrees attributes this process's own tree", async () => {
+  it.runIf(posix)("sampleTrees attributes this process's own tree", async () => {
     const { trees, unattributed } = await sampleTrees([process.pid], { windowMs: 100 });
     const mine = trees.get(process.pid);
     expect(mine).toBeDefined();
     expect(mine!.procs).toBeGreaterThanOrEqual(1);
     expect(unattributed.procs).toBeGreaterThanOrEqual(0);
+  });
+
+  it.runIf(!posix)("sampleTrees returns an empty rollup on Windows", async () => {
+    const { trees, unattributed } = await sampleTrees([process.pid], { windowMs: 100 });
+    expect(trees.size).toBe(0);
+    expect(unattributed.procs).toBe(0);
   });
 });

--- a/ts/procStats.spec.ts
+++ b/ts/procStats.spec.ts
@@ -396,9 +396,15 @@ describe("real host adapters", () => {
     expect(unattributed.procs).toBeGreaterThanOrEqual(0);
   });
 
-  it.runIf(!posix)("sampleTrees returns an empty rollup on Windows", async () => {
+  it.runIf(!posix)("sampleTrees still yields a zero row per root on Windows", async () => {
+    // There is nothing to sample there, but every requested root MUST come back
+    // with an entry: cmdPs renders `trees.get(pid) ?? zero`, and a missing entry
+    // would drop the agent from the table entirely rather than showing it at 0.
     const { trees, unattributed } = await sampleTrees([process.pid], { windowMs: 100 });
-    expect(trees.size).toBe(0);
+    expect(trees.size).toBe(1);
+    const mine = trees.get(process.pid)!;
+    expect(mine.procs).toBe(0);
+    expect(mine.rss).toBe(0);
     expect(unattributed.procs).toBe(0);
   });
 });

--- a/ts/procStats.ts
+++ b/ts/procStats.ts
@@ -1,0 +1,484 @@
+/**
+ * Per-process-TREE resource rollup, for `ay ps`.
+ *
+ * Why this exists: `ay ls` lists WRAPPER pids, but a single ay-managed agent is
+ * a whole subtree — the wrapper, the CLI, its version process, `bg-pty-host`,
+ * `bg-spare`, the daemon, plus whatever the agent itself spawned. On a busy box
+ * one session can be 30+ processes. `ps`/`htop`/`glances` see those as
+ * unrelated rows and cannot attribute them to an agent; only ay knows the
+ * wrapper pids, so only ay can roll the cost up to "this session costs 612 MiB".
+ *
+ * Two things here are deliberately NOT the obvious approach:
+ *
+ * 1. CPU is a SAMPLED DELTA, never `ps`'s lifetime average. A session alive for
+ *    7 days shows a meaningless smeared percentage; "is this agent busy right
+ *    now" needs two reads of the cumulative counter a moment apart. That's why
+ *    the caller must await a sampling window — see `sampleTrees`.
+ *
+ * 2. Rollup walks the FULL descendant closure, not direct children. Agents spawn
+ *    subagents that spawn shells; a depth-1 sum undercounts badly.
+ *
+ * BEST-EFFORT by contract, like `procStartTime.ts`: every reader returns null /
+ * empty when it cannot answer (no /proc, unreadable pid, a process that exited
+ * mid-sample). Callers render "-" rather than failing — this is an inspection
+ * command, it must never be the thing that breaks.
+ */
+
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** One process, as sampled. `cpuSeconds` is CUMULATIVE since its start. */
+export interface ProcSample {
+  pid: number;
+  ppid: number;
+  /** Resident set size in bytes. */
+  rss: number;
+  /** Cumulative CPU (user+sys) in seconds since process start. */
+  cpuSeconds: number;
+  /** Single-letter state: R, S, D, Z, T… */
+  state: string;
+  /**
+   * Opaque "when did this pid start" token, for detecting pid REUSE between the
+   * two samples. Empty when unknowable (the non-Linux `ps` fallback), which
+   * callers must read as "no opinion", never as a mismatch.
+   */
+  startToken: string;
+}
+
+/**
+ * USER_HZ. The kernel reports utime/stime in clock ticks, and this is 100 on
+ * every Linux ABI we run on — it is fixed at the syscall boundary, NOT the
+ * configurable CONFIG_HZ. There is no cheap way to query it from Node.
+ */
+const USER_HZ = 100;
+
+/** Assumed page size when we cannot measure the real one. */
+const DEFAULT_PAGE_SIZE = 4096;
+
+/**
+ * Real page size for the `rss` field of /proc/<pid>/stat, which is in PAGES.
+ *
+ * Hardcoding 4 KiB under-reports by 4× on a 16 KiB-page arm64 kernel, so measure
+ * it instead — for free, with no `getconf` spawn: /proc/self/status reports our
+ * own VmRSS in kB while /proc/self/stat reports the same figure in pages, and
+ * the ratio is the page size. Snapped to the nearest supported power of two
+ * because VmRSS is kB-rounded. Measured once per process, then cached.
+ */
+let cachedPageSize: number | null = null;
+
+export function derivePageSize(statLine: string, statusText: string): number {
+  const close = statLine.lastIndexOf(")");
+  if (close < 0) return DEFAULT_PAGE_SIZE;
+  const pages = Number(
+    statLine
+      .slice(close + 1)
+      .trim()
+      .split(/\s+/)[21],
+  );
+  const kb = Number(/^VmRSS:\s+(\d+)/m.exec(statusText)?.[1]);
+  if (!Number.isFinite(pages) || !Number.isFinite(kb) || pages <= 0 || kb <= 0) {
+    return DEFAULT_PAGE_SIZE;
+  }
+  const raw = (kb * 1024) / pages;
+  let best = DEFAULT_PAGE_SIZE;
+  for (const candidate of [4096, 8192, 16384, 65536]) {
+    if (Math.abs(raw - candidate) < Math.abs(raw - best)) best = candidate;
+  }
+  return best;
+}
+
+async function pageSize(deps?: ProcReaders): Promise<number> {
+  if (cachedPageSize !== null) return cachedPageSize;
+  const readSys = deps?.readSys ?? defaultReadSys;
+  const [stat, status] = await Promise.all([readSys("self/stat"), readSys("self/status")]);
+  cachedPageSize = stat && status ? derivePageSize(stat, status) : DEFAULT_PAGE_SIZE;
+  return cachedPageSize;
+}
+
+/**
+ * Parse the fields of a /proc/<pid>/stat line that we need.
+ *
+ * As in `parseLinuxStartTime`, the parse MUST start after the last `)`: field 2
+ * is the comm and may contain spaces and parens, so naive splitting mis-indexes
+ * everything after it. Post-`)` fields begin at field 3, so field N is at index
+ * N-3: state=3→0, ppid=4→1, utime=14→11, stime=15→12, starttime=22→19, rss=24→21.
+ */
+export function parseProcStat(
+  pid: number,
+  stat: string,
+  pageSizeBytes: number = DEFAULT_PAGE_SIZE,
+): ProcSample | null {
+  const close = stat.lastIndexOf(")");
+  if (close < 0) return null;
+  const f = stat
+    .slice(close + 1)
+    .trim()
+    .split(/\s+/);
+  const state = f[0];
+  const ppid = Number(f[1]);
+  const utime = Number(f[11]);
+  const stime = Number(f[12]);
+  const rssPages = Number(f[21]);
+  if (!state || !Number.isFinite(ppid) || !Number.isFinite(utime) || !Number.isFinite(stime)) {
+    return null;
+  }
+  return {
+    pid,
+    ppid,
+    rss: Number.isFinite(rssPages) ? rssPages * pageSizeBytes : 0,
+    cpuSeconds: (utime + stime) / USER_HZ,
+    state,
+    startToken: f[19] ?? "",
+  };
+}
+
+/** Injection seam so specs can drive every path without a real /proc. */
+export interface ProcReaders {
+  platform?: string;
+  /** Numeric pid entries of /proc. */
+  listPids?: () => Promise<number[]>;
+  /** Contents of /proc/<pid>/stat, or null when gone. */
+  readStat?: (pid: number) => Promise<string | null>;
+  /** Whole-file read of /proc/loadavg, /proc/meminfo, … or null. */
+  readSys?: (name: string) => Promise<string | null>;
+  /** `ps -eo pid=,ppid=,rss=,time=,state=` output, for the non-Linux fallback. */
+  readPsTable?: () => Promise<string | null>;
+}
+
+async function defaultListPids(): Promise<number[]> {
+  try {
+    const entries = await readdir("/proc");
+    const out: number[] = [];
+    for (const e of entries) {
+      // /proc holds plenty of non-pid entries (self, meminfo, sys…); the
+      // all-digits test is the standard way to pick out the processes.
+      if (/^\d+$/.test(e)) out.push(Number(e));
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+async function defaultReadStat(pid: number): Promise<string | null> {
+  try {
+    return await readFile(`/proc/${pid}/stat`, "utf8");
+  } catch {
+    // Racing a process that exited between readdir and read is NORMAL on a busy
+    // box, not an error worth surfacing.
+    return null;
+  }
+}
+
+async function defaultReadSys(name: string): Promise<string | null> {
+  try {
+    return await readFile(`/proc/${name}`, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function defaultReadPsTable(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid=,rss=,time=,state="], {
+      encoding: "utf8",
+      timeout: 3000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse `[[dd-]hh:]mm:ss` (ps `time=`) into seconds. */
+export function parsePsTime(raw: string): number {
+  const [dayPart, clockPart] = raw.includes("-") ? raw.split("-", 2) : [null, raw];
+  const parts = (clockPart ?? "").split(":").map(Number);
+  if (parts.some((n) => !Number.isFinite(n))) return 0;
+  let seconds = 0;
+  for (const p of parts) seconds = seconds * 60 + p;
+  if (dayPart !== null) {
+    const days = Number(dayPart);
+    if (Number.isFinite(days)) seconds += days * 86400;
+  }
+  return seconds;
+}
+
+/** Parse the `ps -eo pid=,ppid=,rss=,time=,state=` fallback table. */
+export function parsePsTable(out: string): Map<number, ProcSample> {
+  const procs = new Map<number, ProcSample>();
+  for (const line of out.split("\n")) {
+    const m = line.trim().split(/\s+/);
+    if (m.length < 5) continue;
+    const [pidS, ppidS, rssS, timeS, state] = m;
+    const pid = Number(pidS);
+    const ppid = Number(ppidS);
+    const rssKib = Number(rssS);
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+    procs.set(pid, {
+      pid,
+      ppid,
+      // ps reports RSS in KiB; /proc gives bytes. Normalize to bytes so both
+      // backends feed identical numbers into the rollup.
+      rss: Number.isFinite(rssKib) ? rssKib * 1024 : 0,
+      cpuSeconds: parsePsTime(timeS ?? ""),
+      state: state ?? "?",
+      // No start token from this table: `ps -o lstart=` contains spaces and
+      // would break the column split, and `etimes` changes between samples so
+      // it cannot serve as a stable identity. The pid-reuse guard is therefore
+      // Linux-only; elsewhere we fall back to matching on pid alone.
+      startToken: "",
+    });
+  }
+  return procs;
+}
+
+/** One snapshot of every visible process, keyed by pid. */
+export async function snapshotProcs(deps?: ProcReaders): Promise<Map<number, ProcSample>> {
+  const platform = deps?.platform ?? process.platform;
+  if (platform !== "linux" && !deps?.listPids) {
+    const table = await (deps?.readPsTable ?? defaultReadPsTable)();
+    return table ? parsePsTable(table) : new Map();
+  }
+  const pids = await (deps?.listPids ?? defaultListPids)();
+  const readStat = deps?.readStat ?? defaultReadStat;
+  const bytesPerPage = await pageSize(deps);
+  const procs = new Map<number, ProcSample>();
+  const samples = await Promise.all(
+    pids.map(async (pid) => {
+      const stat = await readStat(pid);
+      return stat ? parseProcStat(pid, stat, bytesPerPage) : null;
+    }),
+  );
+  for (const s of samples) if (s) procs.set(s.pid, s);
+  return procs;
+}
+
+/** ppid → children index, for descendant walks. */
+export function buildChildIndex(procs: Map<number, ProcSample>): Map<number, number[]> {
+  const kids = new Map<number, number[]>();
+  for (const p of procs.values()) {
+    const list = kids.get(p.ppid);
+    if (list) list.push(p.pid);
+    else kids.set(p.ppid, [p.pid]);
+  }
+  return kids;
+}
+
+/**
+ * Every pid in the subtree rooted at `root`, inclusive.
+ *
+ * Iterative with a seen-set: a corrupt/racing snapshot can present a parent
+ * cycle, and recursion would blow the stack rather than degrade.
+ */
+export function descendantsOf(
+  root: number,
+  kids: Map<number, number[]>,
+  seen = new Set<number>(),
+): Set<number> {
+  const out = new Set<number>();
+  const stack = [root];
+  while (stack.length > 0) {
+    const pid = stack.pop() as number;
+    if (out.has(pid) || seen.has(pid)) continue;
+    out.add(pid);
+    for (const child of kids.get(pid) ?? []) stack.push(child);
+  }
+  return out;
+}
+
+/** Rolled-up cost of one agent's whole process subtree. */
+export interface TreeStats {
+  /** The wrapper pid this tree is rooted at. */
+  pid: number;
+  /** Summed RSS in bytes across the subtree. */
+  rss: number;
+  /** Percent of ONE core, summed across the subtree (may exceed 100). */
+  cpuPercent: number;
+  /** Number of live processes in the subtree, inclusive of the root. */
+  procs: number;
+}
+
+function rollup(
+  root: number,
+  members: Set<number>,
+  first: Map<number, ProcSample>,
+  second: Map<number, ProcSample>,
+  elapsedSeconds: number,
+): TreeStats {
+  let rss = 0;
+  let cpuDelta = 0;
+  let count = 0;
+  for (const pid of members) {
+    const now = second.get(pid);
+    if (!now) continue; // exited during the window
+    count++;
+    rss += now.rss;
+    const before = first.get(pid);
+    // Two reasons to skip the delta:
+    //
+    // - No baseline: the process appeared DURING the window. Counting its full
+    //   cumulative CPU would credit a long-lived child's entire history to this
+    //   one-second window and spike the row to nonsense, so a newcomer
+    //   contributes 0 until the next sample. It under-reports a genuinely new
+    //   busy child for one tick, which beats a wildly wrong number.
+    //
+    // - PID REUSE: the pid is the same but the process behind it is not, so the
+    //   two counters belong to unrelated processes and subtracting them is
+    //   meaningless. An empty token means "no opinion" (the ps fallback), which
+    //   must not be read as a mismatch.
+    const reused =
+      before !== undefined &&
+      before.startToken !== "" &&
+      now.startToken !== "" &&
+      before.startToken !== now.startToken;
+    if (before && !reused) cpuDelta += Math.max(0, now.cpuSeconds - before.cpuSeconds);
+  }
+  return {
+    pid: root,
+    rss,
+    cpuPercent: elapsedSeconds > 0 ? (cpuDelta / elapsedSeconds) * 100 : 0,
+    procs: count,
+  };
+}
+
+/**
+ * Sample every root's subtree over a real time window.
+ *
+ * Roots are attributed in the order given, and a pid is claimed by the FIRST
+ * root that reaches it — so a nested agent whose wrapper is itself listed as a
+ * root is never double-counted into its parent's total.
+ *
+ * Pass DEEPEST-FIRST (children before parents). A nested agent must claim its
+ * own subtree before its parent walks through it; parent-first instead makes the
+ * parent absorb everything and renders the child as a bogus 0-proc row.
+ */
+export async function sampleTrees(
+  roots: number[],
+  opts: { windowMs?: number; deps?: ProcReaders } = {},
+): Promise<{ trees: Map<number, TreeStats>; unattributed: TreeStats }> {
+  const windowMs = Math.max(100, opts.windowMs ?? 1000);
+  // Measure the ACTUAL elapsed time, not the requested window: a loaded box (the
+  // exact case this command is for) can oversleep by hundreds of ms, and
+  // dividing by the nominal window would over-report every row.
+  //
+  // MIDPOINT to MIDPOINT, not end-of-first to end-of-second: a snapshot of ~1400
+  // processes is not instantaneous, so each pid's counter is read at some moment
+  // *inside* each pass. Anchoring on the ends charges the second pass's whole
+  // duration to the window while ignoring the first's, which systematically
+  // under-reports CPU% by exactly the scan time — worst on the loaded boxes this
+  // command exists for. The midpoints are the unbiased estimate of when the
+  // average counter was actually read.
+  const firstStart = Date.now();
+  const first = await snapshotProcs(opts.deps);
+  const firstMid = (firstStart + Date.now()) / 2;
+  await new Promise((r) => setTimeout(r, windowMs));
+  const secondStart = Date.now();
+  const second = await snapshotProcs(opts.deps);
+  const secondMid = (secondStart + Date.now()) / 2;
+  const elapsedSeconds = Math.max(0.001, (secondMid - firstMid) / 1000);
+
+  const kids = buildChildIndex(second);
+  const claimed = new Set<number>();
+  const trees = new Map<number, TreeStats>();
+  for (const root of roots) {
+    const members = descendantsOf(root, kids, claimed);
+    for (const pid of members) claimed.add(pid);
+    trees.set(root, rollup(root, members, first, second, elapsedSeconds));
+  }
+
+  // Everything ay does NOT manage, as one row. This is the answer to "is there
+  // anything safe to reap?" — without it you cannot tell a fully-accounted-for
+  // box from one quietly hoarding orphans.
+  const rest = new Set<number>();
+  for (const pid of second.keys()) if (!claimed.has(pid)) rest.add(pid);
+  return { trees, unattributed: rollup(0, rest, first, second, elapsedSeconds) };
+}
+
+/** Whole-box vitals for the header line. */
+export interface SystemStats {
+  load: [number, number, number] | null;
+  ncpu: number;
+  memTotalBytes: number | null;
+  memAvailableBytes: number | null;
+  swapTotalBytes: number | null;
+  swapFreeBytes: number | null;
+  zombies: number;
+}
+
+/** Parse /proc/meminfo (`MemTotal:  16316360 kB`) into a kB-valued map. */
+export function parseMeminfo(raw: string): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const line of raw.split("\n")) {
+    const m = /^(\w+):\s+(\d+)/.exec(line);
+    if (m?.[1] && m[2]) out.set(m[1], Number(m[2]) * 1024);
+  }
+  return out;
+}
+
+export async function systemStats(
+  procs: Map<number, ProcSample>,
+  deps?: ProcReaders,
+): Promise<SystemStats> {
+  const readSys = deps?.readSys ?? defaultReadSys;
+  const [loadRaw, memRaw] = await Promise.all([readSys("loadavg"), readSys("meminfo")]);
+  const loadFields = loadRaw?.trim().split(/\s+/) ?? [];
+  const load =
+    loadFields.length >= 3
+      ? ([Number(loadFields[0]), Number(loadFields[1]), Number(loadFields[2])] as [
+          number,
+          number,
+          number,
+        ])
+      : null;
+  const mem = memRaw ? parseMeminfo(memRaw) : new Map<string, number>();
+  let zombies = 0;
+  for (const p of procs.values()) if (p.state === "Z") zombies++;
+
+  // Off Linux there is no /proc, so the header would otherwise be entirely
+  // blank. node:os supplies load and memory on macOS/BSD — no swap breakdown,
+  // and loadavg is always [0,0,0] on Windows, so both stay null there.
+  const os = await import("node:os");
+  const osLoad = os.loadavg();
+  const loadFallback =
+    process.platform !== "win32" && osLoad.some((n) => n > 0)
+      ? ([osLoad[0], osLoad[1], osLoad[2]] as [number, number, number])
+      : null;
+
+  return {
+    load: load && load.every(Number.isFinite) ? load : loadFallback,
+    ncpu: os.cpus().length || 1,
+    memTotalBytes: mem.get("MemTotal") ?? os.totalmem() ?? null,
+    // MemAvailable is the kernel's own estimate of what a new allocation can
+    // actually get; "free" is misleading on any box with a warm page cache — but
+    // os.freemem() is the only portable stand-in.
+    memAvailableBytes: mem.get("MemAvailable") ?? os.freemem() ?? null,
+    swapTotalBytes: mem.get("SwapTotal") ?? null,
+    swapFreeBytes: mem.get("SwapFree") ?? null,
+    zombies,
+  };
+}
+
+/** `612Mi`, `1.4Gi` — fixed-width-ish, no trailing noise. */
+export function humanBytes(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes)) return "-";
+  const units: [number, string][] = [
+    [1024 ** 3, "Gi"],
+    [1024 ** 2, "Mi"],
+    [1024, "Ki"],
+  ];
+  for (const [scale, suffix] of units) {
+    if (bytes >= scale) {
+      const v = bytes / scale;
+      // Keep one decimal up to 3 significant digits: at Gi scale a bare integer
+      // rounds 15.6Gi to "16Gi", which visibly disagrees with `free -h` and
+      // makes the header look wrong.
+      return `${v >= 100 ? Math.round(v) : v.toFixed(1)}${suffix}`;
+    }
+  }
+  return `${Math.round(bytes)}B`;
+}

--- a/ts/procStats.ts
+++ b/ts/procStats.ts
@@ -148,7 +148,7 @@ export interface ProcReaders {
   readPsTable?: () => Promise<string | null>;
 }
 
-async function defaultListPids(): Promise<number[]> {
+export async function defaultListPids(): Promise<number[]> {
   try {
     const entries = await readdir("/proc");
     const out: number[] = [];
@@ -163,7 +163,7 @@ async function defaultListPids(): Promise<number[]> {
   }
 }
 
-async function defaultReadStat(pid: number): Promise<string | null> {
+export async function defaultReadStat(pid: number): Promise<string | null> {
   try {
     return await readFile(`/proc/${pid}/stat`, "utf8");
   } catch {
@@ -173,7 +173,7 @@ async function defaultReadStat(pid: number): Promise<string | null> {
   }
 }
 
-async function defaultReadSys(name: string): Promise<string | null> {
+export async function defaultReadSys(name: string): Promise<string | null> {
   try {
     return await readFile(`/proc/${name}`, "utf8");
   } catch {
@@ -181,7 +181,7 @@ async function defaultReadSys(name: string): Promise<string | null> {
   }
 }
 
-async function defaultReadPsTable(): Promise<string | null> {
+export async function defaultReadPsTable(): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid=,rss=,time=,state="], {
       encoding: "utf8",

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -584,8 +584,11 @@ export async function runSubcommand(argv: string[]): Promise<number | null> {
     switch (sub) {
       case "ls":
       case "list":
-      case "ps":
         return await cmdLs(rest);
+      // `ps` was an alias for `ls`; it is now the RESOURCE view — same agents,
+      // rolled up per process tree with box vitals. See ts/cmdPs.ts.
+      case "ps":
+        return await (await import("./cmdPs.ts")).cmdPs(rest);
       case "status":
         return await cmdStatus(rest);
       case "whoami":
@@ -832,6 +835,8 @@ export async function cmdHelp(managerCommands = true): Promise<number> {
       `\n` +
       `Management:\n` +
       `  ay ls [keyword]                     list running agents\n` +
+      `  ay ps [keyword]                     per-agent CPU/RSS, rolled up over each\n` +
+      `                                        agent's whole process tree, + box vitals\n` +
       `  ay tail [-f] [-n N] <keyword>       last N lines (96), -f to follow\n` +
       `  ay read <keyword> [page opts]       paginate: --last/--head N, --range A:B,\n` +
       `                                        --before-line L [--limit N]\n` +
@@ -1822,9 +1827,9 @@ async function cmdLs(rest: string[]): Promise<number> {
   const y = yargs(rest)
     .usage(
       "Usage: ay ls [keyword] [options]\n" +
-        "       ay list [keyword] [options]\n" +
-        "       ay ps   [keyword] [options]\n\n" +
-        "List running agents. Optionally filter by keyword (pid, cwd substring, or prompt substring).",
+        "       ay list [keyword] [options]\n\n" +
+        "List running agents. Optionally filter by keyword (pid, cwd substring, or prompt substring).\n" +
+        "For per-agent CPU/memory usage, see `ay ps`.",
     )
     .option("all", {
       type: "boolean",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -125,6 +125,13 @@ export default defineConfig({
         // branches are unreachable and the file would sink the coverage gate.
         // Measured on POSIX runners, where the code path actually exists.
         ...(process.platform === "win32" ? ["ts/systemPathLink.ts"] : []),
+        // procStats reads /proc on Linux and shells out to `ps` everywhere else,
+        // so its two I/O halves are mutually exclusive by platform and NO single
+        // runner can cover both. Windows has neither, leaving the whole /proc
+        // half structurally dead there. The tests still RUN on Windows (they
+        // assert the degrade-to-empty contract); this only takes the file out of
+        // the coverage denominator, where it is measured on the POSIX runners.
+        ...(process.platform === "win32" ? ["ts/procStats.ts"] : []),
         // Guided onboarding — the workspace-setting path is unit-tested
         // (setup.spec.ts); the TTY prompt and the daemon install it delegates to
         // are integration-only.


### PR DESCRIPTION
#371 の `feat(ps)` を main の上に取り込んだもの (#371 は superseded として close する)。

`ay ls` が並べるのは **wrapper の pid** だが、1 エージェントは**サブツリー全体**である
(wrapper、CLI、version プロセス、bg-pty-host、bg-spare、daemon、およびエージェント自身が
spawn したもの)。忙しいマシンでは 1 セッションで 30 プロセスを超える。
ps / htop / glances はそれらを無関係な行として見るため紐付けられず、
「このエージェントはいくら食っているのか」を知るには子孫を手で辿るしかなかった。
**どの pid がどのセッションに畳まれるかを知っているのは ay だけ**なので、これに答えられるのも ay だけである。

```
 load 16.19 12.41 10.22 (8 cpu, 2.0x)  mem 10.9Gi/15.6Gi  swap 4.8Gi/4.8Gi FULL

 PID      CLI        STATUS   CPU%     RSS  PROCS  REPO
 30402    claude     active    2.0   559Mi      7  symval
 17733    claude     active   11.7   493Mi      3  symval
 ...
 -        unmanaged     -     18.3   2.1Gi     84  -
```

## `ay ps` と `ay ls` の分担

`ps` はこれまで `ls` の**単なる別名**だったが、別名をやめて独立したコマンドにする。
**`ay ls` は従来どおりの機能を維持する** (taku 判断)。

| | 答える質問 |
|---|---|
| `ay ls` | 何が動いていて何をしているか (prompt、git、バッジ、フォレスト) |
| `ay ps` | このマシンが何にいくら使っていて、回収できるものがあるか |

`--sort rss\|cpu\|procs\|pid` / `--tree` / `--json` / `--all` / `--cwd` / `--interval` に対応。
リソースの数字はマシンごとで、リモートをまたいで足す意味が無いため、意図的に local 限定
(フリート全体のビューは `ay ls` のまま)。

## 追加したテスト

**#371 のままではカバレッジ閾値 (branches 90%) を下回っており CI が赤になる** (`cmdPs.ts` が 48.5%)。
実際に意味のあるテストを追加した。

- **`cmdPs` 本体** — 依存を差し替えて、ヘッダ描画、エージェント 0 件、keyword 不一致、
  `--json` の集計形、`--sort` 4 種の並び、`--tree` のフォレスト順維持、
  **サンプラが取りこぼした行を落とさず 0 として出すこと**、`--help`、
  box 統計が全て読めないときにヘッダ行ごと省くこと
- **`isSelfTree`** — ppid リーダを注入可能にして export。/proc 依存は Linux 限定だが、
  **祖先を辿るホップ上限とサイクル検出は plat 非依存であり、実際に間違いうるのはそちら**である。
  `← this session` の印は、将来 kill 操作を生やしたときにコマンド発行元のセッションを
  撃たないための土台になる
- **`procStats` の実アダプタ** — 他のテストは全て偽リーダを注入しており、
  既定の /proc 読み取りと `ps` フォールバックが**一度も実行されていなかった**。
  実ホストに対して呼ぶテストを足す (読み取りのみ)

`cmdPs.ts` は **48.5% → 95.1%**、全体の branches は **90.05%** で閾値を満たす。

## テスト

TS **1550 passed** / 1 skipped、カバレッジ閾値通過。

なお `ts/tests/shared-e2e.spec.ts` の `[rs]` PTY サイズ 2 件は、Rust バイナリを
ビルドしていない worktree では main でも同様に落ちる (TS ランタイムに fallback して
80×24 になるため)。`cargo build` 後は通ることを確認済み。

Supersedes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)