### PR TITLE
fix(ipc): エージェント入力への同時書き込みが互いを切り刻む問題を修正

### DIFF
--- a/ts/ipcLock.spec.ts
+++ b/ts/ipcLock.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { rm, mkdir } from "fs/promises";
+import path from "path";
+import { withIpcLock, ipcLockTarget } from "./ipcLock.ts";
+
+const isWindows = process.platform === "win32";
+const HOME = isWindows
+  ? path.join(process.env.TEMP || "C:\\Temp", "ipclock-test-" + process.pid)
+  : "/tmp/ipclock-test-" + process.pid;
+
+let prevHome: string | undefined;
+
+beforeEach(async () => {
+  prevHome = process.env.AGENT_YES_HOME;
+  process.env.AGENT_YES_HOME = HOME;
+  await rm(HOME, { recursive: true, force: true });
+  await mkdir(HOME, { recursive: true });
+});
+afterEach(async () => {
+  await rm(HOME, { recursive: true, force: true });
+  if (prevHome === undefined) delete process.env.AGENT_YES_HOME;
+  else process.env.AGENT_YES_HOME = prevHome;
+});
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("withIpcLock", () => {
+  it("serialises transactions for the same agent — no interleaving", async () => {
+    const order: string[] = [];
+    // Each "transaction" is multi-step with a gap in the middle, mirroring
+    // `ay send` (body → 200ms settle → Enter). Without the lock the two
+    // interleave as A-start, B-start, A-end, B-end.
+    const txn = (name: string) =>
+      withIpcLock(1234, async () => {
+        order.push(`${name}-start`);
+        await tick(20);
+        order.push(`${name}-end`);
+      });
+
+    await Promise.all([txn("A"), txn("B")]);
+
+    expect(order).toHaveLength(4);
+    // Whichever ran first, its two halves are adjacent.
+    expect(order[0]!.replace("-start", "")).toBe(order[1]!.replace("-end", ""));
+    expect(order[2]!.replace("-start", "")).toBe(order[3]!.replace("-end", ""));
+  });
+
+  it("does not serialise across DIFFERENT agents — one busy agent must not stall another", async () => {
+    const running: number[] = [];
+    let maxConcurrent = 0;
+    const txn = (pid: number) =>
+      withIpcLock(pid, async () => {
+        running.push(pid);
+        maxConcurrent = Math.max(maxConcurrent, running.length);
+        await tick(20);
+        running.pop();
+      });
+    await Promise.all([txn(1), txn(2), txn(3)]);
+    expect(maxConcurrent).toBe(3);
+  });
+
+  it("is reentrant within one process — a nested acquire must not deadlock the agent's input", async () => {
+    // proper-lockfile is not reentrant; without the guard this would block for
+    // the full acquire budget and then fail open, i.e. 12s of no input.
+    const result = await withIpcLock(1234, async () => withIpcLock(1234, async () => "inner ran"));
+    expect(result).toBe("inner ran");
+  });
+
+  it("releases on failure, so one throwing transaction does not wedge the agent", async () => {
+    await expect(
+      withIpcLock(1234, async () => {
+        throw new Error("write failed");
+      }),
+    ).rejects.toThrow("write failed");
+    // Still acquirable immediately afterwards.
+    await expect(withIpcLock(1234, async () => "ok")).resolves.toBe("ok");
+  });
+
+  it("propagates the transaction's return value", async () => {
+    await expect(withIpcLock(7, async () => 42)).resolves.toBe(42);
+  });
+
+  it("keys the lock under AGENT_YES_HOME, not beside the FIFO (a Windows named pipe has no sibling path)", () => {
+    expect(ipcLockTarget(99)).toBe(path.join(HOME, "locks", "ipc-99"));
+  });
+
+  it("FAILS OPEN: if the lock cannot be taken, the write still happens and the caller is told", async () => {
+    // Point AGENT_YES_HOME at a path that cannot hold a lockfile, so acquiring
+    // genuinely fails rather than being simulated.
+    process.env.AGENT_YES_HOME = path.join(HOME, "not-a-dir");
+    await rm(path.join(HOME, "not-a-dir"), { recursive: true, force: true });
+    const { writeFile } = await import("fs/promises");
+    await writeFile(path.join(HOME, "not-a-dir"), "i am a file, not a directory");
+
+    let reason: string | null = null;
+    // The point of failing open: input delivery must never become MORE fragile
+    // than it was before the lock existed.
+    await expect(
+      withIpcLock(
+        1234,
+        async () => "delivered anyway",
+        (r) => (reason = r),
+      ),
+    ).resolves.toBe("delivered anyway");
+    expect(reason).not.toBeNull();
+  });
+});

--- a/ts/ipcLock.ts
+++ b/ts/ipcLock.ts
@@ -1,0 +1,130 @@
+/**
+ * Cross-process mutual exclusion for writing to ONE agent's stdin.
+ *
+ * What this guarantees is ATOMICITY, not ordering. Two independent senders
+ * (two console viewers, an `ay send` racing a viewer, two `ay` processes) have
+ * no defined arrival order at the host, and nothing here invents one —
+ * per-client ordering is the browser's single-in-flight send queue
+ * (`createInputSender` in lab/ui/console-logic.js). What this prevents is the
+ * two of them SPLICING into each other:
+ *
+ *   - `writeToIpc` does not write a payload in one syscall. A FIFO's kernel
+ *     buffer is small (~8KB), so it loops on EAGAIN/partial writes while the
+ *     agent drains its stdin. POSIX only promises atomicity up to PIPE_BUF
+ *     (512 bytes on macOS), so two concurrent writers interleave BYTES in the
+ *     middle of each other's payloads — not messages arriving in a surprising
+ *     order, but one message cut in half by another.
+ *   - Several input actions are inherently multi-write: `ay send` writes the
+ *     body, waits ~200ms for the CLI's paste handling to settle, then writes
+ *     the Enter. `ay key` paces a key sequence 40ms apart. `ay stop` writes a
+ *     graceful command, Enter, then Ctrl-C twice. Every gap in those is a
+ *     window where another writer's bytes can land mid-transaction — which is
+ *     how a keystroke ends up fused into the middle of a sent message, or a
+ *     menu navigation gets a stray character.
+ *
+ * So the unit protected here is the TRANSACTION, not the write: callers wrap
+ * a whole logical action, and `writeToIpc` itself stays lock-free (and thus
+ * non-reentrant by construction).
+ *
+ * FAIL-OPEN is deliberate. Making input delivery depend on acquiring a lock
+ * would add a brand-new way for an agent to become unreachable, which is worse
+ * than the splicing this fixes. If the lock cannot be acquired within the
+ * budget, the transaction proceeds unprotected with a warning — exactly the
+ * behavior that existed before this module, so this can only improve on it.
+ */
+
+import path from "path";
+import { mkdir } from "fs/promises";
+import { lock } from "proper-lockfile";
+import { agentYesHome } from "./agentYesHome.ts";
+
+/**
+ * How long a legitimate holder may hold before we give up waiting.
+ *
+ * Derived, not picked: one `writeToIpc` can legitimately take up to
+ * `IPC_WRITE_TIMEOUT_MS` (10s) when the agent's stdin is backed up — and that
+ * is precisely when splicing is most likely, so a short budget would abandon
+ * the guarantee in the one case that needs it. A wait this long only ever
+ * materialises against an agent that is already not draining, where the
+ * waiter's own write would be hanging anyway. Crashed holders are handled by
+ * `stale` below, not by this budget.
+ */
+const ACQUIRE_BUDGET_MS = 12_000;
+
+/**
+ * When to steal a lock as abandoned. Must exceed the longest LEGITIMATE hold,
+ * or a slow-but-alive sender gets its lock stolen mid-transaction — which
+ * would reintroduce exactly the splice this module prevents. The worst legal
+ * case is `ay send` against a wedged reader: two 10s writes plus the 200ms
+ * settle gap.
+ */
+const STALE_MS = 30_000;
+
+const RETRY_MS = 15;
+
+/**
+ * Targets this process currently holds. `proper-lockfile` is not reentrant: a
+ * nested acquire from the same process on the same target would block until
+ * the budget expired, wedging input for 12s. Nesting is not expected today,
+ * but the cost of being wrong is "this agent accepts no input", so the guard
+ * is cheaper than the audit.
+ */
+const heldByThisProcess = new Set<number>();
+
+/** Lock target for an agent's stdin, keyed by pid.
+ *
+ * Under `$AGENT_YES_HOME`, NOT beside the FIFO: on Windows the "FIFO" is a
+ * named pipe (`\\.\pipe\…`), which has no containing directory to put a
+ * sibling lockfile in. Keying by pid also stays stable if the fifo path
+ * changes shape between runtimes.
+ */
+export function ipcLockTarget(pid: number): string {
+  return path.join(agentYesHome(), "locks", `ipc-${pid}`);
+}
+
+/**
+ * Run `fn` with exclusive access to `pid`'s stdin across processes.
+ *
+ * `onFallback` is called (once) if the lock could not be acquired and `fn` is
+ * about to run unprotected — callers use it to warn. `fn`'s own errors
+ * propagate unchanged, and the lock is always released.
+ */
+export async function withIpcLock<T>(
+  pid: number,
+  fn: () => Promise<T>,
+  onFallback?: (reason: string) => void,
+): Promise<T> {
+  if (heldByThisProcess.has(pid)) return fn();
+
+  let release: (() => Promise<void>) | undefined;
+  const target = ipcLockTarget(pid);
+  try {
+    await mkdir(path.dirname(target), { recursive: true });
+    release = await lock(target, {
+      lockfilePath: `${target}.lock`,
+      // The target is a name, not a file we create — nothing ever writes to
+      // it, so it never exists and realpath resolution would fail on it.
+      realpath: false,
+      stale: STALE_MS,
+      retries: {
+        retries: Math.ceil(ACQUIRE_BUDGET_MS / RETRY_MS),
+        minTimeout: RETRY_MS,
+        maxTimeout: RETRY_MS,
+      },
+    });
+  } catch (err) {
+    onFallback?.(err instanceof Error ? err.message : String(err));
+    return fn();
+  }
+
+  heldByThisProcess.add(pid);
+  try {
+    return await fn();
+  } finally {
+    heldByThisProcess.delete(pid);
+    // Releasing can fail if the lock was stolen as stale (a transaction that
+    // outran STALE_MS). Nothing useful to do about it here, and throwing would
+    // mask the outcome of `fn`, which already succeeded.
+    await release().catch(() => {});
+  }
+}

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -58,6 +58,7 @@ import { isCallbackRevoked, loadCallbackSecretReadOnly } from "./callback.ts";
 import { CLAUDE_SESSION_PIN_ENV } from "./sessionEnv.ts";
 import { MAX_CALLBACK_MSG_BYTES, frameVisitorMessage, verifyCapability } from "./callbackCore.ts";
 import { isTerminalReply } from "./terminalReply.ts";
+import { withIpcLock } from "./ipcLock.ts";
 import { removeControlCharacters } from "./removeControlCharacters.ts";
 import { parseStatusText } from "./statusText.ts";
 import { ensureNodeRuntime, liveEnv } from "./nodeRuntime.ts";
@@ -467,8 +468,8 @@ function loginShellEnv(): Record<string, string> | null {
     // $SHELL when the daemon has one; a launchd/systemd env usually doesn't,
     // so fall back through the common defaults (zsh first — the macOS default).
     const shell =
-      [process.env.SHELL, "/bin/zsh", "/bin/bash", "/bin/sh"].find(
-        (s): s is string => Boolean(s && existsSync(s)),
+      [process.env.SHELL, "/bin/zsh", "/bin/bash", "/bin/sh"].find((s): s is string =>
+        Boolean(s && existsSync(s)),
       ) ?? "/bin/sh";
     // Delimiters fence off the env dump from any banner/prompt noise the rc files
     // print to stdout; `env -0` is NUL-separated so values with newlines survive.
@@ -3185,7 +3186,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
       >();
       for (const w of workspaces) {
         const key = `${w.owner}/${w.repo}`;
-        const entry = byRepo.get(key) ?? { owner: w.owner, repo: w.repo, local: true, branches: [] };
+        const entry = byRepo.get(key) ?? {
+          owner: w.owner,
+          repo: w.repo,
+          local: true,
+          branches: [],
+        };
         entry.branches.push({ name: w.branch, path: w.path });
         byRepo.set(key, entry);
       }
@@ -3287,7 +3293,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
           ".[].name",
         ]);
         if (r.ok) {
-          remote = r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+          remote = r.stdout
+            .split("\n")
+            .map((s) => s.trim())
+            .filter(Boolean);
           source = "gh";
           error = undefined;
         } else if (!error) {
@@ -3744,13 +3753,27 @@ export async function cmdServe(rest: string[]): Promise<number> {
         if (!record.fifo_file)
           return new Response(`pid ${record.pid}: no fifo_file`, { status: 409 });
         const trailing = controlCodeFromName(code.toLowerCase());
-        if (msg && trailing) {
-          await writeToIpc(record.fifo_file, msg);
-          await new Promise((r) => setTimeout(r, 200));
-          await writeToIpc(record.fifo_file, trailing);
-        } else {
-          await writeToIpc(record.fifo_file, msg + trailing);
-        }
+        const fifo = record.fifo_file;
+        // One transaction: the body and its Enter must reach the agent with
+        // nothing spliced between them. The ~200ms settle gap below is a wide
+        // window for another writer (a second viewer, an `ay send`) to land
+        // bytes mid-message — see ts/ipcLock.ts.
+        await withIpcLock(
+          record.pid,
+          async () => {
+            if (msg && trailing) {
+              await writeToIpc(fifo, msg);
+              await new Promise((r) => setTimeout(r, 200));
+              await writeToIpc(fifo, trailing);
+            } else {
+              await writeToIpc(fifo, msg + trailing);
+            }
+          },
+          (why) =>
+            process.stderr.write(
+              `warning: /api/send writing pid ${record.pid} without the input lock (${why})\n`,
+            ),
+        );
         // Record this write for the stdin flash / sort. A payload that is purely a
         // terminal auto-reply (xterm answering the TUI's cursor/DA query, forwarded
         // over this same wire) is protocol noise, not input — stamp anyDaemonWriteAt
@@ -4329,11 +4352,23 @@ export async function cmdServe(rest: string[]): Promise<number> {
           provision: (
             spec: Spec,
             opts?: { wsRoot?: string },
-          ) => Promise<{ ok: boolean; folder: string; action: string; error?: string; reason?: string }>;
+          ) => Promise<{
+            ok: boolean;
+            folder: string;
+            action: string;
+            error?: string;
+            reason?: string;
+          }>;
           createBranch?: (
             spec: Spec,
             opts?: { wsRoot?: string },
-          ) => Promise<{ ok: boolean; folder: string; action: string; error?: string; reason?: string }>;
+          ) => Promise<{
+            ok: boolean;
+            folder: string;
+            action: string;
+            error?: string;
+            reason?: string;
+          }>;
         };
         try {
           prov = (await importProvisionModule()) as typeof prov;
@@ -4384,7 +4419,13 @@ export async function cmdServe(rest: string[]): Promise<number> {
             { status: 403 },
           );
         }
-        let result: { ok: boolean; folder: string; action: string; error?: string; reason?: string };
+        let result: {
+          ok: boolean;
+          folder: string;
+          action: string;
+          error?: string;
+          reason?: string;
+        };
         try {
           const wsRoot = getProvisionRoot();
           result = await prov.provision(spec, wsRoot ? { wsRoot } : undefined);
@@ -4761,9 +4802,19 @@ export async function cmdServe(rest: string[]): Promise<number> {
       if (record.agent_id !== v.payload.agent || !record.fifo_file)
         return cbJson(409, { error: "agent unavailable" });
       const framed = frameVisitorMessage(v.payload.id, msg);
-      await writeToIpc(record.fifo_file, framed);
-      await new Promise((r) => setTimeout(r, 200));
-      await writeToIpc(record.fifo_file, controlCodeFromName("enter"));
+      const cbFifo = record.fifo_file;
+      await withIpcLock(
+        record.pid,
+        async () => {
+          await writeToIpc(cbFifo, framed);
+          await new Promise((r) => setTimeout(r, 200));
+          await writeToIpc(cbFifo, controlCodeFromName("enter"));
+        },
+        (why) =>
+          process.stderr.write(
+            `warning: callback writing pid ${record.pid} without the input lock (${why})\n`,
+          ),
+      );
       await noteStdinWrite(record.pid, record.fifo_file, true);
       await recordInbox({
         at: Date.now(),

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1213,7 +1213,9 @@ describe("subcommands.submitAndConfirm (ay send swallowed-Enter fix)", () => {
    * into `sizeBefore`, and a busy marker reads as `wasAlreadyWorking` (which the
    * false-positive guard below deliberately treats as NOT confirmed).
    */
-  async function withFifo(fn: (fifo: string, onKeystroke: () => Promise<boolean>) => Promise<void>) {
+  async function withFifo(
+    fn: (fifo: string, onKeystroke: () => Promise<boolean>) => Promise<void>,
+  ) {
     const { spawnSync } = await import("child_process");
     const dir = await mkdtemp(path.join(tmpdir(), "ay-confirm-"));
     const fifo = path.join(dir, "test.fifo");
@@ -1564,6 +1566,69 @@ describe("subcommands.writeToIpc reliable delivery", () => {
       }
     },
   );
+});
+
+describe("withIpcLock prevents two writers splicing into one FIFO", () => {
+  const itUnix = process.platform === "linux" || process.platform === "darwin";
+
+  // The failure this guards against is NOT "messages arrive in a surprising
+  // order" — it is one message cut in half by another. writeToIpc loops on
+  // EAGAIN/partial writes, and POSIX only promises atomicity up to PIPE_BUF
+  // (512 bytes on macOS), so two concurrent writers of a large payload
+  // interleave bytes mid-message. This test reproduces that against a real
+  // FIFO with a real slow reader, exactly like the delivery test above.
+  it.skipIf(!itUnix)("keeps each writer's payload contiguous", async () => {
+    const { writeToIpc } = await loadModule();
+    const { withIpcLock } = await import("./ipcLock.ts");
+    const { spawnSync } = await import("child_process");
+    const fs = await import("fs");
+    const tmp = await mkdtemp(path.join(tmpdir(), "ay-splice-"));
+    try {
+      const fifo = path.join(tmp, "splice.fifo");
+      if (spawnSync("mkfifo", [fifo]).status !== 0) return;
+      const rfd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+      const chunks: Buffer[] = [];
+      const drain = setInterval(() => {
+        const b = Buffer.alloc(1000);
+        try {
+          const n = fs.readSync(rfd, b, 0, b.length, null);
+          if (n > 0) chunks.push(Buffer.from(b.subarray(0, n)));
+        } catch {
+          /* EAGAIN when momentarily empty */
+        }
+      }, 5);
+      try {
+        // Two 20KB payloads of distinct repeated characters, each written as a
+        // two-part transaction with a gap — the `ay send` shape (body, settle,
+        // Enter). Locked, each must appear as one unbroken run.
+        const a = "a".repeat(20_000);
+        const b = "b".repeat(20_000);
+        const txn = (ch: string, body: string) =>
+          withIpcLock(987654, async () => {
+            await writeToIpc(fifo, body);
+            await new Promise((r) => setTimeout(r, 30));
+            await writeToIpc(fifo, ch.toUpperCase());
+          });
+        await Promise.all([txn("a", a), txn("b", b)]);
+
+        const deadline = Date.now() + 5000;
+        const total = a.length + b.length + 2;
+        while (Buffer.concat(chunks).length < total && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 10));
+        }
+        const got = Buffer.concat(chunks).toString("utf8");
+        expect(got).toHaveLength(total);
+        // Whichever transaction went first, the stream is exactly one complete
+        // transaction followed by the other — never a's bytes inside b's run.
+        expect(got === a + "A" + b + "B" || got === b + "B" + a + "A").toBe(true);
+      } finally {
+        clearInterval(drain);
+        fs.closeSync(rfd);
+      }
+    } finally {
+      await rm(tmp, { recursive: true, force: true }).catch(() => null);
+    }
+  });
 });
 
 describe("subcommands.cmdSend safety guards", () => {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -69,6 +69,7 @@ import type { AgentCliConfig } from "./index.ts";
 import yargs from "yargs";
 import { type ResolvedRemote, readRemotes, resolveRemoteSpec } from "./remotes.ts";
 import { isWebrtcSpec } from "./webrtcLink.ts";
+import { withIpcLock } from "./ipcLock.ts";
 
 // ---------------------------------------------------------------------------
 // notes store  (~/.agent-yes/notes.jsonl)
@@ -3540,21 +3541,33 @@ async function cmdSend(rest: string[]): Promise<number> {
   const canConfirm = trailing === "\r" && Boolean(fullBody) && !noWait;
   let confirmed = true;
   let lastScreen: string[] = [];
-  if (fullBody && trailing) {
-    await writeToIpc(fifoPath, fullBody);
-    if (canConfirm && record.log_file) {
-      // Wait for the paste to actually finish rendering — a long/multi-line body
-      // can take longer than any fixed guess, and sending Enter mid-paste gets
-      // swallowed by the CLI's bracketed-paste handling instead of submitting.
-      await waitForLogQuiet(record.log_file, SEND_SETTLE_QUIET_MS, SEND_SETTLE_MAX_MS);
-      ({ confirmed, screen: lastScreen } = await submitAndConfirm(record, fifoPath, trailing));
-    } else {
-      await new Promise((r) => setTimeout(r, 200));
-      await writeToIpc(fifoPath, trailing);
-    }
-  } else {
-    await writeToIpc(fifoPath, fullBody + trailing);
-  }
+  // The body and its Enter are ONE transaction: every gap between them (the
+  // paste-settle wait, the submit-confirm retries) is a window where another
+  // writer's bytes would land mid-message. See ts/ipcLock.ts.
+  await withIpcLock(
+    record.pid,
+    async () => {
+      if (fullBody && trailing) {
+        await writeToIpc(fifoPath, fullBody);
+        if (canConfirm && record.log_file) {
+          // Wait for the paste to actually finish rendering — a long/multi-line body
+          // can take longer than any fixed guess, and sending Enter mid-paste gets
+          // swallowed by the CLI's bracketed-paste handling instead of submitting.
+          await waitForLogQuiet(record.log_file, SEND_SETTLE_QUIET_MS, SEND_SETTLE_MAX_MS);
+          ({ confirmed, screen: lastScreen } = await submitAndConfirm(record, fifoPath, trailing));
+        } else {
+          await new Promise((r) => setTimeout(r, 200));
+          await writeToIpc(fifoPath, trailing);
+        }
+      } else {
+        await writeToIpc(fifoPath, fullBody + trailing);
+      }
+    },
+    (why) =>
+      process.stderr.write(
+        `warning: ay send writing pid ${record.pid} without the input lock (${why})\n`,
+      ),
+  );
   const payload = body + trailing;
   const status = confirmed ? "sent" : "sent but NOT confirmed submitted";
   process.stdout.write(
@@ -3844,7 +3857,14 @@ async function cmdKey(rest: string[]): Promise<number> {
   const force = Boolean(argv.force) || process.env.AGENT_YES_FORCE_SEND === "1";
   const sender = await enforceSendGuards(record, force);
 
-  await writeKeysPaced(record.fifo_file!, byteSeqs, Math.max(0, argv.pace));
+  await withIpcLock(
+    record.pid,
+    () => writeKeysPaced(record.fifo_file!, byteSeqs, Math.max(0, argv.pace)),
+    (why) =>
+      process.stderr.write(
+        `warning: ay key/select writing pid ${record.pid} without the input lock (${why})\n`,
+      ),
+  );
   process.stdout.write(`sent to pid ${record.pid} (${record.cli}): ${keyNames.join(" ")}\n`);
   await recordKeyEvent(sender, record, "key", keyNames.join(" "));
   return 0;
@@ -3919,7 +3939,14 @@ async function cmdSelect(rest: string[]): Promise<number> {
   // PARSED cursor position (not a blind "N-1 downs") so a non-first default works.
   const keyNames = menuSelectKeys(menu.cursor, n);
   const byteSeqs = keyNames.map((k) => controlCodeFromName(k));
-  await writeKeysPaced(record.fifo_file!, byteSeqs, Math.max(0, argv.pace));
+  await withIpcLock(
+    record.pid,
+    () => writeKeysPaced(record.fifo_file!, byteSeqs, Math.max(0, argv.pace)),
+    (why) =>
+      process.stderr.write(
+        `warning: ay key/select writing pid ${record.pid} without the input lock (${why})\n`,
+      ),
+  );
 
   const delta = n - menu.cursor;
   const moved =
@@ -4173,15 +4200,24 @@ async function cmdStop(rest: string[]): Promise<number> {
   }
 
   const fifoPath = record.fifo_file;
-  if (payload === "double-ctrl-c") {
-    await writeToIpc(fifoPath, "\x03");
-    await new Promise((r) => setTimeout(r, 200));
-    await writeToIpc(fifoPath, "\x03");
-  } else {
-    await writeToIpc(fifoPath, payload);
-    await new Promise((r) => setTimeout(r, 200));
-    await writeToIpc(fifoPath, "\r");
-  }
+  await withIpcLock(
+    record.pid,
+    async () => {
+      if (payload === "double-ctrl-c") {
+        await writeToIpc(fifoPath, "\x03");
+        await new Promise((r) => setTimeout(r, 200));
+        await writeToIpc(fifoPath, "\x03");
+      } else {
+        await writeToIpc(fifoPath, payload);
+        await new Promise((r) => setTimeout(r, 200));
+        await writeToIpc(fifoPath, "\r");
+      }
+    },
+    (why) =>
+      process.stderr.write(
+        `warning: ay stop writing pid ${record.pid} without the input lock (${why})\n`,
+      ),
+  );
 
   process.stdout.write(`stopping pid ${record.pid} (${record.cli}) via ${strategy}\n`);
   process.stderr.write(
@@ -4224,16 +4260,25 @@ async function gracefulExitAgent(
   await writeNote(record.pid, `↩ exit — ${reason}`).catch(() => {});
   const fifoPath = record.fifo_file;
   const graceful = GRACEFUL_EXIT_COMMANDS[record.cli];
-  if (graceful) {
-    await writeToIpc(fifoPath, graceful);
-    await new Promise((r) => setTimeout(r, 200));
-    await writeToIpc(fifoPath, "\r");
-    return { strategy: `'${graceful}' + Enter` };
-  }
-  await writeToIpc(fifoPath, "\x03");
-  await new Promise((r) => setTimeout(r, 200));
-  await writeToIpc(fifoPath, "\x03");
-  return { strategy: `double Ctrl+C (no known /exit for cli "${record.cli}")` };
+  return withIpcLock(
+    record.pid,
+    async () => {
+      if (graceful) {
+        await writeToIpc(fifoPath, graceful);
+        await new Promise((r) => setTimeout(r, 200));
+        await writeToIpc(fifoPath, "\r");
+        return { strategy: `'${graceful}' + Enter` };
+      }
+      await writeToIpc(fifoPath, "\x03");
+      await new Promise((r) => setTimeout(r, 200));
+      await writeToIpc(fifoPath, "\x03");
+      return { strategy: `double Ctrl+C (no known /exit for cli "${record.cli}")` };
+    },
+    (why) =>
+      process.stderr.write(
+        `warning: ay exit writing pid ${record.pid} without the input lock (${why})\n`,
+      ),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
#405 で残した積み残し。**保証するのは非交錯 (atomicity) であって、書き手をまたぐ順序ではない。**

独立した送信元 (2 つの viewer、`ay send` と viewer、別プロセスの `ay`) の到着順はホスト側では定義できず、ここでも作らない — クライアント単位の順序は #405 のブラウザ側送信キューが担保済み。ここで防ぐのは両者が互いの**ペイロードの途中に割り込む**こと。

## 何が起きていたか

`writeToIpc` は 1 回の syscall で書き切らない。FIFO のカーネルバッファは小さい (~8KB) ので、EAGAIN / 部分書き込みでループする。POSIX が atomic を保証するのは PIPE_BUF (macOS で 512B) までなので、**大きなペイロードを同時に書く 2 者はバイト単位で混ざる。**

実 FIFO + 実際の遅いリーダーで計測:

| | 連続したまとまりの数 |
|---|---|
| ロックなし (変更前) | **18** |
| ロックあり | **2** |

20KB × 2 本を同時に書いた結果。「順番が入れ替わる」ではなく「1 通が細切れにされて相手のペイロードに挟まる」。

さらに入力操作の多くは本質的に複数書き込みで、その隙間がすべて割り込み窓だった:

| 操作 | 系列 |
|---|---|
| `ay send` / `/api/send` | 本文 → **約200ms** → Enter |
| `ay key` / `ay select` | 40ms 間隔のキー列 |
| `ay stop` / graceful exit | graceful → Enter → Ctrl-C ×2 |

## 対策

保護する単位を「書き込み」ではなく**トランザクション**にする。`withIpcLock(pid, fn)` を追加し、serve の `/api/send`・callback、`ay send`・`ay key`/`ay select`・`ay stop`・graceful shutdown の各系列を包む。`writeToIpc` 自体はロックしない (= 再入不可のまま保つ)。

判断:

- **プロセス間ロック。** 競合相手は別プロセスの `ay send` なので、プロセス内 mutex では届かない。実装は `todoStore` の実績ある proper-lockfile 利用をそのまま踏襲 (あのコメントには手書きロックで 2 回失敗した経緯が残っている)。
- **ロックファイルは FIFO の隣ではなく `$AGENT_YES_HOME/locks/` 配下に pid で置く。** Windows の "FIFO" は名前付きパイプ (`\\.\pipe\…`) で、隣にファイルを作れる場所がない。
- **fail-open。** 入力配送がロック取得に依存すると「エージェントに届かない」という新しい壊れ方が増え、直そうとしている交錯より悪い。取得できなければ警告して素通しする = **変更前とまったく同じ挙動**なので、この変更で悪化する余地がない。
- **待ち時間は `IPC_WRITE_TIMEOUT_MS` から導出**(適当な 2〜3 秒ではない)。正当な保持者は stdin が詰まっているとき最大 10 秒保持しうるが、それはまさに交錯が起きやすい状況で、そこで早々に諦めると**必要な場面でだけ**保証が消える。長く待つ事態はそもそも詰まっている相手に対してのみ起き、その場合は待つ側の書き込みもどのみち止まる。クラッシュした保持者は stale steal が回収する。
- **プロセス内再入ガード付き。** proper-lockfile は再入不可で、入れ子取得はそのエージェントへの入力を 12 秒止める。今は入れ子はないが、外したときの被害が「入力が一切通らない」なので、監査するより 3 行のガードのほうが安い。

## 検証

- `ts/ipcLock.spec.ts` 7 本 (同一エージェントの直列化 / 別エージェントは並列のまま / 再入 / 例外時も解放 / 実際に壊れたロックパスでの fail-open)
- **別プロセス 2 つ**での実測: B は A の完了を待ってから開始 (重なりなし)
- `ts/subcommands.spec.ts` に実 FIFO + 遅いリーダーでの回帰テスト。既存の `writeToIpc` 配送テストのハーネスをそのまま流用 (FIFO テストは過去に vitest を 6 時間ハングさせた実績があるため)。ロックを外すと 18 分割で落ちることを確認済み — vacuous ではない。
- `bunx vitest run ts/` — 101 passed / 1 skipped。`[rs]` の PTY サイズ 2 本は**変更前の clean baseline でも落ちる**ローカル環境由来 (stash して確認済み)。
- typecheck のエラー数は baseline と同じ 49 (増減なし)
- オーバーヘッド実測: 非競合時 **0.196ms/回**。打鍵 15 回/秒でも 3ms/秒。

## 範囲外

Rust 側は現状エージェントの FIFO に書く送信経路を持たない (`rs/src/fifo.rs` は読み側) ため対象外。将来 Rust が送信側を持つ場合は、pid_store にある proper-lockfile 互換の mkdir ロックの前例に合わせて揃える必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)