### PR TITLE
fix(ci): prod deploy が promote 直後の push と競合し、古い commit を配信していた問題を修正

### DIFF
--- a/.github/workflows/deploy-agent-yes.yml
+++ b/.github/workflows/deploy-agent-yes.yml
@@ -21,7 +21,26 @@ on:
       - "lab/ui/**"
       - "scripts/build-rgui.ts"
       - ".github/workflows/deploy-agent-yes.yml"
+  # Deploying a NAMED REF is a race when the caller has just moved that ref:
+  # promote-release.yml pushed release 8b4f24f→5f55ed9 and dispatched this
+  # workflow 1.3s later, and the dispatch resolved `release` to the PRE-push
+  # commit — so prod redeployed the old site and reported success, while main
+  # and release both carried the fix. Nothing was red; the site was just stale.
+  # Both entry points therefore take an explicit commit, and the checkout below
+  # honours it. `sha` is optional: without it this deploys the ref it ran on,
+  # which is what a manual rollback dispatch wants.
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit to deploy (default: tip of the selected branch)"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      sha:
+        description: "Commit to deploy"
+        required: false
+        type: string
 
 concurrency:
   group: deploy-agent-yes
@@ -37,6 +56,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ inputs.sha || github.sha }}
+      # State the deployed commit in the log. The failure this guards against
+      # looked like a success, so "which commit went live" must be readable
+      # without cross-referencing the caller's run.
+      - name: Show what is being deployed
+        run: |
+          echo "deploying $(git rev-parse HEAD)"
+          echo "  $(git log -1 --format='%s')"
       # bun runs scripts/build-rgui.ts inside wrangler's build step.
       - uses: oven-sh/setup-bun@v2
       # worker.ts imports `codehost/tunnel` (a root-package npm dep) — without

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -72,10 +72,18 @@ jobs:
           # path filters). Dispatch it explicitly when the promoted batch
           # touches the site; deploy-agent-yes.yml is idempotent so a spurious
           # dispatch is merely a ~40s no-op redeploy.
+          #
+          # Pass the SHA we just promoted. Dispatching `--ref release` alone
+          # races our own push: measured 2026-08-09, this step promoted
+          # 8b4f24f→5f55ed9 and the deploy it launched 1.3s later ran at
+          # 8b4f24f — the pre-push tip. Prod redeployed the OLD site and went
+          # green, so the console served a stale service worker for hours with
+          # nothing red anywhere. --ref still selects the workflow file; the
+          # `sha` input decides what actually gets checked out and deployed.
           if [ -z "$CURRENT" ] || ! git diff --quiet "$CURRENT" "$TARGET" -- \
               lab/ui scripts/build-rgui.ts .github/workflows/deploy-agent-yes.yml; then
-            echo "Batch touches site paths — dispatching prod deploy."
-            gh workflow run deploy-agent-yes.yml --ref release
+            echo "Batch touches site paths — dispatching prod deploy for $TARGET."
+            gh workflow run deploy-agent-yes.yml --ref release -f sha="$TARGET"
           else
             echo "No site-path changes in this batch — deploy not needed."
           fi


### PR DESCRIPTION
## 症状

**PR は merged、main も release も修正を含み、CI は全部緑。それでも本番だけ古いまま。**しかもどこも赤くならないので気づけない。

実際 #397 (Service Worker のナビゲーション deadlock) はこれで数時間、本番に出ていなかった。`curl` で取ってきた `agent-yes.com/w/sw.js` が**修正前のバイトと完全一致**していたことで発覚した。

## 原因

`promote-release.yml` は release を push した直後に deploy を dispatch する:

```sh
git push origin "$TARGET:refs/heads/release"
...
gh workflow run deploy-agent-yes.yml --ref release
```

この `--ref release` は **dispatch を受け取った時点でブランチを解決し直す**。push が反映される前に解決されると、古い commit を掴む。

実測 (2026-08-09):

```
promote  21:44:42  Promoting release: 8b4f24f → 5f55ed9
promote  21:44:43  Batch touches site paths — dispatching prod deploy
deploy   21:44:44  headSha = 8b4f24f      ← push 前の tip
```

deploy は **8b4f24f を配信して success を返した**。1.3 秒の窓である。

なお promote 側は正しく動いていた (ログに `Promoting release: … → 5f55ed9` と `dispatching prod deploy` が残っている)。壊れていたのは「何を配信するか」の解決だけ。

## 修正

- `deploy-agent-yes.yml` に任意入力 `sha` を追加し、checkout の ref を `inputs.sha || github.sha` にする。**名前で解決し直すのではなく、渡された commit をそのまま配信する。**
- `promote-release.yml` は promote した `$TARGET` を `-f sha=` で明示的に渡す。
- 配信した commit をログ先頭に出す。今回の失敗は success に見えたので、「どの commit が本番に出たか」を呼び出し元の run と突き合わせずに読めるようにする。

`sha` を**任意**にしてあるのは、手動の rollback dispatch では「選んだ branch/tag の先端を配信する」という従来の挙動が欲しいため。`workflow_call` も併せて追加し、将来 promote から直接呼べるようにした。

## 検証

- 両ファイルの YAML パース確認と構造確認: triggers = `push` / `workflow_dispatch` / `workflow_call`、`sha` 入力が両方に存在、checkout の ref が `${{ inputs.sha || github.sha }}`
- 本番は先行して手動 dispatch 済みで、現在は修正後の sw.js を配信している (実測: SW 有効のまま tab1 86ms / tab2 48ms / tab3 39ms。修正前は tab2 が 302 秒)

**この PR 自体の効果は次回の promote で初めて観測できる** (site パスを含むバッチが promote された時)。今回は手動 dispatch で本番を先に直してあるので、この変更は再発防止のみ。

## 補足: 当初の誤診について

最初は `chore(release): … [skip ci]` が deploy を skip させていると考えたが、**それは誤り**だった。promote のログを読むと dispatch は実行されている。`[skip ci]` は push トリガを抑止するが、この経路は明示 dispatch なので無関係。実際の原因は上記の解決タイミングの競合である。

🤖 Generated with [Claude Code](https://claude.com/claude-code)