### PR TITLE
feat(console): localhost リンククリックに選択メニュー + AGENTS に build 確認手順

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ For the `ay send` guards, the check is:
 ay send 99999 --body-file /tmp/x   # pid 99999 does not exist — nothing is sent
 ```
 
-- guards present → `ay send: no message. These are not ay send options...`
+- guards present → `ay send: Unknown arguments: body-file, bodyFile`
 - guards absent → `ay send: no agent matched "99999"` (the unknown flag was
   swallowed and the send proceeded — which is the bug)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,27 @@ bun run build:rs && bun run build && bun link
 
 `build:rs` runs `cargo install --path rs` (release build, installs to `~/.cargo/bin/agent-yes`).
 Must be done whenever any `.rs` file changes, otherwise the old binary stays in place.
+
+## Verifying that a fix is in the running build
+
+`dist/` is gitignored and this machine runs ONE checkout, so a fix can vanish
+when anyone rebuilds or rebases — with no signal. Don't claim "fixed"; leave a
+check anyone can run in one command.
+
+**Take the check from the fix's own output. Do not add detection-only code.**
+Detection code you add can survive while the fix it reports on is gone; output
+the fix itself produces cannot.
+
+For the `ay send` guards, the check is:
+
+```bash
+ay send 99999 --body-file /tmp/x   # pid 99999 does not exist — nothing is sent
+```
+
+- guards present → `ay send: no message. These are not ay send options...`
+- guards absent → `ay send: no agent matched "99999"` (the unknown flag was
+  swallowed and the send proceeded — which is the bug)
+
+Confirm with BOTH controls. A new message appearing does not prove it is new;
+run the pre-fix source directly (`bun ts/cli.ts ...` from a worktree without the
+change) and check the output actually differs.


### PR DESCRIPTION
放置ブランチ `fix/ay-send-guards-marker` から、main に未反映の分だけを回収した。

- **console**: localhost URL をクリックしたとき、いきなり expose モーダルに飛ばず「直接開く / URL をコピー / agent-yes.com 経由で expose」の選択メニューを出す。publish するのは expose を選んだ場合だけ。
- **AGENTS.md**: 「修正が走っている build に入っているか」を 1 コマンドで確かめる手順。

同ブランチの `ay send` unknown-flag 拒否と空本文 guard は main に等価実装が既に入っている (`strictOptions()` + 空本文チェック) ため回収対象から外した。AGENTS.md の判定文言は現行 main の実際の出力 (`Unknown arguments: body-file, bodyFile`) を実行して確認し、それに合わせて直してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)