### PR TITLE
test(ui-dom): Settings パネルが開いたままになる仕様に fold テストを合わせる

### DIFF
--- a/tests/ui-dom/console-dom.test.ts
+++ b/tests/ui-dom/console-dom.test.ts
@@ -955,13 +955,16 @@ describe("fold subagent trees", () => {
     const { ctx, page } = await openConsole(browser, url);
     try {
       await expect.poll(() => page.locator(".list .row").count()).toBe(1);
-      // The fold toggle now lives inside the Settings dropdown.
+      // The fold toggle now lives inside the Settings dropdown, which stays OPEN
+      // after an item click (416bedb — most items are toggles you may want to
+      // spin several times). So open it once and click the toggle twice; a
+      // second #viewmenubtn click here would CLOSE the panel and the following
+      // #foldbtn click would hang waiting for a hidden element.
       await page.click("#viewmenubtn");
       await page.click("#foldbtn");
       // All four agents (root + 3 descendants) now render; the chip is gone.
       await expect.poll(() => page.locator(".list .row").count()).toBe(4);
       expect(await page.locator(".subs").count()).toBe(0);
-      await page.click("#viewmenubtn");
       await page.click("#foldbtn");
       await expect.poll(() => page.locator(".list .row").count()).toBe(1);
     } finally {


### PR DESCRIPTION
## 現象

`ui-dom` (required check) が **main 上で壊れており**、今日以降に切った PR がすべて巻き添えで赤になる。#440 / #441 で同一の失敗を確認した:

```
× fold subagent trees > the toolbar button unfolds every tree, and folds again  30260ms
  → page.click: Timeout 30000ms exceeded.
```

**素の `origin/main` をチェックアウトして再現することを確認済み** —— どちらの PR の内容とも無関係。

## 原因

`416bedb` (fix(ui): keep Settings panel open on item click) で、Settings ドロップダウンは項目クリックでは閉じなくなった。意図的な変更で、fold / sort / stale はトグルなので連続で回したいことが多いため。

しかしテストは旧仕様のまま「毎回 ⚙ を開き直す」書き方だった:

| 手順 | 旧仕様 | 現仕様 |
|---|---|---|
| `click #viewmenubtn` | 開く | 開く |
| `click #foldbtn` | クリック後に閉じる | **開いたまま** |
| `click #viewmenubtn` | 開き直す | **閉じる** |
| `click #foldbtn` | OK | 非表示の要素を待ち続けて 30 秒でタイムアウト |

## なぜ CI で検出されなかったか

`416bedb` は **PR を経由せず main に直接 push** されており、`ui-dom` は PR にしか走らない。今日マージした 4 本 (#434 / #435 / #437 / #439) はいずれもこの commit より前に分岐していたため緑で、その後に切った PR から落ち始めた。

## 対処

2 回目の `#viewmenubtn` を落とし、開いたパネルのトグルを 2 回押す形にする。テストを現仕様に合わせるだけで、プロダクトコードは変更しない (パネルが開いたままになるのは意図した挙動)。

## 検証

素の `origin/main` に対して:

- 修正前: 30 秒でタイムアウト
- 修正後: **2.7 秒で pass**

これがマージされれば #440 / #441 / #442 の `ui-dom` も通るようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)