### PR TITLE
fix(ci): DOCKERHUB_USERNAME が空なら Docker Hub の image tag を出さない

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY_DOCKER }}/${{ secrets.DOCKERHUB_USERNAME }}/agent-yes
+            ${{ secrets.DOCKERHUB_USERNAME != '' && format('{0}/{1}/agent-yes', env.REGISTRY_DOCKER, secrets.DOCKERHUB_USERNAME) || '' }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -136,7 +136,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY_DOCKER }}/${{ secrets.DOCKERHUB_USERNAME }}/agent-yes
+            ${{ secrets.DOCKERHUB_USERNAME != '' && format('{0}/{1}/agent-yes', env.REGISTRY_DOCKER, secrets.DOCKERHUB_USERNAME) || '' }}
           tags: |
             type=ref,event=branch,suffix=-mini
             type=ref,event=pr,suffix=-mini


### PR DESCRIPTION
fork からの PR で `build-and-push` / `build-and-push-mini` が構造的に必ず落ちる問題を直す。

## 症状

```
ERROR: failed to build: invalid tag "docker.io//agent-yes:pr-368": invalid reference format
```

## 原因

GitHub は fork 発の `pull_request` 実行に repository secrets を渡さない。そのため
`${{ secrets.DOCKERHUB_USERNAME }}` が空文字に展開され、metadata-action の
`images:` が `docker.io/<空>/agent-yes` = `docker.io//agent-yes` という不正な参照になる。

login step は既に `if: github.event_name != 'pull_request'` で除外されていたが、
`images:` は無条件だったため **tag 生成だけが残っていた** のが見落とし。

## 直し方

secret がある時だけ Docker Hub の image を並べる。`docker/metadata-action` は
入力リストの空要素を捨てる (actions-toolkit の `Util.getList` が
`.filter(item => item)` — [util.ts](https://github.com/docker/actions-toolkit/blob/main/src/util.ts)) ので、
secret が無い環境では GHCR の 1 行だけが残る。

`push:` は元から `github.event_name != 'pull_request'` なので、PR ビルドは
«ビルドするが push しない» のままで **挙動は変わらない**。secret がある実行
(main への push / 同一リポジトリの PR) でも従来どおり両方に tag が付く。

## この PR 自体が回帰テストになっている

**この PR は fork (`takusym/agent-yes`) から出している** ので、CI は secrets が
渡らない条件下でそのまま走る。つまり `build-and-push` / `build-and-push-mini` が
緑になれば、それがそのまま修正が効いている証拠になる。

## 経緯

同一リポジトリのブランチから出す PR には secrets が渡るため今まで表面化して
おらず、#368 (fork 発) で初めて露見した。あの PR はこれが理由で main repo の
ブランチとして出し直され #395 として merge されている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
