### PR TITLE
fix(console): New-agent の CLI 候補に存在しない CLI を出さない

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -8564,9 +8564,28 @@ my.translate = async (text, lang) => {
       // picker (options from /api/spawn-config `clis`), preselected from the
       // chain: selected agent's cli → last used cli → explicit user pick.
       const LAST_CLI_KEY = "ay.lastSpawnCli";
-      const CLI_FALLBACK = ["claude", "codex", "copilot", "cursor-agent", "goose", "aider"];
-      function cliOptions(clis, preferred) {
-        const list = clis && clis.length ? clis : CLI_FALLBACK;
+      // Last-resort names for a room with no agents to learn from. Every entry
+      // MUST be a real CLI key from default.config.yaml — the daemon rejects an
+      // unknown `cli` with 400, and the picker is the only place the user sees
+      // what is on offer, so a name invented here reads as "supported" and fails
+      // at Launch. The previous list carried three that never existed on either
+      // runtime (`goose`, `aider`, and `cursor-agent` — which is the BINARY for
+      // the CLI named `cursor`, not a CLI name).
+      const CLI_FALLBACK = ["claude", "codex", "copilot"];
+      // Fallback CLIs for a host we have not heard back from yet: the CLIs its
+      // own agents are already running. Those are host-scoped and proven to be
+      // accepted here, unlike a static guess. /api/spawn-config still replaces
+      // this with the daemon's authoritative list as soon as it answers.
+      function cliFallback(room) {
+        const seen = new Set();
+        for (const e of entries) {
+          if (room && e._src !== room) continue;
+          if (e.cli) seen.add(e.cli);
+        }
+        return seen.size ? [...seen].sort() : CLI_FALLBACK;
+      }
+      function cliOptions(clis, preferred, room) {
+        const list = clis && clis.length ? clis : cliFallback(room);
         const has = preferred && list.includes(preferred);
         return (
           `<option value=""${has ? "" : " selected"} disabled>choose a CLI…</option>` +
@@ -8621,7 +8640,7 @@ my.translate = async (text, lang) => {
       <div class="ltitle">New agent · ${esc(sourceLabel(target) || "local")}</div>
       ${hostRow}
       <div class="nfield"><label>Working dir</label><input id="nf-cwd" list="nf-cwd-list" value="${esc(cwd)}" placeholder="(host default — ignored when a Provision repo is set)" spellcheck="false" autocapitalize="off" /><datalist id="nf-cwd-list">${cwdOptions(target ? target.id : "")}</datalist></div>
-      <div class="nfield"><label>CLI</label><select id="nf-cli">${cliOptions(null, preferredCli)}</select></div>
+      <div class="nfield"><label>CLI</label><select id="nf-cli">${cliOptions(null, preferredCli, target ? target.id : "")}</select></div>
       <div class="nfield"><label>Provision repo — optional</label><input id="nf-repo" list="nf-repo-list" placeholder="owner/repo · github URL · git URL (gitlab etc.) — provisions a worktree" spellcheck="false" autocapitalize="off" /><datalist id="nf-repo-list"></datalist><div class="lhint" id="nf-repo-hint" style="display:none"></div></div>
       <div class="nfield" id="nf-branch-row" style="display:none"><label>Branch</label><input id="nf-branch" list="nf-branch-list" placeholder="(repo default) — pick one, or type a new name to create it" spellcheck="false" autocapitalize="off" /><datalist id="nf-branch-list"></datalist><div class="lhint" id="nf-branch-hint" style="display:none"></div></div>
       <div class="nfield"><label>Prompt — optional</label><textarea id="nf-prompt" rows="3" placeholder="initial message to send the agent…"></textarea></div>
@@ -8854,7 +8873,7 @@ my.translate = async (text, lang) => {
             const cliSel = $("nf-cli");
             if (cliSel && c && Array.isArray(c.clis) && c.clis.length) {
               const cur = cliSel.value;
-              cliSel.innerHTML = cliOptions(c.clis, cur || null);
+              cliSel.innerHTML = cliOptions(c.clis, cur || null, forId);
             }
           })
           .catch(() => {});


### PR DESCRIPTION
## 問題

New agent フォームの CLI picker は `/api/spawn-config` の応答が返るまで `CLI_FALLBACK` を描いている。そこに **どちらのランタイムにも存在しない CLI が 3 つ** 入っていた:

| 名前 | 実態 |
|---|---|
| `goose` | 一度も実装されたことがない |
| `aider` | 同上 |
| `cursor-agent` | CLI 名ではなく `cursor` の **binary 名** (`default.config.yaml` の `clis.cursor.binary`) |

daemon は未知の `cli` を 400 で弾く。picker はユーザーが「何を選べるか」を知る唯一の場所なので、実在しない名前を出すと「対応している」と読めてしまい、**Launch して初めて失敗する**。

実測で確認 (`default.config.yaml` の `clis` キー 19 個と突き合わせ):

```
claude       OK
codex        OK
copilot      OK
cursor-agent PHANTOM
goose        PHANTOM
aider        PHANTOM
```

## 前提の訂正

調査の過程で、当初の見立て「CLI リストが host-related になっていない」は **成立しないこと** が分かった。`showHook()` は既に host ごとに `/api/spawn-config` を引き直しており、stale-response guard も入っている (`lab/ui/index.html`)。

実際の欠陥は **応答が返るまでの最初の 1 フレームが壊れたデータを描いていること** であり、host-scoping の欠如ではない。本 PR はその 1 フレームだけを直す。

なお「一覧は `ay --help` から取れる」も実測では成立しない。`ay --help` の CLI は `ay <claude|codex|...>` というプレースホルダ表記のみで、機械可読な完全一覧も `--json` 版も無い。機械可読な出所は既存の `/api/spawn-config.clis` である。

## 対処 (2 段)

1. 最終手段の `CLI_FALLBACK` を、実在する 3 つだけに絞る
2. その手前に `cliFallback(room)` を挟み、**その room のエージェントが実際に動かしている CLI** を候補にする。host スコープであり、そこで受理されることが実証済みなので静的な推測より確実で、オフラインでも意味を持つ (`cwdOptions` が既に採っているのと同じ発想)

`/api/spawn-config` が応答すれば従来どおり daemon の正式な一覧で置き換わるため、本変更が効くのは「まだ応答が無い」「host が `fetchJSON` を持たない」場合のみ。

## 検証

抽出した実ソースの関数をそのまま実行して確認:

- 空 room → `claude,codex,copilot` (全て `default.config.yaml` に実在)
- roomA → そのエージェントの CLI のみ (roomB のものは出ない = host スコープが効いている)
- daemon の一覧は常に優先される
- fallback 経路から幻の 3 つが出ることは無い

ui-dom は `#nf-cli` に対して `claude` を選ぶだけで、どの一覧でも成立するため影響しない。

**既知の別件**: `console-dom.test.ts` の provisioning テストが 1 本落ちるが、**本変更を revert しても同じく落ちる** ことを確認済み (`spawns[…]` の assertion で、CLI picker とは無関係)。本 PR の対象外。

## 残る課題 (本 PR の範囲外)

同じ調査で判明した、独立して対処すべき点:

- **Rust は cascading config を無視し、TS は無視しない** — ユーザーが `~/.agent-yes.config.yaml` に足した CLI は TS host では動き、Rust host では 400 になる。どちらに揃えるかは能力拡張の判断を含むため要相談
- **`SUPPORTED_CLIS` が Rust 側に 2 つある** (`rs/src/cli.rs` と `rs/src/serve/control.rs`) が、テストは前者しか見ておらず後者のドリフトを検出できない
- **「対応している」と「インストール済み」の区別が無い** — 19 個並ぶが実際に入っているのは数個かもしれない。`/api/spawn-config` に `cliInfo` を足す案があるが、daemon の PATH に `~/.bun/bin` が無い問題と `binary:` マッピングの考慮が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)