### PR TITLE
test: coverage gate を回復する (branches 89.16% → 90.11%)

### DIFF
--- a/ts/agentNice.spec.ts
+++ b/ts/agentNice.spec.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { agentNiceValue } from "./agentNice.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// applyAgentNice reaches setPriority through a dynamic `await import("os")`, so
+// the module has to be mocked rather than spied — a namespace object's exports
+// are frozen and a spy on them never takes effect.
+const setPriority = vi.fn();
+vi.mock("os", async (importActual) => {
+  const actual = await importActual<typeof import("os")>();
+  return { ...actual, default: { ...actual, setPriority }, setPriority };
+});
+
+import { agentNiceValue, applyAgentNice } from "./agentNice.ts";
 
 describe("agentNice.agentNiceValue", () => {
   it("defaults to 5 when unset or empty", () => {
@@ -20,5 +30,35 @@ describe("agentNice.agentNiceValue", () => {
   it("falls back to the default on garbage", () => {
     expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "abc" })).toBe(5);
     expect(agentNiceValue({ AGENT_YES_AGENT_NICE: "3.9" })).toBe(3); // truncates
+  });
+});
+
+describe("agentNice.applyAgentNice", () => {
+  afterEach(() => {
+    setPriority.mockReset();
+  });
+
+  it("deprioritizes the spawned pid to the configured nice", async () => {
+    await applyAgentNice(4242, { AGENT_YES_AGENT_NICE: "7" });
+
+    expect(setPriority).toHaveBeenCalledWith(4242, 7);
+  });
+
+  it("does nothing when nice is 0 (explicitly disabled)", async () => {
+    await applyAgentNice(4242, { AGENT_YES_AGENT_NICE: "0" });
+
+    // 0 means "leave the agent at the default priority" — calling setPriority(0)
+    // anyway would be a no-op syscall, but skipping it keeps the disabled path
+    // free of a platform call that can throw.
+    expect(setPriority).not.toHaveBeenCalled();
+  });
+
+  it("swallows a setPriority failure — a scheduling hint must never break a spawn", async () => {
+    setPriority.mockImplementation(() => {
+      // What an unprivileged container or a pid that already exited looks like.
+      throw new Error("EPERM: operation not permitted");
+    });
+
+    await expect(applyAgentNice(4242, { AGENT_YES_AGENT_NICE: "5" })).resolves.toBeUndefined();
   });
 });

--- a/ts/serveSampler.spec.ts
+++ b/ts/serveSampler.spec.ts
@@ -1,16 +1,390 @@
-import { describe, expect, it } from "vitest";
-import { sweep, windowLen } from "./serveSampler.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("serveSampler", () => {
-  it("windowLen tracks the adaptive bucket width", () => {
+// The sampler's only outside dependency is one `sampleTrees` call per sweep, so
+// mocking it here lets every branch below run against synthetic process trees —
+// no /proc, no live fleet, and identical behaviour on macOS and Linux CI.
+const sampleTrees = vi.fn();
+vi.mock("./procStats.ts", () => ({
+  sampleTrees: (...args: unknown[]) => sampleTrees(...args),
+}));
+
+import {
+  getBucketSecs,
+  getSnapshot,
+  resField,
+  resourcesField,
+  startSampler,
+  stopSampler,
+  sweep,
+  windowLen,
+} from "./serveSampler.ts";
+
+/** A TreeStats literal — the shape sampleTrees hands back per root pid. */
+function tree(pid: number, rss: number, cpuPercent: number, procs: number) {
+  return { pid, rss, cpuPercent, procs };
+}
+
+/** A whole sampleTrees result: the given trees plus an unattributed rollup. */
+function result(
+  trees: Array<ReturnType<typeof tree>>,
+  unattributed = tree(0, 0, 0, 0),
+) {
+  return {
+    trees: new Map(trees.map((t) => [t.pid, t])),
+    unattributed,
+    claimed: new Map(),
+  };
+}
+
+// The sampler keeps its window in module-level state (one sampler per daemon),
+// so each test starts from a known-empty snapshot rather than inheriting the
+// previous test's buckets.
+function resetState() {
+  stopSampler();
+  const snap = getSnapshot();
+  snap.agents.clear();
+  snap.unattributed = { cpu_seconds: 0, rss: 0, procs: 0 };
+  snap.bucketSecs = 0;
+  // getBucketSecs() reads the same private width `sweep` sets; drive it back to
+  // the unchosen state through the public path (an empty sweep re-primes it).
+}
+
+beforeEach(() => {
+  sampleTrees.mockReset();
+  resetState();
+});
+
+afterEach(() => {
+  stopSampler();
+  vi.useRealTimers();
+});
+
+describe("windowLen", () => {
+  it("tracks the adaptive bucket width", () => {
     expect(windowLen(60)).toBe(60); // fast: 1m buckets, 1h window
     expect(windowLen(300)).toBe(12); // slow: 5m buckets, 1h window
     expect(windowLen(1)).toBe(60); // anything ≤60 counts as fast
   });
+});
 
-  it("sweep with no live roots still settles a bucket width", async () => {
+describe("sweep", () => {
+  it("with no live roots still settles a bucket width without sampling", async () => {
     const width = await sweep([]);
     expect(width).toBeGreaterThan(0);
     expect([60, 300]).toContain(width);
+    // No roots means there is nothing to snapshot — the expensive process walk
+    // must be skipped entirely, not called with an empty list.
+    expect(sampleTrees).not.toHaveBeenCalled();
+    expect(getSnapshot().bucketSecs).toBe(width);
+  });
+
+  it("keeps the already-chosen width when a later sweep finds no roots", async () => {
+    sampleTrees.mockResolvedValueOnce(result([tree(100, 1, 0, 1)]));
+    const chosen = await sweep([100]);
+
+    // The whole fleet exiting must not re-open the width decision: the console's
+    // axis label would jump under it mid-session.
+    expect(await sweep([])).toBe(chosen);
+    expect(getSnapshot().bucketSecs).toBe(chosen);
+  });
+
+  it("records one bucket per sampled agent and the unattributed rollup", async () => {
+    sampleTrees.mockResolvedValue(
+      result([tree(100, 2048, 50, 3), tree(200, 4096, 10, 1)], tree(0, 8192, 20, 9)),
+    );
+
+    await sweep([100, 200]);
+
+    const snap = getSnapshot();
+    expect([...snap.agents.keys()].sort()).toEqual([100, 200]);
+    expect(snap.agents.get(100)).toHaveLength(1);
+    expect(snap.agents.get(100)![0][1].rss).toBe(2048);
+    expect(snap.agents.get(100)![0][1].procs).toBe(3);
+    expect(snap.unattributed.rss).toBe(8192);
+    expect(snap.unattributed.procs).toBe(9);
+  });
+
+  it("walks roots deepest-first so a nested agent claims its subtree before its parent", async () => {
+    sampleTrees.mockResolvedValue(result([tree(100, 1, 0, 1)]));
+
+    await sweep([100, 200, 300]);
+
+    // `ay ps` semantics: sampleTrees attributes first-come, so the caller must
+    // hand it the reversed list. Getting this backwards silently credits a
+    // child's memory to its parent.
+    expect(sampleTrees.mock.calls[0][0]).toEqual([300, 200, 100]);
+  });
+
+  it("converts cpuPercent into cpu-seconds of one core over the pass", async () => {
+    sampleTrees.mockResolvedValue(result([tree(100, 0, 100, 1)], tree(0, 0, 50, 1)));
+
+    await sweep([100]);
+
+    // 100% of one core is at most the pass duration in seconds, and the floor on
+    // elapsed (1ms) keeps a sub-millisecond pass from producing a huge number.
+    const cpu = getSnapshot().agents.get(100)![0][1].cpu_seconds;
+    expect(cpu).toBeGreaterThan(0);
+    expect(cpu).toBeLessThan(1);
+    // The unattributed rollup goes through the same conversion, at half the rate.
+    expect(getSnapshot().unattributed.cpu_seconds).toBeCloseTo(cpu / 2, 10);
+  });
+
+  it("keeps the last good snapshot when a sweep throws", async () => {
+    sampleTrees.mockResolvedValueOnce(result([tree(100, 4096, 0, 2)]));
+    await sweep([100]);
+    const width = getBucketSecs();
+
+    sampleTrees.mockRejectedValueOnce(new Error("/proc vanished"));
+    const after = await sweep([100]);
+
+    // Best-effort: a failed snapshot degrades to "no new data", never to a
+    // cleared window (which the console would render as the agent dying).
+    expect(after).toBe(width);
+    expect(getSnapshot().agents.get(100)).toHaveLength(1);
+    expect(getSnapshot().agents.get(100)![0][1].rss).toBe(4096);
+  });
+
+  it("falls back to the fast width when the very first sweep throws", async () => {
+    sampleTrees.mockRejectedValueOnce(new Error("boom"));
+    // Width was never chosen (state.bucketSecs === 0), so the catch path has no
+    // previous value to keep and must still return a usable cadence.
+    expect(await sweep([100])).toBe(60);
+  });
+
+  it("picks the slow bucket width when the first pass is slow", async () => {
+    // The width is chosen ONCE, on the first timed pass, and then sticks for the
+    // life of the daemon — so this needs a module instance no earlier test has
+    // already driven to the fast width.
+    vi.resetModules();
+    const fresh = await import("./serveSampler.ts");
+
+    // sweep() times its own pass with Date.now(), so stub the clock to report a
+    // pass over the 1s threshold rather than actually sleeping for one.
+    let now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    sampleTrees.mockImplementationOnce(async () => {
+      now += 1500; // pass >= 1s → 5m buckets
+      return result([tree(100, 1, 0, 1)]);
+    });
+
+    try {
+      expect(await fresh.sweep([100])).toBe(300);
+      expect(fresh.getBucketSecs()).toBe(300);
+      // 5m buckets ⇒ a 12-slot window, so an hour of history still fits.
+      expect(fresh.windowLen(300)).toBe(12);
+    } finally {
+      nowSpy.mockRestore();
+      fresh.stopSampler();
+    }
+  });
+
+  it("trims the rolling window to the bucket count and keeps the newest samples", async () => {
+    // Force the fast width (60 buckets) with a fast first pass, then overfill.
+    for (let i = 0; i < 63; i++) {
+      sampleTrees.mockResolvedValueOnce(result([tree(100, i, 0, 1)]));
+      await sweep([100]);
+    }
+
+    const series = getSnapshot().agents.get(100)!;
+    expect(series).toHaveLength(windowLen(60));
+    // Oldest-first ordering, with the three oldest dropped — the console draws
+    // left-to-right, so a reversed window would render the heatmap backwards.
+    expect(series[0][1].rss).toBe(3);
+    expect(series[series.length - 1][1].rss).toBe(62);
+  });
+});
+
+describe("resField", () => {
+  it("is null for an agent the sampler has not recorded", async () => {
+    sampleTrees.mockResolvedValue(result([tree(100, 1, 0, 1)]));
+    await sweep([100]);
+
+    expect(resField(999)).toBeNull();
+  });
+
+  it("transposes the window into the parallel arrays /api/ls expects", async () => {
+    sampleTrees.mockResolvedValueOnce(result([tree(100, 10, 0, 1)]));
+    await sweep([100]);
+    sampleTrees.mockResolvedValueOnce(result([tree(100, 20, 0, 2)]));
+    await sweep([100]);
+
+    const field = resField(100)!;
+    // Byte-compatible with the Rust /api/ls shape: one array per metric, all the
+    // same length, sharing the `t` index.
+    expect(field.bucket_secs).toBe(getSnapshot().bucketSecs);
+    expect(field.rss).toEqual([10, 20]);
+    expect(field.procs).toEqual([1, 2]);
+    expect(field.t).toHaveLength(2);
+    expect(field.cpu_seconds).toHaveLength(2);
+  });
+});
+
+describe("resourcesField", () => {
+  it("reports zeroes before the first sweep", () => {
+    const f = resourcesField();
+    expect(f.managed_rss).toBe(0);
+    expect(f.managed_procs).toBe(0);
+    expect(f.unattributed_rss).toBe(0);
+  });
+
+  it("skips an agent whose window is empty rather than counting a missing bucket", async () => {
+    sampleTrees.mockResolvedValueOnce(result([tree(100, 1000, 0, 2)]));
+    await sweep([100]);
+    // An agent registered with no samples yet (its series trimmed to nothing) must
+    // contribute zero, not throw on the absent last bucket.
+    getSnapshot().agents.set(777, []);
+
+    const f = resourcesField();
+    expect(f.managed_rss).toBe(1000);
+    expect(f.managed_procs).toBe(2);
+  });
+
+  it("sums only the LAST bucket of each agent against the unattributed rollup", async () => {
+    sampleTrees.mockResolvedValueOnce(
+      result([tree(100, 1000, 0, 1), tree(200, 2000, 0, 2)], tree(0, 500, 0, 5)),
+    );
+    await sweep([100, 200]);
+    // A second sweep must replace, not accumulate: summing every bucket in the
+    // window would report an hour of history as current memory use.
+    sampleTrees.mockResolvedValueOnce(
+      result([tree(100, 1500, 0, 3), tree(200, 2500, 0, 4)], tree(0, 700, 0, 6)),
+    );
+    await sweep([100, 200]);
+
+    const f = resourcesField();
+    expect(f.managed_rss).toBe(4000); // 1500 + 2500, not 1000+2000+1500+2500
+    expect(f.managed_procs).toBe(7); // 3 + 4
+    expect(f.unattributed_rss).toBe(700);
+    expect(f.unattributed_procs).toBe(6);
+  });
+});
+
+describe("startSampler", () => {
+  it("primes a sweep immediately and re-arms on the chosen width", async () => {
+    vi.useFakeTimers();
+    sampleTrees.mockResolvedValue(result([tree(100, 4096, 0, 1)]));
+
+    startSampler(async () => [100]);
+    await vi.advanceTimersByTimeAsync(0); // let the priming tick settle
+
+    // The first bucket must land before the console's first list poll, so the
+    // heatmap is never empty on a freshly started daemon.
+    expect(getSnapshot().agents.get(100)).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(getSnapshot().agents.get(100)!.length).toBeGreaterThan(1);
+  });
+
+  it("is idempotent — a second call does not start a second timer", async () => {
+    vi.useFakeTimers();
+    sampleTrees.mockResolvedValue(result([tree(100, 1, 0, 1)]));
+
+    startSampler(async () => [100]);
+    startSampler(async () => [100]);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Two timers would double every bucket and halve the effective window.
+    expect(getSnapshot().agents.get(100)).toHaveLength(1);
+  });
+
+  it("survives a getRoots that throws", async () => {
+    vi.useFakeTimers();
+    startSampler(async () => {
+      throw new Error("registry unreadable");
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Best-effort: the serve path must not fall over because the pid store was
+    // momentarily unreadable — the loop keeps its cadence and tries again.
+    expect(sampleTrees).not.toHaveBeenCalled();
+    // The rejection is swallowed and the loop re-arms, so draining the next tick
+    // must not surface an unhandled rejection.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(sampleTrees).not.toHaveBeenCalled();
+  });
+
+  it("does not re-arm when stopped during an in-flight sweep", async () => {
+    vi.useFakeTimers();
+    let release: (() => void) | undefined;
+    sampleTrees.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(result([tree(100, 1, 0, 1)]));
+        }),
+    );
+
+    startSampler(async () => [100]);
+    await vi.advanceTimersByTimeAsync(0);
+    // Stop lands while the sweep is still awaiting: the tick must notice on
+    // resume and NOT schedule another timer, else a stopped daemon keeps walking
+    // /proc forever.
+    stopSampler();
+    release!();
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    expect(sampleTrees).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a timer handle with no unref (browser-shaped setTimeout)", async () => {
+    vi.useFakeTimers();
+    sampleTrees.mockResolvedValue(result([tree(100, 1, 0, 1)]));
+    // Node hands back a Timeout carrying .unref(); a bare numeric handle (jsdom,
+    // some bundlers) has none, and the optional call must simply skip it.
+    const raw = globalThis.setTimeout;
+    const stub = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(((fn: () => void, ms?: number) => {
+        const h = raw(fn, ms);
+        return { ...(h as object), unref: undefined } as unknown as ReturnType<typeof raw>;
+      }) as typeof raw);
+
+    try {
+      startSampler(async () => [100]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getSnapshot().agents.get(100)).toHaveLength(1);
+    } finally {
+      stub.mockRestore();
+    }
+  });
+
+  it("uses the fast width for its first re-arm before any sweep has timed one", async () => {
+    // A fresh instance has no chosen width yet, so the tick's own
+    // `state.bucketSecs || BUCKET_FAST_SECS` fallback is what schedules the
+    // second pass. Exercised here because the shared instance is always warm.
+    vi.resetModules();
+    const fresh = await import("./serveSampler.ts");
+    vi.useFakeTimers();
+    sampleTrees.mockResolvedValue(result([tree(100, 1, 0, 1)]));
+
+    try {
+      fresh.startSampler(async () => [100]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sampleTrees).toHaveBeenCalledTimes(1);
+
+      // 60s is the fast cadence; re-arming any slower would leave the console
+      // without a second data point for five minutes.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(sampleTrees).toHaveBeenCalledTimes(2);
+    } finally {
+      fresh.stopSampler();
+    }
+  });
+
+  it("stopSampler halts the loop and allows a later restart", async () => {
+    vi.useFakeTimers();
+    sampleTrees.mockResolvedValue(result([tree(100, 1, 0, 1)]));
+
+    startSampler(async () => [100]);
+    await vi.advanceTimersByTimeAsync(0);
+    const afterPrime = getSnapshot().agents.get(100)!.length;
+
+    stopSampler();
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(getSnapshot().agents.get(100)!.length).toBe(afterPrime);
+
+    // `started` is cleared, so a restart primes again rather than no-opping.
+    startSampler(async () => [100]);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getSnapshot().agents.get(100)!.length).toBeGreaterThan(afterPrime);
   });
 });

--- a/ts/serveSampler.spec.ts
+++ b/ts/serveSampler.spec.ts
@@ -98,8 +98,8 @@ describe("sweep", () => {
     const snap = getSnapshot();
     expect([...snap.agents.keys()].sort()).toEqual([100, 200]);
     expect(snap.agents.get(100)).toHaveLength(1);
-    expect(snap.agents.get(100)![0][1].rss).toBe(2048);
-    expect(snap.agents.get(100)![0][1].procs).toBe(3);
+    expect(snap.agents.get(100)![0]![1].rss).toBe(2048);
+    expect(snap.agents.get(100)![0]![1].procs).toBe(3);
     expect(snap.unattributed.rss).toBe(8192);
     expect(snap.unattributed.procs).toBe(9);
   });
@@ -112,7 +112,7 @@ describe("sweep", () => {
     // `ay ps` semantics: sampleTrees attributes first-come, so the caller must
     // hand it the reversed list. Getting this backwards silently credits a
     // child's memory to its parent.
-    expect(sampleTrees.mock.calls[0][0]).toEqual([300, 200, 100]);
+    expect(sampleTrees.mock.calls[0]![0]).toEqual([300, 200, 100]);
   });
 
   it("converts cpuPercent into cpu-seconds of one core over the pass", async () => {
@@ -122,7 +122,7 @@ describe("sweep", () => {
 
     // 100% of one core is at most the pass duration in seconds, and the floor on
     // elapsed (1ms) keeps a sub-millisecond pass from producing a huge number.
-    const cpu = getSnapshot().agents.get(100)![0][1].cpu_seconds;
+    const cpu = getSnapshot().agents.get(100)![0]![1].cpu_seconds;
     expect(cpu).toBeGreaterThan(0);
     expect(cpu).toBeLessThan(1);
     // The unattributed rollup goes through the same conversion, at half the rate.
@@ -141,7 +141,7 @@ describe("sweep", () => {
     // cleared window (which the console would render as the agent dying).
     expect(after).toBe(width);
     expect(getSnapshot().agents.get(100)).toHaveLength(1);
-    expect(getSnapshot().agents.get(100)![0][1].rss).toBe(4096);
+    expect(getSnapshot().agents.get(100)![0]![1].rss).toBe(4096);
   });
 
   it("falls back to the fast width when the very first sweep throws", async () => {
@@ -189,8 +189,8 @@ describe("sweep", () => {
     expect(series).toHaveLength(windowLen(60));
     // Oldest-first ordering, with the three oldest dropped — the console draws
     // left-to-right, so a reversed window would render the heatmap backwards.
-    expect(series[0][1].rss).toBe(3);
-    expect(series[series.length - 1][1].rss).toBe(62);
+    expect(series[0]![1].rss).toBe(3);
+    expect(series[series.length - 1]![1].rss).toBe(62);
   });
 });
 


### PR DESCRIPTION
## 何が起きていたか

main の Matrix Test (required check 4 本すべて) が **coverage gate で落ちており、main から切った全 PR も同時に赤**になっていた。テスト自体は 105 files 全て pass しており、唯一の失敗は:

```
ERROR: Coverage for branches (89.36%) does not meet global threshold (90%)
```

## 原因は 1 ファイル

`Matrix Test` の履歴を辿ると `335aa9d4` (緑) → `0b3bbc81` (赤) の間で壊れており、その範囲の実装コミットは 1 本だけだった:

- **#396 で TS serve daemon に移植された `ts/serveSampler.ts` (218 行) に、16 行の spec しか付いていなかった** → branch coverage **12.5%**

他のファイルは 64〜78% の通常帯にあり、閾値割れはここに集中している。緩やかな drift ではなく、特定の 1 マージが落とした。

## 対応

閾値を下げるのではなく、**実際に未実行だった分岐を埋めた**。

### `ts/serveSampler.spec.ts` (12.5% → 93.75% branches, lines/functions 100%)

`sampleTrees` を mock して合成プロセスツリーを与えることで、`/proc` にも実際の fleet にも依存せず macOS/Linux CI で同一に走る。単に行を通すのではなく、壊れたら実害の出る性質を書いている:

- **deepest-first の順序** — 逆順だと子のメモリが親に計上される
- **例外時に直前スナップショットを保持** — クリアするとコンソール上ではエージェント死亡に見える
- **最終バケットのみ集計 (累積しない)** — 累積すると 1 時間の履歴が現在のメモリ使用量として出る
- **rolling window の切り詰めと oldest-first 順序** — 逆順だとヒートマップが左右反転する
- **停止中の再武装抑止** — 止めた daemon が `/proc` を歩き続けてしまう
- 他: 空 sweep での幅維持、cpuPercent → cpu 秒の換算、初回例外時の fast 幅 fallback、遅いパスでの 5m 幅選択、`resField` の転置と null、`startSampler` の冪等性・即時 prime・`getRoots` 例外の握り潰し

バケット幅は初回パスで一度だけ決まり以降固定されるため、5m 幅と初回 re-arm のテストは `vi.resetModules()` で新しいモジュール実体を取得している (同一実体では先行テストが既に fast 幅を確定させてしまう)。

### `ts/agentNice.spec.ts` (70% → 100% 全指標)

マージン確保。`applyAgentNice` はこれまで一度も実行されていなかった (spec は `agentNiceValue` のみを見ていた)。`await import("os")` 経由で参照されるため namespace object への spy では差し替わらず (exports が frozen)、`vi.mock("os", …)` を使っている。

## 結果

| | before | after |
|---|---|---|
| branches | **89.16%** | **90.11%** |
| lines | 92.67% | 94.10% |
| functions | 92.02% | 93.52% |
| statements | 94.23% | 95.75% |

`serveSampler` 単体では 12.5% → 93.75%、`agentNice` は 100%。

**マージンについて**: CI 4 環境の実測値は 89.21〜89.36 と 0.15 ほど散る。serveSampler だけだと 90.01% で 0.01 しか余裕がなく Windows で落ちる可能性があったため、agentNice を足して 90.11% まで引き上げている。

## 検証

- 全 suite: 1708 passed / 3 skipped、**branches 90.11%** で gate 通過
- `bunx tsc --noEmit`: 新規 spec にエラーなし (`noUncheckedIndexedAccess` の非 null アサーション込みで修正済み)
- `bunx oxlint`: 0 warnings / 0 errors
- 新規 spec 単体: serveSampler 22 passed、agentNice 7 passed

なおローカルでは `procStartTime.spec.ts` と `todoCli.spec.ts` が環境差で落ちるが、**CI では両方 pass している**ことを実際の run ログで確認済み (本変更とは無関係)。

これで #434 / #435 / #438 の required check が通るようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)