### PR TITLE
test(messageLog): derive the cap sizes from the constant, and pin its value separately

### DIFF
--- a/ts/messageLog.bun.spec.ts
+++ b/ts/messageLog.bun.spec.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import {
+  MAILBOX_MAX_LINES,
   mailboxPath,
   partyMatches,
   readMailbox,
@@ -277,6 +278,16 @@ describe("messageLog unprompted-reply filter", () => {
     expect(raw.split("\n").filter((l) => l.trim())).toHaveLength(1);
   });
 
+  it("pins the cap's VALUE, because deriving from it costs the ability to notice a change", () => {
+    // The behaviour test below derives its sizes from MAILBOX_MAX_LINES so a
+    // deliberate cap change does not silently stop it crossing the boundary.
+    // That robustness has a price: it can no longer notice the constant moving.
+    // One cheap assertion buys that back — an UNintended change fails here and
+    // an intended one is a single line to update, with the behaviour test still
+    // valid at the new size.
+    expect(MAILBOX_MAX_LINES).toBe(2000);
+  });
+
   it("compacts to MAILBOX_MAX_LINES, dropping the OLDEST and keeping the newest", async () => {
     // The cap whose exhaustion caused the incident had no coverage at all before
     // this. It is the other half of the contract: the filter keeps replies out,
@@ -290,17 +301,20 @@ describe("messageLog unprompted-reply filter", () => {
     const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
     const file = mailboxPath(to, "inbox");
     await mkdir(path.dirname(file), { recursive: true });
-    const seeded = Array.from({ length: 1999 }, (_, i) =>
+    // Derived from the constant, not hard-coded: if the cap moves, a literal
+    // seed count would quietly stop crossing the boundary and this test would
+    // pass without ever compacting — the exact failure the rename above is about.
+    const seeded = Array.from({ length: MAILBOX_MAX_LINES - 1 }, (_, i) =>
       JSON.stringify(makeRecord({ from, to: toParty, body: `seed ${i}` })),
     );
     await writeFile(file, seeded.join("\n") + "\n");
 
-    // 1999 + 3 = 2002, so exactly two must be evicted, oldest first.
+    // (MAX - 1) + 3 = MAX + 2, so exactly two must be evicted, oldest first.
     for (const body of ["real A", "real B", "real C"])
       await recordInbox(makeRecord({ from, to: toParty, body }));
 
     const inbox = await readMailbox(to, "inbox");
-    expect(inbox).toHaveLength(2000);
+    expect(inbox).toHaveLength(MAILBOX_MAX_LINES);
     expect(inbox.at(-1)!.body).toBe("real C");
     expect(inbox.at(-2)!.body).toBe("real B");
     expect(inbox.at(-3)!.body).toBe("real A");

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import {
+  MAILBOX_MAX_LINES,
   mailboxPath,
   partyMatches,
   readMailbox,
@@ -277,6 +278,16 @@ describe("messageLog unprompted-reply filter", () => {
     expect(raw.split("\n").filter((l) => l.trim())).toHaveLength(1);
   });
 
+  it("pins the cap's VALUE, because deriving from it costs the ability to notice a change", () => {
+    // The behaviour test below derives its sizes from MAILBOX_MAX_LINES so a
+    // deliberate cap change does not silently stop it crossing the boundary.
+    // That robustness has a price: it can no longer notice the constant moving.
+    // One cheap assertion buys that back — an UNintended change fails here and
+    // an intended one is a single line to update, with the behaviour test still
+    // valid at the new size.
+    expect(MAILBOX_MAX_LINES).toBe(2000);
+  });
+
   it("compacts to MAILBOX_MAX_LINES, dropping the OLDEST and keeping the newest", async () => {
     // The cap whose exhaustion caused the incident had no coverage at all before
     // this. It is the other half of the contract: the filter keeps replies out,
@@ -290,17 +301,20 @@ describe("messageLog unprompted-reply filter", () => {
     const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
     const file = mailboxPath(to, "inbox");
     await mkdir(path.dirname(file), { recursive: true });
-    const seeded = Array.from({ length: 1999 }, (_, i) =>
+    // Derived from the constant, not hard-coded: if the cap moves, a literal
+    // seed count would quietly stop crossing the boundary and this test would
+    // pass without ever compacting — the exact failure the rename above is about.
+    const seeded = Array.from({ length: MAILBOX_MAX_LINES - 1 }, (_, i) =>
       JSON.stringify(makeRecord({ from, to: toParty, body: `seed ${i}` })),
     );
     await writeFile(file, seeded.join("\n") + "\n");
 
-    // 1999 + 3 = 2002, so exactly two must be evicted, oldest first.
+    // (MAX - 1) + 3 = MAX + 2, so exactly two must be evicted, oldest first.
     for (const body of ["real A", "real B", "real C"])
       await recordInbox(makeRecord({ from, to: toParty, body }));
 
     const inbox = await readMailbox(to, "inbox");
-    expect(inbox).toHaveLength(2000);
+    expect(inbox).toHaveLength(MAILBOX_MAX_LINES);
     expect(inbox.at(-1)!.body).toBe("real C");
     expect(inbox.at(-2)!.body).toBe("real B");
     expect(inbox.at(-3)!.body).toBe("real A");

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -99,7 +99,7 @@ export function shouldRecord(record: MessageRecord): boolean {
 }
 
 /** Keep at most this many lines per mailbox; older entries are compacted away. */
-const MAILBOX_MAX_LINES = 2000;
+export const MAILBOX_MAX_LINES = 2000;
 
 export type Mailbox = "inbox" | "outbox";
 


### PR DESCRIPTION
codex nitpick on #449: the compaction test hard-coded `1999` / `2002` / `2000` instead of deriving them from `MAILBOX_MAX_LINES`.

Fair — and it is the same class the rename in #449 was about. If the cap moved, a literal seed count would quietly stop crossing the boundary and the test would go on passing **without ever compacting**: a test that silently stops testing its subject.

## Deriving alone would have traded one blind spot for another

Verified rather than assumed: with the sizes derived, changing the cap leaves the behaviour test **green**, because it correctly re-centres on the new boundary. So a derived test can no longer notice the constant moving.

Both properties are wanted, so they are separated:

- the **behaviour** test derives, and stays valid at any cap;
- a **one-line** test pins the value at `2000`.

An unintended change fails the second and says so in its name. An intended one is a single line to update, with the behaviour test still meaningful at the new size.

## Mutation

`MAILBOX_MAX_LINES` 2000 → 1500 reddens **only** "pins the cap's VALUE…", and the compaction test stays green — the separation working, not a gap.

`bun run test:bun` 1210 tests / 0 fail. `ts/messageLog.spec.ts` 15 pass. Tests plus one `export` keyword; no behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWdcjosttjawxkff1WSvGq