### PR TITLE
fix(ui): 未実装だった `/new` オムニコマンドを実装する

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -7206,6 +7206,11 @@ my.translate = async (text, lang) => {
         // in runOmni before this builder runs. Needs no anchor: workspaces exist
         // independently of any open agent.
         if ("ws".startsWith(cmdTerm)) rows.push({ kind: "wshint" });
+        // "/new" — the same spawn form the "+ New agent" button opens, reachable
+        // from the palette. Global like /ws and /filter: spawning needs no open
+        // agent (showNew prefills from the selection when there happens to be
+        // one), so it is offered unconditionally.
+        if ("new".startsWith(cmdTerm)) rows.push({ kind: "new" });
         // "/filter [tokens…]" — global: sets the left panel's filter box (#q) to the
         // arguments, same tokens the box itself takes (space = AND, repo:x tags).
         // With no args it clears the filter. Needs no anchor agent — it acts on the
@@ -7463,6 +7468,14 @@ my.translate = async (text, lang) => {
                   <div class="omni-sub">browse every workspace on the fleet — spawn into idle checkouts &nbsp;·&nbsp; ⏎ to open</div>
                 </div></div>`;
             }
+            if (r.kind === "new") {
+              return `<div class="omni-row omni-spawn${sc}" data-i="${i}">
+                <span class="dot active"></span>
+                <div class="omni-main">
+                  <div class="omni-title">＋ New agent <span style="opacity:.55">/new</span></div>
+                  <div class="omni-sub">open the spawn form — pick host, working dir and CLI &nbsp;·&nbsp; ⏎ to open</div>
+                </div></div>`;
+            }
             if (r.kind === "wsinfo") {
               return `<div class="omni-row${sc}" data-i="${i}">
                 <div class="omni-main"><div class="omni-sub">${esc(r.text)}</div></div></div>`;
@@ -7717,6 +7730,15 @@ my.translate = async (text, lang) => {
           $("omni-input").value = "/ws ";
           runOmni();
           return; // stays open — the browser replaces the command list
+        }
+        // "/new" — hand off to the very same opener the "+ New agent" button
+        // uses, so the form (host default, cwd prefill, CLI chain) behaves
+        // identically however it was reached. Closes the palette first: the
+        // spawn form is a modal of its own, not a narrowing of the command list.
+        if (row && row.kind === "new") {
+          closeOmni(false);
+          showNew();
+          return;
         }
         if (row && row.kind === "wsinfo") return; // informational, not activatable
         if (row && row.kind === "ws") {


### PR DESCRIPTION
## main が壊れています（`ui-dom` は required check）

`fd76403`（test(ui-dom): add /new omni-command test）が**テスト側だけ先に入っており**、期待行数を 4 → 5 に上げて `toContain("new")` を追加したのに、`/new` コマンド自体が実装されていない。

`omniCommandRows` が返すのは restart / kill / fork / ws / filter の 5 種類だが、ui-dom の fixture のエージェントは git 情報を持たないため `/fork` は**正しく**省かれ、実際には 4 行しか出ない → `expected 4 to be 5`。

結果として `ui-dom` が main 上で恒常的に赤。`ui-dom` は required check なので、**UI に触る PR は全部マージできない状態**だった。

Rust だけの PR で気付かれなかったのは、`ui-dom` が UI 非変更の PR では **skip-pass する**（4 秒で pass）ため。直近の PR がたまたま Rust 側ばかりだったので隠れていた。

## 直し方

テストが記述している通りに実装する。`/new` は「+ New agent」ボタンと**同じ** `showNew()` を呼ぶ — フォームの挙動（ホストの既定値・cwd の prefill・CLI の選択チェーン）をどちらの入口から来ても同一にするため、ロジックを複製しない。

パレットは先に閉じる。spawn フォームはコマンド一覧の絞り込みではなく独立したモーダルなので、`/ws` のように「開いたまま置き換える」挙動は誤読になる。

`/ws` や `/filter` と同じく**グローバル扱い**にした。spawn は開いているエージェントを必要とせず（`showNew` は選択があればそこから prefill するだけ）、アンカーが無くても意味を持つため。

## テスト

`tests/ui-dom` は **28 passed / 1 failed**。

残る 1 件（`New-agent form provisions from a picked repo/branch`）は**このマシンの高負荷でのみ落ちるローカル既知の flake** で、本 PR とは無関係。根拠: 同じ 1 件は `origin/main` の素の状態（`59bbcf7` および `6b261d5`）でもローカルで同様に落ちる一方、**CI 側の失敗は `/new` の 1 件だけ**だった（CI ログも `1 failed | 28 passed`）。CI で判定されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)