### PR TITLE
perf(serve): エッジ走査を時刻窓で打ち切り、/api/ls のメタ収集を並列化

### DIFF
--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -205,10 +205,15 @@ fn strip_control(s: &str) -> String {
 /// non-empty one labels the console row. Cached per (size, mtime).
 fn log_title(log_file: Option<&str>) -> Option<String> {
     let log_file = log_file?;
-    let (size, mtime, buf) = read_file_tail(log_file, 65_536).ok()?;
+    // stat first, read second: the cache key IS (size, mtime), so consulting it
+    // before the 64 KB tail read turns a hit into one stat instead of one stat
+    // plus 64 KB of I/O. Over a fleet-sized list that is the difference between
+    // megabytes and nothing per poll tick. Same shape as log_tasks/log_badges.
+    let (size, mtime) = file_version(log_file)?;
     if let Some(hit) = cache_get(&TITLE_CACHE, log_file, size, mtime) {
         return hit;
     }
+    let (size, mtime, buf) = read_file_tail(log_file, 65_536).ok()?;
     // /\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)/g — last non-empty match wins.
     static OSC_TITLE: once_cell::sync::Lazy<regex::bytes::Regex> =
         once_cell::sync::Lazy::new(|| {
@@ -272,10 +277,12 @@ fn parse_status_text(lines: &[String]) -> Option<String> {
 /// Cached per (size, mtime) so the 1s subscribe tick stays cheap.
 fn log_status_text(log_file: Option<&str>) -> Option<String> {
     let log_file = log_file?;
-    let (size, mtime, buf) = read_file_tail(log_file, 32_768).ok()?;
+    // stat-then-read, see log_title.
+    let (size, mtime) = file_version(log_file)?;
     if let Some(hit) = cache_get(&STATUS_CACHE, log_file, size, mtime) {
         return hit;
     }
+    let (size, mtime, buf) = read_file_tail(log_file, 32_768).ok()?;
     let mut vt = crate::vterm::VTermProxy::new(50, 200);
     vt.process(&buf);
     let rendered = if vt.alternate_screen() {
@@ -748,15 +755,41 @@ pub fn mark_exited(pid: u32, reason: &str) {
     }
 }
 
+/// Upper bound on the threads `ls_json` fans `with_meta` out over. `with_meta`
+/// is I/O plus terminal-emulator replay per agent, so it parallelizes cleanly;
+/// the cap keeps a big fleet from stampeding a box that is already running
+/// every one of those agents. Small and fixed rather than `available_par-
+/// allelism`: the daemon is a background service, not the workload.
+const LS_META_THREADS: usize = 8;
+
 fn ls_json(all: bool, active: bool, keyword: &str) -> Vec<Value> {
     let mut recs = read_records();
     recs.sort_by_key(|r| -r.started_at);
-    recs.iter()
+    let selected: Vec<&PidRecord> = recs
+        .iter()
         .filter(|r| all || r.status != "exited")
         .filter(|r| !active || is_process_alive(r.pid))
         .filter(|r| matches_keyword(r, keyword))
-        .map(with_meta)
-        .collect()
+        .collect();
+    if selected.len() < 2 {
+        return selected.into_iter().map(with_meta).collect();
+    }
+    // Sequentially this is O(agents) tail reads and screen replays on one
+    // thread, and the console re-runs it every LS_TICK_MS per viewer — a
+    // fleet-sized list measured whole seconds that way. Chunk it across a
+    // handful of scoped threads and stitch the results back in the original
+    // order, which the console relies on (newest first).
+    let chunk = selected.len().div_ceil(LS_META_THREADS.min(selected.len()));
+    std::thread::scope(|s| {
+        let handles: Vec<_> = selected
+            .chunks(chunk)
+            .map(|part| s.spawn(move || part.iter().map(|r| with_meta(r)).collect::<Vec<_>>()))
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap_or_default())
+            .collect()
+    })
 }
 
 // ---- SSE helpers ------------------------------------------------------------
@@ -1302,7 +1335,11 @@ pub async fn handle(method: &str, path_with_query: &str, body: &str) -> ApiRespo
             .await
             .unwrap_or_else(|e| text(500, e.to_string()))
         }
-        ("GET", "/api/edges") => {
+        // The console polls this every 1.5s per viewer and it touches one file
+        // per distinct cwd plus the pid index, so it belongs on the blocking
+        // pool for the same reason /api/ls does: run inline and each poll pins
+        // an async worker for the whole scan.
+        ("GET", "/api/edges") => tokio::task::spawn_blocking(|| {
             let cwds: Vec<String> = read_records().into_iter().map(|r| r.cwd).collect();
             json_res(
                 200,
@@ -1311,7 +1348,9 @@ pub async fn handle(method: &str, path_with_query: &str, body: &str) -> ApiRespo
                     "sends": crate::serve::discover::message_edges(&cwds),
                 }),
             )
-        }
+        })
+        .await
+        .unwrap_or_else(|e| text(500, e.to_string())),
         ("GET", "/api/search") => {
             let needle = q.get("q").cloned().unwrap_or_default().trim().to_string();
             let budget = q

--- a/rs/src/serve/discover.rs
+++ b/rs/src/serve/discover.rs
@@ -26,6 +26,70 @@ fn read_jsonl(path: &std::path::Path) -> Vec<Value> {
         .collect()
 }
 
+/// How far back a windowed scan reads. The edge views keep only records newer
+/// than `READ_WINDOW_MS`, so everything before that is parsed and thrown away:
+/// on one live fleet a single `/api/edges` parsed 22 MB across 43 outboxes and
+/// kept **one** line — twice a second, per viewer. 256 KB is orders of
+/// magnitude more than a minute of traffic produces, and still one read.
+const TAIL_SCAN_BYTES: u64 = 256 * 1024;
+
+/// `read_jsonl` for append-only logs that are only ever consumed through a
+/// recent time window. Two bounds, in order of how much they save:
+///
+///  1. **mtime gate** — a file last written before the window opened cannot
+///     hold an in-window record, because `at` is stamped when the line is
+///     appended, so mtime is never older than the newest `at`. Such a file is
+///     skipped without being opened. On a fleet where most agents are idle
+///     this drops nearly every file.
+///  2. **bounded backscan** — read at most the trailing `TAIL_SCAN_BYTES`
+///     rather than the whole file, dropping the leading partial line whenever
+///     the read didn't start at offset 0.
+///
+/// Deliberately NOT "stop at the first out-of-window line": several agents
+/// append to one project's outbox concurrently, so `at` is not monotonic
+/// between adjacent lines and an early break can miss a record a slower writer
+/// interleaved. Scanning the whole window stays cheap once the window is
+/// bounded in bytes.
+fn read_jsonl_window(path: &std::path::Path, now: i64, window_ms: i64) -> Vec<Value> {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return vec![];
+    };
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    // mtime == 0 means "couldn't read it" — scan rather than silently skip. A
+    // future-dated mtime (clock skew) also falls through to the scan.
+    if mtime > 0 && now - mtime > window_ms {
+        return vec![];
+    }
+    let size = meta.len();
+    let start = size.saturating_sub(TAIL_SCAN_BYTES);
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return vec![];
+    };
+    use std::io::{Read, Seek, SeekFrom};
+    if f.seek(SeekFrom::Start(start)).is_err() {
+        return vec![];
+    }
+    let mut buf = Vec::new();
+    if f.read_to_end(&mut buf).is_err() {
+        return vec![];
+    }
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines = text.lines();
+    if start > 0 {
+        lines.next(); // partial first line — the tail of an earlier record
+    }
+    lines
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
 /// GET /api/notes — pid → note, from the append-only ~/.agent-yes/notes.jsonl
 /// (last line wins; an empty note deletes the entry).
 pub fn notes(home: &std::path::Path) -> Value {
@@ -57,7 +121,7 @@ pub fn read_edges(home: &std::path::Path) -> Vec<Value> {
     let now = now_ms();
     // Append-only log, last write per (by, target) wins.
     let mut latest: HashMap<(String, i64), i64> = HashMap::new();
-    for v in read_jsonl(&home.join("reads.jsonl")) {
+    for v in read_jsonl_window(&home.join("reads.jsonl"), now, READ_WINDOW_MS) {
         let (Some(by), Some(target), Some(at)) = (
             v.get("by").and_then(|x| x.as_str()),
             v.get("target").and_then(|x| x.as_i64()),
@@ -86,10 +150,12 @@ pub fn message_edges(cwds: &[String]) -> Vec<Value> {
     let now = now_ms();
     let mut best: HashMap<(i64, i64), (i64, Option<String>)> = HashMap::new();
     for cwd in cwds.iter().collect::<HashSet<_>>() {
-        for rec in read_jsonl(
+        for rec in read_jsonl_window(
             &std::path::Path::new(cwd)
                 .join(".agent-yes")
                 .join("outbox.jsonl"),
+            now,
+            READ_WINDOW_MS,
         ) {
             let Some(at) = rec.get("at").and_then(|x| x.as_i64()) else {
                 continue;
@@ -260,5 +326,108 @@ mod tests {
         let text = "日本語のテキストがたくさん並んでいる状態で needle を探す 日本語";
         let h = search_hit(1, "claude", "/ws", text, "needle").unwrap();
         assert!(h["snippet"].as_str().unwrap().contains("needle"));
+    }
+
+    // ---- read_jsonl_window ---------------------------------------------------
+
+    /// Write `body` and stamp the file's mtime `age_ms` into the past, which is
+    /// what the mtime gate keys off.
+    fn write_aged(path: &std::path::Path, body: &str, age_ms: u64) {
+        std::fs::write(path, body).unwrap();
+        let when = std::time::SystemTime::now() - std::time::Duration::from_millis(age_ms);
+        let f = std::fs::File::options().write(true).open(path).unwrap();
+        f.set_modified(when).unwrap();
+    }
+
+    #[test]
+    fn window_scan_skips_a_file_whose_mtime_predates_the_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("outbox.jsonl");
+        let now = now_ms();
+        // In-window CONTENT, out-of-window mtime. The gate must still skip it:
+        // an append stamps both, so this combination cannot occur in practice,
+        // and asserting on it is what proves the read was actually elided.
+        write_aged(&p, &format!("{{\"at\":{now}}}\n"), 10 * 60_000);
+        assert!(read_jsonl_window(&p, now, READ_WINDOW_MS).is_empty());
+    }
+
+    #[test]
+    fn window_scan_reads_a_recently_written_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("outbox.jsonl");
+        let now = now_ms();
+        write_aged(&p, &format!("{{\"at\":{now},\"n\":1}}\n"), 0);
+        let got = read_jsonl_window(&p, now, READ_WINDOW_MS);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0]["n"], json!(1));
+    }
+
+    #[test]
+    fn window_scan_keeps_the_tail_and_drops_the_partial_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("outbox.jsonl");
+        let now = now_ms();
+        // Overshoot TAIL_SCAN_BYTES with padded records so the read starts
+        // mid-line, then assert the last record survives and the count is
+        // bounded by the scan window rather than the file.
+        let pad = "x".repeat(4096);
+        let mut body = String::new();
+        for i in 0..200 {
+            body.push_str(&format!("{{\"at\":{now},\"n\":{i},\"pad\":\"{pad}\"}}\n"));
+        }
+        write_aged(&p, &body, 0);
+        assert!(std::fs::metadata(&p).unwrap().len() > TAIL_SCAN_BYTES);
+        let got = read_jsonl_window(&p, now, READ_WINDOW_MS);
+        assert!(!got.is_empty());
+        assert_eq!(got.last().unwrap()["n"], json!(199));
+        assert!(got.len() < 200, "scan was not bounded: {} lines", got.len());
+        // Every parsed line is whole — a partial leading line would fail to
+        // deserialize and be dropped silently, so check the first one directly.
+        assert!(got[0]["n"].is_number());
+    }
+
+    #[test]
+    fn window_scan_tolerates_a_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("nope.jsonl");
+        assert!(read_jsonl_window(&p, now_ms(), READ_WINDOW_MS).is_empty());
+    }
+
+    #[test]
+    fn message_edges_still_reports_a_fresh_send() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().join("repo-alpha");
+        std::fs::create_dir_all(cwd.join(".agent-yes")).unwrap();
+        let now = now_ms();
+        write_aged(
+            &cwd.join(".agent-yes").join("outbox.jsonl"),
+            &format!(
+                "{{\"at\":{},\"from\":{{\"pid\":1111}},\"to\":{{\"pid\":2222}},\"kind\":\"send\"}}\n",
+                now - 1_000
+            ),
+            0,
+        );
+        let edges = message_edges(&[cwd.to_string_lossy().to_string()]);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["by"], json!(1111));
+        assert_eq!(edges[0]["target"], json!(2222));
+        assert_eq!(edges[0]["kind"], json!("send"));
+    }
+
+    #[test]
+    fn message_edges_drops_a_stale_outbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = dir.path().join("repo-alpha");
+        std::fs::create_dir_all(cwd.join(".agent-yes")).unwrap();
+        let now = now_ms();
+        write_aged(
+            &cwd.join(".agent-yes").join("outbox.jsonl"),
+            &format!(
+                "{{\"at\":{},\"from\":{{\"pid\":1111}},\"to\":{{\"pid\":2222}}}}\n",
+                now - 10 * 60_000
+            ),
+            10 * 60_000,
+        );
+        assert!(message_edges(&[cwd.to_string_lossy().to_string()]).is_empty());
     }
 }


### PR DESCRIPTION
## 何を直したか

コンソールの p95 はほぼ全て `/api/edges` 一本に由来していた。ブラウザ側の計測リング（WebRTC 経由・125 リクエスト）では、このエンドポイントだけが桁で外れている。

| path | n | p50 | p95 | max |
| --- | --- | --- | --- | --- |
| `/api/send` | 36 | 32ms | 104ms | 141ms |
| `/api/presence` | 66 | 18ms | 81ms | 186ms |
| `/api/size/N` | 22 | 18ms | 42ms | 53ms |
| **`/api/edges`** | **42** | **439ms** | **1074ms** | **1920ms** |

CF エッジ（TTFB 53ms、`/w/` バンドル 397KB を 82ms）とシグナリング（51ms）は白。遅いのはここだけだった。

## 原因

`rs/src/serve/discover.rs` の走査が「全部読んでから時刻で捨てる」形だった。`message_edges` は cwd ごとの `outbox.jsonl` を、`read_edges` は `reads.jsonl` を、それぞれ `read_jsonl` で全行 `Vec<Value>` に collect してから `READ_WINDOW_MS`（60 秒）で絞る。返す本文は 69 バイトなのに、あるフリートでは 1 回あたり 22MB を parse して残るのは 1 行だった。コンソールはこれをビューアあたり 1.5 秒間隔で叩く。

## 直し方

`read_jsonl_window` を追加して二段で抑える。

1. **mtime ゲート** — 窓が開くより前に最後に書かれたファイルは窓内のレコードを持ち得ない（`at` は追記時に押されるので mtime は最新の `at` より古くならない）。開かずに飛ばす。
2. **末尾からの範囲読み** — 全文ではなく末尾 `TAIL_SCAN_BYTES` のみを読み、offset 0 以外から読んだ場合は先頭の欠けた行を捨てる。

「窓外の行に当たったら打ち切る」形は**採らない**。1 つのプロジェクトの outbox には複数のエージェントが並行して追記するため隣接行の `at` は単調ではなく、早期 break は遅い書き手が挟んだレコードを取りこぼす。バイト数で窓を縛れば全走査でも十分安い。

あわせて 3 点:

- `/api/edges` を `spawn_blocking` に載せる。`/api/ls` が既にそうしているのと同じ理由。
- `log_title` / `log_status_text` を stat 先行に直す。キャッシュキーが `(size, mtime)` なのに読み込みが先だったため、ヒットしても毎回 64KB / 32KB を読んでいた。`log_tasks` / `log_badges` と同じ形に揃える。
- `ls_json` の `with_meta` を scoped thread で分割する。エージェント 1 件ごとに tail 読み込みと端末エミュレータ再生を行う処理が 1 スレッド直列で、台数に完全にリニアだった。並び順（新しい順）は維持。

## 計測

同一の実データに対し、stock 版と patch 版を別ポートで同時起動して A/B。

| | stock | patched |
| --- | --- | --- |
| `/api/edges` p50 | 36ms | 2ms |
| `/api/edges` ビューア 4 並列時 p95 | 36ms | 4ms |
| `/api/ls` p50（61 レコード） | 53ms | 16ms |

mtime ゲートは 43 個の outbox のうち 42 個を読まずに落とし、1 回あたり 14.5MB の読み込みが消えた。両者の `/api/ls` 応答は件数・status 内訳とも一致（61 件 / active 13 / idle 48）。

なお stock 側の絶対値がブラウザ計測より小さいのは、A/B が起動直後の daemon 同士の比較だから。ブラウザ側の p95 1074ms は 3.5 時間稼働・ビューア 4 人・load 51 の実運用条件での値。倍率のほうが本質。

## テスト

`read_jsonl_window` の mtime ゲート / 範囲読みと先頭欠け行の除去 / ファイル欠損、および `message_edges` の新鮮な送信の検出と古い outbox の除外を追加。既存の `discover` テストは変更なしで通る。

`cargo test` は **308 passed / 1 failed**。失敗する `cli::tests::test_supported_clis_count` は `origin/main` の素の状態でも同じく失敗する既存の不具合で、本変更とは無関係（stash して確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)