### PR TITLE
test(ayrs): spawn した agent が daemon の session に入らないことを回帰テストで固定

### DIFF
--- a/rs/src/serve/control.rs
+++ b/rs/src/serve/control.rs
@@ -96,6 +96,77 @@ fn spawn_detached(bin: &std::path::Path, args: &[String], cwd: &str) -> std::io:
     Ok(cmd.spawn()?.id())
 }
 
+#[cfg(all(test, unix))]
+mod spawn_detached_tests {
+    use super::*;
+
+    /// A spawned agent must outlive the daemon that spawned it.
+    ///
+    /// The daemon is restarted for ordinary reasons — an upgrade, a launchd
+    /// KeepAlive bounce, `ayrs serve install` — and every one of those would
+    /// take the whole local fleet down with it if agents shared the daemon's
+    /// session or process group. `setsid()` in the pre_exec hook above is the
+    /// only thing preventing that, and nothing else in the tree would fail if
+    /// it were dropped: agents would keep spawning and working, and the damage
+    /// would only appear on the next restart.
+    ///
+    /// So assert the observable property rather than the call: the child must
+    /// land in its OWN session, not ours.
+    ///
+    /// Session id comes from `libc::getsid`, NOT from `ps -o sess=` — on macOS
+    /// that column prints 0 for every process, which silently turns the
+    /// comparison below into 0 != 0 and fails a correct implementation.
+    #[test]
+    fn a_spawned_child_gets_its_own_session() {
+        let sh = std::path::PathBuf::from("/bin/sh");
+        let our_sid = unsafe { libc::getsid(0) };
+        assert!(our_sid > 0, "could not read our own session id");
+
+        let dir = tempfile::tempdir().unwrap();
+        let ready = dir.path().join("ready");
+        // Keep the child alive long enough to inspect it. `ps -o ppid=` would
+        // not do as the signal: an orphan is reparented to pid 1
+        // asynchronously, so reading it races. The session id is set by setsid
+        // at exec time and never changes — and we read it with getsid from
+        // here, where libc is already linked, rather than asking the child to
+        // report it (no portable shell or perl equivalent exists).
+        let pid = spawn_detached(
+            &sh,
+            &[
+                "-c".into(),
+                format!("touch {} && sleep 5", ready.display()),
+            ],
+            dir.path().to_str().unwrap(),
+        )
+        .expect("spawn_detached succeeds");
+        assert!(pid > 0, "spawn_detached returned a pid");
+
+        for _ in 0..100 {
+            if ready.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert!(ready.exists(), "detached child never started");
+
+        let child_sid = unsafe { libc::getsid(pid as libc::pid_t) };
+        assert!(
+            child_sid > 0,
+            "could not read the child's session id (already exited?)"
+        );
+        assert_ne!(
+            child_sid, our_sid,
+            "spawn_detached put the agent in the spawner's session — a daemon \
+             restart would kill every agent it ever spawned (setsid lost?)"
+        );
+        // setsid makes the child a session LEADER: its sid equals its own pid.
+        assert_eq!(
+            child_sid, pid as libc::pid_t,
+            "the child is not a session leader — setsid did not take effect"
+        );
+    }
+}
+
 fn bad(status: u16, msg: impl Into<String>) -> super::api::ApiResponse {
     super::api::ApiResponse {
         status,


### PR DESCRIPTION
## 背景

`ayrs serve` を再起動しても、そこから spawn された agent は生き残る。これを単独で支えているのが `spawn_detached` の `pre_exec` にある `libc::setsid()` である (rs/src/serve/control.rs)。

daemon は日常的に再起動する —— upgrade、launchd の KeepAlive による bounce、`ayrs serve install`。agent が daemon と session / process group を共有していたら、そのたびにローカルの fleet が全滅する。

**実測 (2026-08-10、本番機で `ayrs serve` を再起動して確認):**

```
再起動前の agent プロセス: 34
再起動後の agent プロセス: 34
消えた pid: なし
```

agent の `ppid` は 1 (init に再親付け済み)、`sid` は自分自身の pid。daemon の sid とは別である。**現状の実装は正しい。**

## この PR が守るもの

問題は、`setsid()` が消えても**他のテストが一つも落ちない**ことである。agent の spawn も動作も従来どおりで、被害は次の daemon 再起動まで表に出ない。しかもその時には「なぜか agent が全部死んだ」という形でしか現れず、原因に辿り着くのは難しい。

そこで呼び出しの有無ではなく、観測可能な性質を固定する:

- 子は spawner とは**別の session** に入る
- 子は **session leader** である (sid == 自分の pid)

## 検証

- setsid あり → **green**
- `pre_exec` から setsid だけ外す → **red**「spawn_detached put the agent in the spawner's session」
- rs 全体 **484 件 green**、clippy は control.rs に新規警告なし

## 実装メモ (踏んだ罠)

- **session id は `libc::getsid` を親側から読む。** 最初 `ps -o sess=` を使ったが、**macOS ではこの列が全プロセスで 0 を返す**。比較が 0 != 0 になり、正しい実装が落ちた。
- 子に自分で報告させる案も試したが、getsid には移植性のある shell / perl の等価物が無い (perl の POSIX は `getsid` を export しない)。
- **`ps -o ppid=` を信号にしない。** 孤児の pid 1 への再親付けは非同期なので読み取りが race する。session id は exec 時に決まりその後変わらないため、こちらが安定した信号になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)