### PR TITLE
feat(cli): Codex×DeepSeek の 2 経路 (codex-ds / codex-ds-direct) を追加

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -389,6 +389,57 @@ clis:
     noEOL: true
 
 
+  # codex-ds-direct — same idea as codex-ds, but pointed straight at DeepSeek's
+  # own endpoint instead of going through OpenRouter. DeepSeek gained native
+  # Responses API support in the 2026-08-13 V4 Pro update
+  # (https://api-docs.deepseek.com/guides/responses_api/), so no translating
+  # proxy is needed on this path either — one less hop and no reseller margin.
+  # Requires `DEEPSEEK_API_KEY`; get one at https://platform.deepseek.com.
+  #
+  # Model id differs from the OpenRouter route: DeepSeek's own /models lists
+  # exactly `deepseek-v4-flash` and `deepseek-v4-pro` — there are no dated
+  # snapshot ids here, so this uses the plain `deepseek-v4-pro`.
+  #
+  # Drive markers are copied from the `codex` block, as with codex-ds.
+  codex-ds-direct:
+    binary: codex
+    promptArg: first-arg
+    defaultArgs:
+      - -c
+      - model_providers.deepseek={name="DeepSeek",base_url="https://api.deepseek.com",env_key="DEEPSEEK_API_KEY",wire_api="responses"}
+      - -c
+      - model_provider="deepseek"
+      - -c
+      - model="deepseek-v4-pro"
+      - --search
+    yesArgs:
+      - --dangerously-bypass-approvals-and-sandbox
+    install:
+      npm: "npm install -g @openai/codex@latest"
+    help: https://api-docs.deepseek.com/guides/responses_api/
+    updateAvailable:
+      - "^✨⬆️ Update available!"
+    ready:
+      - ⏎ send
+      - "› "
+      - '\? for shortcuts'
+    working:
+      - esc to interrupt
+    needsInput:
+      - pattern: '[›>] ?\d+\.'
+        flags: m
+    enter:
+      - pattern: '[›>] ?1\. ?Yes'
+        flags: m
+      - pattern: '[›>] ?1\. ?Approve'
+        flags: m
+      - pattern: '[›>] ?1\. ?Allow'
+        flags: m
+    fatal:
+      - "Error: The cursor position could not be read within"
+    noEOL: true
+
+
   qwen:
     install:
       npm: "npm install -g @qwen-code/qwen-code@latest"

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -334,6 +334,61 @@ clis:
       - --search
     noEOL: true
 
+  # codex-ds — the `codex` binary pointed at DeepSeek V4 Pro over OpenRouter
+  # instead of the built-in OpenAI models. Everything the provider needs rides
+  # in `defaultArgs` as `-c` overrides, so this works against a stock codex
+  # install with no `~/.codex/*.config.toml` of your own; the only external
+  # requirement is `OPENROUTER_API_KEY` in the environment (same shape as glm's
+  # ZAI_API_KEY). Get one at https://openrouter.ai/keys.
+  #
+  # Two codex-version constraints are baked into the override:
+  #   - `wire_api` must be "responses"; codex >= 0.147 removed the "chat"
+  #     wire protocol, and OpenRouter serves POST /api/v1/responses.
+  #   - the provider table is passed inline rather than as a named profile,
+  #     because codex >= 0.147 rejects a `[profiles.X]` table in config.toml
+  #     and wants it in a separate `<X>.config.toml`.
+  #
+  # All drive markers below are copied from the `codex` block — same binary,
+  # same TUI — because per-CLI config does not inherit.
+  codex-ds:
+    binary: codex
+    promptArg: first-arg
+    defaultArgs:
+      - -c
+      - model_providers.openrouter={name="OpenRouter",base_url="https://openrouter.ai/api/v1",env_key="OPENROUTER_API_KEY",wire_api="responses"}
+      - -c
+      - model_provider="openrouter"
+      - -c
+      - model="deepseek/deepseek-v4-pro-0813"
+      - --search
+    yesArgs:
+      - --dangerously-bypass-approvals-and-sandbox
+    install:
+      npm: "npm install -g @openai/codex@latest"
+    help: https://openrouter.ai/deepseek/deepseek-v4-pro
+    updateAvailable:
+      - "^✨⬆️ Update available!"
+    ready:
+      - ⏎ send
+      - "› "
+      - '\? for shortcuts'
+    working:
+      - esc to interrupt
+    needsInput:
+      - pattern: '[›>] ?\d+\.'
+        flags: m
+    enter:
+      - pattern: '[›>] ?1\. ?Yes'
+        flags: m
+      - pattern: '[›>] ?1\. ?Approve'
+        flags: m
+      - pattern: '[›>] ?1\. ?Allow'
+        flags: m
+    fatal:
+      - "Error: The cursor position could not be read within"
+    noEOL: true
+
+
   qwen:
     install:
       npm: "npm install -g @qwen-code/qwen-code@latest"

--- a/docs/deepseek-codex.md
+++ b/docs/deepseek-codex.md
@@ -1,0 +1,75 @@
+# Codex with DeepSeek
+
+Two ways to run the Codex CLI against DeepSeek's V4 Pro model. Both are pure
+configuration — `binary: codex` plus a few `-c` overrides in
+`default.config.yaml`. Neither needs a translating proxy, an isolated
+`CODEX_HOME`, a helper script, or a config file of your own: a stock `codex`
+install is enough.
+
+| | `ay codex-ds` | `ay codex-ds-direct` |
+|---|---|---|
+| Route | OpenRouter | DeepSeek's own endpoint |
+| Model | `deepseek/deepseek-v4-pro-0813` | `deepseek-v4-pro` |
+| Requires | `OPENROUTER_API_KEY` | `DEEPSEEK_API_KEY` |
+| Billing | OpenRouter credits | DeepSeek account |
+
+Pick `codex-ds` to keep one key across many providers, or `codex-ds-direct` to
+bill DeepSeek straight and drop a network hop plus the reseller margin.
+
+## Setup
+
+Export the key for whichever route you use:
+
+```bash
+export OPENROUTER_API_KEY=...   # for codex-ds
+export DEEPSEEK_API_KEY=...     # for codex-ds-direct
+```
+
+To set it per machine instead of per shell, add it to `~/.agent-yes.config.yaml`
+under the CLI's `env` block — that file is cascaded over the packaged defaults
+by both runtimes:
+
+```yaml
+clis:
+  codex-ds-direct:
+    env:
+      DEEPSEEK_API_KEY: your-key
+```
+
+## Run
+
+```bash
+ay codex-ds                              # interactive
+ay codex-ds "explain this codebase"      # with a prompt
+ay -y codex-ds "refactor the parser"     # auto-approve tool use
+```
+
+`ay -y` maps to codex's `--dangerously-bypass-approvals-and-sandbox`, and the
+`enter:` markers auto-accept codex's `› 1. Yes / Approve / Allow` menus. Both
+work the same on `codex-ds-direct`.
+
+## Why no adapter is needed
+
+Codex 0.147 dropped the Chat Completions wire protocol — `wire_api` must be
+`"responses"`. Both providers serve that natively:
+
+- OpenRouter exposes `POST /api/v1/responses`.
+- DeepSeek gained Responses API support in the 2026-08-13 V4 Pro update
+  ([docs](https://api-docs.deepseek.com/guides/responses_api/)).
+
+Because reasoning arrives as a first-class `{"type": "reasoning"}` output item
+on this protocol, there is also nothing to shuttle out of band between turns —
+that was a Chat Completions constraint.
+
+## Model ids differ per route
+
+DeepSeek's own `/models` lists exactly `deepseek-v4-flash` and `deepseek-v4-pro`
+— there are no dated snapshot ids there. OpenRouter does publish dated
+snapshots, which is why the two entries name different models.
+
+## Provider config is passed inline
+
+Codex 0.147 rejects a `[profiles.X]` table inside `config.toml` and wants it in
+a separate `<X>.config.toml`. Passing the provider table as `-c` overrides
+sidesteps that entirely, which is what keeps these entries free of any
+user-side config file.

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -200,12 +200,26 @@ fn delegate_to_js(forward_args: &[String]) -> i32 {
 // MUST mirror the `clis:` keys in default.config.yaml — this list gates CLI
 // validation and binary-name detection (`glm-yes` → "glm"). A new CLI added to
 // the YAML won't be runnable via the Rust runtime until it's listed here too.
+/// True for the codex CLI and every codex-derived variant (`codex-ds`,
+/// `codex-ds-direct`, …) — they all run the same `codex` binary and print the
+/// same session-id banner, so the session capture/resume path must treat them
+/// alike. Keying those sites on an exact `== "codex"` made `--continue` on a
+/// variant silently start a fresh session instead of resuming.
+///
+/// The per-cwd session store is therefore shared across codex variants. That is
+/// fine: resuming re-applies the launching CLI's own `defaultArgs`, so a session
+/// resumed via `codex-ds` still talks to DeepSeek.
+pub fn is_codex_family(cli: &str) -> bool {
+    cli == "codex" || cli.starts_with("codex-")
+}
+
 pub const SUPPORTED_CLIS: &[&str] = &[
     "claude",
     "glm",
     "pi",
     "codex",
     "codex-ds",
+    "codex-ds-direct",
     "copilot",
     "cursor",
     "grok",
@@ -763,7 +777,7 @@ mod tests {
 
     #[test]
     fn test_supported_clis_count() {
-        assert_eq!(SUPPORTED_CLIS.len(), 18);
+        assert_eq!(SUPPORTED_CLIS.len(), 19);
         // The claude-compatible providers (run the `claude` binary via env) must
         // be present, else their `*-yes` bins fail validation in the Rust runtime.
         for cli in ["glm", "pi"] {

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -205,6 +205,7 @@ pub const SUPPORTED_CLIS: &[&str] = &[
     "glm",
     "pi",
     "codex",
+    "codex-ds",
     "copilot",
     "cursor",
     "grok",
@@ -762,7 +763,7 @@ mod tests {
 
     #[test]
     fn test_supported_clis_count() {
-        assert_eq!(SUPPORTED_CLIS.len(), 14);
+        assert_eq!(SUPPORTED_CLIS.len(), 18);
         // The claude-compatible providers (run the `claude` binary via env) must
         // be present, else their `*-yes` bins fail validation in the Rust runtime.
         for cli in ["glm", "pi"] {

--- a/rs/src/context.rs
+++ b/rs/src/context.rs
@@ -1101,7 +1101,7 @@ impl AgentContext {
         }
 
         // Extract and store codex session ID (once per session)
-        if self.cli == "codex" && !self.codex_session_found {
+        if crate::cli::is_codex_family(&self.cli) && !self.codex_session_found {
             if let Some(session_id) = codex_sessions::extract_session_id(output) {
                 codex_sessions::store_session(&self.cwd, &session_id);
                 self.codex_session_found = true;

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -320,7 +320,7 @@ async fn run_agent(args: CliArgs, cwd: &str) -> Result<i32> {
     }
 
     // Codex session resume: look up stored session ID for this cwd
-    if args.continue_session && args.cli == "codex" {
+    if args.continue_session && crate::cli::is_codex_family(&args.cli) {
         if let Some(session_id) = codex_sessions::get_session(cwd) {
             info!("Resuming codex session: {}", session_id);
             cmd_args.push("--session".to_string());

--- a/rs/src/serve/control.rs
+++ b/rs/src/serve/control.rs
@@ -16,6 +16,8 @@ pub const SUPPORTED_CLIS: &[&str] = &[
     "glm",
     "pi",
     "codex",
+    "codex-ds",
+    "codex-ds-direct",
     "copilot",
     "cursor",
     "grok",

--- a/ts/core/responders.ts
+++ b/ts/core/responders.ts
@@ -4,7 +4,7 @@ import { sendEnter, sendMessage } from "./messaging.ts";
 import type { AgentContext } from "./context.ts";
 import type { AgentCliConfig } from "../index.ts";
 import type { SUPPORTED_CLIS } from "../SUPPORTED_CLIS.ts";
-import { extractSessionId, storeSessionForCwd } from "../resume/codexSessionManager.ts";
+import { extractSessionId, isCodexFamily, storeSessionForCwd } from "../resume/codexSessionManager.ts";
 
 /**
  * Auto-response handlers for CLI-specific patterns
@@ -107,7 +107,7 @@ export async function createAutoResponseHandler(
   }
 
   // session ID capture for codex
-  if (cli === "codex") {
+  if (isCodexFamily(cli)) {
     const sessionId = extractSessionId(line);
     if (sessionId) {
       logger.debug(`session|captured session ID: ${sessionId}`);

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -10,6 +10,7 @@ import { agentYesHome } from "./agentYesHome.ts";
 import {
   extractSessionId,
   getSessionForCwd,
+  isCodexFamily,
   storeSessionForCwd,
 } from "./resume/codexSessionManager.ts";
 import pty, { ptyPackage } from "./pty.ts";
@@ -435,7 +436,7 @@ export default async function agentYes({
 
   // Handle --continue flag for codex session restoration
   if (resume) {
-    if (cli === "codex" && resume) {
+    if (isCodexFamily(cli) && resume) {
       // Try to get stored session for this directory
       const storedSessionId = await getSessionForCwd(workingDir);
       if (storedSessionId) {
@@ -827,7 +828,7 @@ export default async function agentYes({
 
       // For codex, try to use stored session ID for this directory
       let restoreArgs = conf.restoreArgs;
-      if (cli === "codex") {
+      if (isCodexFamily(cli)) {
         const storedSessionId = await getSessionForCwd(workingDir);
         if (storedSessionId) {
           // Use specific session ID instead of --last
@@ -1060,7 +1061,7 @@ export default async function agentYes({
         }
 
         // session ID capture for codex
-        if (cli === "codex") {
+        if (isCodexFamily(cli)) {
           const sessionId = extractSessionId(line);
           if (sessionId) {
             logger.debug(`heartbeat|session|captured session ID: ${sessionId}`);
@@ -1447,7 +1448,7 @@ export default async function agentYes({
             }
 
             // session ID capture for codex
-            if (cli === "codex") {
+            if (isCodexFamily(cli)) {
               const sessionId = extractSessionId(line);
               if (sessionId) {
                 logger.debug(`session|captured session ID: ${sessionId}`);

--- a/ts/resume/codexSessionManager.ts
+++ b/ts/resume/codexSessionManager.ts
@@ -187,6 +187,21 @@ export async function getSessionForCwd(cwd: string): Promise<string | null> {
  * Extract session ID from codex output
  * Session IDs are UUIDs in the format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  */
+/**
+ * True for the codex CLI and every codex-derived variant (`codex-ds`,
+ * `codex-ds-direct`, …) — they all run the same `codex` binary and print the
+ * same session-id banner, so the session capture/resume path must treat them
+ * alike. Keying those sites on an exact `=== "codex"` made `--continue` on a
+ * variant silently start a fresh session instead of resuming.
+ *
+ * The per-cwd session store is therefore shared across codex variants. That is
+ * fine: resuming re-applies the launching CLI's own `defaultArgs`, so a session
+ * resumed via `codex-ds` still talks to DeepSeek.
+ */
+export function isCodexFamily(cli: string): boolean {
+  return cli === "codex" || cli.startsWith("codex-");
+}
+
 export function extractSessionId(output: string): string | null {
   // Look for session ID in various contexts where it might appear
   const sessionIdRegex = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;


### PR DESCRIPTION
## 概要

Codex CLI を DeepSeek V4 Pro で動かす経路を 2 本追加する。**どちらも設定のみで完結する** — `binary: codex` と `defaultArgs` の `-c` オーバーライドだけで、変換プロキシ・隔離 `CODEX_HOME`・補助スクリプト・利用者側の設定ファイルのいずれも要らない。素の codex install で動く。

| | `ay codex-ds` | `ay codex-ds-direct` |
|---|---|---|
| 経路 | OpenRouter | DeepSeek 直結 |
| モデル | `deepseek/deepseek-v4-pro-0813` | `deepseek-v4-pro` |
| 要件 | `OPENROUTER_API_KEY` | `DEEPSEEK_API_KEY` |

要件が環境変数 1 本だけという形は glm の `ZAI_API_KEY` と同じ。

## なぜアダプタが要らないか

codex 0.147 は Chat Completions を廃止し `wire_api = "responses"` しか話さなくなったが、**両プロバイダとも Responses API をネイティブに提供している**。

- OpenRouter: `POST /api/v1/responses`
- DeepSeek: 2026-08-13 の V4 Pro API 更新で対応 ([docs](https://api-docs.deepseek.com/guides/responses_api/))

実測 (存在しないパスは 404、実パスは 200):

```
POST https://api.deepseek.com/responses-nope  → 404
POST https://api.deepseek.com/responses       → 200
  {"status":"completed","model":"deepseek-v4-pro",
   "output":[{"type":"reasoning",…},{"type":"message","content":[{"text":"PONG"}]}]}
```

reasoning が一級の output item として往復するため、ターン間で `reasoning_content` を持ち回る必要も無い (これは Chat Completions 経路に固有の制約だった)。

もう 1 点、プロバイダ定義は名前付き profile ではなくインラインで渡している。codex 0.147 は `config.toml` 内の `[profiles.X]` テーブルを起動時に拒否し、別ファイル `<X>.config.toml` を要求するため。

## ハードコードされた "codex" 判定の解消

`default.config.yaml` に派生 CLI を足すだけでは塞がらない穴が 2 つあった。

1. **Rust の `SUPPORTED_CLIS` は 2 本ある。** `rs/src/cli.rs` の他に `rs/src/serve/control.rs` にも `/api/spawn` の許可リストがあり、更新しないと **CLI からは起動できるのに web console からだけ spawn できない**。
2. **session の捕捉・resume が `== "codex"` の完全一致で分岐していた。** 派生 CLI で `--continue` すると黙って新規セッションが始まる。該当は Rust 2 箇所 (`main.rs` / `context.rs`)、TS 5 箇所 (`index.ts` 4 + `core/responders.ts` 1)。

述語 `is_codex_family` / `isCodexFamily` (`cli == "codex" || 前置詞 "codex-"`) に置き換えた。cwd ごとの session store は派生間で共有になるが、resume 時に起動側 CLI の `defaultArgs` が再適用されるため provider は混ざらない。

意図的に触っていないもの: `graph.rs` / `ts/serve.ts` の codex ノード (rgui のデモチェーン用で表示のみ)、`ts/SUPPORTED_CLIS.ts` (yaml から導出するため drift 不能)。

## auto-yes

設定駆動なので追加のコードは不要。`main.rs` は `cli_config.yes_args` を読むだけで CLI 名は見ていない。両ブロックに `yesArgs` と `enter:` を複製済み。

## 既存の赤テストの修正

`test_supported_clis_count` のアサーションが 14 のまま据え置かれ、bash / cmd / powershell / dsh-tui / dsh-legacy が追加された時点で既に赤だった (17 != 14)。正しい 19 に修正している。

## 動作確認

- `ay codex-ds` / `ay codex-ds-direct` を、**環境変数を export していないシェル**から起動。フッタがそれぞれ `deepseek/deepseek-v4-pro-0813` / `deepseek-v4-pro` を表示し、ツール呼び出しを伴う複数ターンのセッションが完走、`ay send` による親への報告まで到達することを確認。
- `ay -y codex-ds` の codex 子プロセスの argv 末尾が `--search --dangerously-bypass-approvals-and-sandbox` になることを実測。
- `cargo test` 全件 **317 + 214 + 9 passed / 0 failed** (汚染のないクリーン worktree で実行)、`cargo fmt --check` clean。
- TS は `bunx tsc --noEmit` に本変更由来のエラーなし。configLoader / configShared / subcommands / resume / index の各 spec が green。

## 備考

`codex-ds-yes` / `codex-ds-direct-yes` のバイナリは生成されない。postbuild が「新規 CLI キーには `-yes` bin を自動生成しない (`ay <cli>` が primary entry)」という既存の設計になっているため、意図した挙動。

CI の 4 本の test check は coverage branch gate (89.3% < 90%) で赤くなるが、**main 自身が同じ数値で落ちている既存の負債**であり本 PR とは無関係。アサーションの失敗は 1 件も無い。

Closes #436
Closes #438