### PR TITLE
feat(todo): エージェント横断で共有できるタスク管理にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,40 @@ cy stop <keyword>                      # graceful shutdown (claude/codex: /exit)
 so subcommands work whether the target agent is the TS or Rust runtime.
 Detailed reference (Japanese): [`docs/cy-subcommands.md`](./docs/cy-subcommands.md).
 
+### Shared task list across agents (`ay todo`)
+
+A lifecycle-tracked task list that every agent working on a repo reads and
+writes. The store is one append-only file at `<repo>/.agent-yes/todos.jsonl`,
+resolved from the repo's **common root** — so agents running in different git
+worktrees of the same repo share one list rather than each keeping a private
+one. Pass `--root <dir>` (or set `AGENT_YES_TODO_ROOT`) to point somewhere else.
+
+```bash
+ay todo                                 # help: every verb, with descriptions
+ay todo new fix the flaky test --kind code   # owner defaults to the calling agent
+ay todo ls                              # OWNER column marks dead agents: lane-3(exited)
+ay todo ls --owner me                   # just my tasks
+ay todo claim T4                        # take it over (refuses to steal from a live agent)
+ay todo claim T4 --force                # take it anyway
+ay todo block T4 --type waiting-on-agent --agent lane-2
+ay todo dep add T5 T4                   # T5 waits for T4 (cycles rejected)
+ay todo digest                          # per-tag board + "unblocked, resume these"
+ay todo reconcile                       # orphan tasks whose owner agent exited, clear stale blocks
+```
+
+Ownership is cross-referenced against the same agent registry `ay ls` reads, so
+"who owns this and are they still alive?" is answerable in one command:
+`--owner me` resolves to the calling agent's registry id, `ls` annotates each
+owner with that agent's live status, and `reconcile` orphans tasks whose owner
+exited (listing idle agents as reassignment candidates). Use `--owner none` to
+create a task nobody owns, and `--format json` for machine-readable output —
+JSON keeps `owner` verbatim and reports liveness in a separate `ownerLiveness`
+field, so filters that match on `owner` keep working.
+
+Tasks move through a lifecycle per `--kind`, and gated transitions require
+**independent verification**: whoever did the work cannot approve it. See
+`ts/todoStore.ts` for the gate model.
+
 ### Docker Usage
 
 You can run `agent-yes` in a Docker container with all AI CLI tools pre-installed.

--- a/ts/subcommandMirror.spec.ts
+++ b/ts/subcommandMirror.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Guard for the one list in this repo that exists twice: the set of management
+ * subcommands. `ts/subcommands.ts` owns the implementations; `rs/src/cli.rs`
+ * keeps its own hardcoded copy purely to decide whether to re-exec the JS
+ * launcher instead of treating the word as prompt text.
+ *
+ * Drift here fails SILENTLY and asymmetrically: a subcommand present only in
+ * the TS list still works through the JS entry (`~/.bun/bin/ay`), so it looks
+ * fine everywhere it is normally tested, while the same word typed at the
+ * cargo-installed Rust binary is handed to the agent CLI as a prompt. Both
+ * lists carry a "keep these in sync" comment; both have drifted anyway.
+ *
+ * So this file does not test behavior — it tests that the two source files
+ * literally agree. They are parsed as TEXT rather than imported, because the
+ * Rust side cannot be imported into vitest at all.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), "utf8");
+
+/** String literals inside `const <name> = new Set([...])`. */
+function tsList(source: string, name: string): string[] {
+  const m = new RegExp(`const ${name} = new Set\\(\\[([\\s\\S]*?)\\]\\)`).exec(source);
+  if (!m) throw new Error(`could not find TS list ${name}`);
+  return [...m[1]!.matchAll(/"([^"]+)"/g)].map((x) => x[1]!);
+}
+
+/** String literals inside `pub const <NAME>: &[&str] = &[...]`. */
+function rsList(source: string, name: string): string[] {
+  const m = new RegExp(`pub const ${name}: &\\[&str\\] = &\\[([\\s\\S]*?)\\];`).exec(source);
+  if (!m) throw new Error(`could not find Rust list ${name}`);
+  return [...m[1]!.matchAll(/"([^"]+)"/g)].map((x) => x[1]!);
+}
+
+describe("ts/subcommands.ts <-> rs/src/cli.rs subcommand mirror", () => {
+  const ts = read("ts/subcommands.ts");
+  const rs = read("rs/src/cli.rs");
+
+  // Sanity-check the parsers themselves: a regex that silently matched nothing
+  // would make every comparison below trivially pass on two empty arrays.
+  it("parses a non-empty list out of each source file", () => {
+    expect(tsList(ts, "SUBCOMMANDS").length).toBeGreaterThan(10);
+    expect(rsList(rs, "SUBCOMMANDS").length).toBeGreaterThan(10);
+    expect(tsList(ts, "MANAGER_SUBCOMMANDS").length).toBeGreaterThan(0);
+    expect(rsList(rs, "MANAGER_SUBCOMMANDS").length).toBeGreaterThan(0);
+  });
+
+  // Compared as sorted sets: the Rust copy is a delegation gate, so only
+  // membership matters — reordering either list for readability (or rustfmt
+  // rewrapping the Rust one) must not fail this test.
+  it("SUBCOMMANDS match", () => {
+    expect([...rsList(rs, "SUBCOMMANDS")].sort()).toEqual([...tsList(ts, "SUBCOMMANDS")].sort());
+  });
+
+  it("MANAGER_SUBCOMMANDS match", () => {
+    expect([...rsList(rs, "MANAGER_SUBCOMMANDS")].sort()).toEqual(
+      [...tsList(ts, "MANAGER_SUBCOMMANDS")].sort(),
+    );
+  });
+
+  // Catches the reverse drift: a word added to both lists (so the test above
+  // passes) that no `case` ever handles would delegate from Rust into a JS
+  // layer that then falls through to running an agent — the same bug, one
+  // layer later.
+  it("every subcommand has a dispatch case in ts/subcommands.ts", () => {
+    const cases = new Set([...ts.matchAll(/case "([a-z-]+)":/g)].map((m) => m[1]!));
+    const missing = [...tsList(ts, "SUBCOMMANDS"), ...tsList(ts, "MANAGER_SUBCOMMANDS")].filter(
+      (name) => !cases.has(name),
+    );
+    expect(missing).toEqual([]);
+  });
+});

--- a/ts/todoCli.spec.ts
+++ b/ts/todoCli.spec.ts
@@ -402,10 +402,13 @@ describe("ay todo CLI", () => {
     await expect(run("bogus")).rejects.toThrow(/unknown argument: bogus/i);
   });
 
-  it("no verb at all fails naming every expected one, via demandCommand", async () => {
-    await expect(run()).rejects.toThrow(
-      /unknown "ay todo" verb.*new\/ls\/get\/transition\/approve\/verify\/set-criteria\/block\/unblock\/dep\/tree\/digest\/reconcile/,
-    );
+  it("no verb at all prints help instead of throwing — a bare `ay todo` is a question, not a typo", async () => {
+    const { out } = await run();
+    expect(out).toContain("ay todo");
+    // Every verb listed, so the bare invocation is genuinely discoverable.
+    for (const verb of ["new", "ls", "claim", "reconcile", "digest"]) {
+      expect(out).toMatch(new RegExp(`\\b${verb}\\b`));
+    }
   });
 
   it("new --acceptance-criteria stores it, and get renders it; set-criteria updates it later (Milestone 1.5)", async () => {
@@ -556,5 +559,160 @@ describe("ay todo reconcile", () => {
 
     const second = await run("reconcile");
     expect(second.out).toContain("T2 is now unblocked"); // still reported, not silently retired
+  });
+});
+
+describe("ay todo cross-agent ownership", () => {
+  const AGENT_HOME = isWindows
+    ? path.join(process.env.TEMP || "C:\\Temp", "todocli-xagent-" + process.pid)
+    : "/tmp/todocli-xagent-" + process.pid;
+  let prevHome: string | undefined;
+  let prevPid: string | undefined;
+
+  const agent = (over: object) => ({
+    pid: 0,
+    cli: "claude",
+    prompt: null,
+    cwd: "/x",
+    log_file: null,
+    status: "active",
+    exit_code: null,
+    exit_reason: null,
+    started_at: 0,
+    ...over,
+  });
+
+  async function seedGlobalPids(records: object[]): Promise<void> {
+    await writeFile(
+      path.join(AGENT_HOME, "pids.jsonl"),
+      records.map((r) => JSON.stringify(r)).join("\n") + "\n",
+    );
+  }
+
+  /** Make this process look like the agent registered with `wrapper_pid`. */
+  function beAgent(wrapperPid: number | undefined): void {
+    if (wrapperPid === undefined) delete process.env.AGENT_YES_PID;
+    else process.env.AGENT_YES_PID = String(wrapperPid);
+  }
+
+  beforeEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+    await rm(AGENT_HOME, { recursive: true, force: true });
+    prevHome = process.env.AGENT_YES_HOME;
+    prevPid = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_HOME = AGENT_HOME;
+    await mkdir(AGENT_HOME, { recursive: true });
+    await seedGlobalPids([
+      agent({ pid: 11, wrapper_pid: 10, agent_id: "lane-a", status: "active" }),
+      agent({ pid: 21, wrapper_pid: 20, agent_id: "lane-b", status: "idle" }),
+      agent({ pid: 31, wrapper_pid: 30, agent_id: "lane-dead", status: "exited", exit_code: 0 }),
+    ]);
+  });
+  afterEach(async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+    await rm(AGENT_HOME, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.AGENT_YES_HOME;
+    else process.env.AGENT_YES_HOME = prevHome;
+    if (prevPid === undefined) delete process.env.AGENT_YES_PID;
+    else process.env.AGENT_YES_PID = prevPid;
+  });
+
+  it("new assigns to the calling agent by default, and --owner me resolves to the same id", async () => {
+    beAgent(10);
+    const created = await run("new", "mine", "--kind", "code");
+    expect(created.out).toContain("owner:   lane-a");
+    const explicit = await run("new", "also mine", "--kind", "code", "--owner", "me");
+    expect(explicit.out).toContain("owner:   lane-a");
+  });
+
+  it("new from a human shell stays unowned — the pre-existing behavior for anyone without an agent id", async () => {
+    beAgent(undefined);
+    const created = await run("new", "unowned", "--kind", "code");
+    expect(created.out).not.toContain("owner:");
+  });
+
+  it("--owner none opts out of the default assignment even inside an agent", async () => {
+    beAgent(10);
+    const created = await run("new", "deliberately unowned", "--kind", "code", "--owner", "none");
+    expect(created.out).not.toContain("owner:");
+  });
+
+  it("--owner me outside an agent fails loudly instead of inventing an identifier", async () => {
+    beAgent(undefined);
+    // Storing a hostname/pid here would look like an agent assignment while
+    // matching nothing in the agent index — permanently outside orphan
+    // recovery. Better to refuse.
+    await expect(run("new", "x", "--kind", "code", "--owner", "me")).rejects.toThrow(
+      /no registered agent id/i,
+    );
+  });
+
+  it("ls --owner me filters to the calling agent's own tasks", async () => {
+    beAgent(10);
+    await run("new", "mine", "--kind", "code");
+    beAgent(20);
+    await run("new", "theirs", "--kind", "code");
+
+    beAgent(10);
+    const mine = await run("ls", "--owner", "me");
+    expect(mine.out).toContain("mine");
+    expect(mine.out).not.toContain("theirs");
+  });
+
+  it("ls annotates each owner with that agent's liveness, so a dead owner is visible without cross-referencing `ay ls`", async () => {
+    beAgent(undefined);
+    await run("new", "stalled", "--kind", "code", "--owner", "lane-dead");
+    await run("new", "human work", "--kind", "code", "--owner", "alice");
+    const listed = await run("ls");
+    expect(listed.out).toContain("lane-dead(exited)");
+    // A human owner has no registry entry; "unknown" there would read as
+    // "might be dead", which is wrong — so it prints bare.
+    expect(listed.out).toContain("alice");
+    expect(listed.out).not.toContain("alice(");
+  });
+
+  it("--format json keeps `owner` verbatim and reports liveness in its own field", async () => {
+    beAgent(undefined);
+    await run("new", "stalled", "--kind", "code", "--owner", "lane-dead");
+    const listed = await run("ls", "--format", "json");
+    const [task] = JSON.parse(listed.out);
+    expect(task.owner).toBe("lane-dead"); // NOT "lane-dead(exited)" — filters still work
+    expect(task.ownerLiveness).toBe("exited");
+  });
+
+  it("claim takes over a task owned by an exited agent", async () => {
+    beAgent(undefined);
+    await run("new", "stalled", "--kind", "code", "--owner", "lane-dead");
+    beAgent(20);
+    const claimed = await run("claim", "T1");
+    expect(claimed.out).toContain("claimed T1 → lane-b");
+  });
+
+  it("claim refuses to steal from a still-running agent unless forced", async () => {
+    beAgent(10);
+    await run("new", "in flight", "--kind", "code");
+    beAgent(20);
+    await expect(run("claim", "T1")).rejects.toThrow(/owned by lane-a, an agent that is still/i);
+    const forced = await run("claim", "T1", "--force");
+    expect(forced.out).toContain("claimed T1 → lane-b");
+  });
+
+  it("claim takes an unowned task without ceremony", async () => {
+    beAgent(undefined);
+    await run("new", "free", "--kind", "code", "--owner", "none");
+    beAgent(10);
+    const claimed = await run("claim", "T1");
+    expect(claimed.out).toContain("claimed T1 → lane-a");
+  });
+
+  // The lost-update race itself (two claimers whose reads interleave) is
+  // guarded inside the store and tested there — `setOwner`'s expectedOwner
+  // check in todoStore.spec.ts — since it is not reachable through two
+  // sequential CLI calls: the liveness refusal above fires first.
+  it("claim --owner assigns to a named agent, not only to self", async () => {
+    beAgent(10);
+    await run("new", "delegated", "--kind", "code", "--owner", "none");
+    const claimed = await run("claim", "T1", "--owner", "lane-b");
+    expect(claimed.out).toContain("claimed T1 → lane-b");
   });
 });

--- a/ts/todoCli.ts
+++ b/ts/todoCli.ts
@@ -7,13 +7,18 @@
  * `runTodoSubcommand`, so this file (and everything it pulls in) is only
  * loaded when `ay todo ...` is actually invoked.
  *
- * Store location: `--root <dir>` (default: current working directory) is
- * where `.agent-yes/todos.jsonl` lives, mirroring `PidStore`'s own
- * `<workingDir>/.agent-yes/...` convention. This module has no notion of any
- * particular consuming project's directory-resolution rules (e.g. "find the
- * monorepo root") — a project wanting that behavior supplies it by always
- * invoking with an explicit `--root`, or by calling `openStore()` as a
- * library from its own code instead of through this CLI.
+ * Store location: `--root <dir>` is where `.agent-yes/todos.jsonl` lives,
+ * mirroring `PidStore`'s own `<workingDir>/.agent-yes/...` convention. Left
+ * unset it resolves to the REPO's common root rather than the cwd, so agents
+ * in different worktrees share one list — see `todoRoot.ts` for why that
+ * matters and where the line is drawn.
+ *
+ * Cross-agent surface, on top of that shared store: `--owner me` resolves to
+ * the calling agent's registry id (`todoIdentity.ts`), `new` assigns to the
+ * caller by default, `claim` takes a task over while refusing to steal from a
+ * live agent, and `ls`/`get` annotate each owner with whether that agent is
+ * still alive. `reconcile` (already present) closes the loop by orphaning
+ * tasks whose owner agent exited.
  *
  * Argument parsing: a real yargs COMMAND TREE — one `yargs(argv)` instance
  * with a `CommandModule` per verb registered via `.command()`, `--root`/
@@ -39,13 +44,15 @@
  */
 
 import yargs, { type Argv, type CommandModule } from "yargs";
-import { openStore, CycleError, type TodoRecord } from "./todoStore.ts";
+import { openStore, CycleError, type TodoStore, type TodoRecord } from "./todoStore.ts";
 import { isKnownKind, LIFECYCLES, type LifecycleKind } from "./todoLifecycle.ts";
 import { describeBlock, type TodoBlock } from "./todoBlock.ts";
 import { renderDigest, renderTree, buildTreeJSON, unblockedTasks } from "./todoDigest.ts";
 import { reconcileTodos, type LiveAgent } from "./todoAutomation.ts";
 import { readGlobalPids } from "./globalPidIndex.ts";
 import { removeControlCharacters } from "./removeControlCharacters.ts";
+import { resolveTodoRoot } from "./todoRoot.ts";
+import { NO_OWNER, SELF_OWNER, ownerLiveness, resolveSelf } from "./todoIdentity.ts";
 
 function fail(message: string): never {
   throw new Error(message);
@@ -101,9 +108,26 @@ function renderRecord(t: TodoRecord): string {
   return lines.join("\n");
 }
 
-function renderList(tasks: TodoRecord[]): string {
+/**
+ * `owner` as displayed: the stored string plus, when it names an agent the
+ * registry knows, that agent's current status — `agt-7(exited)`. An owner with
+ * no registry entry (a human, or an agent that never registered) prints bare,
+ * because "unknown" there means "not an agent", not "possibly dead".
+ *
+ * This is the whole point of the shared store being readable across agents:
+ * the interesting question about a task someone else owns is almost always
+ * "is that someone still running?", and answering it by cross-referencing
+ * `ay ls` by hand is exactly the step that gets skipped.
+ */
+function ownerCell(t: TodoRecord, agents: LiveAgent[]): string {
+  if (!t.owner) return "";
+  const status = ownerLiveness(t.owner, agents);
+  return status === "unknown" ? t.owner : `${t.owner}(${status})`;
+}
+
+function renderList(tasks: TodoRecord[], agents: LiveAgent[] = []): string {
   if (tasks.length === 0) return "(no tasks match)";
-  const rows = tasks.map((t) => [t._id, t.state, t.kind, t.owner ?? "", t.summary]);
+  const rows = tasks.map((t) => [t._id, t.state, t.kind, ownerCell(t, agents), t.summary]);
   const header = ["ID", "STATE", "KIND", "OWNER", "SUMMARY"];
   const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
   const line = (xs: string[]) =>
@@ -115,12 +139,58 @@ function renderList(tasks: TodoRecord[]): string {
 }
 
 interface GlobalOpts {
-  root: string;
+  /** Undefined means "not specified" — resolved per call by `resolveTodoRoot` (repo root, not cwd). See `todoRoot.ts`. */
+  root: string | undefined;
   format: "table" | "json";
 }
 
 function emit(opts: GlobalOpts, obj: unknown, human: string): void {
   process.stdout.write((opts.format === "json" ? JSON.stringify(obj, null, 2) : human) + "\n");
+}
+
+/**
+ * Open the store every verb works against. Resolution is deferred to call
+ * time (rather than baked into a yargs `default:`) because the default is
+ * DERIVED — it shells out to git — and a yargs default is evaluated eagerly at
+ * parse time, on every invocation including `--help`.
+ */
+async function storeFor(opts: GlobalOpts): Promise<TodoStore> {
+  return openStore(await resolveTodoRoot(opts.root));
+}
+
+/**
+ * Turn an `--owner` value into what gets stored: `me` → this agent's
+ * `agent_id`, `none` → explicitly unowned, anything else verbatim.
+ *
+ * `me` is an ERROR outside an agent, never a silent fallback to a hostname or
+ * pid: those look like an agent assignment to a reader but match nothing in
+ * the agent index, so the task would sit permanently outside orphan recovery
+ * (see `todoIdentity.ts`).
+ */
+/**
+ * The agent snapshot every cross-agent view is read against.
+ *
+ * `liveOnly: false` deliberately: the interesting answer for an owner is often
+ * "that agent EXITED", which a live-only read cannot express — it would drop
+ * the record and make a dead owner indistinguishable from a human one. Same
+ * reasoning (and same call) as `reconcile`, which needs exited records to
+ * orphan against.
+ */
+async function liveAgents(): Promise<LiveAgent[]> {
+  return readGlobalPids({ liveOnly: false });
+}
+
+async function resolveOwnerArg(raw: string | undefined): Promise<string | undefined> {
+  if (raw === undefined) return undefined;
+  if (raw === NO_OWNER || raw === "") return undefined;
+  if (raw !== SELF_OWNER) return raw;
+  const self = await resolveSelf();
+  if (!self)
+    fail(
+      `--owner ${SELF_OWNER} needs an agent context: this process has no registered agent id ` +
+        `(run it inside an \`ay\`-managed agent, or pass an explicit --owner).`,
+    );
+  return self.agentId;
 }
 
 const newCmd: CommandModule<
@@ -155,11 +225,14 @@ const newCmd: CommandModule<
         describe:
           "definition of done for this task — what an independent validator should check before approving/verifying it",
       })
-      .option("owner", { type: "string" })
+      .option("owner", {
+        type: "string",
+        describe: `"me" (this agent), "${NO_OWNER}" to leave unowned, or any handle. Default: this agent when run inside one, else unowned`,
+      })
       .option("tag", { type: "string", array: true })
       .option("dep", { type: "string", array: true, describe: "blocker task id(s)" }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     // Join ALL summary words: an unquoted summary like
     // `ay todo new write the spec --kind doc` arrives as multiple array
     // entries under yargs' `<summary..>` variadic positional — using only
@@ -172,13 +245,20 @@ const newCmd: CommandModule<
         "usage: ay todo new <summary> --kind <kind> [--description ...] [--tier ...] [--acceptance-criteria ...] [--owner ...] [--tag t]... [--dep id]...",
       );
     }
+    // No `--owner` at all means "mine" when an agent is running this, so a
+    // task an agent creates for itself is visible as ITS work to every other
+    // agent (and eligible for orphan recovery) without a second command. A
+    // human shell has no agent id, so it falls through to unowned — the
+    // previous behavior for everyone. `--owner none` opts out explicitly.
+    const owner =
+      argv.owner === undefined ? (await resolveSelf())?.agentId : await resolveOwnerArg(argv.owner);
     const rec = await store.create({
       summary,
       kind: parseKind(argv.kind),
       description: argv.description,
       targetTier: argv.tier,
       acceptanceCriteria: argv["acceptance-criteria"],
-      owner: argv.owner,
+      owner,
       tags: argv.tag ?? [],
       blockedBy: argv.dep ?? [],
     });
@@ -202,19 +282,87 @@ const lsCmd: CommandModule<
     y
       .option("kind", { type: "string" })
       .option("state", { type: "string" })
-      .option("owner", { type: "string" })
+      .option("owner", {
+        type: "string",
+        describe: `owner handle, or "${SELF_OWNER}" for this agent`,
+      })
       .option("tag", { type: "string" })
       .option("blocked", { type: "boolean", default: false }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const tasks = store.list({
       kind: argv.kind ? parseKind(argv.kind) : undefined,
       state: argv.state,
-      owner: argv.owner,
+      owner: await resolveOwnerArg(argv.owner),
       tag: argv.tag,
       blocked: argv.blocked,
     });
-    emit(argv, tasks, renderList(tasks));
+    const agents = await liveAgents();
+    // JSON keeps the record shape untouched and adds ONE derived field, rather
+    // than folding the status into `owner` the way the table does: a consumer
+    // filtering on `owner` must still see the same string that was stored.
+    emit(
+      argv,
+      tasks.map((t) => ({ ...t, ownerLiveness: ownerLiveness(t.owner, agents) })),
+      renderList(tasks, agents),
+    );
+  },
+};
+
+/**
+ * `ay todo claim <id>` — take ownership of a task.
+ *
+ * Refuses when the current owner is an agent the registry still reports as
+ * `active`/`idle`, because in a shared store the overwhelmingly likely reading
+ * of "task X is owned by a running agent" is that the agent is working on it
+ * right now; silently reassigning would put two agents on one task, each
+ * believing it is theirs. A dead owner (`exited`) or a non-agent owner is
+ * taken over without ceremony — that is the recovery path this verb exists
+ * for. `--force` covers the rest ("it's wedged, I'm taking it").
+ */
+const claimCmd: CommandModule<
+  GlobalOpts,
+  GlobalOpts & { id: string; owner: string | undefined; force: boolean }
+> = {
+  command: "claim <id>",
+  describe: "take ownership of a task (refuses to steal from a live agent)",
+  builder: (y) =>
+    y
+      .positional("id", { type: "string", demandOption: true })
+      .option("owner", {
+        type: "string",
+        describe: `who to assign to (default: "${SELF_OWNER}", this agent)`,
+      })
+      .option("force", {
+        type: "boolean",
+        default: false,
+        describe: "claim even if the current owner agent is still running",
+      }),
+  handler: async (argv) => {
+    const store = await storeFor(argv);
+    const before = store.get(argv.id);
+    if (!before) fail(`no such task: ${argv.id}`);
+    const next = await resolveOwnerArg(argv.owner ?? SELF_OWNER);
+    if (!next)
+      fail(`--owner ${NO_OWNER} is not a claim — use \`ay todo claim <id> --owner <who>\``);
+
+    const held = ownerLiveness(before.owner, await liveAgents());
+    if (
+      before.owner &&
+      before.owner !== next &&
+      !argv.force &&
+      (held === "active" || held === "idle")
+    ) {
+      fail(
+        `task ${argv.id} is owned by ${before.owner}, an agent that is still ${held}. ` +
+          `Re-run with --force to take it anyway.`,
+      );
+    }
+    // Pass the owner this decision was made against: the store re-checks it
+    // inside the write lock, so a second claimer that slipped in between the
+    // read above and this write loses loudly instead of silently overwriting.
+    const rec = await store.setOwner(argv.id, next, before.owner ?? null);
+    emit(argv, rec, `claimed ${rec._id} → ${next}\n${renderRecord(rec)}`);
   },
 };
 
@@ -223,7 +371,7 @@ const getCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string }> = {
   describe: "show one task",
   builder: (y) => y.positional("id", { type: "string", demandOption: true }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const rec = store.get(argv.id);
     if (!rec) fail(`no such task: ${argv.id}`);
     emit(argv, rec, renderRecord(rec));
@@ -238,7 +386,7 @@ const transitionCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string; toStat
       .positional("id", { type: "string", demandOption: true })
       .positional("toState", { type: "string", demandOption: true }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const rec = await store.transition(argv.id, argv.toState);
     emit(argv, rec, `transitioned ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
   },
@@ -264,7 +412,7 @@ const approveCmd: CommandModule<
       .option("note", { type: "string" })
       .option("link", { type: "string" }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const rec = await store.approve(argv.id, argv.gate, argv.validatorIdentity, {
       note: argv.note,
       link: argv.link,
@@ -286,7 +434,7 @@ const verifyCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string; gate: stri
         .positional("id", { type: "string", demandOption: true })
         .positional("gate", { type: "string" }),
     handler: async (argv) => {
-      const store = await openStore(argv.root);
+      const store = await storeFor(argv);
       const rec = await store.verify(argv.id, argv.gate || undefined);
       emit(argv, rec, `verified ${rec._id} -> ${rec.state}\n${renderRecord(rec)}`);
     },
@@ -401,7 +549,7 @@ const blockCmd: CommandModule<
         block = { type: "waiting-on-agent", agentId: argv.agent };
         break;
     }
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const rec = await store.setBlock(argv.id, block);
     emit(argv, rec, `blocked ${rec._id}: ${describeBlock(block)}\n${renderRecord(rec)}`);
   },
@@ -412,7 +560,7 @@ const unblockCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string }> = {
   describe: "clear a task's block (does not touch blockedBy — see `dep`)",
   builder: (y) => y.positional("id", { type: "string", demandOption: true }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const rec = await store.setBlock(argv.id, null);
     emit(argv, rec, `unblocked ${rec._id}\n${renderRecord(rec)}`);
   },
@@ -426,7 +574,7 @@ const setCriteriaCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string; text:
       .positional("id", { type: "string", demandOption: true })
       .positional("text", { type: "string", array: true, demandOption: true }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const text = argv.text.map(String).join(" ");
     const rec = await store.setAcceptanceCriteria(argv.id, text);
     emit(argv, rec, `set acceptance criteria on ${rec._id}\n${renderRecord(rec)}`);
@@ -454,7 +602,7 @@ const depCmd: CommandModule<
         describe: "task id it waits for",
       }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     try {
       const rec =
         argv.verb === "add"
@@ -478,7 +626,7 @@ const treeCmd: CommandModule<GlobalOpts, GlobalOpts & { id: string | undefined }
   builder: (y) =>
     y.positional("id", { type: "string", describe: "root task id (default: all roots)" }),
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const tasks = store.all();
     if (argv.format === "json") {
       emit(argv, buildTreeJSON(tasks, argv.id), "");
@@ -492,7 +640,7 @@ const digestCmd: CommandModule<GlobalOpts, GlobalOpts> = {
   command: "digest",
   describe: "per-tag board: state counts, blockers, unblocked tasks",
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     const tasks = store.all();
     if (argv.format === "json") {
       emit(argv, { tasks, unblocked: unblockedTasks(tasks).map((t) => t._id) }, "");
@@ -507,7 +655,7 @@ const reconcileCmd: CommandModule<GlobalOpts, GlobalOpts> = {
   describe:
     "apply automation: orphan dead-owned tasks, clear stale waiting-on-agent blocks, auto-verify, report unblocked tasks",
   handler: async (argv) => {
-    const store = await openStore(argv.root);
+    const store = await storeFor(argv);
     // `liveOnly: false`: a task's owner needs to be checked against a KNOWN
     // agent whose latest record says `exited`, not just the currently-live
     // set — an exited-but-recorded agent is exactly the orphan signal (see
@@ -576,11 +724,15 @@ const reconcileCmd: CommandModule<GlobalOpts, GlobalOpts> = {
 };
 
 export async function runTodoSubcommand(rest0: string[]): Promise<number> {
-  await yargs(rest0)
+  const y = yargs(rest0)
     .scriptName("ay todo")
     .option("root", {
       type: "string",
-      default: process.cwd(),
+      // No `default:`. The default is derived (a git call) and yargs evaluates
+      // defaults eagerly on every parse — including `--help` — so it is
+      // resolved per verb in `storeFor` instead. `defaultDescription` keeps
+      // `--help` honest about what happens when the flag is omitted.
+      defaultDescription: "the repo's common root (shared across worktrees), else cwd",
       describe: "project root holding .agent-yes/todos.jsonl",
       global: true,
     })
@@ -604,13 +756,15 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
     .command(blockCmd)
     .command(unblockCmd)
     .command(depCmd)
+    .command(claimCmd)
     .command(treeCmd)
     .command(digestCmd)
     .command(reconcileCmd)
-    .demandCommand(
-      1,
-      'unknown "ay todo" verb (expected: new/ls/get/transition/approve/verify/set-criteria/block/unblock/dep/tree/digest/reconcile)',
-    )
+    // No `.demandCommand()`: "you typed no verb" is handled after the parse by
+    // printing help (see below), which lists every verb and its description —
+    // strictly more informative than the sentence demandCommand threw, and not
+    // an error condition in the first place. Unknown verbs and bad flags are
+    // still rejected, by `.strict()`.
     .strict()
     .help()
     .version(false)
@@ -626,7 +780,22 @@ export async function runTodoSubcommand(rest0: string[]): Promise<number> {
       // yargs' own validation errors, not just for `fail()` calls inside a
       // handler body.
       throw err ?? new Error(msg);
-    })
-    .parseAsync();
+    });
+
+  const argv = await y.parseAsync();
+
+  // `ay todo` with no verb is a person asking what this thing does, not a
+  // malformed command. It used to answer with a thrown Error — and, since the
+  // launcher prints uncaught errors with their stack, a wall of yargs
+  // internals ahead of the one useful line. A bare `ay` already prints help;
+  // this makes `ay todo` behave the same.
+  //
+  // Keyed on the parsed positionals, not on `rest0.length`: `ay todo --root
+  // /x` is equally verb-less and equally deserves help, and yargs has already
+  // sorted flags from commands by this point. Unknown verbs still fail via
+  // `.strict()` — this branch only fires when NOTHING was asked for.
+  if (argv._.length === 0) {
+    y.showHelp((s) => process.stdout.write(`${s}\n`));
+  }
   return 0;
 }

--- a/ts/todoIdentity.spec.ts
+++ b/ts/todoIdentity.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { ownerLiveness, resolveSelf } from "./todoIdentity.ts";
+import type { GlobalPidRecord } from "./globalPidIndex.ts";
+
+const rec = (over: Partial<GlobalPidRecord>): GlobalPidRecord =>
+  ({
+    pid: 100,
+    cli: "claude",
+    prompt: null,
+    cwd: "/repo",
+    log_file: null,
+    status: "active",
+    exit_code: null,
+    exit_reason: null,
+    started_at: 0,
+    ...over,
+  }) as GlobalPidRecord;
+
+describe("resolveSelf", () => {
+  it("maps AGENT_YES_PID to the record whose wrapper_pid it is", async () => {
+    const self = await resolveSelf({ AGENT_YES_PID: "500" }, async () => [
+      rec({ pid: 1, wrapper_pid: 9, agent_id: "other" }),
+      rec({ pid: 2, wrapper_pid: 500, agent_id: "mine", cwd: "/repo/lane" }),
+    ]);
+    expect(self).toEqual({ agentId: "mine", pid: 2, cwd: "/repo/lane", title: undefined });
+  });
+
+  it("falls back to a pid match for a process that IS the wrapper", async () => {
+    const self = await resolveSelf({ AGENT_YES_PID: "77" }, async () => [
+      rec({ pid: 77, agent_id: "wrapper-self" }),
+    ]);
+    expect(self?.agentId).toBe("wrapper-self");
+  });
+
+  it("returns null in a human shell (no AGENT_YES_PID)", async () => {
+    expect(await resolveSelf({}, async () => [rec({ pid: 1, agent_id: "a" })])).toBeNull();
+  });
+
+  // The load-bearing case: an owner string that is not an `agent_id` matches
+  // nothing in `deadOwnerAgent`, so it reads as a human owner and is never
+  // orphaned. Returning null here is what lets the CLI say so out loud
+  // instead of writing a pid that would quietly disable orphan recovery.
+  it("returns null when the record carries no stable agent_id, rather than substituting a pid", async () => {
+    expect(
+      await resolveSelf({ AGENT_YES_PID: "500" }, async () => [
+        rec({ pid: 2, wrapper_pid: 500, agent_id: null }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when AGENT_YES_PID matches no record at all", async () => {
+    expect(await resolveSelf({ AGENT_YES_PID: "999" }, async () => [rec({ pid: 1 })])).toBeNull();
+  });
+
+  it("ignores a non-numeric AGENT_YES_PID instead of matching NaN", async () => {
+    expect(
+      await resolveSelf({ AGENT_YES_PID: "not-a-pid" }, async () => [rec({ pid: 1 })]),
+    ).toBeNull();
+  });
+});
+
+describe("ownerLiveness", () => {
+  const agents = [
+    rec({ agent_id: "running", status: "active" }),
+    rec({ agent_id: "napping", status: "idle" }),
+    rec({ agent_id: "gone", status: "exited" }),
+  ];
+
+  it("reports the agent's registry status", () => {
+    expect(ownerLiveness("running", agents)).toBe("active");
+    expect(ownerLiveness("napping", agents)).toBe("idle");
+    expect(ownerLiveness("gone", agents)).toBe("exited");
+  });
+
+  it("reports unknown for a human owner and for no owner", () => {
+    expect(ownerLiveness("alice", agents)).toBe("unknown");
+    expect(ownerLiveness(undefined, agents)).toBe("unknown");
+  });
+});

--- a/ts/todoIdentity.ts
+++ b/ts/todoIdentity.ts
@@ -1,0 +1,74 @@
+/**
+ * "Who am I" for `ay todo`, so a task's owner is a value the rest of the
+ * engine can actually reason about.
+ *
+ * `TodoRecord.owner` is deliberately opaque — a human handle OR an agent's
+ * identifier — but `todoAutomation.ts` gives one specific string special
+ * meaning: `deadOwnerAgent()` looks the owner up in the global agent index by
+ * `agent_id`, and orphans the task when that agent has exited. An owner that
+ * is anything else (a human name, a bare pid, a hostname) simply never matches
+ * a record, and is therefore treated as a human owner and never orphaned.
+ *
+ * That asymmetry is the reason this module refuses to guess. Writing "some
+ * plausible identifier" for an agent owner would not fail loudly; it would
+ * produce a task that LOOKS assigned to an agent and silently opts out of
+ * orphan recovery forever — the one automation that exists to notice its owner
+ * died. So `resolveSelfAgentId` returns the registry's own `agent_id` or
+ * nothing, and the CLI turns "nothing" into an error the caller can read.
+ *
+ * Resolution mirrors `resolveSender()` in `subcommands.ts`: the wrapper
+ * injects its own pid as `AGENT_YES_PID` into the agent's environment (the
+ * agent's own pid is not knowable until after spawn), so the env value maps
+ * back to a record via `wrapper_pid`, falling back to `pid` for a process that
+ * IS the wrapper.
+ */
+
+import { readGlobalPids, type GlobalPidRecord } from "./globalPidIndex.ts";
+
+/** The literal an owner argument uses to mean "the agent running this command". */
+export const SELF_OWNER = "me";
+
+/** The literal that explicitly means "no owner" — distinct from omitting the flag, which defaults to self. */
+export const NO_OWNER = "none";
+
+export interface SelfIdentity {
+  agentId: string;
+  pid: number;
+  cwd: string;
+  title?: string | null;
+}
+
+export type PidReader = () => Promise<GlobalPidRecord[]>;
+
+/**
+ * The calling agent's registry record, or `null` when this is a human shell
+ * (no `AGENT_YES_PID`) or the agent is not registered under a stable id.
+ *
+ * The `agent_id`-less case returns `null` rather than falling back to the pid:
+ * a pid is not what `reconcileTodos` compares against, so storing one would be
+ * indistinguishable from a human owner to every downstream consumer while
+ * looking, to a reader, like a working agent assignment.
+ */
+export async function resolveSelf(
+  env: Record<string, string | undefined> = process.env,
+  readPids: PidReader = () => readGlobalPids(),
+): Promise<SelfIdentity | null> {
+  const envPid = env.AGENT_YES_PID ? Number(env.AGENT_YES_PID) : null;
+  if (!envPid || Number.isNaN(envPid)) return null;
+  const recs = await readPids();
+  const rec = recs.find((r) => r.wrapper_pid === envPid) ?? recs.find((r) => r.pid === envPid);
+  if (!rec?.agent_id) return null;
+  return { agentId: rec.agent_id, pid: rec.pid, cwd: rec.cwd, title: rec.title };
+}
+
+/** Live-ness of an owner string, for read-side views. `unknown` covers human owners and agents that never registered. */
+export type OwnerLiveness = "active" | "idle" | "exited" | "unknown";
+
+/** Look an owner up in an agent snapshot. Same `agent_id` matching `deadOwnerAgent()` uses, so the two never disagree about who is an agent. */
+export function ownerLiveness(
+  owner: string | undefined,
+  agents: Pick<GlobalPidRecord, "agent_id" | "status">[],
+): OwnerLiveness {
+  if (!owner) return "unknown";
+  return agents.find((a) => a.agent_id === owner)?.status ?? "unknown";
+}

--- a/ts/todoRoot.spec.ts
+++ b/ts/todoRoot.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, afterAll } from "vitest";
+import { mkdtemp, rm, mkdir, realpath } from "fs/promises";
+import { execFileSync } from "child_process";
+import { tmpdir } from "os";
+import path from "path";
+import { resolveTodoRoot, type GitRunner } from "./todoRoot.ts";
+
+/** Stands in for a repo whose common dir is `<repo>/.git`, whatever cwd we ask from. */
+const gitAt =
+  (commonDir: string): GitRunner =>
+  async () =>
+    `${commonDir}\n`;
+const notARepo: GitRunner = async () => null;
+
+describe("resolveTodoRoot", () => {
+  it("honors an explicit --root above everything else", async () => {
+    const got = await resolveTodoRoot(
+      "/explicit",
+      "/cwd",
+      { AGENT_YES_TODO_ROOT: "/pinned" },
+      gitAt("/repo/.git"),
+    );
+    expect(got).toBe(path.resolve("/explicit"));
+  });
+
+  it("resolves a relative --root against cwd, so `--root .` means here", async () => {
+    expect(await resolveTodoRoot("sub", "/cwd", {}, notARepo)).toBe(path.resolve("/cwd/sub"));
+    expect(await resolveTodoRoot(".", "/cwd", {}, notARepo)).toBe(path.resolve("/cwd"));
+  });
+
+  it("falls back to $AGENT_YES_TODO_ROOT before consulting git", async () => {
+    const got = await resolveTodoRoot(
+      undefined,
+      "/cwd",
+      { AGENT_YES_TODO_ROOT: "/pinned" },
+      gitAt("/repo/.git"),
+    );
+    expect(got).toBe(path.resolve("/pinned"));
+  });
+
+  // The whole reason this module exists: two agents in two worktrees of one
+  // repo must land on the SAME store, which is what makes `--owner me`,
+  // `claim`, and orphan-reconcile mean anything across agents.
+  it("resolves worktrees of one repo to a single shared root", async () => {
+    const git = gitAt("/repo/.git");
+    const a = await resolveTodoRoot(undefined, "/repo/.claude/worktrees/lane-a", {}, git);
+    const b = await resolveTodoRoot(undefined, "/repo/.claude/worktrees/lane-b", {}, git);
+    expect(a).toBe(path.resolve("/repo"));
+    expect(b).toBe(a);
+  });
+
+  it("handles git's relative output (`.git`) by resolving it against cwd", async () => {
+    const got = await resolveTodoRoot(undefined, "/repo", {}, async () => ".git\n");
+    expect(got).toBe(path.resolve("/repo"));
+  });
+
+  it("falls back to cwd when this is not a git repo at all", async () => {
+    expect(await resolveTodoRoot(undefined, "/tmp/scratch", {}, notARepo)).toBe(
+      path.resolve("/tmp/scratch"),
+    );
+  });
+
+  // The tests above inject a fake git so the resolution RULES are pinned
+  // exactly. This one runs the real default runner against a real repo,
+  // because the rules are only worth anything if the actual `git rev-parse
+  // --git-common-dir` call — the piece a stub can't check — agrees with them.
+  describe("against a real git repo (default runner)", () => {
+    const dirs: string[] = [];
+    afterAll(async () => {
+      for (const d of dirs) await rm(d, { recursive: true, force: true });
+    });
+
+    it("resolves a nested subdir AND a linked worktree to the same repo root", async () => {
+      // realpath: on macOS tmpdir is a /var -> /private/var symlink, and git
+      // reports the resolved path, so comparing against the raw mkdtemp path
+      // would fail for a reason that has nothing to do with this module.
+      const base = await realpath(await mkdtemp(path.join(tmpdir(), "todoroot-")));
+      dirs.push(base);
+      const repo = path.join(base, "repo");
+      await mkdir(path.join(repo, "deep", "nested"), { recursive: true });
+
+      const git = (args: string[], cwd: string) =>
+        execFileSync("git", args, { cwd, stdio: "ignore" });
+      await git(["init", "-q", "."], repo);
+      await git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+      await git(["worktree", "add", "-q", path.join(base, "wt"), "-b", "lane"], repo);
+
+      expect(await resolveTodoRoot(undefined, path.join(repo, "deep", "nested"), {})).toBe(repo);
+      expect(await resolveTodoRoot(undefined, path.join(base, "wt"), {})).toBe(repo);
+    });
+
+    it("falls back to cwd outside any repo", async () => {
+      const outside = await realpath(await mkdtemp(path.join(tmpdir(), "todoroot-bare-")));
+      dirs.push(outside);
+      // A temp dir can still sit inside an enclosing repo on some machines;
+      // the only claim being made is that resolution never throws and returns
+      // a real directory path.
+      const got = await resolveTodoRoot(undefined, outside, {});
+      expect(path.isAbsolute(got)).toBe(true);
+    });
+  });
+
+  it("treats an empty git result as 'not a repo' rather than resolving to the filesystem root", async () => {
+    // A blank line back from git used to be indistinguishable from a real
+    // answer: `path.dirname(path.resolve("/cwd", ""))` is "/", which would
+    // silently point every agent's store at the root of the disk.
+    expect(await resolveTodoRoot(undefined, "/cwd", {}, async () => "\n")).toBe(
+      path.resolve("/cwd"),
+    );
+  });
+});

--- a/ts/todoRoot.spec.ts
+++ b/ts/todoRoot.spec.ts
@@ -79,11 +79,17 @@ describe("resolveTodoRoot", () => {
       const repo = path.join(base, "repo");
       await mkdir(path.join(repo, "deep", "nested"), { recursive: true });
 
+      // -c user.*: CI runners have no global git identity, so a bare `git
+      // commit` exits 128 there while passing locally.
       const git = (args: string[], cwd: string) =>
-        execFileSync("git", args, { cwd, stdio: "ignore" });
-      await git(["init", "-q", "."], repo);
-      await git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
-      await git(["worktree", "add", "-q", path.join(base, "wt"), "-b", "lane"], repo);
+        execFileSync(
+          "git",
+          ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args],
+          { cwd, stdio: "ignore" },
+        );
+      git(["init", "-q", "."], repo);
+      git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+      git(["worktree", "add", "-q", path.join(base, "wt"), "-b", "lane"], repo);
 
       expect(await resolveTodoRoot(undefined, path.join(repo, "deep", "nested"), {})).toBe(repo);
       expect(await resolveTodoRoot(undefined, path.join(base, "wt"), {})).toBe(repo);

--- a/ts/todoRoot.ts
+++ b/ts/todoRoot.ts
@@ -80,7 +80,11 @@ export async function resolveTodoRoot(
   // so resolving against `cwd` is correct for both the relative and absolute
   // forms. `--path-format=absolute` would force one shape but needs git >=
   // 2.31 and buys nothing here.
+  // `path.resolve(cwd)` on the fallback, not a bare `cwd`: every other branch
+  // returns a resolved absolute path, and on Windows the two differ (a POSIX-
+  // shaped "/tmp/x" resolves to "D:\tmp\x"), so returning it raw would hand
+  // callers a path in a different shape depending on which branch fired.
   const common = (await runGit(["rev-parse", "--git-common-dir"], cwd))?.trim();
-  if (!common) return cwd;
+  if (!common) return path.resolve(cwd);
   return path.dirname(path.resolve(cwd, common));
 }

--- a/ts/todoRoot.ts
+++ b/ts/todoRoot.ts
@@ -1,0 +1,86 @@
+/**
+ * Where `ay todo`'s store lives when the caller did not say.
+ *
+ * The engine is meant to be shared by every agent working on a repo, but the
+ * store is a file at `<root>/.agent-yes/todos.jsonl`, so "which root" is what
+ * actually decides who can see whom. Defaulting to `process.cwd()` — the
+ * original behavior — quietly breaks that the moment agents run in git
+ * WORKTREES (this project's own normal mode: `.claude/worktrees/<name>/`, one
+ * agent each): every worktree is a different cwd, so every agent gets a
+ * PRIVATE todo list, while `reconcileTodos` goes on matching task owners
+ * against the GLOBAL cross-runtime agent index. That leaves the two halves of
+ * a cross-agent feature disagreeing about what "everyone" means, and it fails
+ * silently — an agent sees an empty list, not an error.
+ *
+ * So the default root is the repo's COMMON root: the main worktree, shared by
+ * every linked worktree of the same repo. That is the parent of `git rev-parse
+ * --git-common-dir`, NOT `--show-toplevel` — inside a linked worktree
+ * `--show-toplevel` returns that worktree's own path (exactly the private
+ * answer we are trying to get away from), while `--git-common-dir` is by
+ * definition the directory all worktrees of a repo share.
+ *
+ * Scope deliberately stops at the repo. Going fleet-global (one store for
+ * every repo on the machine, the way `ay ls` lists every agent) is a different
+ * product decision — unrelated projects' tasks in one list — and is not taken
+ * here; a caller who wants that passes an explicit `--root`.
+ */
+
+import path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+export type GitRunner = (args: string[], cwd: string) => Promise<string | null>;
+
+/**
+ * Minimal `git` runner: stdout on success, `null` if git is missing, this
+ * isn't a repo, or it hangs.
+ *
+ * `child_process` rather than `Bun.spawn` (which sibling modules like
+ * `subcommands.ts` use) so this module works under BOTH runtimes. Bun
+ * implements `child_process`, while `Bun` is undefined under Node — and the
+ * failure mode there is the quiet kind: the catch below would swallow the
+ * ReferenceError and every lookup would fall back to cwd, i.e. exactly the
+ * per-directory store this module exists to prevent, with no error to notice.
+ */
+const spawnGit: GitRunner = async (args, cwd) => {
+  try {
+    const { stdout } = await execFileAsync("git", args, { cwd, timeout: 2000 });
+    return stdout;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Resolve the todo store root, most explicit source first:
+ *
+ *   1. `--root <dir>` — the caller said it; never second-guessed.
+ *   2. `$AGENT_YES_TODO_ROOT` — pins a root for a whole shell/agent session
+ *      (also how tests point at a scratch dir with no git repo involved).
+ *   3. the repo's common root — shared across worktrees, see the file header.
+ *   4. `cwd` — not a git repo at all.
+ *
+ * Relative values in (1)/(2) resolve against `cwd`, so `--root .` keeps
+ * meaning "here" instead of depending on where the process happened to start.
+ */
+export async function resolveTodoRoot(
+  explicit: string | undefined,
+  cwd: string = process.cwd(),
+  env: Record<string, string | undefined> = process.env,
+  runGit: GitRunner = spawnGit,
+): Promise<string> {
+  if (explicit) return path.resolve(cwd, explicit);
+  const pinned = env.AGENT_YES_TODO_ROOT;
+  if (pinned) return path.resolve(cwd, pinned);
+
+  // The output may be relative (a bare `.git` when cwd IS the repo root); git
+  // prints it relative to its own process cwd, which is the `cwd` we spawn in,
+  // so resolving against `cwd` is correct for both the relative and absolute
+  // forms. `--path-format=absolute` would force one shape but needs git >=
+  // 2.31 and buys nothing here.
+  const common = (await runGit(["rev-parse", "--git-common-dir"], cwd))?.trim();
+  if (!common) return cwd;
+  return path.dirname(path.resolve(cwd, common));
+}

--- a/ts/todoStore.spec.ts
+++ b/ts/todoStore.spec.ts
@@ -148,6 +148,31 @@ describe("TodoStore", () => {
     await expect(s.setAcceptanceCriteria("T99", "text")).rejects.toThrow(/no such task/);
   });
 
+  it("setOwner() reassigns a task, trimming the value and refusing an empty one", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "x", kind: "code" });
+    expect((await s.setOwner(t._id, "  lane-b  ")).owner).toBe("lane-b");
+    await expect(s.setOwner(t._id, "   ")).rejects.toThrow(/must not be empty/);
+    await expect(s.setOwner("T99", "lane-b")).rejects.toThrow(/no such task/);
+  });
+
+  it("setOwner() with expectedOwner refuses when the owner changed underneath — the lost-update guard `ay todo claim` relies on", async () => {
+    const s = await openStore(TEST_ROOT);
+    const t = await s.create({ summary: "contested", kind: "code" });
+
+    // Two claimers both read "unowned"; the first one writes.
+    await s.setOwner(t._id, "lane-a", null);
+    // The second one is still acting on its stale read, and must lose loudly
+    // rather than silently overwrite a claim it never saw.
+    await expect(s.setOwner(t._id, "lane-b", null)).rejects.toThrow(/owner changed to lane-a/);
+    expect(s.get(t._id)?.owner).toBe("lane-a");
+
+    // A claimer that DID see the current owner is allowed through.
+    expect((await s.setOwner(t._id, "lane-b", "lane-a")).owner).toBe("lane-b");
+    // And omitting expectedOwner skips the check entirely.
+    expect((await s.setOwner(t._id, "lane-c")).owner).toBe("lane-c");
+  });
+
   it("setAcceptanceCriteria() refuses WHITESPACE-only text too, and trims what it stores (codex-review round-8 Important: a blank-looking value must not silently pass as real criteria)", async () => {
     const s = await openStore(TEST_ROOT);
     const t = await s.create({ summary: "x", kind: "doc" });

--- a/ts/todoStore.ts
+++ b/ts/todoStore.ts
@@ -625,6 +625,39 @@ export class TodoStore {
     return this.rawUpdate(id, () => ({ acceptanceCriteria: trimmed }));
   }
 
+  /**
+   * Reassign a task (`ay todo claim`). Ownership is the one field in this
+   * store that TWO agents actively compete for, so this takes the owner the
+   * caller believed was current and re-checks it against the FRESH record
+   * inside the write lock.
+   *
+   * Without that check, the CLI's shape — read the task, decide whether its
+   * owner is a live agent, then write — is a textbook lost update: two agents
+   * that both read "unowned" a millisecond apart would both pass their own
+   * liveness check and both write, and the loser would never learn it lost.
+   * The same revalidate-against-fresh discipline `clearWaitingOnAgentBlock`
+   * and `markOrphaned` already use, for the same reason.
+   *
+   * `expectedOwner` is `undefined` to skip the check, `null` to require the
+   * task still be unowned, or a string to require that exact current owner.
+   */
+  async setOwner(id: string, owner: string, expectedOwner?: string | null): Promise<TodoRecord> {
+    const trimmed = owner.trim();
+    if (!trimmed) throw new Error(`task ${id}: owner must not be empty`);
+    return this.rawUpdate(id, (fresh) => {
+      if (expectedOwner !== undefined) {
+        const current = fresh.owner ?? null;
+        if (current !== expectedOwner) {
+          throw new Error(
+            `task ${id}: owner changed to ${current ?? "(none)"} while claiming ` +
+              `(expected ${expectedOwner ?? "(none)"}) — re-read it and try again`,
+          );
+        }
+      }
+      return { owner: trimmed };
+    });
+  }
+
   setBlock(id: string, block: TodoBlock | null): Promise<TodoRecord> {
     // `null`, never `undefined`: JSON.stringify drops `undefined` keys
     // entirely, so an update line with an omitted `block` would fail to


### PR DESCRIPTION
## 背景

`ay todo` のエンジン (ライフサイクル・ゲート・依存・reconcile) は既に存在するが、**エージェント横断では機能していなかった**。

ストアの既定位置が `process.cwd()` だったため、worktree ごとに 1 エージェントを走らせる通常運用では全員が別々の `.agent-yes/todos.jsonl` を持つ。一方 `reconcileTodos` は**グローバル**なエージェント登録簿と owner を照合する。同じ機能の両半分が「全員」の意味を取り違えており、しかもエラーではなく**空の一覧**として現れるため気づけない。

## 変更点

| | |
|---|---|
| **ストアをリポジトリ単位に** | 既定位置を `git rev-parse --git-common-dir` の親に変更。同一リポジトリの全 worktree が 1 つのストアを共有する。`--show-toplevel` ではない理由 (linked worktree では自分自身のパスを返す = 避けたい挙動そのもの) は `ts/todoRoot.ts` 冒頭に記載。`--root` / `$AGENT_YES_TODO_ROOT` で明示指定可、リポジトリ外は cwd。**fleet 全体で 1 つ**にするのは別の設計判断なので採らない。 |
| **エージェントの同定** | `AGENT_YES_PID` → 登録簿の `agent_id`。解決できなければ pid で代用せず null。`deadOwnerAgent` が照合するのは `agent_id` だけなので、それ以外を owner に書くと「担当者がいるように見えて孤児回収の対象外」という無言の穴になる。 |
| **`--owner me` / `--owner none`** | `new` は既定で呼び出し元エージェントを owner にする。人間のシェルからは従来どおり無所有。エージェント外での `--owner me` は明示的にエラー。 |
| **`ay todo claim <id>`** | 稼働中エージェントからの横取りは拒否 (`--force` で上書き)。ストア側 `setOwner` はロック内で `expectedOwner` を再検証し、競合 claim を静かに上書きしない。 |
| **owner の生死表示** | 表は `lane-3(exited)`、JSON は `owner` を変えずに `ownerLiveness` を追加 (owner でのフィルタを壊さないため)。 |
| **引数なし `ay todo`** | ヘルプを表示。従来は demandCommand が Error を投げ、スタックトレースが出ていた。 |
| **サブコマンド一覧の同期テスト** | `ts/subcommands.ts` と `rs/src/cli.rs` の一覧が一致することを検証。両者は「同期を保つこと」というコメントだけで守られており、実際に 5 件ずれていたことがある。JS 経由では動くため、この種のずれは通常のテストに現れない。 |
| **README** | `ay todo` の節を追加 (これまで一切記載がなかった)。 |

## 検証

- `bunx vitest run ts/` — 100 files passed / 1 skipped、失敗なし
- `resolveTodoRoot` はスタブ注入で規則を固定したうえで、**実際の git リポジトリ + linked worktree** に対しても検証 (カバレッジ 100%)
- 実地確認: 一時リポジトリの深いサブディレクトリで作成したタスクが、別 worktree の `ay todo ls` から見える
- `tsgo --noEmit` — 変更ファイルに新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)