### PR TITLE
feat(pid_store): 登録を失ったまま動き続けているエージェントを起動時に復帰させる

### DIFF
--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -357,6 +357,28 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
     let pid_store = PidStore::new();
     pid_store.prune_old_logs();
     pid_store.clean_stale();
+    // ...then recover any agent that a PRIOR clean_stale dropped while it was
+    // still running (see PidStore::recover_orphans). Ordered after the sweep so
+    // it observes the post-sweep registry, and scoped to this agent's own
+    // project dir plus the global one — a startup must not stat the whole disk.
+    {
+        let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+        if let Some(g) = crate::log_files::global_dir() {
+            dirs.push(g);
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            if let Some(d) = crate::log_files::project_log_dir(&cwd.to_string_lossy()) {
+                dirs.push(d);
+            }
+        }
+        let recovered = pid_store.recover_orphans(&dirs);
+        if recovered > 0 {
+            info!(
+                "recovered {} unregistered but still-running agent(s)",
+                recovered
+            );
+        }
+    }
 
     // Defense-in-depth: sweep the orphan-reaper registry, killing the recorded
     // process group of any PRIOR agent whose wrapper died without running its own

--- a/rs/src/pid_store.rs
+++ b/rs/src/pid_store.rs
@@ -263,6 +263,115 @@ impl PidStore {
         }
     }
 
+    /// Re-register agents that are RUNNING but have no registry record.
+    ///
+    /// `clean_stale` used to evict live agents on a bad `kill(pid, 0)` reading
+    /// (see `keep_record`), and nothing re-registers after spawn — so those
+    /// agents kept running and logging for days while absent from `ay ls`,
+    /// unreachable by `ay send`, and invisible to the reaper. Fixing the
+    /// eviction stops NEW losses; it cannot recover the ones already dropped.
+    ///
+    /// This recovers them. A `<pid>.raw.log` under a project's `.agent-yes/`
+    /// whose pid is still alive, with no record in the registry, can only be an
+    /// agent whose record was lost: the log is created by the wrapper at spawn,
+    /// so its existence means the agent WAS registered once.
+    ///
+    /// Deliberately conservative — it only adds, never removes, and reconstructs
+    /// just the fields the log path itself proves (pid, cwd, log_file). The
+    /// prompt and cli are unknown at this point; `cli` is recorded as "unknown"
+    /// rather than guessed, so a recovered row is visibly distinct from a
+    /// natively registered one instead of silently wrong.
+    pub fn recover_orphans(&self, dirs: &[PathBuf]) -> usize {
+        let _lock = acquire_lock(&self.path);
+        let known: std::collections::HashSet<u32> = match self.read_all() {
+            Ok(rs) => rs.iter().map(|r| r.pid).collect(),
+            Err(_) => return 0,
+        };
+        let mut found: Vec<PidRecord> = Vec::new();
+        for dir in dirs {
+            let Ok(entries) = fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                let Some(pid_str) = name.strip_suffix(".raw.log") else {
+                    continue;
+                };
+                let Ok(pid) = pid_str.parse::<u32>() else {
+                    continue;
+                };
+                if known.contains(&pid) || !is_process_alive(pid) {
+                    continue;
+                }
+                // The log lives at <cwd>/.agent-yes/<pid>.raw.log, so the cwd is
+                // its grandparent.
+                let cwd = path
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                if cwd.is_empty() {
+                    continue;
+                }
+                let started_at = fs::metadata(&path)
+                    .ok()
+                    .and_then(|m| m.created().or_else(|_| m.modified()).ok())
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+                // Built inline rather than through register_full: that stamps
+                // OUR pid as wrapper_pid and OUR env as parent_pid, which would
+                // be a lie about someone else's agent. Only what the log path
+                // itself proves is filled in.
+                found.push(PidRecord {
+                    pid,
+                    // Not guessable from the log path. "unknown" keeps a
+                    // recovered row visibly distinct instead of silently wrong;
+                    // the console renders it as the CLI name, so a wrong guess
+                    // would be worse than an honest gap.
+                    cli: "unknown".to_string(),
+                    prompt: None,
+                    cwd,
+                    log_file: Some(path.to_string_lossy().to_string()),
+                    fifo_file: None,
+                    // Liveness was just proven by is_process_alive above; the
+                    // usual active/idle refresh takes over from here.
+                    status: "active".to_string(),
+                    unresponsive: false,
+                    exit_code: None,
+                    exit_reason: None,
+                    started_at,
+                    // The real wrapper is whatever ppid this pid has; we are not
+                    // it, and claiming otherwise would corrupt the agent tree.
+                    wrapper_pid: None,
+                    parent_pid: None,
+                    agent_id: Some(new_agent_id()),
+                    title: None,
+                    permissions: None,
+                });
+            }
+        }
+        if found.is_empty() {
+            return 0;
+        }
+        let n = found.len();
+        let result = (|| -> Result<()> {
+            let mut all = self.read_all()?;
+            all.extend(found);
+            self.write_all(&all)
+        })();
+        match result {
+            Ok(()) => n,
+            Err(e) => {
+                warn!("PidStore: failed to recover orphans: {}", e);
+                0
+            }
+        }
+    }
+
     pub fn clean_stale(&self) {
         // Lock spans read..write_all: a truncating rewrite must not race an
         // append, or a freshly registered (still-running) agent gets dropped.
@@ -717,6 +826,75 @@ mod tests {
         let records = store.read_all().unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].pid, std::process::id());
+    }
+
+    #[test]
+    fn test_recover_orphans_readopts_a_running_agent_with_no_record() {
+        // The exact field shape: a live pid, a <pid>.raw.log under a project's
+        // .agent-yes/, and nothing in the registry.
+        let dir = tempfile::tempdir().unwrap();
+        let proj = dir.path().join("repo-alpha").join(".agent-yes");
+        std::fs::create_dir_all(&proj).unwrap();
+        let me = std::process::id();
+        std::fs::write(proj.join(format!("{me}.raw.log")), b"live output").unwrap();
+        let store = PidStore::with_path(dir.path().join("pids.jsonl"));
+        assert_eq!(store.recover_orphans(&[proj.clone()]), 1);
+        let recs = store.read_all().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].pid, me);
+        // cwd is the log's GRANDparent, not the .agent-yes dir itself.
+        assert!(recs[0].cwd.ends_with("repo-alpha"), "{}", recs[0].cwd);
+        assert_eq!(recs[0].cli, "unknown");
+        // Never claim to be the wrapper of someone else's agent.
+        assert_eq!(recs[0].wrapper_pid, None);
+        assert_eq!(recs[0].parent_pid, None);
+    }
+
+    #[test]
+    fn test_recover_orphans_ignores_dead_pids_and_known_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let proj = dir.path().join("repo-alpha").join(".agent-yes");
+        std::fs::create_dir_all(&proj).unwrap();
+        let me = std::process::id();
+        // Dead pid: its log is leftover, not an orphaned record.
+        std::fs::write(proj.join("999999.raw.log"), b"old").unwrap();
+        // Live pid that IS already registered: must not be duplicated.
+        std::fs::write(proj.join(format!("{me}.raw.log")), b"live").unwrap();
+        let store = PidStore::with_path(dir.path().join("pids.jsonl"));
+        store.register(me, "claude", None, "/repo/alpha", None);
+        assert_eq!(store.recover_orphans(&[proj]), 0);
+        assert_eq!(store.read_all().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_recover_orphans_is_idempotent_and_only_adds() {
+        let dir = tempfile::tempdir().unwrap();
+        let proj = dir.path().join("repo-alpha").join(".agent-yes");
+        std::fs::create_dir_all(&proj).unwrap();
+        let me = std::process::id();
+        std::fs::write(proj.join(format!("{me}.raw.log")), b"live").unwrap();
+        let store = PidStore::with_path(dir.path().join("pids.jsonl"));
+        // A pre-existing UNRELATED record must survive the recovery write.
+        store.register(4242, "codex", None, "/repo/beta", None);
+        assert_eq!(store.recover_orphans(&[proj.clone()]), 1);
+        // Second sweep finds nothing new — the pid is now known.
+        assert_eq!(store.recover_orphans(&[proj]), 0);
+        let recs = store.read_all().unwrap();
+        assert_eq!(recs.len(), 2);
+        assert!(recs.iter().any(|r| r.pid == 4242), "existing record kept");
+    }
+
+    #[test]
+    fn test_recover_orphans_skips_junk_filenames_and_missing_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let proj = dir.path().join("repo-alpha").join(".agent-yes");
+        std::fs::create_dir_all(&proj).unwrap();
+        std::fs::write(proj.join("notes.jsonl"), b"x").unwrap();
+        std::fs::write(proj.join("not-a-pid.raw.log"), b"x").unwrap();
+        let store = PidStore::with_path(dir.path().join("pids.jsonl"));
+        let missing = dir.path().join("gone");
+        assert_eq!(store.recover_orphans(&[proj, missing]), 0);
+        assert!(store.read_all().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
#431 の続き。あちらは `clean_stale` が**生きているエージェントを登録解除する**のを止めたが、**既に失われたレコードは戻らない**（spawn 後に再登録する経路が存在しない）。結果、動き続けたまま `ay ls` から消え、`ay send` で到達できず、reaper からも見えないエージェントが残る。実機では 4〜12 日生存していた個体が複数あった。

## 判定根拠

`<cwd>/.agent-yes/<pid>.raw.log` が存在し、その pid が生きていて、レジストリに記録が無い ─ これは「記録を失ったエージェント」以外ではありえない。ログは wrapper が spawn 時に作るので、**ログの存在自体が「かつて登録されていた」ことの証拠**になる。

## 保守的に作った点

- **追加のみ、削除は一切しない。** 既存レコードには触らない。
- **ログパスから証明できるフィールドだけ**を埋める（pid / cwd / log_file）。cwd はログの祖父ディレクトリ。
- `cli` は `"unknown"`。ログパスからは推測できないので、当てずっぽうを書くより空白であることが見えている方がよい（コンソールは cli 名をそのまま表示するため、誤った推測は無言の嘘になる）。
- **`register_full` を経由しない。** あれは呼び出し側の pid を `wrapper_pid`、呼び出し側の env を `parent_pid` として刻むので、他人のエージェントについてそれを書くのは嘘になる。両方 None のままにし、エージェントツリーを壊さない。
- 走査範囲は**自分の project dir と global dir のみ**。起動時にディスク全体を stat しない。
- `clean_stale` の**後**に走らせ、sweep 後のレジストリを観測する。

## テスト（4 件追加、316 passed）

- 生きた pid + ログあり + 未登録 → 復帰する。cwd がログの祖父になること、`wrapper_pid`/`parent_pid` を詐称しないことも検証
- 死んだ pid のログ / 既に登録済みの pid → 何もしない
- 冪等であること、かつ既存の無関係レコードが書き込みで消えないこと
- pid として解釈できないファイル名 / 存在しないディレクトリを無視する

**実機のレジストリのコピーに対する dry-run で、実際に失われていた 7 件を復帰させた**（77 → 84 レコード）。

crate 全体は **316 passed / 1 failed**。失敗する `cli::tests::test_supported_clis_count` は `origin/main` の時点で既に失敗する既存の不具合で、本変更とは無関係。

## 制限

復帰は**エージェント起動時**に走るので、該当 project dir で次のエージェントが起動するまでは復帰しない。即時に効かせたい場合は別途 `ay` 側のコマンドが要る（本 PR の範囲外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)