### PR TITLE
fix(lab): lab ホストの open redirect を塞ぎ、記事の事実誤りを訂正する

### DIFF
--- a/docs/auth-and-permissions.md
+++ b/docs/auth-and-permissions.md
@@ -383,6 +383,6 @@ Core **does** own the verb taxonomy, the route→action map, the `Authorizer` se
 - `ts/serve.ts` — `apiFetch`, `checkAuth`, `loadOrCreateToken` (today's token).
 - `ts/share.ts`, `lab/ui/e2e.js`, `lab/ui/cf/worker.ts` — the E2E + signaling the
   fragment-borne capability must not regress.
-- `lab/ui/blog/e2ee-share-links/index.html` — how the current E2E secret works.
+- `lab/ui/lab/posts/2026-06-15-e2ee-share-links.html` — how the current E2E secret works.
 - [`docs/provisioning.md`](./provisioning.md) — spawn/cwd resolution that
   `agent:spawn` scoping must cooperate with.

--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -108,11 +108,26 @@ function withDocHeaders(res: Response): Response {
 // relying on the asset server's path normalization, which would answer with a
 // redirect whose Location still carried the internal /lab prefix.
 async function labFetch(url: URL, req: Request, env: Env): Promise<Response> {
-  // Normalize away a trailing slash first: relative links inside a page (./slug,
-  // and the shared nav's ./) resolve against a different base with one.
-  if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
-    const to = new URL(url.pathname.replace(/\/+$/, ""), url);
-    to.search = url.search;
+  // Normalize the path before anything else looks at it. Two things matter here:
+  //
+  //   1. DUPLICATE SLASHES. Cloudflare does NOT collapse them, so `//evil.com/`
+  //      arrives intact. A path in that shape is a PROTOCOL-RELATIVE URL
+  //      reference, so resolving it against the request URL — `new URL(path, url)`
+  //      — reuses the scheme but takes the AUTHORITY from the path, yielding
+  //      https://evil.com/. That is an open redirect, cached by the browser
+  //      because it is a 301, on a link that previews as agent-yes.com. Collapse
+  //      first, and build the target by mutating a copy of the request URL
+  //      (assigning .pathname never re-parses an authority) so the origin is
+  //      structurally pinned rather than merely expected.
+  //   2. A TRAILING SLASH, which would make a page's relative links (./slug, and
+  //      the shared nav's ./) resolve against the wrong base.
+  //
+  // "/" is already canonical and never enters here (length > 1 guard); "//" and
+  // friends collapse to "/", so the `|| "/"` keeps that from redirecting to "".
+  const clean = url.pathname.replace(/\/{2,}/g, "/");
+  if (clean !== url.pathname || (clean.length > 1 && clean.endsWith("/"))) {
+    const to = new URL(url); // same origin by construction
+    to.pathname = clean.replace(/\/+$/, "") || "/";
     return Response.redirect(to.toString(), 301);
   }
   // Ask the asset server for the path SHAPE the lab publishes — extensionless,
@@ -182,10 +197,16 @@ export default {
     // Both 301 so the lab subdomain is the single canonical origin.
     if (url.pathname === "/blog" || url.pathname.startsWith("/blog/")) {
       const slug = url.pathname.replace(/^\/blog\/?/, "").split("/")[0] ?? "";
-      return Response.redirect(`${LAB_ORIGIN}/${BLOG_MOVED[slug] ?? ""}`, 301);
+      // hasOwn, not `?? ""`: a bare object literal inherits Object.prototype, so
+      // /blog/constructor would otherwise redirect to a stringified builtin.
+      const to = Object.hasOwn(BLOG_MOVED, slug) ? BLOG_MOVED[slug] : "";
+      return Response.redirect(`${LAB_ORIGIN}/${to}${url.search}`, 301);
     }
     if (url.pathname === "/lab" || url.pathname.startsWith("/lab/")) {
-      return Response.redirect(`${LAB_ORIGIN}${url.pathname.replace(/^\/lab\/?/, "/")}`, 301);
+      // Collapse duplicate slashes here too: /lab//evil.com/ would otherwise hand
+      // the lab host a protocol-relative path (see labFetch for why that matters).
+      const rest = url.pathname.replace(/^\/lab\/?/, "/").replace(/\/{2,}/g, "/");
+      return Response.redirect(`${LAB_ORIGIN}${rest}${url.search}`, 301);
     }
 
     // WebSocket to /<room> → signaling DO (this is the s.agent-yes.com path).

--- a/lab/ui/lab/build.ts
+++ b/lab/ui/lab/build.ts
@@ -162,6 +162,12 @@ function markdown(src: string): string {
       while (i < lines.length && lines[i]!.trim()) {
         const cur = lines[i]!;
         if (bullet.test(cur)) items.push(cur.replace(bullet, ""));
+        // A non-bullet line is a lazy continuation of the previous item — UNLESS
+        // it opens another block. Without this stop-set a fenced code block or
+        // heading written straight after a list (no blank line) is swallowed into
+        // the last <li> and then mangled by the inline pass. Same set as the
+        // paragraph loop below.
+        else if (/^(```|#{1,4}\s|\||>\s|<[a-zA-Z/!])/.test(cur)) break;
         else if (items.length) items[items.length - 1] += ` ${cur.trim()}`;
         else break;
         i++;
@@ -241,6 +247,12 @@ padding:16px 18px;margin:12px 0;color:inherit}
 footer{color:var(--muted);font-size:.9em;margin-top:52px;border-top:1px solid var(--border);
 padding-top:20px}
 .up{display:inline-block;margin:36px 0 0}
+.note{border-left:3px solid var(--accent);background:var(--card);padding:10px 16px;
+border-radius:0 8px 8px 0;margin:18px 0}
+.ok{color:var(--green)}
+.no{color:var(--red)}
+h2 a.anchor{color:var(--muted);text-decoration:none;margin-left:6px;opacity:0}
+h2:hover a.anchor{opacity:1}
 `.trim();
 
 const NAV = `

--- a/lab/ui/lab/index.md
+++ b/lab/ui/lab/index.md
@@ -52,7 +52,7 @@ The system reads cleanly top-down, and the
 | --- | --- |
 | **① Agent core** | The PTY wrapper. Spawns any agent CLI, matches ready / enter / fatal patterns, restarts on crash, resumes sessions, propagates terminal size. Rust is the primary binary; TypeScript is the reference implementation. |
 | **② Local fabric** | `pids.jsonl` (every agent, both runtimes), a FIFO per pid for stdin, a raw PTY log per agent for stdout. Files, not a daemon. |
-| **③ Exposure** | One transport-agnostic handler, `apiFetch(req) → Response`. HTTP, WebRTC and port tunnels are all just callers. |
+| **③ Exposure** | One transport-agnostic handler, `apiFetch(req) → Response`. HTTP and the WebRTC bridge are both just callers; port tunnels and libp2p peers fold in next. |
 | **④ Trust & discovery** | Signaling that is a rendezvous only, an HKDF key split so the relay never holds a key, and signed capability tokens that carry their own scope. |
 | **⑤ Reach surfaces** | The browser console, the CLI on another box, embeddable widgets, a system tray, peers. |
 

--- a/lab/ui/lab/posts/2026-06-15-e2ee-share-links.html
+++ b/lab/ui/lab/posts/2026-06-15-e2ee-share-links.html
@@ -148,12 +148,3 @@ e2e keys  = HKDF(S, "ay/ay-e2e-1/key/…")  →  never leave your machine or bro
         browser's local storage until it ages out. Forward secrecy / rekeying, and the separate
         codehost transport, are future work.
       </p>
-<style>
-  /* Post-local styles carried over from the original standalone page. */
-  h2 a.anchor{color:var(--muted);text-decoration:none;margin-left:6px;opacity:0}
-  h2:hover a.anchor{opacity:1}
-  .note{border-left:3px solid var(--accent);background:var(--card);padding:10px 16px;
-    border-radius:0 8px 8px 0;margin:18px 0}
-  .ok{color:var(--green)}
-  .no{color:var(--red)}
-</style>

--- a/lab/ui/lab/posts/2026-07-22-ay-callback.html
+++ b/lab/ui/lab/posts/2026-07-22-ay-callback.html
@@ -161,15 +161,6 @@ $ ay callback --expires 7d --title "Ask the report bot"</code></pre>
         the conversation.
       </p>
 <style>
-  /* Post-local styles carried over from the original standalone page. */
-  h2 a.anchor{color:var(--muted);text-decoration:none;margin-left:6px;opacity:0}
-  h2:hover a.anchor{opacity:1}
-  .note{border-left:3px solid var(--accent);background:var(--card);padding:10px 16px;
-    border-radius:0 8px 8px 0;margin:18px 0}
-  .ok{color:var(--green)}
-  .no{color:var(--red)}
-</style>
-<style>
   /* Inert demo replica of the widget the snippet renders. */
   .demo{position:relative;background:var(--card);border:1px dashed var(--border);
     border-radius:12px;min-height:180px;margin:18px 0;padding:12px 16px;color:var(--muted);font-size:.9em}

--- a/lab/ui/lab/posts/2026-08-11-an-address-space-for-agents.md
+++ b/lab/ui/lab/posts/2026-08-11-an-address-space-for-agents.md
@@ -109,10 +109,11 @@ Not a bigger console. The measure is whether these become boring:
 - Ask a fleet a question and get an answer that survives every process that participated in it.
 - Have an agent publish something a person can reply to, in the place they read it.
 - Reconstruct, a week later, who asked for a change and who checked it.
-- Lose any single machine, daemon, or console and lose no work.
+- Lose any daemon or console and lose no work.
 
 The last one already holds — it is what the [local fabric](./2026-08-11-no-daemon-owns-your-agents)
-buys. The other four are the project.
+buys. The other four are the project, and so is the one not on the list: the fabric is per-machine
+files, so losing a *machine* still loses its agents, its logs and its task store.
 
 <p class="note">Start at the beginning: <a href="./2026-08-11-the-terminal-is-the-api">the terminal
 is the API</a> — why one small edit forced all of this.</p>

--- a/lab/ui/lab/posts/2026-08-11-no-daemon-owns-your-agents.md
+++ b/lab/ui/lab/posts/2026-08-11-no-daemon-owns-your-agents.md
@@ -17,7 +17,9 @@ share no parent. Nothing sits above them.
 
 That means the web console, `ay serve`, is a **stateless observer**. It reads a file to discover
 agents, tails files to render them, and writes a pipe to talk to them. Restart it, upgrade it,
-crash it, kill it with `SIGKILL` — no agent is disturbed, because no agent was ever its child.
+crash it, kill it with `SIGKILL` — no agent is disturbed, because every agent runs in its own
+session. Even the ones the console itself spawns are detached at birth, so none of them is ever
+in `ay serve`'s session or process group.
 
 The comparison worth making is with the obvious design: a daemon that spawns and supervises
 everything. That design is easier to write and gives you an in-memory registry for free. It also
@@ -66,7 +68,8 @@ is. Everything below is live today, from any terminal, against agents started by
 | **Provision** | `ay ws` (clone or refresh `<owner>/<repo>/tree/<branch>` workspaces), `ay setup`, `ay reap` |
 
 The pattern repeats: each of those is a small program over the same three files, which is why they
-compose. `ay ls --json` piped into `ay tail` is a fleet dashboard. `ay ls --watch` is a single
+compose. Looping the pids from `ay ls --json` into a per-pid `ay tail` is a fleet dashboard.
+`ay ls --watch` is a single
 NDJSON stream of state changes across every matched agent — one watcher for an entire fan-out,
 rather than N pollers.
 
@@ -94,13 +97,15 @@ Above the fabric there is exactly one handler:
 apiFetch(req: Request) → Response
 ```
 
-`ay serve`'s HTTP listener calls it. The WebRTC bridge calls it in-process. The port-exposure
-tunnel calls it. None of them is a control plane; they are pipes into the same function. Adding a
+`ay serve`'s HTTP listener calls it. The WebRTC bridge calls it in-process. Neither is a control
+plane; they are pipes into the same function. (The port-exposure tunnel sits on the other side of
+that line — it is *started* through the handler, by `POST /api/expose`, and then proxies raw bytes
+to a local port. A consumer, not a caller.) Adding a
 transport — a relay, a peer mesh, something not invented yet — means writing a caller, not a second
 system with its own notion of what an agent is.
 
 This is why a share link and a LAN URL and a localhost port all produce an identical console: they
-are the same handler reached three ways.
+are the same handler reached two ways.
 
 ## Where files are hard
 

--- a/lab/ui/lab/posts/2026-08-11-the-terminal-is-the-api.md
+++ b/lab/ui/lab/posts/2026-08-11-the-terminal-is-the-api.md
@@ -53,6 +53,9 @@ clis:
   someagent:
     promptArg: last-arg
     yesArgs: [--dangerously-skip-permissions]
+    enter:            # a prompt to answer — press Enter on it
+      - "Do you want to proceed\\?"
+      - "Yes, and don't ask again"
     ready:            # parked at a prompt, safe to type
       - '\? for shortcuts'
       - "^>[  ]"
@@ -65,8 +68,8 @@ clis:
     wedgeTimeoutSecs: 1800
 ```
 
-From those four states — `ready`, `working`, `needsInput`, `fatal` — you get auto-answering, but
-you also get something more valuable: **a machine-readable liveness signal for a program that was
+The `enter:` list is what actually presses the key. The four *screen states* — `ready`, `working`,
+`needsInput`, `fatal` — buy something less obvious and more valuable: **a machine-readable liveness signal for a program that was
 never designed to emit one.** `ay ls` can tell you an agent is `needs_input` rather than `active`
 because the pattern set says so. That single classification is what later makes notifications,
 watchdogs, task automation and the web console possible.


### PR DESCRIPTION
#410 のマージ後レビュー（5 観点 + 各指摘に反証パス）で **13 件確定**。release train が prod に載せる前に全部直す。

## 🔴 high: lab ホストの open redirect

`labFetch` の末尾スラッシュ正規化が `new URL(url.pathname, url)` で転送先を組み立てていた。Cloudflare は重複スラッシュを潰さないので `//evil.com/` がそのまま Worker に届き、**この形は protocol-relative な URL 参照**として解決される — scheme は据え置きのまま **authority がパス側に乗っ取られ**、`https://evil.com/` への 301 になる。

- 301 なのでブラウザにキャッシュされる
- リンクのプレビューは `agent-yes.com` のまま（フィッシング / リダイレクトチェーンの洗浄に使える）
- apex 経由の 2 ホップでも到達: `agent-yes.com/lab//evil.com/` → `lab.agent-yes.com//evil.com/` → `evil.com`

対策を 2 つ重ねた:

1. 重複スラッシュを先に潰す
2. 転送先は **request URL のコピーを作って `.pathname` だけ差し替える** — `.pathname` への代入は authority を再解釈しないので、origin が「期待」ではなく**構造として**固定される

### 実機確認（`wrangler dev --local --host lab.agent-yes.com`, curl --path-as-is）

| path | before | after |
| --- | --- | --- |
| `//evil.com/` | 301 → `https://evil.com/` | 301 → 自ホスト `/evil.com` |
| `//evil.com/?a=1` | 301 → `https://evil.com/?a=1` | 301 → 自ホスト `/evil.com?a=1` |
| `///evil.com/` | 301 → `https://evil.com/` | 301 → 自ホスト `/evil.com` |
| `//evil.com/login/` | 301 → `https://evil.com/login` | 301 → 自ホスト `/evil.com/login` |
| apex `/lab//evil.com/` | → 最終的に `evil.com` | 301 → `lab.agent-yes.com/evil.com/` |

## その他の worker 修正

- `//` が自分自身へ 301 する**無限ループ**（`|| "/"` で index へ落とす）
- `BLOG_MOVED[slug]` が **prototype チェーンを辿る** — `/blog/constructor` が組み込み関数を文字列化した URL へ飛んでいた → `Object.hasOwn` で own property に限定
- apex → lab の 301 が**クエリを捨てていた** → `url.search` を引き継ぐ

## 生成器

- **共有 CSS に `.note` が無かった** — 新規 3 記事の末尾コールアウトがただの段落として表示されていた（beta で現に発生中）。`.note` / `.ok` / `.no` / `h2 a.anchor` を共有 CSS へ引き上げ、記事側の重複定義を削除
- リスト項目の継続行判定が、空行なしで直後に続くコードフェンスや見出しを `<li>` に飲み込んでいた → 段落ループと同じ stop-set で打ち切る（クラフトした記事で確認済み）

## 記事の事実誤り（公開される技術的主張なので重視）

| 誤り | 訂正 |
| --- | --- |
| `ay ls --json \| ay tail` を「fleet dashboard」と紹介 | `ay tail` は stdin を読まず keyword 必須で、実行するとエラー。CLI 自身の help どおり「pid をループして per-pid `ay tail`」へ |
| 「port-exposure tunnel も `apiFetch` を呼ぶ」 | 逆。`POST /api/expose` で**起動される側**。「3 通り」→ 2 通り |
| 「no agent was ever its child」 | 結論は正しいが理由が誤り。console 起動の agent は serve の子。生き残る理由は spawn 時の session 切り離し |
| 「4 つの状態から auto-answering が得られる」 | キーを押すのは `enter:` パターン。例 YAML に `enter:` を追加し文を再スコープ |
| 「マシン / daemon / console のどれを失っても仕事を失わない」を**今日成立**として提示 | fabric はマシンローカルなファイル。daemon / console に限定し、マシン障害は未達側へ |
| plane ③「port tunnels も caller」 | architecture map の記述に合わせて訂正 |

`docs/auth-and-permissions.md` に残っていた最後の `lab/ui/blog/...` 参照も更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
