### PR TITLE
fix(console): 2枚目以降のタブが真っ白のまま開かない問題を修正

### DIFF
--- a/lab/ui/sw.js
+++ b/lab/ui/sw.js
@@ -175,7 +175,16 @@ self.addEventListener("fetch", (e) => {
 // If the request came from a preview iframe, proxy it to that iframe's port
 // (appPath = the request's own path); otherwise fall back to the shell handler.
 async function maybePreviewFromClient(e, req, url) {
-  const clientId = e.clientId || e.resultingClientId;
+  // A top-level navigation has NO existing client — only a *reserved* one, named
+  // by resultingClientId. clients.get() never settles for a reserved client: it
+  // becomes gettable only once the navigation commits, which can't happen until
+  // this respondWith() settles. Awaiting it here deadlocked every navigation
+  // once the worker took control — the first tab (still uncontrolled) loaded
+  // fine, every later tab on the same origin hung blank forever. Preview
+  // navigations are already handled by the PREVIEW branch in the fetch listener
+  // above, so navigations never need the client lookup at all.
+  if (req.mode === "navigate") return shellFetch(req, url);
+  const clientId = e.clientId;
   if (clientId) {
     const client = await self.clients.get(clientId).catch(() => null);
     const cm = client && PREVIEW.exec(new URL(client.url).pathname);

--- a/tests/ui-dom/sw-navigation.test.ts
+++ b/tests/ui-dom/sw-navigation.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression guard: opening a SECOND tab on the console must not hang.
+ *
+ * The service worker (lab/ui/sw.js) intercepts every same-origin request,
+ * including top-level navigations. A navigation has no existing client — only a
+ * *reserved* one named by `FetchEvent.resultingClientId` — and `clients.get()`
+ * never settles for a reserved client, because the client only becomes gettable
+ * once the navigation commits, which cannot happen until `respondWith()`
+ * settles. Awaiting it inside the fetch handler therefore deadlocks the
+ * navigation.
+ *
+ * The failure is invisible on a cold profile: the first tab loads before the
+ * worker takes control, so it is fast. Every tab opened afterwards — the case a
+ * user hits by sharing the console link with themselves in a second tab — hangs
+ * on a blank page indefinitely. Measured before the fix: tab 1 committed in
+ * 24ms, tabs 2 and 3 never committed (>45s, >180s against production).
+ *
+ * This test needs the REAL sw.js on a secure origin, so it runs its own static
+ * server over lab/ui rather than the shared stub in ./server.ts (which
+ * deliberately does not serve sw.js — registering it there would deadlock every
+ * other DOM test).
+ */
+import { chromium, type Browser } from "playwright";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import http from "node:http";
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname, extname, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const UI = join(dirname(fileURLToPath(import.meta.url)), "../../lab/ui");
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css",
+  ".svg": "image/svg+xml",
+  ".webmanifest": "application/manifest+json",
+};
+
+// A plain static server over lab/ui. 127.0.0.1 is a secure context, so the
+// service worker installs exactly as it does on https://agent-yes.com/w/.
+function startStatic(): Promise<{ url: string; close: () => void }> {
+  const server = http.createServer((req, res) => {
+    let p = decodeURIComponent((req.url || "/").split("?")[0]);
+    if (p === "/") p = "/index.html";
+    const file = join(UI, normalize(p).replace(/^(\.\.[/\\])+/, ""));
+    if (!existsSync(file)) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": MIME[extname(file)] ?? "application/octet-stream" });
+    res.end(readFileSync(file));
+  });
+  return new Promise((resolve) =>
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as { port: number };
+      resolve({ url: `http://127.0.0.1:${port}/index.html`, close: () => server.close() });
+    }),
+  );
+}
+
+describe("service worker navigation", () => {
+  let browser: Browser;
+  let srv: { url: string; close: () => void };
+
+  beforeAll(async () => {
+    browser = await chromium.launch();
+    srv = await startStatic();
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    srv?.close();
+  });
+
+  it("serves a second tab once the worker controls the origin", async () => {
+    // A fresh context per run: no worker registered, so tab 1 is uncontrolled.
+    const ctx = await browser.newContext();
+    try {
+      const first = await ctx.newPage();
+      await first.goto(srv.url, { waitUntil: "commit", timeout: 30_000 });
+      // Wait for the worker to install and claim — `activate` calls clients.claim(),
+      // so this resolves as soon as it has taken over the origin. Until it does,
+      // a second tab would bypass the fetch handler and pass trivially.
+      await first.waitForFunction(() => !!navigator.serviceWorker.controller, undefined, {
+        timeout: 30_000,
+      });
+
+      // The regression: this navigation goes through the worker's fetch handler.
+      // Before the fix it never committed. The timeout is the assertion — a
+      // healthy commit takes tens of milliseconds.
+      const second = await ctx.newPage();
+      const started = Date.now();
+      await second.goto(srv.url, { waitUntil: "commit", timeout: 20_000 });
+      expect(Date.now() - started).toBeLessThan(20_000);
+
+      // And it really was served by the worker, not by a bypass.
+      expect(await second.evaluate(() => !!navigator.serviceWorker.controller)).toBe(true);
+    } finally {
+      await ctx.close();
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## 症状

コンソールの共有 URL を **2枚目のタブ**で開くと、真っ白のまま数分待っても表示されない。1枚目は一瞬で開く。

## 原因

`lab/ui/sw.js` の fetch ハンドラが、ナビゲーション要求に対して `self.clients.get(e.resultingClientId)` を await していた。

ナビゲーションには既存クライアントが存在せず、あるのは `resultingClientId` が指す**予約クライアント**だけである。予約クライアントはそのナビゲーションが commit されるまで `clients.get()` の対象にならず、commit は `respondWith()` が解決するまで起こらない。**自己待ちのデッドロック**であり、ナビゲーションは永久に完了しない。

1枚目のタブは Service Worker がまだ制御下に置いていないため fetch ハンドラを通らず高速に読み込まれる。`activate` の `clients.claim()` で制御が確立した後に開いたタブが、すべて固まる。

## 実測 (Playwright headless Chromium)

本番 `https://agent-yes.com/w/` に対する A/B:

| | tab1 | tab2 | tab3 |
|---|---|---|---|
| Service Worker 有効 | 168ms | **180000ms 超で commit せず** | **180000ms 超で commit せず** |
| Service Worker 無効 | 86ms | 30ms | 25ms |

`lab/ui` をローカル配信しての修正前後:

| | tab1 | tab2 | tab3 |
|---|---|---|---|
| 修正前 | 24ms | **HUNG** | **HUNG** |
| 修正後 | 7ms | 58ms | 31ms |

## 修正

ナビゲーションではクライアント検索を行わず、直接 `shellFetch` に渡す。プレビュー用 iframe のナビゲーションは fetch リスナ側の `PREVIEW` 分岐が先に処理するため、そもそもこの経路を通らない。サブリソースは従来どおり `e.clientId` で解決する (ナビゲーション以外では `e.clientId` が正しく埋まる)。

## テスト

`tests/ui-dom/sw-navigation.test.ts` を追加。実際の `sw.js` を 127.0.0.1 (secure context) 上で配信し、worker が origin を制御したことを確認してから2枚目のタブが commit することを検証する。

共有スタブサーバ `tests/ui-dom/server.ts` は `sw.js` を配信しない (そこで登録させると他の DOM テストが全部同じデッドロックに落ちる) ため、専用の静的サーバを内蔵している。

- 修正あり → green (1001ms)
- `sw.js` のみ元に戻す → **2枚目のタブのタイムアウトで red**
- ui-dom スイート全体 27 件 green

## 展開に関する注意

既存ユーザのブラウザには古い `sw.js` が登録済みだが、Service Worker の更新チェックは fetch ハンドラを経由しないため、1枚目のタブを開いた時点で新しい worker が取得される。`CACHE` 名はキャッシュ内容が変わらないので据え置き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)