### PR TITLE
refactor(rs): SUPPORTED_CLIS の二重定義を解消し単一の出所にする

### DIFF
--- a/rs/src/bin/ayrs.rs
+++ b/rs/src/bin/ayrs.rs
@@ -19,6 +19,8 @@ mod fifo;
 mod log_files;
 #[path = "../reaper.rs"]
 mod reaper;
+#[path = "../supported_clis.rs"]
+mod supported_clis;
 #[path = "../serve/mod.rs"]
 mod serve;
 #[path = "../vterm.rs"]

--- a/rs/src/cli.rs
+++ b/rs/src/cli.rs
@@ -213,27 +213,7 @@ pub fn is_codex_family(cli: &str) -> bool {
     cli == "codex" || cli.starts_with("codex-")
 }
 
-pub const SUPPORTED_CLIS: &[&str] = &[
-    "claude",
-    "glm",
-    "pi",
-    "codex",
-    "codex-ds",
-    "codex-ds-direct",
-    "copilot",
-    "cursor",
-    "grok",
-    "qwen",
-    "auggie",
-    "amp",
-    "opencode",
-    "dsh",
-    "dsh-tui",
-    "dsh-legacy",
-    "bash",
-    "cmd",
-    "powershell",
-];
+pub use crate::supported_clis::SUPPORTED_CLIS;
 
 // Most fields here are read elsewhere in the binary; the ones that aren't
 // are kept either for forward use (auto-install, use-skills) or as deprecated

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -18,6 +18,7 @@ mod pty_spawner;
 mod ready_manager;
 mod reaper;
 mod running_lock;
+mod supported_clis;
 mod swarm;
 mod title_scanner;
 mod utils;

--- a/rs/src/serve/control.rs
+++ b/rs/src/serve/control.rs
@@ -11,27 +11,7 @@ use serde_json::{json, Value};
 
 /// CLIs `/api/spawn` accepts — the same list the runtime validates against, so
 /// the console's picker can't offer something the spawn will reject.
-pub const SUPPORTED_CLIS: &[&str] = &[
-    "claude",
-    "glm",
-    "pi",
-    "codex",
-    "codex-ds",
-    "codex-ds-direct",
-    "copilot",
-    "cursor",
-    "grok",
-    "qwen",
-    "auggie",
-    "amp",
-    "opencode",
-    "dsh",
-    "dsh-tui",
-    "dsh-legacy",
-    "bash",
-    "cmd",
-    "powershell",
-];
+pub use crate::supported_clis::SUPPORTED_CLIS;
 
 /// Absolute path to an `ay`-equivalent executable.
 ///

--- a/rs/src/supported_clis.rs
+++ b/rs/src/supported_clis.rs
@@ -1,0 +1,43 @@
+//! The one list of CLI names both binaries agree on.
+//!
+//! This used to be copy-pasted into `cli.rs` (the `agent-yes` binary, which
+//! validates `ay <cli>`) and `serve/control.rs` (the `ayrs` daemon, which both
+//! advertises the list over `/api/spawn-config` and rejects an unknown `cli` on
+//! `/api/spawn`). The two binaries include disjoint module sets — `main.rs` does
+//! not pull in `serve/`, and `ayrs.rs` does not pull in `cli.rs` — so neither
+//! could `use` the other's copy, and the duplication was load-bearing.
+//!
+//! Two copies of a list that MUST agree is a drift waiting to happen: a CLI
+//! added to one side only would be accepted by `ay` but 400 from the daemon
+//! (or offered by the console's picker and then refused at launch). Nothing
+//! failed loudly, because each copy is internally consistent.
+//!
+//! This module has no dependencies beyond `core`, so both binaries can include
+//! it with `#[path]` and share the single definition.
+
+/// Every CLI name agent-yes knows how to launch.
+///
+/// Must stay in step with the `clis:` keys of `default.config.yaml`, which is
+/// the ultimate source of truth (it carries each CLI's binary, markers and
+/// install command). `cli.rs`'s test asserts that correspondence.
+pub const SUPPORTED_CLIS: &[&str] = &[
+    "claude",
+    "glm",
+    "pi",
+    "codex",
+    "codex-ds",
+    "codex-ds-direct",
+    "copilot",
+    "cursor",
+    "grok",
+    "qwen",
+    "auggie",
+    "amp",
+    "opencode",
+    "dsh",
+    "dsh-tui",
+    "dsh-legacy",
+    "bash",
+    "cmd",
+    "powershell",
+];


### PR DESCRIPTION
## 問題

`SUPPORTED_CLIS` は 2 箇所にコピペされていた:

| 場所 | バイナリ | 用途 |
|---|---|---|
| `rs/src/cli.rs` | `agent-yes` | `ay <cli>` の検証 |
| `rs/src/serve/control.rs` | `ayrs` | `/api/spawn-config` で一覧を公開、`/api/spawn` で未知の `cli` を弾く |

**重複には理由があった**。2 つのバイナリのモジュール構成は互いに素で、`main.rs` は `serve/` を取り込まず、`ayrs.rs` は `cli.rs` を取り込まない。そのためどちらからも相手の定義を `use` できず、コピーが必要だった。

## なぜ直すか

「一致していなければならない一覧」が 2 つあるのはドリフト待ちである。片方にだけ CLI を足すと:

- `ay <新CLI>` は通るのに、デーモンは 400 を返す
- あるいはコンソールの picker には出るのに、起動時に拒否される

**どちらのコピーもそれ単体では整合しているため、何も失敗せず気付けない。** 実際 `cli.rs` の `test_supported_clis_count` は `control.rs` のコピーを一切見ておらず、後者のドリフトを検出できない。

(現時点では 2 つは一致している。これは顕在化したバグの修正ではなく、構造的なリスクの除去。)

## 対処

依存を持たない `rs/src/supported_clis.rs` を新設し、両バイナリが `#[path]` で取り込む (`ayrs.rs` が `pid_store` などの共有モジュールを取り込んでいるのと同じ方法)。

**ドリフトを監視するテストを足すのではなく、定義を 1 つにして構造的に起こり得なくする。** 重複していた 42 行が消える。

## 検証

- `cargo check --bins` — 両バイナリとも通過
- `cargo test --bin agent-yes cli::tests` — **36 passed / 0 failed** (`test_supported_clis_count` と、各エントリが `default.config.yaml` に実在することの検証を含む)

## 補足

`ui-dom` が赤い場合、それは main 側の既存の破損 (#443 で修正) であり本 PR とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)