### PR TITLE
fix(console): 速く打つと文字順が入れ替わる問題を修正

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -773,3 +773,67 @@ export function omniScore(e, query) {
   if ((e.prompt || "").toLowerCase().includes(q)) return 20;
   return 0;
 }
+
+// ---- ordered keystroke delivery ------------------------------------------
+//
+// Every keystroke the terminal emits used to become its own fire-and-forget
+// POST /api/send. Nothing tied those requests together, so a fast typist had
+// several in flight at once — and independent requests have no ordering
+// guarantee on ANY of the three transports the console uses (plain fetch, the
+// /api/mux socket's request/response pairs, the WebRTC room's). Worse, the
+// host resolves the target agent (`resolveOne`, disk I/O) before writing to
+// its FIFO, so two requests that arrive in order can still reach the write in
+// the other order. Nothing is dropped and nothing errors — the characters just
+// land transposed, which is exactly how it was reported: typing "which is also
+// the r" produced " which il sao sthe r".
+//
+// The fix is to never have two writes in flight for one agent. `push` queues,
+// and a single drain loop sends one request at a time. While that request is
+// out, the burst of typing behind it accumulates and goes as ONE payload, so
+// the common case (typing faster than the round trip) gets fewer requests than
+// before rather than more.
+//
+// Deliberately NOT a debounce: delaying input would hide the race behind added
+// latency while leaving two concurrent writes possible whenever the delay was
+// beaten. Serializing removes it.
+export function createInputSender(send) {
+  const queue = [];
+  let draining = false;
+
+  async function drain() {
+    if (draining) return;
+    draining = true;
+    try {
+      while (queue.length) {
+        let msg = queue.shift();
+        // Coalesce only an adjacent RUN of strings. A binary chunk (xterm's
+        // onBinary, e.g. UTF-8 mouse reports) is passed through on its own so
+        // it is never concatenated into a text payload — but it still holds
+        // its place in the queue, so ordering is preserved across a mixed run.
+        if (typeof msg === "string") {
+          while (queue.length && typeof queue[0] === "string") msg += queue.shift();
+        }
+        try {
+          await send(msg);
+        } catch {
+          // Same as the old fire-and-forget `.catch(() => {})`: a failed write
+          // must not wedge the queue, or one dropped request would silently
+          // stop the agent from receiving anything typed after it.
+        }
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  return {
+    push(chunk) {
+      queue.push(chunk);
+      void drain();
+    },
+    /** Queue depth, for tests and the perf overlay. */
+    pending() {
+      return queue.length;
+    },
+  };
+}

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -2317,6 +2317,7 @@
         centerOffset,
         docTitle,
         omniScore,
+        createInputSender,
       } from "./console-logic.js";
       // The ay-share (rtc) remote-room transport lives in a shared module so the
       // /r/ rgui viewer reuses the exact same WebRTC + e2e wire (rtc.js imports
@@ -6327,12 +6328,20 @@ my.translate = async (text, lang) => {
         // keyword MUST be a string — ay serve's POST /api/send rejects a numeric
         // keyword with 400 (pid arrives as a number from /api/ls JSON).
         const kw = String(pid);
+        // One /api/send in flight at a time for this agent. A request per
+        // keystroke let a fast typist have several racing at once, and nothing
+        // in any transport (fetch / mux / RTC) — nor in the host's
+        // resolve-then-write handler — kept them in order, so characters
+        // arrived transposed. See createInputSender in console-logic.js.
+        const input = createInputSender((msg) =>
+          tx.post("/api/send", { keyword: kw, msg, code: "none" }),
+        );
         const fwd = (d) => {
           if (sel !== e._key) return; // ignore a stale terminal mid-switch
           // a soft-keyboard character may be decorated by an armed sticky Ctrl/Alt
           if (typeof d === "string") d = applyStickyMods(d);
           perfNote("in", typeof d === "string" ? d.length : (d?.byteLength ?? 0));
-          tx.post("/api/send", { keyword: kw, msg: d, code: "none" }).catch(() => {});
+          input.push(d);
         };
         term.onData(fwd);
         term.onBinary(fwd);

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -38,6 +38,7 @@ import {
   docTitle,
   statusGlyph,
   omniScore,
+  createInputSender,
 } from "../../lab/ui/console-logic.js";
 
 const agent = (over = {}) => ({
@@ -1044,5 +1045,112 @@ describe("sortEntries", () => {
       a({ _k: "amy", cwd: "/x/amy/repo/tree/main" }),
     ];
     expect(keys(sortEntries(list, "identity"))).toEqual(["amy", "zed"]);
+  });
+});
+
+// Regression cover for the reported "typing fast transposes characters" bug on
+// agent-yes.com: `which is also the r` arriving as ` which il sao sthe r`.
+// Nothing was lost, only reordered — the signature of concurrent writes, not
+// dropped input. The model below is the whole bug in miniature: a transport
+// whose per-request latency varies, which is true of all three the console
+// uses.
+describe("createInputSender", () => {
+  /**
+   * A send() whose completion order does NOT match its call order. `delays`
+   * supplies the latency of each successive call, so a later call can finish
+   * first — exactly what a varying-latency request path does.
+   */
+  function jitterySend(delays: number[]) {
+    const landed: string[] = [];
+    let i = 0;
+    const send = (msg: string) => {
+      const wait = delays[i++] ?? 0;
+      return new Promise<void>((resolve) =>
+        setTimeout(() => {
+          landed.push(msg); // "landed" = reached the agent's FIFO
+          resolve();
+        }, wait),
+      );
+    };
+    return { send, landed };
+  }
+
+  const settle = () => new Promise((r) => setTimeout(r, 50));
+
+  it("delivers in order even when the first request is slower than the second", async () => {
+    // Without serialization these two overlap and the fast one wins the race —
+    // the transposition users actually saw.
+    const { send, landed } = jitterySend([20, 0]);
+    const input = createInputSender(send);
+    input.push("a");
+    input.push("b");
+    await settle();
+    expect(landed.join("")).toBe("ab");
+  });
+
+  it("preserves the exact character order of a fast burst", async () => {
+    const typed = "which is also the r".split("");
+    // Descending latencies: every request would overtake the one before it.
+    const { send, landed } = jitterySend(typed.map((_, i) => typed.length - i));
+    const input = createInputSender(send);
+    for (const ch of typed) input.push(ch);
+    await settle();
+    expect(landed.join("")).toBe(typed.join(""));
+  });
+
+  it("coalesces the keystrokes that pile up behind an in-flight request into one payload", async () => {
+    const sent: string[] = [];
+    let release: (() => void) | null = null;
+    const input = createInputSender((msg: string) => {
+      sent.push(msg);
+      // Hold the FIRST request open so the rest of the burst queues behind it.
+      return sent.length === 1 ? new Promise<void>((r) => (release = r)) : Promise.resolve();
+    });
+
+    input.push("h");
+    for (const ch of "ello") input.push(ch);
+    expect(sent).toEqual(["h"]); // still only one request in flight
+    expect(input.pending()).toBe(4);
+
+    release!();
+    await settle();
+    // Four keystrokes, one follow-up request — fewer round trips than the
+    // per-keystroke version it replaces, not more.
+    expect(sent).toEqual(["h", "ello"]);
+    expect(input.pending()).toBe(0);
+  });
+
+  it("keeps a binary chunk as its own payload without losing its place in the order", async () => {
+    const sent: unknown[] = [];
+    const mouse = new Uint8Array([0x1b, 0x5b, 0x4d]);
+    let release: (() => void) | null = null;
+    const input = createInputSender((msg: unknown) => {
+      sent.push(msg);
+      return sent.length === 1 ? new Promise<void>((r) => (release = r)) : Promise.resolve();
+    });
+
+    input.push("open"); // holds the wire so everything below queues up
+    input.push("a");
+    input.push("b");
+    input.push(mouse);
+    input.push("c");
+    release!();
+    await settle();
+    // "ab" coalesced into one payload; the binary chunk passed through
+    // untouched rather than being concatenated into text; "c" still after it.
+    expect(sent).toEqual(["open", "ab", mouse, "c"]);
+  });
+
+  it("a failed send does not wedge the queue — later keystrokes still go out", async () => {
+    const sent: string[] = [];
+    const input = createInputSender((msg: string) => {
+      sent.push(msg);
+      return sent.length === 1 ? Promise.reject(new Error("network")) : Promise.resolve();
+    });
+    input.push("a");
+    await settle();
+    input.push("b");
+    await settle();
+    expect(sent).toEqual(["a", "b"]);
   });
 });


### PR DESCRIPTION
## 症状

agent-yes.com のコンソールで速くタイプすると文字が転置する (報告: taku 2026-08-10)。

```
打った内容:  which is also the r
届いた内容:   which il sao sthe r
```

同一ウィンドウ内でも発生。**文字は 1 つも欠落せず、順序だけが壊れる** — 入力の取りこぼしや PTY のバックプレッシャではなく、書き込みが並行しているときの症状。

## 原因

ターミナルが出す 1 打鍵ごとに、独立した fire-and-forget の `POST /api/send` を投げていた (`lab/ui/index.html` の `fwd`)。要求同士を束ねるものが何もないため、速いタイピストは常に複数を in-flight にする。

- 独立した要求の順序は、コンソールが使う **3 経路すべて** で保証されない (素の `fetch`・`/api/mux` ソケットの request/response・WebRTC ルームの `req`)。
- さらにホスト側の `/api/send` は、FIFO に書く前に対象エージェントを解決する (`resolveOne`、ディスク I/O)。この所要時間は呼び出しごとに揺れるため、**順番どおりに届いた 2 要求が逆順で書き込みに到達しうる**。

## 対策

1 エージェントにつき in-flight を 1 本に直列化する (`createInputSender`, `lab/ui/console-logic.js`)。送信中に溜まった打鍵は 1 つのペイロードにまとめて送るので、往復より速く打つ通常のケースでは**要求数はむしろ従来より減る**。

**debounce は採らない**: 遅延で隠すだけで、遅延を上回る速さで打てば並行書き込みが再発するため。順序保証は送信経路そのもので担保する。

バイナリチャンク (xterm の `onBinary`、UTF-8 マウスレポート) はテキストに連結せず単独で送るが、キューの順番は保持する。送信失敗はキューを止めない (従来の `.catch(() => {})` と同じく、1 回の失敗で以降の入力が届かなくなることはない)。

## 検証

- `tests/ui-logic/console-logic.spec.ts` に回帰テストを追加。「呼び出し順と完了順が一致しない送信関数」でバグを再現するモデルを使う (この latency のばらつきは 3 経路すべてに当てはまる)。同じモデルで**直列化前の実装は文字列を完全に反転させる** (`"which is also the r"` → `"r eht osla si hcihw"`) ため、テストは vacuous ではない。
- `bunx vitest run` — 100 files passed / 1 skipped
- `bun run test:ui-dom` — 27 passed

## 残る課題 (別件)

ホスト側の `/api/send` は依然として要求ごとに並行実行される。単一ビューアからの入力は上記で完全に順序保証されるが、**複数の書き手** (2 つのビューア、あるいは `ay send` と同時) の間の順序はホスト側で pid ごとに直列化しない限り保証されない。影響範囲と `ay send` の 200ms ギャップとの兼ね合いがあるため、本 PR には含めない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)