### PR TITLE
fix(send): the over-cap hint named a remedy that does not work

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1669,7 +1669,7 @@ describe("subcommands.cmdSend safety guards", () => {
     }
   });
 
-  it("refuses a body longer than the 4096-char cap and points at the stdin path", async () => {
+  it("refuses an over-cap body and points at a remedy that WORKS (the path, not `-`)", async () => {
     const { runSubcommand } = await loadModule();
     const { appendGlobalPid } = await import("./globalPidIndex.ts");
     // Register a target agent so resolveOne succeeds and we reach the length gate.
@@ -1696,9 +1696,55 @@ describe("subcommands.cmdSend safety guards", () => {
       const code = await runSubcommand(["bun", "cli.js", "send", String(process.pid), long]);
       expect(code).toBe(1);
       expect(stderr.join("")).toMatch(/over the 1024-char limit/);
-      expect(stderr.join("")).toMatch(/ay send <keyword> - < file\.txt/);
+      // It must point at sending the PATH...
+      expect(stderr.join("")).toMatch(/send the PATH/);
+      expect(stderr.join("")).toMatch(/\/path\/to\/notes\.md/);
+      // ...and must not resurrect `- < file.txt`, which hits this same cap. The
+      // previous version of this test asserted that exact string, so the defect
+      // was pinned GREEN: an operator followed the hint and was rejected again.
+      expect(stderr.join("")).not.toMatch(/- < file\.txt/);
     } finally {
       process.stderr.write = orig;
+    }
+  });
+
+  it("applies the same cap to the `-` (stdin) body — the form the old hint recommended", async () => {
+    const { runSubcommand } = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: null,
+      cwd: process.cwd(),
+      log_file: null,
+      fifo_file: "/tmp/ay-length-stdin-test.fifo",
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+    });
+    const stderr: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (s: any) => {
+      stderr.push(String(s));
+      return true;
+    };
+    const origStdin = Object.getOwnPropertyDescriptor(process, "stdin")!;
+    const long = "y".repeat(1780);
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: (async function* () {
+        yield Buffer.from(long, "utf-8");
+      })(),
+    });
+    try {
+      const code = await runSubcommand(["bun", "cli.js", "send", String(process.pid), "-"]);
+      expect(code).toBe(1);
+      // The cap is on the body however it arrives, so `-` buys nothing.
+      expect(stderr.join("")).toMatch(/1780 chars, over the 1024-char limit/);
+    } finally {
+      process.stderr.write = orig;
+      Object.defineProperty(process, "stdin", origStdin);
     }
   });
 });

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -3436,13 +3436,25 @@ async function cmdSend(rest: string[]): Promise<number> {
 
   // Length cap: a body longer than this is a document, not a prompt — rejecting it
   // is kinder than pasting it into a live CLI where bracketed-paste will fuse or
-  // truncate it. The `-` (stdin) path carries multi-line bodies verbatim too, so
-  // the hint points at a real alternative that doesn't silently lose text.
+  // truncate it.
+  //
+  // The hint used to say `ay send <keyword> - < file.txt`, and that does not work.
+  // The `-` form only changes where the body is READ from: it is resolved into
+  // this same `body` a few lines above, so it meets this identical cap. An error
+  // naming a non-working remedy is worse than one naming none — it costs the
+  // reader a second attempt and teaches the wrong habit. Reported by an operator
+  // who followed the hint and was rejected again at 1,780 chars.
+  //
+  // What works is not sending the text at all: send the PATH and let the reader
+  // open it. That also survives a truncated delivery, since the tail is what
+  // arrives and a path is short enough to sit in it.
   if (body.length > SEND_BODY_MAX_CHARS) {
     throw new Error(
       `message is ${body.length} chars, over the ${SEND_BODY_MAX_CHARS}-char limit. ` +
-        `Longer text isn't a terminal prompt — write it to a file and pipe it, ` +
-        `e.g. 'ay send <keyword> - < file.txt', or shorten to ≤${SEND_BODY_MAX_CHARS} chars.`,
+        `Longer text isn't a terminal prompt. Piping it in with '-' hits this same ` +
+        `cap — the body is capped however it arrives. Write it to a file and send ` +
+        `the PATH instead, e.g. 'ay send <keyword> "details: /path/to/notes.md"', ` +
+        `or shorten to ≤${SEND_BODY_MAX_CHARS} chars.`,
     );
   }
 


### PR DESCRIPTION
`ay send` rejects a body over 1024 chars and told the reader to:

```
ay send <keyword> - < file.txt
```

**That form hits the same cap.** `-` only changes where the body is *read from* — it is resolved into the same `body` a few lines above the length gate. An operator followed the hint and was rejected again at 1,780 chars.

An error naming a non-working remedy is worse than one naming none: it costs a second attempt, and it teaches the wrong habit to everyone who reads it — this hint is the most-read line in the codebase for anyone who hits the cap.

## What changed

The message now names what works — write it to a file and send the **path** — and says outright that `-` shares the cap, so nobody rediscovers that by being rejected twice. Sending the path is also what survives a truncated delivery, since the tail is what arrives and a path is short enough to sit in it.

## The old hint was pinned green by its own test

```js
expect(stderr.join("")).toMatch(/ay send <keyword> - < file\.txt/);
```

The suite was *enforcing* the defect, not catching it. That assertion is now inverted — the message must **not** contain `- < file.txt` — and a second test drives an over-cap body through the `-` path and asserts `1780 chars, over the 1024-char limit`. That test is also the first evidence the stdin form shares the cap; before it, the claim rested on reading the code.

(The old test's title said "4096-char cap" while the cap has been 1024 since 2026-08-20. Corrected.)

## Mutation

| mutant | reddens |
|---|---|
| restore the old hint | only "points at a remedy that WORKS" |
| exempt `-` from the cap | only "applies the same cap to the `-` (stdin) body" |

`bun run test:bun` 1208 tests / 0 fail. `ts/subcommands.spec.ts` 131 pass.

Diff is 64 added / 6 deleted across 2 files — no formatter churn. (Worth noting for anyone else touching this repo from a symval lane: it formats with **oxfmt** via lint-staged, and running `prettier --write` on `ts/subcommands.ts` rewrites 1,113 lines.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWdcjosttjawxkff1WSvGq