### PR TITLE
test(dsh): cmdDsh に spawn の注入口とテストを入れ、カバレッジゲートを戻す

### DIFF
--- a/ts/cmdDsh.spec.ts
+++ b/ts/cmdDsh.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { cmdDsh, type DshSpawn, dshTuiPrefix } from "./cmdDsh.ts";
+
+/**
+ * Records every spawn so the assertions can be about the ARGV that would be
+ * executed, which is the whole contract of this module — it never interprets
+ * dsh-tui's output, it only decides how to invoke it and forwards the rest.
+ */
+function recorder(behavior: (cmd: string[]) => number | Error): {
+  spawn: DshSpawn;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const spawn: DshSpawn = (cmd) => {
+    calls.push(cmd);
+    const outcome = behavior(cmd);
+    if (outcome instanceof Error) throw outcome;
+    return { exited: Promise.resolve(outcome) };
+  };
+  return { spawn, calls };
+}
+
+describe("dshTuiPrefix", () => {
+  it("uses the bare bin when the probe exits 0 (dsh-tui already installed)", async () => {
+    const { spawn, calls } = recorder(() => 0);
+    expect(await dshTuiPrefix(spawn)).toEqual(["dsh-tui"]);
+    expect(calls).toEqual([["dsh-tui", "--version"]]);
+  });
+
+  it("falls back to bunx when the probe exits non-zero", async () => {
+    const { spawn } = recorder(() => 1);
+    expect(await dshTuiPrefix(spawn)).toEqual(["bunx", "dsh-tui"]);
+  });
+
+  it("falls back to bunx when the probe throws (bin not on PATH)", async () => {
+    // Bun.spawn raises rather than resolving non-zero when the program is
+    // missing entirely, so this is a distinct path from the exit-code one.
+    const { spawn } = recorder(() => new Error("ENOENT"));
+    expect(await dshTuiPrefix(spawn)).toEqual(["bunx", "dsh-tui"]);
+  });
+});
+
+describe("cmdDsh", () => {
+  it("forwards args verbatim after the resolved prefix", async () => {
+    const { spawn, calls } = recorder(() => 0);
+    await cmdDsh(["alpha", "--flag", "x"], spawn);
+    // [0] is the probe; [1] is the real launch.
+    expect(calls[1]).toEqual(["dsh-tui", "alpha", "--flag", "x"]);
+  });
+
+  it("prefixes with bunx when dsh-tui is not installed", async () => {
+    const { spawn, calls } = recorder((cmd) => (cmd[1] === "--version" ? 1 : 0));
+    await cmdDsh(["alpha"], spawn);
+    expect(calls[1]).toEqual(["bunx", "dsh-tui", "alpha"]);
+  });
+
+  it("does not intercept --help — it is forwarded so dsh-tui prints its own", async () => {
+    const { spawn, calls } = recorder(() => 0);
+    await cmdDsh(["--help"], spawn);
+    expect(calls[1]).toEqual(["dsh-tui", "--help"]);
+    const short = recorder(() => 0);
+    await cmdDsh(["-h"], short.spawn);
+    expect(short.calls[1]).toEqual(["dsh-tui", "-h"]);
+  });
+
+  it("runs with no args at all", async () => {
+    const { spawn, calls } = recorder(() => 0);
+    await cmdDsh([], spawn);
+    expect(calls[1]).toEqual(["dsh-tui"]);
+  });
+
+  it("propagates the child's exit code", async () => {
+    const { spawn } = recorder((cmd) => (cmd[1] === "--version" ? 0 : 42));
+    expect(await cmdDsh(["alpha"], spawn)).toBe(42);
+  });
+
+  it("reports 0 when the child yields no exit code", async () => {
+    // `proc.exited` is typed as possibly-undefined, hence the `?? 0` guard.
+    const calls: string[][] = [];
+    const spawn: DshSpawn = (cmd) => {
+      calls.push(cmd);
+      return {
+        exited: Promise.resolve(
+          cmd[1] === "--version" ? 0 : (undefined as unknown as number),
+        ),
+      };
+    };
+    expect(await cmdDsh(["alpha"], spawn)).toBe(0);
+  });
+});

--- a/ts/cmdDsh.ts
+++ b/ts/cmdDsh.ts
@@ -3,7 +3,9 @@
  * (dsh-tui), acting like `bunx dsh-tui` (or bare `dsh-tui` when already
  * installed). This is a thin exec of the upstream TUI: agent-yes does not wrap
  * or capture it, it just hands the terminal over, so `ay dsh-legacy <alpha>`
- * runs dsh-tui verbatim.
+ * runs dsh-tui verbatim. Passing `--help`/`-h` is not special-cased on purpose:
+ * the args are forwarded and dsh-tui prints its own help, so agent-yes never
+ * has a second copy of it to keep in sync.
  *
  * NOTE: `dsh-legacy` as a SUBCOMMAND shadows the DeepSeek *agent* CLI name in
  * the manager entry. The canonical `dsh` agent CLI is now the minimal config
@@ -15,14 +17,28 @@
 const DSH_TUI_BIN = "dsh-tui";
 
 /**
+ * The slice of `Bun.spawn` this module uses. Declared as a seam so the launch
+ * DECISION (installed bin vs `bunx` fallback) is testable without spawning
+ * anything: the real spawns here either probe the host's PATH or hand over the
+ * terminal, neither of which a unit test can do. Defaults to `Bun.spawn`, so
+ * production callers pass nothing and behavior is unchanged.
+ */
+export type DshSpawn = (
+  cmd: string[],
+  opts: { stdin: "ignore" | "inherit"; stdout: "ignore" | "inherit"; stderr: "ignore" | "inherit" },
+) => { exited: Promise<number> };
+
+const defaultSpawn: DshSpawn = (cmd, opts) => Bun.spawn(cmd, opts);
+
+/**
  * Resolve the argv prefix that launches dsh-tui: the bare bin when it is
  * already on PATH (fast, deterministic), else `bunx` (which fetches/uses the
  * cached package — the exact behavior of `bunx dsh-tui`).
  */
-async function dshTuiPrefix(): Promise<[string, ...string[]]> {
+export async function dshTuiPrefix(spawn: DshSpawn = defaultSpawn): Promise<[string, ...string[]]> {
   // Prefer a real install — no network, no bunx resolution quirks.
   try {
-    const probe = Bun.spawn([DSH_TUI_BIN, "--version"], {
+    const probe = spawn([DSH_TUI_BIN, "--version"], {
       stdin: "ignore",
       stdout: "ignore",
       stderr: "ignore",
@@ -35,12 +51,9 @@ async function dshTuiPrefix(): Promise<[string, ...string[]]> {
 }
 
 /** Run `dsh-tui` in the foreground with the user's terminal (forward args). */
-export async function cmdDsh(rest: string[]): Promise<number> {
-  if (rest.includes("--help") || rest.includes("-h")) {
-    // Show dsh-tui's own help verbatim by exec'ing it rather than re-documenting.
-  }
-  const prefix = await dshTuiPrefix();
-  const proc = Bun.spawn([...prefix, ...rest], {
+export async function cmdDsh(rest: string[], spawn: DshSpawn = defaultSpawn): Promise<number> {
+  const prefix = await dshTuiPrefix(spawn);
+  const proc = spawn([...prefix, ...rest], {
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",


### PR DESCRIPTION
## 何が起きているか

`Matrix Test` が **main 上で落ち続けている**（`70a8852` / `040a2d1` / `253cf49` と直近 3 コミット連続で failure）。テストの失敗ではなく**カバレッジゲート**で、`branches` が閾値 90% に対して 89.84〜89.98%。

required check は `test (ubuntu-latest, bun|node)` / `test (windows-latest, bun|node)` / `ui-dom` なので、**現状この repo の PR はすべてマージできない**状態になっている。

## 原因

`ts/cmdDsh.ts` が stmts / branch / funcs / lines すべて **0%**、ファイル全体（15-48 行）が一度も実行されていない。

```
  cmdDsh.ts        |       0 |        0 |       0 |       0 | 15-48
```

`Bun.spawn` を直に叩くため外から差し替えられず、テストの書きようがなかった。

## 直し方

`DshSpawn` 型の注入口を足す。既定値は `Bun.spawn` なので呼び出し側（`ts/subcommands.ts` の `cmdDsh(rest)`）は無変更で、実行時の挙動も変わらない。これで「どう起動するか」の判断部分だけを、実際に何も起動せずに検証できる。

- `dshTuiPrefix` を export し、プローブが 0 で終了したときは素の `dsh-tui`、非 0 のときと **throw したとき**（PATH に無い場合は `Bun.spawn` が解決に失敗して投げるので、終了コード経路とは別の分岐）は `bunx dsh-tui` に落ちることを検証。
- `cmdDsh` は解決した prefix の後ろに引数をそのまま渡すこと、子の終了コードをそのまま返すこと、終了コードが取れない場合に `?? 0` で 0 になることを検証。

`ts/oxmgrService.ts` のように exclude する道も取れたが（あちらの理由書き「a thin Bun.spawn wrapper … mocking the spawn would only test the mock」は cmdDsh にもそのまま当てはまる）、`dshTuiPrefix` の「インストール済みなら素の bin、無ければ bunx」は利用者が実際に踏む本物の分岐なので、**分母から外すのではなく実際にテストする**方を選んだ。

あわせて `--help` / `-h` の空の `if` を削除。中身が無く何もしていなかった上に、到達しても観測できない分岐としてカバレッジ計測に乗っていた。意図（引数を素通しして dsh-tui 自身の help を出させる）はモジュール冒頭の doc コメントに移した。挙動は変わらない。

## テスト

`ts/cmdDsh.spec.ts` を新規追加、**9 件すべて green**。

ローカル全体は **1657 passed / 3 failed**。失敗する 3 件は `ts/todoCli.spec.ts` のもので、yargs 18 のエラー文言が macOS の AppleLocale を見て日本語になるための環境依存の既存不具合（`LANG` / `LC_ALL` では変わらない）。本変更とは無関係で、CI のランナー上では通る。なお vitest はテストが落ちるとカバレッジ表を出さないため、閾値を超えたかどうかの最終確認は本 PR の CI で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)