### PR TITLE
fix(ayrs): ルーム占有中は即時終了せずその場で待機する (再投入嵐の解消)

### DIFF
--- a/rs/src/serve/share.rs
+++ b/rs/src/serve/share.rs
@@ -41,6 +41,19 @@ const PEER_OP_TIMEOUT_MS: u64 = 30_000;
 const PEER_CLOSE_TIMEOUT_MS: u64 = 10_000;
 const STUN_URL: &str = "stun:stun.l.google.com:19302";
 const MAX_ROTATES: u32 = 5;
+/// How long to wait between re-checks while parked behind a live room holder.
+///
+/// The only thing this poll does is one `kill(pid, 0)`, so the cost of a short
+/// interval is nil; what sets the floor is the OS supervisor. Under launchd
+/// (`KeepAlive = true`) a daemon that exits immediately is relaunched
+/// immediately, and the old fail-fast claim turned that into a fork/exec storm:
+/// tens of thousands of spawn→refuse→exit cycles, each one a fresh Gatekeeper
+/// exec evaluation, which shows up as sustained system-wide CPU burn in
+/// `syspolicyd` plus a multi-megabyte error log of the same refusal line.
+/// Parking in-process removes the churn entirely, so the interval only trades
+/// takeover latency after the holder dies. 5s keeps that handoff well under the
+/// signaling server's host-heartbeat window while polling ~12x/min.
+const CLAIM_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 fn global_dir() -> PathBuf {
     if let Ok(h) = std::env::var("AGENT_YES_HOME") {
@@ -201,24 +214,29 @@ fn room_lock_path(room: &str) -> std::path::PathBuf {
     global_dir().join(format!(".share-host-{room}.pid"))
 }
 
+/// Result of one non-blocking attempt at the room's advisory lock.
+#[derive(Debug, PartialEq, Eq)]
+enum ClaimOutcome {
+    /// The lock file now records our pid; we are the room's host.
+    Claimed,
+    /// A different, still-live pid holds the room. Carries the holder so the
+    /// caller can wait on it without re-parsing an error string.
+    HeldBy(i32),
+}
+
 /// Two `ayrs` hosts in the same signaling room both answer every `peer-join`,
 /// so each viewer's answer reaches the host that did *not* originate the offer
 /// and blows up with "invalid proposed signaling state transition from stable".
 /// Nothing recovers from that — the room just stops accepting viewers — so
-/// refuse to start rather than degrade the room that's already working.
-fn claim_room(room: &str) -> Result<()> {
-    claim_room_at(&room_lock_path(room), room)
-}
-
-fn claim_room_at(path: &std::path::Path, room: &str) -> Result<()> {
+/// never start a second host on a room that's already working.
+///
+/// This is the whole invariant, and none of the wrappers below relax it: they
+/// only differ in what happens *after* a refusal (bail vs. park and retry).
+fn try_claim_room_at(path: &std::path::Path) -> ClaimOutcome {
     if let Ok(txt) = std::fs::read_to_string(path) {
         if let Ok(pid) = txt.trim().parse::<i32>() {
             if pid != std::process::id() as i32 && crate::pid_store::is_process_alive(pid as u32) {
-                bail!(
-                    "another ayrs host (pid {pid}) is already serving room {room}\n\
-                     running two hosts in one room breaks WebRTC answering for every viewer.\n\
-                     stop it first (`ayrs serve uninstall`, or kill {pid}), or host a different room."
-                );
+                return ClaimOutcome::HeldBy(pid);
             }
         }
     }
@@ -226,7 +244,78 @@ fn claim_room_at(path: &std::path::Path, room: &str) -> Result<()> {
         std::fs::create_dir_all(p).ok();
     }
     std::fs::write(path, std::process::id().to_string()).ok();
-    Ok(())
+    ClaimOutcome::Claimed
+}
+
+fn held_by_error(pid: i32, room: &str) -> anyhow::Error {
+    anyhow!(
+        "another ayrs host (pid {pid}) is already serving room {room}\n\
+         running two hosts in one room breaks WebRTC answering for every viewer.\n\
+         stop it first (`ayrs serve uninstall`, or kill {pid}), or host a different room."
+    )
+}
+
+/// Fail-fast claim: refuse immediately if the room is held by a live pid.
+/// For callers that must not block (see the rotation path in `run_share`).
+fn claim_room_at(path: &std::path::Path, room: &str) -> Result<()> {
+    match try_claim_room_at(path) {
+        ClaimOutcome::Claimed => Ok(()),
+        ClaimOutcome::HeldBy(pid) => Err(held_by_error(pid, room)),
+    }
+}
+
+/// Parking claim: wait for the incumbent host to go away, then take over.
+///
+/// Returning an error here would hand control back to the OS supervisor, which
+/// (launchd `KeepAlive = true`, and equivalently under the other managers) just
+/// relaunches us — spawn, refuse, exit, repeat, forever. That fork/exec storm is
+/// far more damaging than the wait it was avoiding, so the daemon startup path
+/// parks in-process instead: the invariant is still "exactly one host per room",
+/// we simply queue for it rather than thrashing on it.
+///
+/// The banner is printed ONCE per distinct holder, not once per poll — the
+/// per-attempt log line is precisely what grew the daemon's stderr log into
+/// millions of identical rows.
+///
+/// Interruptibility: this awaits `tokio::time::sleep`, so a foreground run stays
+/// killable with Ctrl-C under SIGINT's default disposition. Deliberately NOT a
+/// `select!` on `tokio::signal::ctrl_c()` — awaiting that installs a
+/// process-wide handler that outlives this loop and would silently make Ctrl-C
+/// a no-op for the rest of the daemon's life (the `ayrs` binary installs no
+/// signal handler of its own; see `rs/src/bin/ayrs.rs`).
+async fn claim_room_blocking_at(
+    path: &std::path::Path,
+    room: &str,
+    interval: Duration,
+) -> Result<()> {
+    let mut announced: Option<i32> = None;
+    loop {
+        match try_claim_room_at(path) {
+            ClaimOutcome::Claimed => {
+                if announced.is_some() {
+                    eprintln!("[ayrs share] room {room} released — taking over as host");
+                }
+                return Ok(());
+            }
+            ClaimOutcome::HeldBy(pid) => {
+                if announced != Some(pid) {
+                    announced = Some(pid);
+                    eprintln!(
+                        "[ayrs share] {}\nwaiting for pid {pid} to exit (re-checking every {}s); \
+                         this message is not repeated.",
+                        held_by_error(pid, room),
+                        interval.as_secs().max(1)
+                    );
+                }
+                tokio::time::sleep(interval).await;
+            }
+        }
+    }
+}
+
+/// Daemon startup claim on the real lock path, with the production interval.
+async fn claim_room_blocking(room: &str) -> Result<()> {
+    claim_room_blocking_at(&room_lock_path(room), room, CLAIM_RETRY_INTERVAL).await
 }
 
 #[cfg(test)]
@@ -280,6 +369,87 @@ mod claim_tests {
         claim_room_at(&p, "r1").unwrap();
         claim_room_at(&p, "r1").unwrap();
     }
+
+    #[tokio::test]
+    async fn blocking_claim_returns_immediately_for_a_free_room() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("lock.pid");
+        // A free room must not sleep even once, so a tiny timeout is a real
+        // assertion here rather than just a CI guard.
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            claim_room_blocking_at(&p, "r1", Duration::from_secs(3600)),
+        )
+        .await
+        .expect("free room must not park")
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&p).unwrap(),
+            std::process::id().to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn blocking_claim_parks_then_takes_over_when_the_holder_exits() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("lock.pid");
+        // Same live-process trick as `refuses_a_room_held_by_a_live_pid`: a real
+        // short-lived child, never pid 1 (kill(1,0) is EPERM for a normal user,
+        // which reads as "dead" and would make this test vacuous).
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        std::fs::write(&p, child.id().to_string()).unwrap();
+
+        // The reap is load-bearing: a killed-but-unwaited child stays a zombie,
+        // and `kill(zombie, 0)` keeps returning 0 — i.e. "alive" — so without
+        // `wait()` the park loop would spin forever.
+        let holder = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            let _ = child.kill();
+            let _ = child.wait();
+        });
+
+        // Injected interval keeps the test at ~0.1s of real time; the outer
+        // timeout turns any regression into a fast failure instead of a hung CI.
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            claim_room_blocking_at(&p, "r1", Duration::from_millis(25)),
+        )
+        .await
+        .expect("park must take over once the holder exits")
+        .unwrap();
+
+        holder.join().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&p).unwrap(),
+            std::process::id().to_string()
+        );
+    }
+
+    #[test]
+    fn fail_fast_and_parking_claims_disagree_on_a_live_holder() {
+        // The rotation call site depends on the fail-fast wrapper staying
+        // fail-fast: same lock file, same live holder, but it returns an error
+        // where `claim_room_blocking_at` would park. (It is a plain sync `fn`,
+        // so "does not block" is enforced by its type, not by a timeout.)
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("lock.pid");
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        std::fs::write(&p, child.id().to_string()).unwrap();
+        let err = claim_room_at(&p, "r1").unwrap_err().to_string();
+        assert_eq!(
+            try_claim_room_at(&p),
+            ClaimOutcome::HeldBy(child.id() as i32)
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(err.contains("already serving room r1"), "{err}");
+    }
 }
 
 pub async fn run_share(cfg: ShareConfig) -> Result<()> {
@@ -295,7 +465,11 @@ pub async fn run_share(cfg: ShareConfig) -> Result<()> {
         );
     }
     let mut secret = s;
-    claim_room(&room.room)?;
+    // Startup claim → PARK. This is the path the OS supervisor re-runs, so
+    // exiting here is what produced the relaunch storm. Waiting costs nothing:
+    // the room is already being served correctly by the incumbent, and we take
+    // over the moment it dies.
+    claim_room_blocking(&room.room).await?;
     let api_token = api::load_or_create_token().context("serve token")?;
 
     let peers: Peers = Arc::new(Mutex::new(HashMap::new()));
@@ -335,7 +509,15 @@ pub async fn run_share(cfg: ShareConfig) -> Result<()> {
                 room = mint_room(&room.host);
                 secret = e2e::parse_secret(&room.token)?.0;
                 persist_room(&room);
-                claim_room(&room.room)?;
+                // Rotation claim → FAIL FAST. `mint_room` just generated a
+                // fresh random room id, so a live foreign holder here is a
+                // collision or a bug, not the normal "the box already has a
+                // host" case; parking would wait on something that will never
+                // be released and hide the fault. Bailing does not resurrect
+                // the relaunch storm either: `persist_room` above already
+                // wrote the new room, so the supervisor's relaunch loads it
+                // and lands on the PARKING startup claim instead.
+                claim_room_at(&room_lock_path(&room.room), &room.room)?;
                 let link = format_share_link(&room.room, &secret, &room.host);
                 eprintln!("[ayrs share] room rotated: {link}");
             }


### PR DESCRIPTION
## 症状

`ayrs serve --webrtc` のデーモンが、同じルームを既に別プロセスがホスト
している状況で **spawn → 拒否 → exit → 再投入** を延々と繰り返す。

デーモンの stderr ログの大半が以下の同一行で占められ、ファイルサイズが
数メガバイト規模まで膨張する。

```
Error: another ayrs host (pid N) is already serving room rXXXX
running two hosts in one room breaks WebRTC answering for every viewer.
stop it first (`ayrs serve uninstall`, or kill N), or host a different room.
```

## 原因

`rs/src/serve/share.rs` の起動時ルームクレーム (`claim_room`) は、生存中の
別 pid がルームを保持している場合に即座に `bail!` していた。

OS のスーパーバイザ (launchd の `KeepAlive = true`、他マネージャでも同様)
は「終了したデーモンは直ちに再投入する」ので、この即時終了がそのまま
無限の再投入ループになる。macOS では exec 1 回ごとに Gatekeeper の判定が
走るため、この churn は `syspolicyd` の CPU を継続的に押し上げる。

つまり **不変条件のチェック自体は正しく、拒否後の振る舞いだけが誤っていた**。

## 修正方針

不変条件はそのまま維持する。1 ルームに 2 つのホストが同居すると、双方が
すべての `peer-join` に応答するため viewer の answer が offer を出していない
側に届き、`invalid proposed signaling state transition from stable` でルームが
恒久的に新規 viewer を受けられなくなる。ここは緩めない。

変えたのは拒否された後の扱いで、**プロセスを終了させずその場で待機
(park) し、周期的に保持者の生存を再確認して、保持者が消えたら引き継ぐ**。
スーパーバイザから見るとプロセスは生き続けているため、再投入は起きない。

### 実装

- `try_claim_room_at(path) -> ClaimOutcome` を追加。`Claimed` / `HeldBy(pid)`
  を返し、保持者 pid をエラー文字列のパースなしに取り出せるようにした。
- `claim_room_at` は従来どおりの即時失敗版として維持 (メッセージも不変)。
- `claim_room_blocking_at(path, room, interval)` を追加。
  - 案内ログは **保持者ごとに 1 回だけ**。ポーリングごとには出さない
    (ログ肥大の再発防止)。誰を待っているか、強制的に引き継ぐ方法も併記。
  - 待機は `tokio::time::sleep` の await なので、フォアグラウンド実行時は
    SIGINT の既定動作でそのまま Ctrl-C により中断できる。
    `tokio::signal::ctrl_c()` を使う `select!` は **意図的に避けた**。
    await した時点でプロセス全体のハンドラが登録され、この待機ループを
    抜けた後もそれが残るため、デーモン本体に対する Ctrl-C が無反応に
    なってしまう (`ayrs` バイナリは独自のシグナルハンドラを持たない)。
- 再試行間隔は定数 `CLAIM_RETRY_INTERVAL = 5s`。
  ポーリングの実体は `kill(pid, 0)` 1 回なので短い間隔でもコストはほぼ
  ゼロで、間隔が決めるのは「保持者が死んでから引き継ぐまでの遅延」だけ。
  5 秒はシグナリングのホストハートビート窓に対して十分小さい。
  テストからは引数で注入するため、CI が実時間の sleep で詰まることはない。

### 呼び出し箇所の使い分け

`run_share` の 2 箇所を読んだうえで挙動を分けた。判断根拠はソース中の
コメントにも記載してある。

| 箇所 | 挙動 | 理由 |
|---|---|---|
| 起動時クレーム | **待機** | スーパーバイザが再投入するのはこの経路で、嵐の発生源そのもの。待っても損失はなく (ルームは現ホストが正しく提供している)、現ホストが死んだ瞬間に引き継げる |
| ローテーション後のクレーム | **即時失敗** | 直前の `mint_room` でランダムな新規ルーム ID を生成しており、そこに生存中の他 pid がいるのは通常ケースではなく衝突ないし不具合。待機しても解放されず障害を隠すだけ。かつ即時失敗でも嵐は再発しない — `persist_room` が新ルームを保存済みなので、再投入された側は**待機する**起動時クレームの経路に入る |

なお `run_scoped_session` は元々クレームロックを取らない設計なので変更なし。

## テスト

既存の `claim_tests` 4 件は意味論を変えていないため**そのまま維持**。
新規 3 件を追加した。

- `blocking_claim_returns_immediately_for_a_free_room`
  空きルームでは 1 度も sleep せずに取得すること。
- `blocking_claim_parks_then_takes_over_when_the_holder_exits`
  実在する短命の子プロセスを保持者に立て、それが終了した後に待機側が
  引き継ぐこと。
  - pid 1 は使わない。一般ユーザーからは `kill(1,0)` が EPERM となり
    「死亡」と誤判定されるため (既存コメントにある落とし穴)。
  - 子プロセスの `wait()` による回収が **load-bearing**。回収しないと
    ゾンビが `kill(pid,0)==0` を返し続け、待機が永久に終わらない。
  - 間隔を 25ms に注入して実時間 ~0.1s。さらに外側を
    `tokio::time::timeout` で囲み、退行時は CI がハングせず即座に落ちる。
- `fail_fast_and_parking_claims_disagree_on_a_live_holder`
  ローテーション経路が依存する即時失敗版が、生存中の保持者に対して
  従来どおりエラーを返すこと。

```
$ cargo build --tests && cargo test claim
running 7 tests
test serve::share::claim_tests::reclaiming_our_own_room_is_a_no_op ... ok
test serve::share::claim_tests::claims_a_free_room_and_records_our_pid ... ok
test serve::share::claim_tests::takes_over_a_room_held_by_a_dead_pid ... ok
test serve::share::claim_tests::blocking_claim_returns_immediately_for_a_free_room ... ok
test serve::share::claim_tests::refuses_a_room_held_by_a_live_pid ... ok
test serve::share::claim_tests::fail_fast_and_parking_claims_disagree_on_a_live_holder ... ok
test serve::share::claim_tests::blocking_claim_parks_then_takes_over_when_the_holder_exits ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 176 filtered out; finished in 0.11s
```

`cargo fmt --check` もクリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
