### PR TITLE
perf(serve): 旧版の書き手が残す raw ログを daemon 側で回収し、log_tasks の再計算を間引く

### DIFF
--- a/rs/src/bin/ayrs.rs
+++ b/rs/src/bin/ayrs.rs
@@ -105,6 +105,11 @@ async fn main() -> anyhow::Result<()> {
             // eventually clears any zombie an old (pre-fix) daemon left behind.
             reaper::sweep();
 
+            // Reclaim raw logs whose own writer cannot: an agent exec'd before
+            // log compaction shipped keeps that image for its whole life, so
+            // nothing inside it will ever cap its log (see serve/log_gc.rs).
+            serve::log_gc::spawn();
+
             // --port and --webrtc are independent transports over the SAME API
             // surface; running both is the normal local+remote setup.
             let http = port.map(|p| tokio::spawn(serve::http::run(p)));

--- a/rs/src/log_files.rs
+++ b/rs/src/log_files.rs
@@ -20,8 +20,8 @@ use tracing::warn;
 /// `COMPACT_KEEP_BYTES`, which stays comfortably above the render window so no
 /// visible output is lost. Compaction runs in-process under the writer's own
 /// lock, so nothing else appends to the file while it happens.
-const COMPACT_KEEP_BYTES: u64 = 80 * 1024 * 1024;
-const COMPACT_TRIGGER_BYTES: u64 = 160 * 1024 * 1024;
+pub(crate) const COMPACT_KEEP_BYTES: u64 = 80 * 1024 * 1024;
+pub(crate) const COMPACT_TRIGGER_BYTES: u64 = 160 * 1024 * 1024;
 
 struct WriterState {
     file: Option<fs::File>,
@@ -100,7 +100,7 @@ impl LogWriter {
 /// is crash-atomicity: a kill mid-rewrite can leave a duplicated-then-stale tail,
 /// which is harmless for an ephemeral render log (deleted on clean exit; resume
 /// falls back to `--continue`) and self-heals on the next compaction.
-fn compact_tail(path: &Path, keep: u64) -> std::io::Result<u64> {
+pub(crate) fn compact_tail(path: &Path, keep: u64) -> std::io::Result<u64> {
     let len = fs::metadata(path)?.len();
     if len <= keep {
         return Ok(len);

--- a/rs/src/serve/api.rs
+++ b/rs/src/serve/api.rs
@@ -88,7 +88,7 @@ pub fn load_or_create_token() -> std::io::Result<String> {
 
 // ---- pids.jsonl -------------------------------------------------------------
 
-fn read_records() -> Vec<PidRecord> {
+pub(crate) fn read_records() -> Vec<PidRecord> {
     let path = global_dir().join("pids.jsonl");
     let Ok(content) = std::fs::read_to_string(&path) else {
         return Vec::new();
@@ -356,6 +356,51 @@ fn json_cache_get(cache: &JsonCache, key: &str, size: u64, mtime: i64) -> Option
     }
 }
 
+/// When `log_tasks` last recomputed, per log file. Separate from `TASKS_CACHE`
+/// so the cache's `(size, mtime)` contract — and the shared `json_cached`
+/// helper — stay exactly as they are.
+type StampMap = std::sync::Mutex<std::collections::HashMap<String, i64>>;
+static TASKS_STAMP: once_cell::sync::Lazy<StampMap> = once_cell::sync::Lazy::new(Default::default);
+
+/// The previously computed task count, if it was computed recently enough to
+/// keep serving. `None` means "recompute now", which is also what an entry with
+/// no recorded stamp gets — a first call always computes.
+fn tasks_recent_enough(log_file: &str) -> Option<Value> {
+    let fresh = TASKS_STAMP
+        .lock()
+        .ok()?
+        .get(log_file)
+        .is_some_and(|at| now_ms() - *at < TASKS_MAX_STALE_MS);
+    if !fresh {
+        return None;
+    }
+    // Any stored value under this key, whatever (size, mtime) produced it.
+    let map = TASKS_CACHE.lock().ok()?;
+    map.get(log_file).map(|(_, _, v)| v.clone())
+}
+
+fn stamp_tasks(log_file: &str) {
+    if let Ok(mut m) = TASKS_STAMP.lock() {
+        m.insert(log_file.to_string(), now_ms());
+    }
+}
+
+/// Longest a task count may be served after the log has already moved on.
+///
+/// The `(size, mtime)` key alone is the right invalidation rule for the cheap
+/// derived fields, but it has a pathology on the expensive one: an ACTIVE agent
+/// appends every tick, so its key changes every tick and `log_tasks` — the
+/// heaviest item in `with_meta`, a 256KB terminal replay plus a scrollback dump
+/// bounded only by the emulator's 10k-row history — recomputes on every poll,
+/// for every viewer.
+///
+/// Task counts do not move at that rate. They change when a task transitions,
+/// not when a character is printed, so serving a slightly stale count between
+/// recomputes costs the console nothing observable while cutting the work by
+/// the ratio of this value to the poll tick. Bounded by wall clock rather than
+/// by a tick count so it does not scale with the number of connected viewers.
+const TASKS_MAX_STALE_MS: i64 = 15_000;
+
 /// Task progress from the rendered todo block. Reads a 256KB window (vs 32KB
 /// elsewhere) and keeps the WHOLE render — the latest block is often scrolled
 /// well back from the final rows.
@@ -369,9 +414,16 @@ fn log_tasks(log_file: Option<&str>) -> Value {
     if let Some(v) = json_cache_get(&TASKS_CACHE, log_file, size, mtime) {
         return v;
     }
+    // Key miss, i.e. the log grew. Recompute at most every TASKS_MAX_STALE_MS.
+    if let Some(v) = tasks_recent_enough(log_file) {
+        return v;
+    }
     let Some((size, mtime, lines)) = render_tail_lines(log_file, 256 * 1024, 0) else {
         return Value::Null;
     };
+    // Stamped on the compute path only, so the staleness clock measures time
+    // between real renders rather than time between calls.
+    stamp_tasks(log_file);
     json_cached(&TASKS_CACHE, log_file, size, mtime, || {
         crate::serve::meta::parse_task_counts(&lines)
             .map(|t| json!({ "done": t.done, "total": t.total }))

--- a/rs/src/serve/log_gc.rs
+++ b/rs/src/serve/log_gc.rs
@@ -1,0 +1,215 @@
+//! Periodic raw-log reclamation for logs whose WRITER cannot compact itself.
+//!
+//! `log_files::LogWriter` already caps its own file: past
+//! `COMPACT_TRIGGER_BYTES` it rewrites the log down to `COMPACT_KEEP_BYTES`.
+//! That covers every agent started by a binary containing this code — but not
+//! the ones that matter. Compaction shipped after some long-lived agents had
+//! already been exec'd, and a running process keeps the image it was loaded
+//! with: updating the on-disk binary does nothing for it, and it will never
+//! compact its own log no matter how large that log grows. One such writer, a
+//! full-screen TUI repainting roughly once a second, reached ~18 GB over eleven
+//! days and accounted for 96% of its state directory.
+//!
+//! Nothing in the writer can fix that, so the daemon does it from the outside:
+//! sweep the known log directories and apply the same in-place compaction to
+//! any raw log over the trigger, whoever wrote it.
+
+use crate::log_files::{compact_tail, global_dir, COMPACT_KEEP_BYTES, COMPACT_TRIGGER_BYTES};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+use tracing::info;
+
+/// How often the daemon sweeps for oversized logs.
+///
+/// This is a disk-reclamation backstop, not a hot path, and it only does real
+/// work when a file is actually over the trigger — otherwise it is a `read_dir`
+/// plus a `stat` per log. The interval bounds how far past the trigger a
+/// runaway writer can get: a log has to gain `TRIGGER - KEEP` (80 MiB) before
+/// it qualifies again, which at the ~28 KB/s of the observed runaway TUI takes
+/// close to an hour, so a 10-minute tick keeps the overshoot to a rounding
+/// error while staying far too infrequent to matter for load.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Directories that can hold raw logs: one per distinct agent cwd (raw logs are
+/// per-project — `<cwd>/.agent-yes/<pid>.raw.log`, see
+/// `log_files::project_log_dir`) plus the machine-global dir, which holds the
+/// logs of agents whose cwd is the home directory.
+fn log_dirs() -> Vec<PathBuf> {
+    let mut dirs: HashSet<PathBuf> = HashSet::new();
+    if let Some(g) = global_dir() {
+        dirs.insert(g);
+    }
+    for rec in crate::serve::api::read_records() {
+        if rec.cwd.is_empty() {
+            continue;
+        }
+        if let Some(d) = crate::log_files::project_log_dir(&rec.cwd) {
+            dirs.insert(d);
+        }
+    }
+    dirs.into_iter().collect()
+}
+
+/// Compact every oversized `*.raw.log` under `dirs`. Returns one
+/// `(path, before, after)` per file actually reclaimed, so the caller can log
+/// only when something happened.
+///
+/// Split out from the loop so tests can drive it against a tempdir without a
+/// runtime, a pid store, or a ten-minute wait.
+pub(crate) fn sweep_dirs(dirs: &[PathBuf]) -> Vec<(PathBuf, u64, u64)> {
+    let mut done = Vec::new();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue; // agent cwd deleted, or not readable — nothing to do
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.to_string_lossy().ends_with(".raw.log") {
+                continue;
+            }
+            let Ok(meta) = entry.metadata() else { continue };
+            if !meta.is_file() || meta.len() <= COMPACT_TRIGGER_BYTES {
+                continue;
+            }
+            let before = meta.len();
+            // Same in-place rewrite the writer uses: the inode is preserved, so
+            // a live follower (`/api/tail`, and the web console over WebRTC)
+            // resumes from the new frontier via its `size < offset` guard
+            // instead of being pinned to an unlinked file forever.
+            match compact_tail(&path, COMPACT_KEEP_BYTES) {
+                Ok(after) if after < before => done.push((path, before, after)),
+                _ => {}
+            }
+        }
+    }
+    done
+}
+
+/// Start the sweep loop. Fire-and-forget: a failure to reclaim disk must never
+/// take the daemon down, so every error is swallowed and retried next tick.
+pub fn spawn() {
+    tokio::spawn(async move {
+        loop {
+            // compact_tail reads and rewrites up to COMPACT_KEEP_BYTES, so this
+            // belongs on the blocking pool rather than an async worker.
+            let reclaimed = tokio::task::spawn_blocking(|| sweep_dirs(&log_dirs()))
+                .await
+                .unwrap_or_default();
+            // Silent when there is nothing to say. A per-tick line would grow
+            // this daemon's own log without bound, which is the exact failure
+            // this module exists to clean up after.
+            for (path, before, after) in reclaimed {
+                info!(
+                    "raw log compacted: {} {} -> {} bytes",
+                    path.display(),
+                    before,
+                    after
+                );
+            }
+            tokio::time::sleep(SWEEP_INTERVAL).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `compact_tail` only engages past COMPACT_TRIGGER_BYTES, so the fixtures
+    /// have to actually exceed it; keep the body cheap to generate.
+    fn write_sized(path: &std::path::Path, len: u64) {
+        let chunk = vec![b'x'; 1024 * 1024];
+        let mut f = std::fs::File::create(path).unwrap();
+        use std::io::Write;
+        let mut written = 0u64;
+        while written < len {
+            let n = chunk.len().min((len - written) as usize);
+            f.write_all(&chunk[..n]).unwrap();
+            written += n as u64;
+        }
+    }
+
+    #[cfg(unix)]
+    fn inode_of(path: &std::path::Path) -> u64 {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(path).unwrap().ino()
+    }
+
+    #[test]
+    fn sweeps_an_oversized_log_down_to_keep() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("1111.raw.log");
+        write_sized(&p, COMPACT_TRIGGER_BYTES + 8 * 1024 * 1024);
+        let done = sweep_dirs(&[dir.path().to_path_buf()]);
+        assert_eq!(done.len(), 1, "oversized log should have been reclaimed");
+        assert_eq!(
+            std::fs::metadata(&p).unwrap().len(),
+            COMPACT_KEEP_BYTES,
+            "compacted file should be exactly KEEP bytes"
+        );
+    }
+
+    #[test]
+    fn leaves_a_log_under_the_trigger_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("1111.raw.log");
+        write_sized(&p, 4 * 1024 * 1024);
+        let before = std::fs::read(&p).unwrap();
+        assert!(sweep_dirs(&[dir.path().to_path_buf()]).is_empty());
+        assert_eq!(
+            std::fs::read(&p).unwrap(),
+            before,
+            "an under-threshold log must not be modified at all"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preserves_the_inode_so_live_followers_are_not_frozen() {
+        // This is the whole reason compaction rewrites in place instead of
+        // temp-file + rename: a follower's fd stays bound to the old inode and
+        // would never see another append.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("1111.raw.log");
+        write_sized(&p, COMPACT_TRIGGER_BYTES + 4 * 1024 * 1024);
+        let before = inode_of(&p);
+        assert_eq!(sweep_dirs(&[dir.path().to_path_buf()]).len(), 1);
+        assert_eq!(inode_of(&p), before, "compaction must not swap the inode");
+    }
+
+    #[test]
+    fn ignores_non_raw_logs_and_missing_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let other = dir.path().join("notes.jsonl");
+        write_sized(&other, COMPACT_TRIGGER_BYTES + 1024 * 1024);
+        let len = std::fs::metadata(&other).unwrap().len();
+        let missing = dir.path().join("gone");
+        assert!(sweep_dirs(&[dir.path().to_path_buf(), missing]).is_empty());
+        assert_eq!(
+            std::fs::metadata(&other).unwrap().len(),
+            len,
+            "only *.raw.log is in scope"
+        );
+    }
+
+    #[test]
+    fn keeps_the_tail_not_the_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("1111.raw.log");
+        write_sized(&p, COMPACT_TRIGGER_BYTES + 2 * 1024 * 1024);
+        // Stamp a marker at the very end; the newest bytes are the ones the
+        // renderer needs, so they must survive.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new().append(true).open(&p).unwrap();
+            f.write_all(b"NEWEST-MARKER").unwrap();
+        }
+        assert_eq!(sweep_dirs(&[dir.path().to_path_buf()]).len(), 1);
+        let body = std::fs::read(&p).unwrap();
+        assert!(
+            body.ends_with(b"NEWEST-MARKER"),
+            "the trailing bytes must be preserved"
+        );
+    }
+}

--- a/rs/src/serve/mod.rs
+++ b/rs/src/serve/mod.rs
@@ -11,6 +11,7 @@ pub mod e2e;
 pub mod expose;
 pub mod graph;
 pub mod http;
+pub mod log_gc;
 pub mod meta;
 pub mod nego;
 pub mod service;


### PR DESCRIPTION
#422 の続き。残っていた 2 件。

## 1. raw ログの GC (`rs/src/serve/log_gc.rs` 新規)

`log_files::LogWriter` は自分の書くファイルを既に抑えている（`COMPACT_TRIGGER_BYTES` を超えたら `COMPACT_KEEP_BYTES` まで詰める）。問題は**これが書き手のプロセス内でしか効かない**こと。

compaction が入るより前に exec されたエージェントは、そのときのプロセスイメージを一生持ち続ける。ディスク上のバイナリを更新しても、そのプロセスは自分のログを永遠に詰めない。実際に、全画面を毎秒描き直す TUI が 11 日で約 18GB まで育ち、その state ディレクトリの 96% を占めた例がある。**書き手の中には直しようがない。**

そこで daemon 側から掃除する。

| | |
|---|---|
| 走査対象 | raw ログは **cwd ごと**（`<cwd>/.agent-yes/`）なので、pid レコードの distinct cwd + `global_dir()` |
| 間隔 | 10 分（`SWEEP_INTERVAL`）|
| 実装 | `compact_tail` を `pub(crate)` にして**共有**。再実装しない。閾値も既存定数をそのまま使い、数字を二重に持たない |
| 実行場所 | `spawn_blocking`（最大 80MiB を読んで書き戻すので async worker に置かない）|
| ログ | **回収できたときだけ**出す |

**in-place の意味は維持する。** 同じ inode を上書きして truncate するので live follower（`/api/tail`、WebRTC 経由の web console）は `size < offset` ガードで新しい先頭から再開できる。temp + rename は inode が変わって follower が二度と追記を見なくなるので使わない。

間隔が 10 分で足りる理由: 詰めた直後のファイルが再び対象になるには `TRIGGER - KEEP` = 80MiB 増える必要があり、観測された暴走 TUI の約 28KB/s でも 1 時間近くかかる。超過分は誤差に収まる。

ログを毎回出さないのも意図的で、毎 tick 出すとこの daemon 自身のログが際限なく育つ。それはまさにこのモジュールが後始末している失敗そのもの。

## 2. `log_tasks` の再計算を時間で間引く

`log_tasks` は `with_meta` の中で**単項最重量**。256KB の窓を端末エミュレータで再生し、スクロールバック全体（エミュレータの 1 万行履歴が上限）をダンプする。

キャッシュキーが `(size, mtime)` なので、**active なエージェントは毎 tick キーが変わり毎回フル再計算**していた。しかもビューア数だけ倍になる。

タスク数はその速度では動かない（文字が出るたびではなく、タスクが遷移したときに変わる）。`(size, mtime)` キャッシュの上に `TASKS_MAX_STALE_MS` = 15 秒の下限を足し、キーが変わっていても前回計算から 15 秒以内なら前の値を返す。**3 秒 tick に対して再計算は 1/5。** 壁時計で縛っているので接続ビューア数に比例して増えることもない。

`(size, mtime)` の契約と共有ヘルパ `json_cached` はそのままにするため、最終計算時刻は別マップ（`TASKS_STAMP`）に持つ。スタンプは**計算経路でのみ**更新するので、この時計は「呼ばれた間隔」ではなく「実際に描画した間隔」を測る。

### 採らなかった案

当初は `log_tasks` の**出力行数に上限**を入れるつもりだったが、`render_tail_lines` は `dump_scrollback` の**後**に行を切っているため、行数上限では重い vterm 再生を一切削減できない。効かない変更なので採らなかった。

窓を 256KB から縮めるのも行わない。doc comment にある「todo ブロックは後続出力に押し上げられていることが多い」という実際の理由があるため。

## テスト

`serve::log_gc` に 5 件追加:

- 閾値超えのログが KEEP ちょうどまで詰まる
- 閾値未満のログは **1 バイトも変わらない**（内容ごと比較）
- **inode が変わらない** — follower が凍らない保証そのものなので直接断言する
- `*.raw.log` 以外と存在しないディレクトリを無視する
- 残るのは先頭ではなく**末尾**（末尾にマーカーを書いて確認）

`cargo test --bin ayrs` は **194 passed / 0 failed**。

crate 全体では 308 passed / 1 failed。失敗する `cli::tests::test_supported_clis_count` は `origin/main` の素の状態でも同じく失敗する既存の不具合で（#422 で stash して確認済み）、本変更とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)