### PR TITLE
test(send): submitAndConfirm の 2 件を wall-clock 依存から外して flaky を解消

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1200,7 +1200,20 @@ describe("subcommands.submitAndConfirm (ay send swallowed-Enter fix)", () => {
     ...over,
   });
 
-  async function withFifo(fn: (fifo: string) => Promise<void>) {
+  /**
+   * `fn` gets the fifo path plus `onKeystroke()`, which resolves once
+   * submitAndConfirm's trailing code actually lands on the fifo.
+   *
+   * Tests that need the agent to "react" MUST hang that reaction off
+   * `onKeystroke()` rather than a `setTimeout`. submitAndConfirm snapshots the
+   * log size and the current working-marker state BEFORE it writes to the fifo,
+   * and it only does that after `cliDefaults()` has parsed the config — so a
+   * wall-clock timer races that setup. Under load the setup wins, the "reaction"
+   * lands in the pre-write snapshot, and the assertion flips: growth gets folded
+   * into `sizeBefore`, and a busy marker reads as `wasAlreadyWorking` (which the
+   * false-positive guard below deliberately treats as NOT confirmed).
+   */
+  async function withFifo(fn: (fifo: string, onKeystroke: () => Promise<boolean>) => Promise<void>) {
     const { spawnSync } = await import("child_process");
     const dir = await mkdtemp(path.join(tmpdir(), "ay-confirm-"));
     const fifo = path.join(dir, "test.fifo");
@@ -1209,9 +1222,27 @@ describe("subcommands.submitAndConfirm (ay send swallowed-Enter fix)", () => {
       if (r.status !== 0) return; // mkfifo unavailable — skip
       const fs = await import("fs");
       const rdwrFd = fs.openSync(fifo, fs.constants.O_RDWR); // keeps writes from blocking
+      // A SEPARATE non-blocking reader: rdwrFd is never read from, so the
+      // keystroke is still here to be observed. O_NONBLOCK is load-bearing —
+      // a blocking readSync on an empty fifo wedges the whole vitest worker.
+      const readFd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+      const onKeystroke = async (timeoutMs = 5_000): Promise<boolean> => {
+        const buf = Buffer.alloc(64);
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+          try {
+            if (fs.readSync(readFd, buf, 0, buf.length, null) > 0) return true;
+          } catch (err: any) {
+            if (err?.code !== "EAGAIN") throw err; // EAGAIN = nothing yet
+          }
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        return false;
+      };
       try {
-        await fn(fifo);
+        await fn(fifo, onKeystroke);
       } finally {
+        fs.closeSync(readFd);
         fs.closeSync(rdwrFd);
       }
     } finally {
@@ -1227,11 +1258,16 @@ describe("subcommands.submitAndConfirm (ay send swallowed-Enter fix)", () => {
         const log = path.join(dir, "a.log");
         await writeFile(log, "❯ \r\n"); // idle — no busy marker yet
         const { submitAndConfirm } = await loadModule();
-        await withFifo(async (fifo) => {
-          // The Enter kicks off work: the busy marker appears shortly after,
-          // well within the confirm window — a genuine idle→busy transition.
-          setTimeout(() => appendFileSync(log, BUSY), 100);
+        await withFifo(async (fifo, onKeystroke) => {
+          // The Enter kicks off work: the busy marker appears once the keystroke
+          // has actually landed — a genuine idle→busy transition, and one that
+          // provably happens AFTER submitAndConfirm's pre-write snapshot.
+          const reacted = onKeystroke().then((got) => {
+            if (got) appendFileSync(log, BUSY);
+            return got;
+          });
           const { confirmed, screen } = await submitAndConfirm(rec({ log_file: log }), fifo, "\r");
+          expect(await reacted).toBe(true); // the fifo really carried the Enter
           expect(confirmed).toBe(true);
           expect(screen.join("\n")).toContain("esc to interrupt");
         });
@@ -1270,11 +1306,15 @@ describe("subcommands.submitAndConfirm (ay send swallowed-Enter fix)", () => {
       const log = path.join(dir, "a.log");
       await writeFile(log, "❯ \r\n");
       const { submitAndConfirm } = await loadModule();
-      await withFifo(async (fifo) => {
-        // Simulate the CLI starting to respond shortly after Enter lands — well
-        // within the first attempt's confirm window.
-        setTimeout(() => appendFileSync(log, "some real response text appears here\r\n"), 100);
+      await withFifo(async (fifo, onKeystroke) => {
+        // The CLI starts responding once the Enter lands. Keyed off the actual
+        // keystroke so the growth cannot be folded into `sizeBefore`.
+        const reacted = onKeystroke().then((got) => {
+          if (got) appendFileSync(log, "some real response text appears here\r\n");
+          return got;
+        });
         const { confirmed } = await submitAndConfirm(rec({ log_file: log }), fifo, "\r");
+        expect(await reacted).toBe(true);
         expect(confirmed).toBe(true);
       });
     } finally {


### PR DESCRIPTION
`ts/subcommands.spec.ts` の 2 件が **負荷時に必ず落ちる** flaky だった (単体では通る)。フル実行のたびに赤が混ざり、本物の失敗と見分けが付かない状態だったので潰す。

- `confirms on the first attempt when the busy marker newly appears after sending`
- `confirms via log growth even without a recognized busy marker`

## 原因は「タイマーが遅れる」ではなく「早すぎる」

両テストは `setTimeout(() => appendFileSync(log, …), 100)` を `submitAndConfirm` の呼び出し **前** に仕掛けてエージェントの反応を模していた。しかし `submitAndConfirm` は fifo へ書く前に

1. `cliDefaults()` — 設定 YAML の読み込み・パース
2. `stat(logFile)` → `sizeBefore`
3. `renderLogTailLines()` → `wasAlreadyWorking`

を行う。負荷が高いとこの前処理が 100ms を超え、**反応が「書き込み前スナップショット」の側に入ってしまう**。すると:

| | 期待 | 実際 (負荷時) |
|---|---|---|
| 追記分 | `sizeAfter` に出る → `grew` | `sizeBefore` に畳み込まれる → `grew` = false |
| busy マーカー | 新規に working → confirm | `wasAlreadyWorking` = true → confirm しない |

つまり **production コードの不具合ではなく**、テストが「反応は書き込みの後に起きる」という前提を時計で近似していたのが原因。

なお `wasAlreadyWorking` を confirm 扱いしないのは、すぐ下の false-positive guard テストが守っている **仕様そのもの** なので、閾値や待ち時間を緩める方向では直せない。

## 直し方: 反応をキーストロークに紐付ける

`withFifo` が `onKeystroke()` を渡すようにし、**実際に trailing code が fifo に届いてから** 追記する。時計を一切使わないので順序が保証され、かつ「Enter を受け取ったから忙しくなる」という現実の因果にも近い。

読み取りは専用の `O_RDONLY | O_NONBLOCK` fd で行う (既存の `rdwrFd` は読まないので keystroke はそのまま観測できる)。**`O_NONBLOCK` は必須** — 空の fifo に対する blocking `readSync` は vitest の worker ごと固まる (過去に 6 時間ハングした事例あり)。

`expect(await reacted).toBe(true)` も足した。fifo が本当に Enter を運んだことを確かめずに `confirmed` だけ見ると、「反応が起きなかったのに何かの拍子に通った」ケースを見逃すため。

## 検証

負荷 (loadavg 22→89) を掛けた状態で、**同一条件の A/B**:

```
OLD: 2 failed | 2 passed   ← 当該 2 件がそのまま落ちる
NEW: 4 passed              ← 同じ負荷で全通過
```

再現させたうえで直っていることを確認しているので、「たまたま通った」ではない。

フル: **1566 passed / 0 failed**、global branches **90.23%** (gate 通過)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
