### PR TITLE
feat(ps): プロセス展開を `--procs` として `--tree` から分離する

### DIFF
--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -452,7 +452,7 @@ describe("renderTable --tree", () => {
     expect(out).not.toContain("ΣRSS");
   });
 
-  it("lists each agent's OS processes under it, but only in tree mode", () => {
+  it("lists each agent's OS processes only when --procs asks for them", () => {
     const withProcs = [
       {
         ...treeRows[0]!,
@@ -465,9 +465,12 @@ describe("renderTable --tree", () => {
         ],
       },
     ];
-    const flat = renderTable(withProcs, null);
-    expect(flat).not.toContain("bash"); // flat mode stays a one-row-per-agent table
-    const out = renderTable(withProcs, null, { tree: true });
+    // Default: a one-row-per-agent table, whatever procRows happens to hold.
+    expect(renderTable(withProcs, null)).not.toContain("bash");
+    // --tree alone is the AGENT forest; it must not drag the processes in.
+    expect(renderTable(withProcs, null, { tree: true })).not.toContain("bash");
+    // --procs is what expands them, and works without --tree.
+    const out = renderTable(withProcs, null, { procs: true });
     expect(out).toContain("claude");
     expect(out).toContain("bash");
     // A zombie is called out — it is the one process state worth acting on.
@@ -483,15 +486,23 @@ describe("renderTable --tree", () => {
     expect(line).toBeTruthy();
   });
 
+  it("expands processes without --tree, with no forest indent to inherit", () => {
+    const kid = { pid: 9, ppid: 1, comm: "zsh", rss: 1, cpuPercent: 0, state: "S" };
+    const out = renderTable([{ ...treeRows[0]!, procRows: [kid] }], null, { procs: true });
+    expect(out).toContain("zsh");
+    expect(out).not.toContain("ΣCPU%"); // --procs alone adds no forest columns
+  });
+
   it("indents process rows relative to their agent's rails", () => {
     const kid = { pid: 9, ppid: 1, comm: "zsh", rss: 1, cpuPercent: 0, state: "S" };
     const nested = renderTable(
       [{ ...treeRows[0]!, depth: 1, prefix: "└─ ", subtree: null, procRows: [kid] }],
       null,
-      { tree: true },
+      { tree: true, procs: true },
     );
     const root = renderTable([{ ...treeRows[0]!, subtree: null, procRows: [kid] }], null, {
       tree: true,
+      procs: true,
     });
     const indentOf = (out: string) =>
       (out.split("\n").find((l) => l.includes("zsh")) as string).match(/^ */)![0].length;

--- a/ts/cmdPs.ts
+++ b/ts/cmdPs.ts
@@ -154,9 +154,13 @@ function padStart(s: string, n: number): string {
 export function renderTable(
   rows: PsRow[],
   unattributed: TreeStats | null,
-  opts: { tree?: boolean } = {},
+  opts: { tree?: boolean; procs?: boolean } = {},
 ): string {
   const tree = opts.tree === true;
+  // Independent of `tree`: the Σ columns describe the AGENT forest, while the
+  // process rows describe what is inside one agent. They answer different
+  // questions and are each expensive in vertical space, so they are each opt-in.
+  const showProcs = opts.procs === true;
   const cells = rows.map((r) => ({
     // In tree mode the rails live on the PID cell, so the hierarchy reads down
     // the left edge exactly like `ay ls`.
@@ -257,8 +261,10 @@ export function renderTable(
     // DIFFERENT kind of thing (an OS process, not an agent), and giving them
     // the agent columns would invite reading a shell as a fifth agent.
     const kids = rows[i]?.procRows;
-    if (!tree || !kids?.length) return;
-    const indent = " ".repeat((rows[i]?.prefix ?? "").length + 2);
+    if (!showProcs || !kids?.length) return;
+    // Indent under the agent's rails when they exist (--tree), else a plain
+    // two-space nest under a flat row.
+    const indent = " ".repeat((tree ? (rows[i]?.prefix ?? "").length : 0) + 2);
     const pw = Math.max(...kids.map((k) => String(k.pid).length));
     const cw = Math.max(...kids.map((k) => k.comm.length));
     for (const k of kids) {
@@ -298,6 +304,11 @@ export async function cmdPs(rest: string[]): Promise<number> {
       description:
         "Forest order with ├─ rails, plus Σ columns rolling each agent up with its subagents",
     })
+    .option("procs", {
+      type: "boolean",
+      default: false,
+      description: "Expand each agent into the OS processes it owns (wrapper, CLI, shells)",
+    })
     .option("interval", {
       type: "number",
       default: DEFAULT_WINDOW_MS / 1000,
@@ -308,6 +319,7 @@ export async function cmdPs(rest: string[]): Promise<number> {
     .example("ay ps", "biggest agents first, with box vitals")
     .example("ay ps --sort cpu", "who is actually burning CPU right now")
     .example("ay ps --tree", "parent>child forest; Σ columns include each agent's subagents")
+    .example("ay ps --procs", "expand each agent into its wrapper/CLI/shell processes")
     .example("ay ps --json", "machine-readable rollup")
     .help(false)
     .version(false)
@@ -369,10 +381,14 @@ export async function cmdPs(rest: string[]): Promise<number> {
     const totals = subtreeTotals(rows);
     rows.forEach((r, i) => {
       r.subtree = totals[i] ?? null;
+    });
+  }
+  if (argv.procs) {
+    for (const r of rows) {
       // Heaviest first: the reason to expand an agent is to find what inside it
       // is costing something, and that is almost never the wrapper.
       r.procRows = [...(members?.get(r.pid) ?? [])].sort((x, y) => y.rss - x.rss);
-    });
+    }
   }
 
   if (!argv.tree) {
@@ -417,7 +433,12 @@ export async function cmdPs(rest: string[]): Promise<number> {
 
   const header = formatSystemLine(sys);
   if (header) process.stdout.write(` ${header}\n\n`);
-  process.stdout.write(renderTable(rows, unattributed, { tree: argv.tree === true }) + "\n");
+  process.stdout.write(
+    renderTable(rows, unattributed, {
+      tree: argv.tree === true,
+      procs: argv.procs === true,
+    }) + "\n",
+  );
   return 0;
 }
 


### PR DESCRIPTION
#429 では `--tree` がエージェントの forest とプロセス単位の内訳を**両方**出していた。実フリートで 347 行（フラットは 75 行）になり、木構造だけを見たいときに長すぎる。

2 つは別々の問いに答えている:

| フラグ | 答える問い | 出すもの |
|---|---|---|
| `--tree` | どのエージェントがどのエージェントを生んだか | `├─ └─` レール + 親と子孫を合算する Σ 列 |
| `--procs` | 1 つのエージェントの中で何が食っているか | wrapper・CLI 本体・シェル・pty ホストの内訳 |

どちらも縦方向のコストが大きいので、それぞれ opt-in にする。両方指定すれば組み合わさる（レール + Σ 列 + 各エージェントのプロセス）。

```
$ ay ps --procs agent-yes
PID    CLI      STATUS   CPU%    RSS  PROCS  REPO       CWD
4443   claude   active    5.8  352Mi      8  agent-yes  ~/repo/alpha
  ·  4459  claude       3.9  270Mi
  · 33514  bun          1.0  63.8Mi
  ·  4443  agent-yes    1.0   9.1Mi
  · 33335  zsh          0.0   2.9Mi
```

`--procs` を単独で使えるようにしたことで、インデントは forest のレール幅に依存しなくなった。レールがあればその下に、無ければフラット行の下に 2 文字だけ下げる。

## 行数（このフリート）

| | 行数 |
|---|---|
| `ay ps` | 71 |
| `ay ps --tree` | 71 |
| `ay ps --procs` | 318 |

## テスト

- `--tree` 単独ではプロセス行が出ない
- `--procs` 単独では出る一方、Σ 列は出ない
- 両方指定時、インデントがレール深さに追随する

**49 passed**。実機でも 5 回連続で `--tree` 単独のプロセス行が 0、Σ 列が `--tree` のときだけ 1 になることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)