### PR TITLE
fix(csp): Cloudflare Web Analytics を 4 箇所すべての CSP で許可する

### DIFF
--- a/lab/ui/cf/_headers
+++ b/lab/ui/cf/_headers
@@ -9,7 +9,7 @@
 # same-origin /w/ assets (see sw.js), which 'self' allows, so the service worker
 # keeps working.
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; worker-src 'self'; manifest-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; connect-src 'self' https://s.agent-yes.com https://agent-yes.com https://cloudflareinsights.com wss:; worker-src 'self'; manifest-src 'self'
 
 # The widget bundles (channels.js / terminal.js) are designed to be imported
 # cross-origin from any page (e.g. `import AyChannel from

--- a/lab/ui/cf/worker.ts
+++ b/lab/ui/cf/worker.ts
@@ -76,8 +76,8 @@ const CSP = [
   "img-src 'self' data:",
   "font-src 'self' data:",
   "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net",
-  "connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com",
+  "connect-src 'self' https://s.agent-yes.com https://agent-yes.com https://cloudflareinsights.com wss:",
   "worker-src 'self'",
   "manifest-src 'self'",
 ].join("; ");

--- a/rs/src/serve/http.rs
+++ b/rs/src/serve/http.rs
@@ -26,8 +26,8 @@ type BoxBody = http_body_util::combinators::BoxBody<Bytes, Infallible>;
 const CONSOLE_CSP: &str = "default-src 'self'; base-uri 'none'; object-src 'none'; \
      frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; \
      font-src 'self' data:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; \
-     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; \
-     connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:; \
+     script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; \
+     connect-src 'self' https://s.agent-yes.com https://agent-yes.com https://cloudflareinsights.com wss:; \
      worker-src 'self'; manifest-src 'self'";
 
 fn full(b: Vec<u8>) -> BoxBody {

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -4724,8 +4724,8 @@ export async function cmdServe(rest: string[]): Promise<number> {
     "img-src 'self' data:",
     "font-src 'self' data:",
     "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net",
-    "connect-src 'self' https://s.agent-yes.com https://agent-yes.com wss:",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://static.cloudflareinsights.com",
+    "connect-src 'self' https://s.agent-yes.com https://agent-yes.com https://cloudflareinsights.com wss:",
     "worker-src 'self'",
     "manifest-src 'self'",
   ].join("; ");


### PR DESCRIPTION
別クローン (`.wt-perf`) に未コミットで残っていた作業を回収した。

## 変更

Cloudflare Web Analytics のビーコンを通すため、`script-src` に `static.cloudflareinsights.com` を、`connect-src` に `cloudflareinsights.com` を追加する。

## 4 箇所すべてに入れる必要がある

コンソールの CSP は **4 箇所** に重複定義されている:

| 定義場所 | 効く経路 |
|---|---|
| `lab/ui/cf/_headers` | Cloudflare の静的アセット |
| `lab/ui/cf/worker.ts` | Worker のレスポンス |
| `ts/serve.ts` | TS daemon |
| `rs/src/serve/http.rs` | Rust daemon |

1 つでも漏らすと **その経路で配信されたときだけ** ビーコンがブロックされ、「特定の host から開いたときだけ計測が欠ける」という追いにくい形で出る。

**元の作業ツリーでは `rs/src/serve/http.rs` だけが漏れていた** (Rust daemon 経由のときだけブロックされる)。回収にあたってそこを補ってある。4 箇所すべてが両方のオリジンを持つことを確認済み。

`cargo check --bin agent-yes` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)