### PR TITLE
feat(ps): CWD 列と、`--tree` でのプロセス単位の内訳を追加する

### DIFF
--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -424,6 +424,16 @@ describe("subtreeTotals", () => {
     expect(out[2]).toMatchObject({ rss: 300 });
   });
 
+  it("skips a row whose stats are missing rather than throwing", () => {
+    // Defensive: the sampler can miss an agent that exited mid-window, and a
+    // rollup must not take the whole table down with it.
+    const missing = { depth: 1, stats: undefined as unknown as ReturnType<typeof stats> };
+    const out = subtreeTotals([n(0, 1, 0, 1), missing, n(1, 4, 0, 1)]);
+    expect(out[0]).toMatchObject({ rss: 5 }); // descendants: skipped + counted
+    // And a row whose OWN stats are missing yields null instead of throwing.
+    expect(subtreeTotals([missing])).toEqual([null]);
+  });
+
   it("treats a missing depth as a root", () => {
     const out = subtreeTotals([{ stats: { pid: 1, rss: 1, cpuPercent: 0, procs: 1 } }, n(1, 2, 0, 1)]);
     expect(out[0]).toMatchObject({ rss: 3 });
@@ -462,6 +472,31 @@ describe("renderTable --tree", () => {
     expect(out).toContain("bash");
     // A zombie is called out — it is the one process state worth acting on.
     expect(out).toContain("zombie");
+  });
+
+  it("renders a tree row that has no prefix at all (a lone root)", () => {
+    // prefix/depth are optional on PsRow; a row built without them must still
+    // render, and must not gain a stray indent.
+    const bare = [{ ...treeRows[0]!, subtree: null }];
+    const out = renderTable(bare, null, { tree: true });
+    const line = out.split("\n").find((l) => l.startsWith("1 ")) as string;
+    expect(line).toBeTruthy();
+  });
+
+  it("indents process rows relative to their agent's rails", () => {
+    const kid = { pid: 9, ppid: 1, comm: "zsh", rss: 1, cpuPercent: 0, state: "S" };
+    const nested = renderTable(
+      [{ ...treeRows[0]!, depth: 1, prefix: "└─ ", subtree: null, procRows: [kid] }],
+      null,
+      { tree: true },
+    );
+    const root = renderTable([{ ...treeRows[0]!, subtree: null, procRows: [kid] }], null, {
+      tree: true,
+    });
+    const indentOf = (out: string) =>
+      (out.split("\n").find((l) => l.includes("zsh")) as string).match(/^ */)![0].length;
+    // A nested agent's processes sit deeper than a root agent's.
+    expect(indentOf(nested)).toBeGreaterThan(indentOf(root));
   });
 
   it("adds the Σ columns and renders forest rails on the PID cell", () => {

--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -8,9 +8,10 @@ import {
   readPpidSync,
   renderTable,
   repoLabel,
+  subtreeTotals,
   type PsRow,
 } from "./cmdPs.ts";
-import type { SystemStats, TreeStats } from "./procStats.ts";
+import type { ProcRow, SystemStats, TreeStats } from "./procStats.ts";
 
 const stats = (over: Partial<TreeStats> = {}): TreeStats => ({
   pid: 1,
@@ -151,11 +152,13 @@ const fixture: {
   trees: Map<number, TreeStats>;
   unattributed: TreeStats;
   system: SystemStats;
+  members: Map<number, ProcRow[]>;
 } = {
   records: [],
   trees: new Map(),
   unattributed: { pid: 0, rss: 0, cpuPercent: 0, procs: 0 },
   system: sys(),
+  members: new Map(),
 };
 
 vi.mock("./subcommands.ts", () => ({
@@ -172,6 +175,7 @@ vi.mock("./procStats.ts", async () => {
     sampleTrees: vi.fn(async () => ({
       trees: fixture.trees,
       unattributed: fixture.unattributed,
+      members: fixture.members ?? new Map(),
     })),
   };
 });
@@ -385,5 +389,91 @@ describe("parsePpidFromStat", () => {
   it("returns null when the ppid field is missing or not a number", () => {
     expect(parsePpidFromStat("1234 (bash) S")).toBeNull();
     expect(parsePpidFromStat("1234 (bash) S notanumber 1234")).toBeNull();
+  });
+});
+
+describe("subtreeTotals", () => {
+  const n = (depth: number, rss: number, cpu: number, procs: number) => ({
+    depth,
+    stats: { pid: depth * 1000 + rss, rss, cpuPercent: cpu, procs },
+  });
+
+  it("returns null for a row with no descendants, so leaves render blank", () => {
+    expect(subtreeTotals([n(0, 10, 1, 1)])).toEqual([null]);
+  });
+
+  it("rolls a parent up with its children", () => {
+    const [parent, a, b] = subtreeTotals([n(0, 10, 1, 2), n(1, 5, 2, 3), n(1, 1, 4, 1)]);
+    expect(parent).toMatchObject({ rss: 16, cpuPercent: 7, procs: 6 });
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+  });
+
+  it("includes grandchildren in the grandparent's total", () => {
+    // sampleTrees attributes exclusively, so without the deep walk a fan-out
+    // parent's real cost stays invisible.
+    const out = subtreeTotals([n(0, 1, 1, 1), n(1, 2, 2, 2), n(2, 4, 4, 4)]);
+    expect(out[0]).toMatchObject({ rss: 7, cpuPercent: 7, procs: 7 });
+    expect(out[1]).toMatchObject({ rss: 6, cpuPercent: 6, procs: 6 });
+    expect(out[2]).toBeNull();
+  });
+
+  it("stops at the next sibling — one subtree never absorbs another", () => {
+    const out = subtreeTotals([n(0, 1, 0, 1), n(1, 2, 0, 1), n(0, 100, 0, 1), n(1, 200, 0, 1)]);
+    expect(out[0]).toMatchObject({ rss: 3 });
+    expect(out[2]).toMatchObject({ rss: 300 });
+  });
+
+  it("treats a missing depth as a root", () => {
+    const out = subtreeTotals([{ stats: { pid: 1, rss: 1, cpuPercent: 0, procs: 1 } }, n(1, 2, 0, 1)]);
+    expect(out[0]).toMatchObject({ rss: 3 });
+  });
+});
+
+describe("renderTable --tree", () => {
+  const treeRows = [
+    row({ pid: 1, repo: "alpha", stats: stats({ rss: 100, cpuPercent: 1, procs: 2 }) }),
+    row({ pid: 2, repo: "alpha", stats: stats({ rss: 50, cpuPercent: 2, procs: 1 }) }),
+  ];
+
+  it("omits the Σ columns entirely in flat mode", () => {
+    const out = renderTable(treeRows, null);
+    expect(out).not.toContain("ΣCPU%");
+    expect(out).not.toContain("ΣRSS");
+  });
+
+  it("lists each agent's OS processes under it, but only in tree mode", () => {
+    const withProcs = [
+      {
+        ...treeRows[0]!,
+        depth: 0,
+        prefix: "",
+        procRows: [
+          { pid: 11, ppid: 1, comm: "claude", rss: 1024, cpuPercent: 2, state: "S" },
+          { pid: 12, ppid: 11, comm: "bash", rss: 512, cpuPercent: 0, state: "S" },
+          { pid: 13, ppid: 11, comm: "gone", rss: 0, cpuPercent: 0, state: "Z" },
+        ],
+      },
+    ];
+    const flat = renderTable(withProcs, null);
+    expect(flat).not.toContain("bash"); // flat mode stays a one-row-per-agent table
+    const out = renderTable(withProcs, null, { tree: true });
+    expect(out).toContain("claude");
+    expect(out).toContain("bash");
+    // A zombie is called out — it is the one process state worth acting on.
+    expect(out).toContain("zombie");
+  });
+
+  it("adds the Σ columns and renders forest rails on the PID cell", () => {
+    const withTree = [
+      { ...treeRows[0]!, depth: 0, prefix: "", subtree: stats({ rss: 150, cpuPercent: 3, procs: 3 }) },
+      { ...treeRows[1]!, depth: 1, prefix: "└─ ", subtree: null },
+    ];
+    const out = renderTable(withTree, null, { tree: true });
+    expect(out).toContain("ΣCPU%");
+    const child = out.split("\n").find((l) => l.includes("└─ 2")) as string;
+    expect(child).toBeTruthy();
+    // A leaf's Σ cells stay blank — repeating its own numbers would be noise.
+    expect(child).not.toMatch(/\s3\s/);
   });
 });

--- a/ts/cmdPs.ts
+++ b/ts/cmdPs.ts
@@ -21,6 +21,7 @@ import yargs from "yargs";
 import { buildAgentForest, flattenForest } from "./agentTree.ts";
 import {
   humanBytes,
+  type ProcRow,
   sampleTrees,
   snapshotProcs,
   systemStats,
@@ -85,8 +86,57 @@ export interface PsRow {
   status: string;
   cwd: string;
   repo: string;
+  /** This agent's OWN cost, exclusive of any nested agent (see sampleTrees). */
   stats: TreeStats;
   self: boolean;
+  /** `├─ `/`└─ ` rails from the agent forest. Empty outside --tree. */
+  prefix?: string;
+  /** Depth in the agent forest; 0 for roots. */
+  depth?: number;
+  /**
+   * This agent's cost PLUS every descendant agent's. Set only in --tree mode,
+   * and only for rows that actually have descendants — a leaf's subtree IS its
+   * own row, so repeating the numbers would be noise.
+   */
+  subtree?: TreeStats | null;
+  /**
+   * The OS processes this agent owns (wrapper, the CLI itself, its shells and
+   * pty hosts). Populated in --tree so the agent's number can be read as a sum
+   * of things you can actually point at.
+   */
+  procRows?: ProcRow[];
+}
+
+/**
+ * Roll each row up with its descendants, using the forest `depth` column: a
+ * row's descendants are the following rows with a strictly greater depth, up to
+ * the next row at or above its own level.
+ *
+ * Needed because sampleTrees attributes DEEPEST-FIRST and exclusively — a
+ * parent's own numbers deliberately omit its subagents, so without this a
+ * fan-out parent looks cheap while its real cost sits in rows below it.
+ *
+ * Returns null for a row with no descendants.
+ */
+export function subtreeTotals(rows: Pick<PsRow, "depth" | "stats">[]): (TreeStats | null)[] {
+  return rows.map((r, i) => {
+    const depth = r.depth ?? 0;
+    let rss = r.stats.rss;
+    let cpuPercent = r.stats.cpuPercent;
+    let procs = r.stats.procs;
+    let found = false;
+    for (let j = i + 1; j < rows.length; j++) {
+      const d = rows[j]?.depth ?? 0;
+      if (d <= depth) break; // left this row's subtree
+      const st = rows[j]?.stats;
+      if (!st) continue;
+      found = true;
+      rss += st.rss;
+      cpuPercent += st.cpuPercent;
+      procs += st.procs;
+    }
+    return found ? { pid: r.stats.pid, rss, cpuPercent, procs } : null;
+  });
 }
 
 function pad(s: string, n: number): string {
@@ -96,15 +146,27 @@ function padStart(s: string, n: number): string {
   return s.length >= n ? s : " ".repeat(n - s.length) + s;
 }
 
-export function renderTable(rows: PsRow[], unattributed: TreeStats | null): string {
+export function renderTable(
+  rows: PsRow[],
+  unattributed: TreeStats | null,
+  opts: { tree?: boolean } = {},
+): string {
+  const tree = opts.tree === true;
   const cells = rows.map((r) => ({
-    pid: String(r.pid),
+    // In tree mode the rails live on the PID cell, so the hierarchy reads down
+    // the left edge exactly like `ay ls`.
+    pid: (tree ? (r.prefix ?? "") : "") + String(r.pid),
     cli: r.cli,
     status: r.status,
     cpu: r.stats.cpuPercent.toFixed(1),
     rss: humanBytes(r.stats.rss),
     procs: String(r.stats.procs),
     repo: r.repo,
+    cwd: shortenPath(r.cwd),
+    // Σ columns: this agent plus its descendants. Blank for leaves.
+    scpu: r.subtree ? r.subtree.cpuPercent.toFixed(1) : "",
+    srss: r.subtree ? humanBytes(r.subtree.rss) : "",
+    sprocs: r.subtree ? String(r.subtree.procs) : "",
     self: r.self,
   }));
   // The unmanaged row participates in the width pass — "unmanaged" is wider than
@@ -118,6 +180,10 @@ export function renderTable(rows: PsRow[], unattributed: TreeStats | null): stri
       rss: humanBytes(unattributed.rss),
       procs: String(unattributed.procs),
       repo: "-",
+      cwd: "-",
+      scpu: "",
+      srss: "",
+      sprocs: "",
       self: false,
     });
   }
@@ -129,6 +195,9 @@ export function renderTable(rows: PsRow[], unattributed: TreeStats | null): stri
     rss: Math.max(5, ...cells.map((c) => c.rss.length)),
     procs: Math.max(5, ...cells.map((c) => c.procs.length)),
     repo: Math.max(4, ...cells.map((c) => c.repo.length)),
+    scpu: Math.max(5, ...cells.map((c) => c.scpu.length)),
+    srss: Math.max(5, ...cells.map((c) => c.srss.length)),
+    sprocs: Math.max(6, ...cells.map((c) => c.sprocs.length)),
   };
   const line = (
     pid: string,
@@ -138,18 +207,63 @@ export function renderTable(rows: PsRow[], unattributed: TreeStats | null): stri
     rss: string,
     procs: string,
     repo: string,
+    cwd: string,
+    scpu = "",
+    srss = "",
+    sprocs = "",
     tail = "",
   ) =>
     `${pad(pid, w.pid)}  ${pad(cli, w.cli)}  ${pad(status, w.status)}  ` +
     `${padStart(cpu, w.cpu)}  ${padStart(rss, w.rss)}  ${padStart(procs, w.procs)}  ` +
-    `${pad(repo, w.repo)}${tail}`;
+    // The Σ block only exists in tree mode, where a parent's own numbers exclude
+    // its subagents and are therefore misleading on their own.
+    (tree
+      ? `${padStart(scpu, w.scpu)}  ${padStart(srss, w.srss)}  ${padStart(sprocs, w.sprocs)}  `
+      : "") +
+    // REPO stays as the at-a-glance identity; CWD follows with the full path
+    // (home collapsed to ~) because sibling worktrees of one repo share a REPO
+    // label and are otherwise indistinguishable here. NOT width-padded: it is
+    // the last column, and paths run long enough (120 chars on a real fleet)
+    // that padding to the widest would trail ~100 blanks on every other row.
+    `${pad(repo, w.repo)}  ${cwd}${tail}`;
 
-  const out: string[] = [line("PID", "CLI", "STATUS", "CPU%", "RSS", "PROCS", "REPO")];
-  for (const c of cells) {
+  const out: string[] = [
+    line("PID", "CLI", "STATUS", "CPU%", "RSS", "PROCS", "REPO", "CWD", "ΣCPU%", "ΣRSS", "ΣPROCS"),
+  ];
+  cells.forEach((c, i) => {
     out.push(
-      line(c.pid, c.cli, c.status, c.cpu, c.rss, c.procs, c.repo, c.self ? "  ← this session" : ""),
+      line(
+        c.pid,
+        c.cli,
+        c.status,
+        c.cpu,
+        c.rss,
+        c.procs,
+        c.repo,
+        c.cwd,
+        c.scpu,
+        c.srss,
+        c.sprocs,
+        c.self ? "  ← this session" : "",
+      ),
     );
-  }
+    // The agent's own processes, one indent deeper than its rails. Rendered as
+    // a continuation of the row above rather than as table rows: they are a
+    // DIFFERENT kind of thing (an OS process, not an agent), and giving them
+    // the agent columns would invite reading a shell as a fifth agent.
+    const kids = rows[i]?.procRows;
+    if (!tree || !kids?.length) return;
+    const indent = " ".repeat((rows[i]?.prefix ?? "").length + 2);
+    const pw = Math.max(...kids.map((k) => String(k.pid).length));
+    const cw = Math.max(...kids.map((k) => k.comm.length));
+    for (const k of kids) {
+      out.push(
+        `${indent}· ${padStart(String(k.pid), pw)}  ${pad(k.comm, cw)}  ` +
+          `${padStart(k.cpuPercent.toFixed(1), 5)}  ${padStart(humanBytes(k.rss), 7)}` +
+          (k.state === "Z" ? "  zombie" : ""),
+      );
+    }
+  });
   return out.join("\n");
 }
 
@@ -176,7 +290,8 @@ export async function cmdPs(rest: string[]): Promise<number> {
     .option("tree", {
       type: "boolean",
       default: false,
-      description: "Keep ay ls's parent>child forest order instead of sorting",
+      description:
+        "Forest order with ├─ rails, plus Σ columns rolling each agent up with its subagents",
     })
     .option("interval", {
       type: "number",
@@ -187,6 +302,7 @@ export async function cmdPs(rest: string[]): Promise<number> {
     .option("help", { alias: "h", type: "boolean", default: false, description: "Show this help" })
     .example("ay ps", "biggest agents first, with box vitals")
     .example("ay ps --sort cpu", "who is actually burning CPU right now")
+    .example("ay ps --tree", "parent>child forest; Σ columns include each agent's subagents")
     .example("ay ps --json", "machine-readable rollup")
     .help(false)
     .version(false)
@@ -216,9 +332,10 @@ export async function cmdPs(rest: string[]): Promise<number> {
   // first-come, so sampling in that order would let a parent absorb a nested
   // agent's whole subtree and render the child as a bogus 0-proc row. Reverse to
   // claim deepest-first, then display in forest order.
-  const ordered = flattenForest(buildAgentForest(records)).map((r) => r.record);
+  const flat = flattenForest(buildAgentForest(records));
+  const ordered = flat.map((r) => r.record);
   const windowMs = Math.max(100, (Number.isFinite(argv.interval) ? argv.interval : 1) * 1000);
-  const { trees, unattributed } = await sampleTrees(
+  const { trees, unattributed, members } = await sampleTrees(
     [...ordered].reverse().map((r) => r.pid),
     { windowMs },
   );
@@ -227,7 +344,7 @@ export async function cmdPs(rest: string[]): Promise<number> {
     await Promise.all(ordered.map(async (r) => [r.pid, (await deriveLiveState(r)).state] as const)),
   );
   const selfPid = process.pid;
-  const rows: PsRow[] = ordered.map((r) => ({
+  const rows: PsRow[] = ordered.map((r, i) => ({
     pid: r.pid,
     cli: r.cli,
     status: states.get(r.pid) ?? r.status,
@@ -237,7 +354,21 @@ export async function cmdPs(rest: string[]): Promise<number> {
     // Mark the tree we are standing in — anything that later grows a kill
     // affordance must not let you shoot the session issuing the command.
     self: trees.get(r.pid) !== undefined && isSelfTree(r.pid, selfPid),
+    prefix: flat[i]?.prefix ?? "",
+    depth: flat[i]?.depth ?? 0,
   }));
+
+  // Only meaningful in forest order — sorting by rss would scatter descendants
+  // away from their parent and make a rollup describe the wrong span of rows.
+  if (argv.tree) {
+    const totals = subtreeTotals(rows);
+    rows.forEach((r, i) => {
+      r.subtree = totals[i] ?? null;
+      // Heaviest first: the reason to expand an agent is to find what inside it
+      // is costing something, and that is almost never the wrapper.
+      r.procRows = [...(members?.get(r.pid) ?? [])].sort((x, y) => y.rss - x.rss);
+    });
+  }
 
   if (!argv.tree) {
     const key = String(argv.sort);
@@ -281,7 +412,7 @@ export async function cmdPs(rest: string[]): Promise<number> {
 
   const header = formatSystemLine(sys);
   if (header) process.stdout.write(` ${header}\n\n`);
-  process.stdout.write(renderTable(rows, unattributed) + "\n");
+  process.stdout.write(renderTable(rows, unattributed, { tree: argv.tree === true }) + "\n");
   return 0;
 }
 

--- a/ts/cmdPs.ts
+++ b/ts/cmdPs.ts
@@ -121,9 +121,14 @@ export interface PsRow {
 export function subtreeTotals(rows: Pick<PsRow, "depth" | "stats">[]): (TreeStats | null)[] {
   return rows.map((r, i) => {
     const depth = r.depth ?? 0;
-    let rss = r.stats.rss;
-    let cpuPercent = r.stats.cpuPercent;
-    let procs = r.stats.procs;
+    // Guard the row's OWN stats the same way its descendants' are guarded
+    // below: the sampler can miss an agent that exited mid-window, and one
+    // absent entry must not take down the whole table.
+    const own = r.stats;
+    if (!own) return null;
+    let rss = own.rss;
+    let cpuPercent = own.cpuPercent;
+    let procs = own.procs;
     let found = false;
     for (let j = i + 1; j < rows.length; j++) {
       const d = rows[j]?.depth ?? 0;
@@ -135,7 +140,7 @@ export function subtreeTotals(rows: Pick<PsRow, "depth" | "stats">[]): (TreeStat
       cpuPercent += st.cpuPercent;
       procs += st.procs;
     }
-    return found ? { pid: r.stats.pid, rss, cpuPercent, procs } : null;
+    return found ? { pid: own.pid, rss, cpuPercent, procs } : null;
   });
 }
 

--- a/ts/procStats.spec.ts
+++ b/ts/procStats.spec.ts
@@ -53,6 +53,7 @@ describe("parseProcStat", () => {
     expect(s).toEqual({
       pid: 42,
       ppid: 7,
+      comm: "claude", // statLine's default
       rss: 10 * 4096,
       cpuSeconds: 2, // (150 + 50) ticks / 100 USER_HZ
       state: "S",
@@ -97,12 +98,37 @@ describe("parsePsTime", () => {
   });
 });
 
+describe("comm extraction", () => {
+  it("takes the comm from a stat line even when it holds spaces and parens", () => {
+    // The killer case: a comm containing ')' is why the field parse anchors on
+    // the LAST ')' — and the comm itself must span the FIRST '(' to that same
+    // anchor, or a name like "Web Content (1)" gets truncated.
+    const s = parseProcStat(9, statLine({ pid: 9, ppid: 1, comm: "Web Content (1)" }));
+    expect(s?.comm).toBe("Web Content (1)");
+    expect(s?.ppid).toBe(1); // fields after the comm still line up
+  });
+
+  it("keeps a plain comm intact", () => {
+    expect(parseProcStat(9, statLine({ pid: 9, ppid: 1, comm: "bash" }))?.comm).toBe("bash");
+  });
+});
+
 describe("parsePsTable", () => {
+  it("rejoins a comm that contains spaces, since it is the LAST column", () => {
+    const procs = parsePsTable("  10  1  2048  00:10 S /usr/bin/Google Chrome Helper\n");
+    expect(procs.get(10)?.comm).toBe("/usr/bin/Google Chrome Helper");
+    // The columns before it must be unaffected by those spaces.
+    expect(procs.get(10)?.rss).toBe(2048 * 1024);
+    expect(procs.get(10)?.state).toBe("S");
+  });
+
   it("normalizes ps KiB into bytes so both backends agree", () => {
     const procs = parsePsTable("  10  1  2048  00:10 S\n  11 10   512  00:00 Z\n");
     expect(procs.get(10)).toEqual({
       pid: 10,
       ppid: 1,
+      // This fixture predates the comm column; an absent one must read as "".
+      comm: "",
       rss: 2048 * 1024,
       cpuSeconds: 10,
       state: "S",
@@ -129,7 +155,7 @@ describe("descendantsOf", () => {
       ] as [number, number][]
     ).map(([pid, ppid]) => [
       pid,
-      { pid, ppid, rss: 0, cpuSeconds: 0, state: "S", startToken: `t${pid}` },
+      { pid, ppid, comm: "node", rss: 0, cpuSeconds: 0, state: "S", startToken: `t${pid}` },
     ]),
   );
   const kids = buildChildIndex(procs);
@@ -144,8 +170,8 @@ describe("descendantsOf", () => {
 
   it("terminates on a parent cycle instead of blowing the stack", () => {
     const cyclic = new Map<number, ProcSample>([
-      [1, { pid: 1, ppid: 2, rss: 0, cpuSeconds: 0, state: "S", startToken: "t1" }],
-      [2, { pid: 2, ppid: 1, rss: 0, cpuSeconds: 0, state: "S", startToken: "t2" }],
+      [1, { pid: 1, ppid: 2, comm: "node", rss: 0, cpuSeconds: 0, state: "S", startToken: "t1" }],
+      [2, { pid: 2, ppid: 1, comm: "node", rss: 0, cpuSeconds: 0, state: "S", startToken: "t2" }],
     ]);
     expect(descendantsOf(1, buildChildIndex(cyclic)).size).toBe(2);
   });
@@ -319,9 +345,9 @@ describe("parseMeminfo", () => {
 describe("systemStats", () => {
   it("reads load/mem and counts zombies from the snapshot", async () => {
     const procs = new Map<number, ProcSample>([
-      [1, { pid: 1, ppid: 0, rss: 0, cpuSeconds: 0, state: "S", startToken: "t1" }],
-      [2, { pid: 2, ppid: 1, rss: 0, cpuSeconds: 0, state: "Z", startToken: "t2" }],
-      [3, { pid: 3, ppid: 1, rss: 0, cpuSeconds: 0, state: "Z", startToken: "t3" }],
+      [1, { pid: 1, ppid: 0, comm: "node", rss: 0, cpuSeconds: 0, state: "S", startToken: "t1" }],
+      [2, { pid: 2, ppid: 1, comm: "node", rss: 0, cpuSeconds: 0, state: "Z", startToken: "t2" }],
+      [3, { pid: 3, ppid: 1, comm: "node", rss: 0, cpuSeconds: 0, state: "Z", startToken: "t3" }],
     ]);
     const sys = await systemStats(procs, {
       readSys: async (name) =>

--- a/ts/procStats.ts
+++ b/ts/procStats.ts
@@ -34,6 +34,8 @@ const execFileAsync = promisify(execFile);
 export interface ProcSample {
   pid: number;
   ppid: number;
+  /** Executable name (`bash`, `node`). May be a full path from the ps fallback. */
+  comm: string;
   /** Resident set size in bytes. */
   rss: number;
   /** Cumulative CPU (user+sys) in seconds since process start. */
@@ -113,6 +115,10 @@ export function parseProcStat(
 ): ProcSample | null {
   const close = stat.lastIndexOf(")");
   if (close < 0) return null;
+  // comm is field 2, wrapped in parens and free to contain spaces AND parens —
+  // hence first '(' to LAST ')', the same anchor the field parse below uses.
+  const open = stat.indexOf("(");
+  const comm = open >= 0 && open < close ? stat.slice(open + 1, close) : "";
   const f = stat
     .slice(close + 1)
     .trim()
@@ -128,6 +134,7 @@ export function parseProcStat(
   return {
     pid,
     ppid,
+    comm,
     rss: Number.isFinite(rssPages) ? rssPages * pageSizeBytes : 0,
     cpuSeconds: (utime + stime) / USER_HZ,
     state,
@@ -144,7 +151,7 @@ export interface ProcReaders {
   readStat?: (pid: number) => Promise<string | null>;
   /** Whole-file read of /proc/loadavg, /proc/meminfo, … or null. */
   readSys?: (name: string) => Promise<string | null>;
-  /** `ps -eo pid=,ppid=,rss=,time=,state=` output, for the non-Linux fallback. */
+  /** `ps -eo pid=,ppid=,rss=,time=,state=,comm=` output, for the non-Linux fallback. */
   readPsTable?: () => Promise<string | null>;
 }
 
@@ -183,7 +190,7 @@ export async function defaultReadSys(name: string): Promise<string | null> {
 
 export async function defaultReadPsTable(): Promise<string | null> {
   try {
-    const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid=,rss=,time=,state="], {
+    const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid=,rss=,time=,state=,comm="], {
       encoding: "utf8",
       timeout: 3000,
       maxBuffer: 16 * 1024 * 1024,
@@ -208,13 +215,20 @@ export function parsePsTime(raw: string): number {
   return seconds;
 }
 
-/** Parse the `ps -eo pid=,ppid=,rss=,time=,state=` fallback table. */
+/**
+ * Parse the `ps -eo pid=,ppid=,rss=,time=,state=,comm=` fallback table.
+ *
+ * comm is requested LAST on purpose: it can contain spaces (`Google Chrome
+ * Helper`), so anywhere else it would shift every column after it. Being last,
+ * everything from field 6 on is simply rejoined.
+ */
 export function parsePsTable(out: string): Map<number, ProcSample> {
   const procs = new Map<number, ProcSample>();
   for (const line of out.split("\n")) {
     const m = line.trim().split(/\s+/);
     if (m.length < 5) continue;
     const [pidS, ppidS, rssS, timeS, state] = m;
+    const comm = m.slice(5).join(" ");
     const pid = Number(pidS);
     const ppid = Number(ppidS);
     const rssKib = Number(rssS);
@@ -222,6 +236,7 @@ export function parsePsTable(out: string): Map<number, ProcSample> {
     procs.set(pid, {
       pid,
       ppid,
+      comm,
       // ps reports RSS in KiB; /proc gives bytes. Normalize to bytes so both
       // backends feed identical numbers into the rollup.
       rss: Number.isFinite(rssKib) ? rssKib * 1024 : 0,
@@ -303,6 +318,52 @@ export interface TreeStats {
   procs: number;
 }
 
+/** One OS process inside an agent's tree, as rendered by `ay ps --tree`. */
+export interface ProcRow {
+  pid: number;
+  ppid: number;
+  /** Executable basename — the full path from `ps -o comm=` is noise in a table. */
+  comm: string;
+  rss: number;
+  /** Percent of ONE core over the sample window. */
+  cpuPercent: number;
+  state: string;
+}
+
+/**
+ * Per-process detail for one claimed member set, same window and pid-reuse
+ * rules as `rollup` (see there for why a newcomer or a reused pid contributes
+ * no CPU delta).
+ */
+function memberRows(
+  members: Set<number>,
+  first: Map<number, ProcSample>,
+  second: Map<number, ProcSample>,
+  elapsedSeconds: number,
+): ProcRow[] {
+  const out: ProcRow[] = [];
+  for (const pid of members) {
+    const now = second.get(pid);
+    if (!now) continue;
+    const before = first.get(pid);
+    const reused =
+      before !== undefined &&
+      before.startToken !== "" &&
+      now.startToken !== "" &&
+      before.startToken !== now.startToken;
+    const delta = before && !reused ? Math.max(0, now.cpuSeconds - before.cpuSeconds) : 0;
+    out.push({
+      pid,
+      ppid: now.ppid,
+      comm: (now.comm || "").split(/[\\/]+/).filter(Boolean).pop() ?? "",
+      rss: now.rss,
+      cpuPercent: elapsedSeconds > 0 ? (delta / elapsedSeconds) * 100 : 0,
+      state: now.state,
+    });
+  }
+  return out;
+}
+
 function rollup(
   root: number,
   members: Set<number>,
@@ -360,7 +421,12 @@ function rollup(
 export async function sampleTrees(
   roots: number[],
   opts: { windowMs?: number; deps?: ProcReaders } = {},
-): Promise<{ trees: Map<number, TreeStats>; unattributed: TreeStats }> {
+): Promise<{
+  trees: Map<number, TreeStats>;
+  unattributed: TreeStats;
+  /** root pid → the OS processes claimed by that root, for --tree. */
+  members: Map<number, ProcRow[]>;
+}> {
   const windowMs = Math.max(100, opts.windowMs ?? 1000);
   // Measure the ACTUAL elapsed time, not the requested window: a loaded box (the
   // exact case this command is for) can oversleep by hundreds of ms, and
@@ -385,10 +451,12 @@ export async function sampleTrees(
   const kids = buildChildIndex(second);
   const claimed = new Set<number>();
   const trees = new Map<number, TreeStats>();
+  const memberRowsByRoot = new Map<number, ProcRow[]>();
   for (const root of roots) {
     const members = descendantsOf(root, kids, claimed);
     for (const pid of members) claimed.add(pid);
     trees.set(root, rollup(root, members, first, second, elapsedSeconds));
+    memberRowsByRoot.set(root, memberRows(members, first, second, elapsedSeconds));
   }
 
   // Everything ay does NOT manage, as one row. This is the answer to "is there
@@ -396,7 +464,11 @@ export async function sampleTrees(
   // box from one quietly hoarding orphans.
   const rest = new Set<number>();
   for (const pid of second.keys()) if (!claimed.has(pid)) rest.add(pid);
-  return { trees, unattributed: rollup(0, rest, first, second, elapsedSeconds) };
+  return {
+    trees,
+    unattributed: rollup(0, rest, first, second, elapsedSeconds),
+    members: memberRowsByRoot,
+  };
 }
 
 /** Whole-box vitals for the header line. */


### PR DESCRIPTION
`ay ps` に 3 つ足す。いずれも「このエージェントは何にいくら使っているか」を、実際に指させる単位まで下ろすため。

## 1. CWD 列

`PsRow` は最初から `cwd` を持っており `--json` でも出していたが、表には出していなかった。REPO は同一リポジトリの worktree を区別できない（`symval` が 20 行並ぶ）ので、フルパス（home は `~`）を併記する。

最終列なので**幅揃えのパディングはしない**。実フリートではパスが 119 文字に達し、最長に合わせると他の全行に約 100 個の空白が末尾に付く。

## 2. `--tree` の Σ 列

`--tree` はこれまで forest 順を保つだけで、木の描画も集計もしていなかった。

`sampleTrees` は**深い方から排他的に**帰属させるため、親の `CPU%`/`RSS` はサブエージェント分を意図的に含まない。結果、fan-out した親ほど「安く」見え、実際のコストは下の行に散らばる。

```
71939      claude  active  10.5  75.5Mi   4   13.4  163Mi  18   ← 自分 + 子孫
└─ 58286   codex   idle     1.0  37.0Mi   6    2.9  87.5Mi 14
   ├─ 87844 codex  idle     1.0  34.2Mi   5                     ← 葉は空
   └─ 84963 codex  idle     1.0  16.4Mi   3
```

- Σ 列は `--tree` のときだけ。RSS でソートすると子孫が親から離れ、集計が別の行範囲を指すことになる。
- 葉の Σ セルは空。葉のサブツリーは自分自身なので、同じ数字の繰り返しはノイズ。
- 集計は forest を歩き直さず `depth` 列から導く（子孫 = 自分より深い後続行、次の同階層行で打ち切り）。`listRecords` が forest 構築より前に絞り込むため、キーワードや `--cwd` で絞っても正しいまま。

## 3. `--tree` で OS プロセスまで展開する

本題。エージェントの数字は wrapper・CLI 本体・シェル・pty ホストの合計だが、その内訳が見えなかった。

`ProcSample` がコマンド名を保持していなかったのが原因。Linux の `/proc/<pid>/stat` は comm を**持っていながら捨てており**、macOS の `ps` フォールバックはそもそも要求していなかった。

```
4443   claude   active   8.1  247Mi   8         agent-yes  ~/repo/alpha
  ·  4459  claude       5.4  180Mi
  · 23146  bun          1.8  52.4Mi
  ·  4443  agent-yes    0.9   8.1Mi     ← wrapper
  · 23139  zsh          0.0   2.2Mi     ← シェル
```

判断:

- **`ps` の書式で `comm` は最後に置く**。`Google Chrome Helper` のように空白を含み得るため、途中に置くと後続の全列がずれる。最後なら 6 番目以降を再結合するだけで済む。
- **Linux の comm は最初の `(` から最後の `)` まで**。フィールド解析が最後の `)` を基準にしているのと同じ理由で、comm 自身が `)` を含み得る（`Web Content (1)`）。素朴な `indexOf(")")` では切れる。
- **プロセス行はテーブル行にしない**（`·` 始まり、エージェント列を持たない）。シェルはエージェントではなく、同じ列を与えると 5 つ目のエージェントとして読まれてしまう。
- **RSS の大きい順**。展開する動機は「中で何が食っているか」を探すことで、それは wrapper ではない。
- **zombie はその場で印を付ける**。対処する価値のある唯一の状態。

## 互換性

フラットな `ay ps` の出力は一切変えない（Σ 列もプロセス行も出ない）。実機で確認済み。

`--tree` は実フリートで 347 行（フラットは 75 行）になる。キーワードや `--cwd` での絞り込みは効くので、`ay ps --tree agent-yes` なら上の抜粋程度に収まる。それでも多すぎるようなら、プロセス展開を別フラグ（`--procs`）に分けて `--tree` はエージェント forest に留める案もある。

## テスト

**91 passed**。`subtreeTotals` は葉が null・親が子を合算・**孫まで祖父に載る**・兄弟のサブツリーを吸わない・depth 欠落はルート扱い、をカバー。comm は括弧と空白を含む名前を両バックエンドでカバー。プロセス行がフラットモードで出ないことと zombie 印もアサート。

なお `ts/procStats.spec.ts:424` の `utime` に関する tsc エラーは `origin/main` の時点で既に存在する既知のもので、本変更とは無関係（stash して確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)