### PR TITLE
feat(ui): ルーム行にホストの CPU/メモリチップを右寄せで表示する

### DIFF
--- a/lab/ui/console-logic.js
+++ b/lab/ui/console-logic.js
@@ -171,6 +171,49 @@ export function gitLabel(e) {
   return parts.join(" ");
 }
 
+// ---- host resources (the room row's CPU/mem chip) ---------------------------
+
+// CPU as a share of the machine's cores. loadavg is a run-queue length, so on an
+// N-core box a load of N is exactly saturated = 100%; values above that are real
+// oversubscription and are deliberately NOT clamped — "320%" is the useful
+// signal. Null when the host didn't report enough to compute it.
+export function cpuPct(h) {
+  const load = h?.loadavg?.[0];
+  return h?.cpus && Number.isFinite(load) ? Math.round((load / h.cpus) * 100) : null;
+}
+
+// Memory USED as a share of total. Prefers `available` over `free`: on macOS
+// `free` counts only wholly-free pages and ignores reclaimable inactive ones, so
+// it reads as ~99% used on a perfectly healthy machine (the two differ by ~20x
+// in practice). Falls back to `free` for daemons that don't send `available`.
+export function memPct(h) {
+  const total = h?.mem?.total;
+  if (!total) return null;
+  const avail = Number.isFinite(h.mem.available) ? h.mem.available : h.mem.free;
+  return Number.isFinite(avail) ? Math.round(((total - avail) / total) * 100) : null;
+}
+
+// Label + severity for a room's resource chip, given every host serving it. A
+// room can hold several machines (a codehost room) and one number cannot
+// honestly describe N of them, so the chip reports the WORST and the caller's
+// tooltip breaks it down per host.
+//
+// Returns { label, warn }. An EMPTY label means "render nothing" — a daemon that
+// stubs mem to 0 and reports no loadavg must not leave a stray empty chip.
+// `warn` marks genuine pressure: at or past core saturation, or memory nearly
+// exhausted — same "only shout when it means something" rule as the git chip.
+export function resLabel(stats) {
+  const list = (stats || []).filter(Boolean);
+  const cpus = list.map(cpuPct).filter((v) => v !== null);
+  const mems = list.map(memPct).filter((v) => v !== null);
+  const cpu = cpus.length ? Math.max(...cpus) : null;
+  const mem = mems.length ? Math.max(...mems) : null;
+  const label = [cpu === null ? "" : `cpu ${cpu}%`, mem === null ? "" : `mem ${mem}%`]
+    .filter(Boolean)
+    .join(" · ");
+  return { label, warn: (cpu !== null && cpu >= 100) || (mem !== null && mem >= 90) };
+}
+
 // Task-progress badge ("2/5") from the agent's parsed todo block (e.tasks =
 // { done, total }, computed live in /api/ls). Empty string when no todo block was
 // confidently detected — the badge is omitted entirely, never shown as "0/0".

--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -799,6 +799,20 @@
         font-family: var(--mono);
         font-size: 10.5px;
       }
+      /* Host CPU/mem chip on a room row. Same visual language as the agent rows'
+         git chip — mono, muted, amber only once the machine is actually under
+         pressure — so a healthy fleet stays quiet and a loaded one stands out.
+         `.rname` above is flex:1, so this needs no margin to sit right-aligned. */
+      .rooms .res {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--muted);
+        white-space: nowrap;
+        flex: none;
+      }
+      .rooms .res.warn {
+        color: var(--amber);
+      }
       .rooms .rx {
         color: var(--muted);
         cursor: pointer;
@@ -2506,6 +2520,9 @@
         sortEntries,
         SORT_MODES,
         taskLabel,
+        cpuPct,
+        memPct,
+        resLabel,
         badgesFor,
         advanceStdinFlashes,
         focusSummary,
@@ -8138,6 +8155,70 @@ my.translate = async (text, lang) => {
         return `<span class="rstat on" title="${c} live ${c === 1 ? "server" : "servers"}">● ${c}</span>`;
       }
 
+      // ---- per-room host resources (CPU / memory) --------------------------
+      // GET /api/host per source, cached by source id. Polled ONLY while the
+      // rooms panel is open: the numbers are just a readout, so an unopened
+      // panel must cost the fleet nothing. Older daemons that 404 simply never
+      // populate an entry and render no chip.
+      const hostStats = new Map(); // source id -> /api/host body
+      const HOST_POLL_MS = 15_000; // machine load moves slowly; don't be chatty
+      let hostPollTimer = null;
+
+      async function pollHostStats() {
+        const live = [...sources.values()].filter((s) => s.tx && s.live);
+        const got = await Promise.allSettled(
+          live.map(async (s) => [s.id, await s.tx.fetchJSON("/api/host")]),
+        );
+        let changed = false;
+        for (const p of got) {
+          if (p.status !== "fulfilled" || !p.value?.[1]) continue;
+          hostStats.set(p.value[0], p.value[1]);
+          changed = true;
+        }
+        if (changed) renderRoomsIfOpen();
+      }
+
+      function startHostPoll() {
+        if (hostPollTimer) return;
+        pollHostStats(); // paint on open rather than after the first interval
+        hostPollTimer = setInterval(pollHostStats, HOST_POLL_MS);
+      }
+      function stopHostPoll() {
+        clearInterval(hostPollTimer);
+        hostPollTimer = null;
+      }
+
+      const gb = (b) => (b / 1024 ** 3).toFixed(1) + "G";
+
+      // The room row's right-aligned CPU/mem chip. Label/severity come from
+      // resLabel (console-logic.js, unit-tested); this only builds the markup
+      // and the per-host tooltip breakdown.
+      function resChipHtml(name) {
+        const stats = roomSources(name)
+          .map((s) => hostStats.get(s.id))
+          .filter(Boolean);
+        if (!stats.length) return "";
+        const { label, warn } = resLabel(stats);
+        if (!label) return "";
+        const tip = stats
+          .map((h) => {
+            const c = cpuPct(h);
+            const m = memPct(h);
+            const load = (h.loadavg || []).map((n) => n.toFixed(2)).join(" ");
+            return (
+              `${h.host || "?"} · ${h.platform || "?"}/${h.arch || "?"} · ${h.cpus || "?"} cpus\n` +
+              `  load ${load}${c === null ? "" : ` (${c}% of cores)`}\n` +
+              (h.mem?.total
+                ? `  mem ${m === null ? "?" : m + "% used"} of ${gb(h.mem.total)}\n`
+                : "") +
+              (h.uptime ? `  up ${Math.floor(h.uptime / 3600)}h` : "")
+            );
+          })
+          .join("\n");
+        const multi = stats.length > 1 ? ` (worst of ${stats.length} machines)` : "";
+        return `<span class="res${warn ? " warn" : ""}" title="${esc(tip + multi)}">${esc(label)}</span>`;
+      }
+
       function renderRooms() {
         const r = loadRooms();
         const names = Object.keys(r).sort((a, b) => r[b].ts - r[a].ts);
@@ -8148,6 +8229,7 @@ my.translate = async (text, lang) => {
           ${roomStatus(n)}
           <span class="rname" data-room="${esc(n)}">${esc(n)}</span>
           <span class="rhost">${esc(r[n].host)}</span>
+          ${resChipHtml(n)}
           <span class="rx" data-del="${esc(n)}" title="forget">✕</span></div>`,
               )
               .join("")
@@ -8170,7 +8252,11 @@ my.translate = async (text, lang) => {
           renderRooms();
           el.style.display = "block";
           $("roomin")?.focus();
-        } else el.style.display = "none";
+          startHostPoll(); // CPU/mem chips only cost anything while visible
+        } else {
+          el.style.display = "none";
+          stopHostPoll();
+        }
       });
       $("rooms").addEventListener("click", (ev) => {
         const name = ev.target.closest(".rname");

--- a/tests/ui-logic/console-logic.spec.ts
+++ b/tests/ui-logic/console-logic.spec.ts
@@ -9,6 +9,9 @@ import {
   ident,
   tagsFor,
   gitLabel,
+  cpuPct,
+  memPct,
+  resLabel,
   age,
   matches,
   nextIndex,
@@ -1166,5 +1169,63 @@ describe("createInputSender", () => {
     input.push("b");
     await waitFor(() => sent.length === 2, "the next keystroke to go out anyway");
     expect(sent).toEqual(["a", "b"]);
+  });
+});
+
+describe("cpuPct / memPct / resLabel — the room row's resource chip", () => {
+  const host = (o = {}) => ({ cpus: 10, loadavg: [5, 5, 5], mem: { total: 1000, free: 500 }, ...o });
+
+  it("reads loadavg as a share of cores, and does NOT clamp oversubscription", () => {
+    expect(cpuPct(host({ loadavg: [5, 0, 0], cpus: 10 }))).toBe(50);
+    expect(cpuPct(host({ loadavg: [10, 0, 0], cpus: 10 }))).toBe(100);
+    // Load above core count is real oversubscription and is the useful signal.
+    expect(cpuPct(host({ loadavg: [32, 0, 0], cpus: 10 }))).toBe(320);
+  });
+
+  it("returns null for cpu when the host reported too little to compute it", () => {
+    expect(cpuPct(host({ cpus: 0 }))).toBe(null);
+    expect(cpuPct(host({ loadavg: [] }))).toBe(null);
+    expect(cpuPct(undefined)).toBe(null);
+  });
+
+  it("prefers mem.available over mem.free, which otherwise reads as ~99% used", () => {
+    // The macOS case that motivated `available`: almost nothing is wholly FREE,
+    // but most of it is reclaimable, so `free` alone would cry wolf.
+    const macish = { cpus: 1, loadavg: [0, 0, 0], mem: { total: 1000, free: 5, available: 400 } };
+    expect(memPct(macish)).toBe(60);
+    // Older daemons send no `available` — fall back rather than render nothing.
+    expect(memPct({ cpus: 1, loadavg: [0, 0, 0], mem: { total: 1000, free: 400 } })).toBe(60);
+  });
+
+  it("returns null for mem when the daemon stubs total to 0", () => {
+    expect(memPct(host({ mem: { total: 0, free: 0 } }))).toBe(null);
+  });
+
+  it("renders whichever halves are available, and nothing at all when neither is", () => {
+    expect(resLabel([host()]).label).toBe("cpu 50% · mem 50%");
+    // A daemon with real loadavg but stubbed memory: cpu only, no stray dot.
+    expect(resLabel([host({ mem: { total: 0, free: 0 } })]).label).toBe("cpu 50%");
+    // Nothing computable at all must render NO chip, not an empty one.
+    expect(resLabel([{ cpus: 0, mem: { total: 0 } }]).label).toBe("");
+    expect(resLabel([]).label).toBe("");
+    expect(resLabel(undefined).label).toBe("");
+  });
+
+  it("reports the WORST machine when a room holds several", () => {
+    const calm = host({ loadavg: [1, 0, 0], mem: { total: 1000, available: 900 } });
+    const busy = host({ loadavg: [9, 0, 0], mem: { total: 1000, available: 200 } });
+    expect(resLabel([calm, busy]).label).toBe("cpu 90% · mem 80%");
+    expect(resLabel([busy, calm]).label).toBe("cpu 90% · mem 80%"); // order-independent
+  });
+
+  it("warns only at real pressure — core saturation or near-exhausted memory", () => {
+    expect(resLabel([host()]).warn).toBe(false);
+    expect(resLabel([host({ loadavg: [10, 0, 0] })]).warn).toBe(true); // load == cores
+    expect(resLabel([host({ mem: { total: 1000, available: 100 } })]).warn).toBe(true); // 90% used
+    expect(resLabel([host({ mem: { total: 1000, available: 150 } })]).warn).toBe(false); // 85%
+  });
+
+  it("ignores hosts that have not reported yet instead of throwing", () => {
+    expect(resLabel([null, undefined, host()]).label).toBe("cpu 50% · mem 50%");
   });
 });


### PR DESCRIPTION
左パネルのルーム一覧の各行に、そのルームを提供しているマシンの CPU / メモリ使用率を出す。エージェント行の git チップと同じ位置（右寄せ）・同じ見た目（mono・muted・逼迫時だけ amber）に揃えた。`.rname` が `flex: 1` なので余分な margin なしでそのまま右端に寄る。

```
● 1  <room>            <sighost>        cpu 198%   ✕
```

## 判断したこと

- **CPU はコア数に対する比**。loadavg はランキュー長なので N コアでロード N はちょうど飽和 = 100%。それを超える値は実際の過剰負荷なので**意図的にクランプしない** — 「320%」という表示そのものが有用な信号。
- **メモリは `available` 優先・`free` フォールバック**。macOS の `free` は完全に空いたページしか数えず回収可能な inactive を無視するため、健全なマシンでも「99% 使用」に見える（実測で両者は 20 倍近く違う）。`available` を持たない古い daemon 向けにフォールバックを残す。
- **1 ルームに複数マシン（codehost ルーム）のときは最悪値**。1 つの数値で N 台を正直に表現することはできないので、チップは最悪値・tooltip でホストごとの内訳。
- **出せる情報が何も無いときはチップ自体を描かない**。空のチップを残さない。
- amber はコア飽和（load ≥ cores）かメモリ 90% 以上のときだけ。git チップと同じ「意味があるときだけ主張する」規則。

## ポーリング

`/api/host` をソースごとに取得しソース id でキャッシュ。取得は**ルームパネルが開いている間だけ**（`startHostPoll` / `stopHostPoll`）。単なる読み取り表示のために、閉じているパネルの分までフリートへリクエストを投げる理由がない。間隔は 15 秒（マシン負荷はその程度でしか動かない）。`/api/host` を持たない古い daemon は 404 になりエントリが埋まらないので、チップが出ないだけで済む。

## 既知の制限（別 PR で解消予定）

Rust 版 daemon の `/api/host` は現状 `mem` を `{total: 0, free: 0}` とハードコードしており、実測値を返すのは TS 版だけ。そのため Rust ホストに対しては当面 **CPU のみ**表示される（メモリ側は「出せないものは描かない」規則で自然に省略）。

実機確認済み: load 44.79 / 18 コアのホストに対し `cpu 249%` が amber で描画され、tooltip は `load 44.79 42.25 34.49 (249% of cores)`、メモリ行は出ない。

## テスト

ロジックを `lab/ui/console-logic.js` に置き（`cpuPct` / `memPct` / `resLabel`）、DOM 組み立てだけを `index.html` に残した — 既存の `gitLabel` / `gitChipHtml` の分け方に合わせている。

`tests/ui-logic/console-logic.spec.ts` に 7 件追加:

- コア比の算出と、過剰負荷をクランプしないこと
- 情報不足のときに null を返すこと
- `available` 優先と `free` フォールバック
- `total: 0` をスタブする daemon で mem が null になること
- 片方しか出せないとき片方だけ描き、両方無いときは何も描かないこと
- 複数マシンで最悪値を採り、順序に依存しないこと
- amber の境界（load == cores / メモリ 90%）

`tests/ui-logic` は **138 passed / 0 failed**。

実ブラウザ検証は rech で実施し、チップが `.rhost` の後・`✕` の前に入ること（右寄せ）、amber クラスが付くこと、tooltip がホストごとの内訳になることを DOM 上で確認した。

なお `lab/ui/console-logic.js` の oxlint warning 2 件は `origin/main` の時点で既に出ているもので、本変更とは無関係（行 667 / 725、追加箇所から離れている）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)