### PR TITLE
perf(console): ローカル daemon が無いときは /api/host を叩かない

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -6163,12 +6163,17 @@ my.translate = async (text, lang) => {
       // every tick, which keeps the relative "age" column fresh.
       async function loadList() {
         // Refresh the local-host system snapshot for the room header line.
-        localTx
-          .fetchJSON("/api/host")
-          .then((h) => {
-            hostRes = h;
-          })
-          .catch(() => {});
+        // Only when a local ay serve is actually present: the public
+        // agent-yes.com/beta origins serve static assets only, so probing
+        // /api/host there 404s (and churns the /api/mux socket) every tick.
+        if (sources.has(LOCAL)) {
+          localTx
+            .fetchJSON("/api/host")
+            .then((h) => {
+              hostRes = h;
+            })
+            .catch(() => {});
+        }
 
         const srcs = [...sources.values()];
         await Promise.all(srcs.filter((s) => !s.streaming).map(listSource));


### PR DESCRIPTION
別クローン (`.wt-perf`) に未コミットで残っていた perf 作業を回収した。

## 問題

`loadList()` は毎ティック `localTx.fetchJSON("/api/host")` を投げていたが、これはローカルに `ay serve` がぶら下がっている場合にしか意味が無い。

公開オリジン (agent-yes.com / beta) は静的アセットしか返さないため、そこを開いているブラウザでは **毎ティック 404 が返り、さらに /api/mux ソケットを無駄に叩き続ける**。`.catch(() => {})` で握り潰されているので、症状は「なんとなく遅い」としてしか出ず原因が見えない。

## 対処

`sources.has(LOCAL)` で実際にローカル daemon が居るときだけ叩く。この判定は同ファイル内で既にローカル有無の判定として使われている書き方 (`lab/ui/index.html` の他 2 箇所と同じ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)