### PR TITLE
feat(ayrs): `ayrs serve restart` でインストール済みデーモンを再起動する

### DIFF
--- a/rs/src/bin/ayrs.rs
+++ b/rs/src/bin/ayrs.rs
@@ -66,6 +66,9 @@ enum ServeAction {
     Install,
     /// Stop and deregister the service
     Uninstall,
+    /// Bounce the installed service (picks up a rebuilt binary; keeps the unit,
+    /// the room and boot-autostart exactly as they are)
+    Restart,
     /// Show whether the service is installed and running
     Status,
 }
@@ -85,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
                 // re-runs `ayrs serve --webrtc` which loads/mints as usual.
                 Some(ServeAction::Install) => return serve::service::install(&webrtc, &sighost),
                 Some(ServeAction::Uninstall) => return serve::service::uninstall(),
+                Some(ServeAction::Restart) => return serve::service::restart(),
                 Some(ServeAction::Status) => return serve::service::status(),
                 None => {}
             }

--- a/rs/src/serve/service.rs
+++ b/rs/src/serve/service.rs
@@ -133,7 +133,9 @@ fn unit_path() -> Result<PathBuf> {
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn unit_path() -> Result<PathBuf> {
-    bail!("`ayrs serve install` is only supported on macOS (launchd) and Linux (systemd --user)")
+    bail!(
+        "`ayrs serve` service management is only supported on macOS (launchd) and Linux (systemd --user)"
+    )
 }
 
 fn xml_escape(s: &str) -> String {
@@ -425,6 +427,111 @@ pub fn uninstall() -> Result<()> {
     Ok(())
 }
 
+// --- restart ---------------------------------------------------------------
+
+/// The supervisor invocation `restart` issues, as (program, args). Split out so
+/// a test pins the exact command — on macOS the `-k` is the whole feature: plain
+/// `launchctl kickstart` starts the service only if it is NOT already running,
+/// so dropping the flag turns a restart into a silent no-op against a live
+/// daemon (and the stale binary keeps serving).
+#[cfg(target_os = "macos")]
+fn restart_argv(uid: u32) -> (String, Vec<String>) {
+    (
+        "launchctl".to_string(),
+        vec![
+            "kickstart".to_string(),
+            "-k".to_string(),
+            format!("gui/{uid}/{LABEL}"),
+        ],
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn restart_argv() -> (String, Vec<String>) {
+    (
+        "systemctl".to_string(),
+        vec![
+            "--user".to_string(),
+            "restart".to_string(),
+            LABEL.to_string(),
+        ],
+    )
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn exec_restart(prog: &str, args: &[String]) -> Result<String> {
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run(prog, &refs)
+}
+
+/// A restart only manages an EXISTING registration — it never writes a unit —
+/// so a missing one is a user error, not something to paper over by installing.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn ensure_installed(path: &std::path::Path) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    bail!(
+        "{LABEL} is not installed ({} missing) — run `ayrs serve install` first",
+        path.display()
+    )
+}
+
+/// Bounce the installed daemon in place, keeping the unit exactly as it is.
+///
+/// This is the command to run after `bun run build:rs` replaces the binary at
+/// the path the unit already names: the supervisor re-execs that path, so the
+/// new build takes over without rewriting (or re-deciding) any config. Unlike
+/// `install`, it never recomputes the service args, so it can't silently rotate
+/// the room or change the sighost — and unlike `uninstall`+`install`, it leaves
+/// boot-autostart untouched.
+///
+/// Safe for the local fleet: agents are spawned into their own session by
+/// `spawn_detached` (see `serve/control.rs`, asserted by
+/// `a_spawned_child_gets_its_own_session`), so bouncing the daemon does not take
+/// the agents it spawned down with it.
+pub fn restart() -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        let path = unit_path()?;
+        ensure_installed(&path)?;
+        let uid = unsafe { libc::getuid() };
+        let (prog, args) = restart_argv(uid);
+        // A plist can exist without ever having been bootstrapped (hand-copied,
+        // or a `bootout` that left the file); kickstart then fails with "Could
+        // not find service". `install` is what loads it, so point there.
+        exec_restart(&prog, &args)
+            .with_context(|| format!("{LABEL} is not loaded — run `ayrs serve install`"))?;
+        println!("restarted {LABEL}");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if systemd_user_available() {
+            let path = unit_path()?;
+            ensure_installed(&path)?;
+            let (prog, args) = restart_argv();
+            exec_restart(&prog, &args)?;
+            println!("restarted {LABEL}");
+        } else if let Some(oxmgr) = which("oxmgr") {
+            // Same fallback `install` uses on a host with no systemd --user bus
+            // (typically a container). oxmgr's `restart` takes an already
+            // registered name, so a failure here means it never was registered.
+            run(&oxmgr, &["restart", OXMGR_NAME])
+                .with_context(|| format!("'{OXMGR_NAME}' is not registered with oxmgr"))?;
+            println!("restarted {OXMGR_NAME} (via oxmgr)");
+        } else {
+            bail!("no systemd --user bus and no oxmgr on PATH — nothing to restart");
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        // Bails with the "only supported on macOS/Linux" message.
+        unit_path()?;
+    }
+
+    Ok(())
+}
+
 pub fn status() -> Result<()> {
     let path = unit_path()?;
     println!(
@@ -587,6 +694,27 @@ mod tests {
             super::super::share::resolve_share_urls(Some(&room_url), "ignored.example").unwrap();
         assert_eq!(webrtc, room_url);
         assert_eq!(console, format!("https://agent-yes.com/w/#r1:e1.{secret}"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn restart_kickstarts_the_loaded_unit_with_k() {
+        let (prog, args) = restart_argv(501);
+        assert_eq!(prog, "launchctl");
+        // `-k` is load-bearing: without it kickstart only starts a service that
+        // is NOT already running, so restarting a live daemon silently no-ops
+        // and the old binary keeps serving.
+        assert_eq!(args, vec!["kickstart", "-k", &format!("gui/501/{LABEL}")]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn restart_targets_the_user_unit() {
+        let (prog, args) = restart_argv();
+        assert_eq!(prog, "systemctl");
+        // `--user`: the unit is installed into the per-user manager, so a
+        // system-scope restart would look for a unit that does not exist there.
+        assert_eq!(args, vec!["--user", "restart", LABEL]);
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## 何をするか

`ayrs serve restart` を追加した。インストール済みの ayrs デーモンを、ユニットを書き換えずにその場で再起動する。

`bun run build:rs` は `~/.cargo/bin/ayrs` を atomic-rename で差し替えるが、稼働中のデーモンは古いプロセスのまま残る。これまで新しいビルドを反映する手段は `ayrs serve install`（ユニットを作り直し、ルームや sighost を計算し直す）か、手で `launchctl` / `systemctl` を叩くかしかなかった。restart はスーパーバイザに「今の登録のまま再起動しろ」とだけ伝える。

## 実装

| プラットフォーム | 実行するコマンド |
| --- | --- |
| macOS | `launchctl kickstart -k gui/<uid>/com.snomiao.ayrs-serve` |
| Linux (systemd --user あり) | `systemctl --user restart com.snomiao.ayrs-serve` |
| Linux (systemd --user なし) | `oxmgr restart ayrs-serve` |

- **`-k` が要点**。付けないと `kickstart` は「起動していなければ起動する」だけになり、稼働中のデーモンに対しては何もせず終了コード 0 を返す。つまり restart が黙って no-op になり、古いバイナリが serve し続ける。この 1 フラグを守るためにテストでコマンド列を固定した（`restart_kickstarts_the_loaded_unit_with_k`）。
- Linux のフォールバックは `install` が使うものと同じ経路。
- 未インストールなら `ayrs serve install` を案内して失敗する。restart はユニットを書かないので、勝手にインストールして取り繕うことはしない。
- ルーム・sighost・起動時自動実行の登録には一切触れない。

## エージェントは巻き込まれない

デーモンが起動したエージェントは `spawn_detached` が `setsid` で別セッションに切り離しているため（`rs/src/serve/control.rs` の `a_spawned_child_gets_its_own_session` が保証）、デーモンを再起動してもエージェントは生き残る。

## 確認したこと

- `cargo test --bin ayrs` — 178 件すべて green（新規 1 件を含む）。
- `cargo clippy` / `cargo fmt --check` — 変更した 2 ファイルについて指摘なし。
- 実機の launchd サービスに対して実行: デーモンの pid が入れ替わり、`state = running` で復帰、稼働中のエージェント数は前後で変化なし。
- 未インストール時のエラー経路（`HOME` を差し替えて実行）: install を案内して終了コード 1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
