### PR TITLE
fix(send): ay send の本文上限を 1024 文字に引き下げ

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1692,10 +1692,10 @@ describe("subcommands.cmdSend safety guards", () => {
       return true;
     };
     try {
-      const long = "x".repeat(4097);
+      const long = "x".repeat(1025);
       const code = await runSubcommand(["bun", "cli.js", "send", String(process.pid), long]);
       expect(code).toBe(1);
-      expect(stderr.join("")).toMatch(/over the 4096-char limit/);
+      expect(stderr.join("")).toMatch(/over the 1024-char limit/);
       expect(stderr.join("")).toMatch(/ay send <keyword> - < file\.txt/);
     } finally {
       process.stderr.write = orig;

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -488,7 +488,10 @@ const SEND_TYPING_MAX_WAIT_MS = 10_000;
 // stdin — it's a document, and pasting it mid-session fuses with / truncates the
 // agent's terminal. Reject it outright and point at the stdin/file path so the
 // full text survives instead of being silently mangled by a bracketed paste.
-const SEND_BODY_MAX_CHARS = 4096;
+// Lowered 4096 → 1024 (operator 2026-08-20): past ~1KB the bracketed paste keeps
+// re-rendering long enough that the trailing Enter lands mid-paste and is
+// swallowed, so the body sits unsent in the target's input line.
+const SEND_BODY_MAX_CHARS = 1024;
 
 /**
  * Whether `name` is a subcommand. `managerCommands` (default true, for the


### PR DESCRIPTION
## 背景

`ay send` で長い本文を送ると、末尾の Enter が送信されず本文が対象エージェントの入力行に残ったままになることがあった。1KB を超えると bracketed paste の再描画が長引き、Enter が paste の途中に着弾して飲み込まれるため。

## 変更

- `SEND_BODY_MAX_CHARS` を 4096 → 1024。
- 超過時のエラーは従来どおり stdin/ファイル経路 (`ay send <keyword> - < file.txt`) を案内する。
- 既存のガードテストを新しい上限に追随。

## 確認

- `bunx vitest run ts/subcommands.spec.ts -t "char"` → pass
- `bun run build && bun link`

🤖 Generated with [Claude Code](https://claude.com/claude-code)