### PR TITLE
fix(update): a version it cannot parse is not older — that downgraded a fleet

### DIFF
--- a/ts/versionChecker.spec.ts
+++ b/ts/versionChecker.spec.ts
@@ -64,6 +64,43 @@ describe("versionChecker", () => {
       expect(compareVersions("1.0.1", "1.0")).toBe(1);
       expect(compareVersions("1.0", "1.0.1")).toBe(-1);
     });
+
+    it("does not read a PRERELEASE as older than the release it is ahead of", () => {
+      // The downgrade. `checkAndAutoUpdate` installs `latest` whenever this
+      // returns < 0, so answering -1 here means installing 1.290.5 OVER
+      // 1.290.6-beta and re-execing. Measured on a live fleet: every machine on
+      // a prerelease reverted itself on its next invocation.
+      expect(compareVersions("1.290.6-beta.719.1", "1.290.5")).toBe(1);
+      expect(compareVersions("1.290.5", "1.290.6-beta.719.1")).toBe(-1);
+    });
+
+    it("ranks a prerelease below its own release, and prereleases among themselves", () => {
+      expect(compareVersions("1.2.3-beta.1", "1.2.3")).toBe(-1);
+      expect(compareVersions("1.2.3", "1.2.3-beta.1")).toBe(1);
+      // Numeric identifiers compare as numbers, not as text: 2 < 10.
+      expect(compareVersions("1.2.3-beta.2", "1.2.3-beta.10")).toBe(-1);
+      expect(compareVersions("1.0.0-alpha", "1.0.0-beta")).toBe(-1);
+      // A numeric identifier ranks below an alphanumeric one, and a shorter run
+      // of identifiers below a longer one sharing its prefix.
+      expect(compareVersions("1.0.0-1", "1.0.0-alpha")).toBe(-1);
+      expect(compareVersions("1.0.0-alpha", "1.0.0-alpha.1")).toBe(-1);
+      expect(compareVersions("1.0.0-beta.1", "1.0.0-beta.1")).toBe(0);
+    });
+
+    it("answers 0 — never -1 — for a version it cannot read", () => {
+      // "I cannot tell" must not arrive at the caller as "older": the caller's
+      // action on -1 is a global install, and its action on 0 is nothing.
+      for (const junk of ["latest", "", "next", "^1.2.3", "1.x", "not-a-version"]) {
+        expect(compareVersions(junk, "1.0.0")).toBe(0);
+        expect(compareVersions("1.0.0", junk)).toBe(0);
+      }
+    });
+
+    it("ignores build metadata, which takes no part in precedence", () => {
+      expect(compareVersions("1.2.3+build.5", "1.2.3")).toBe(0);
+      expect(compareVersions("1.2.3+a", "1.2.3+b")).toBe(0);
+      expect(compareVersions("v1.2.4", "1.2.3")).toBe(1);
+    });
   });
 
   describe("fetchLatestVersion", () => {

--- a/ts/versionChecker.spec.ts
+++ b/ts/versionChecker.spec.ts
@@ -96,6 +96,20 @@ describe("versionChecker", () => {
       }
     });
 
+    it("orders numbers past 2^53, where Number() would call them equal", () => {
+      // The same failure as the NaN this fixes, one order of magnitude out:
+      // Number() is exact only below 2^53, so a build counter past it would
+      // compare EQUAL to its neighbour and the ordering would silently collapse.
+      expect(compareVersions("1.2.3-9007199254740992", "1.2.3-9007199254740993")).toBe(-1);
+      expect(compareVersions("1.2.9007199254740993", "1.2.9007199254740992")).toBe(1);
+    });
+
+    it("treats leading zeros as the same number, not as text", () => {
+      expect(compareVersions("1.02.3", "1.2.3")).toBe(0);
+      expect(compareVersions("1.0.0-01", "1.0.0-1")).toBe(0);
+      expect(compareVersions("1.0.0-002", "1.0.0-10")).toBe(-1);
+    });
+
     it("ignores build metadata, which takes no part in precedence", () => {
       expect(compareVersions("1.2.3+build.5", "1.2.3")).toBe(0);
       expect(compareVersions("1.2.3+a", "1.2.3+b")).toBe(0);
@@ -175,6 +189,36 @@ describe("versionChecker", () => {
       process.env.AGENT_YES_UPDATED = pkg.default.version;
       await checkAndAutoUpdate();
       expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("does NOT install `latest` over a newer prerelease — the downgrade, end to end", async () => {
+      // The comparator tests pin the answer; this pins the ACTION taken on it.
+      // With the previous comparator this call ran
+      // `bun add -g agent-yes@1.290.5` over 1.290.6-beta and re-execed.
+      const { readFile } = await import("fs/promises");
+      const { execaCommand } = await import("execa");
+      _setInstalledPackageForTesting({ name: "agent-yes", version: "1.290.6-beta.719.1" });
+      vi.mocked(readFile).mockResolvedValueOnce(
+        JSON.stringify({ checkedAt: Date.now(), latestVersion: "1.290.5" }) as any,
+      );
+      await checkAndAutoUpdate();
+      expect(execaCommand).not.toHaveBeenCalled();
+      expect(process.stderr.write).not.toHaveBeenCalled();
+    });
+
+    it("still installs a real newer release over a prerelease", async () => {
+      // The other direction, so the fix cannot be "never update" in disguise.
+      const { readFile } = await import("fs/promises");
+      const { execaCommand } = await import("execa");
+      _setInstalledPackageForTesting({ name: "agent-yes", version: "1.290.6-beta.719.1" });
+      vi.mocked(readFile).mockResolvedValueOnce(
+        JSON.stringify({ checkedAt: Date.now(), latestVersion: "1.290.6" }) as any,
+      );
+      await checkAndAutoUpdate();
+      expect(execaCommand).toHaveBeenCalledWith(
+        expect.stringContaining("agent-yes@1.290.6"),
+        expect.anything(),
+      );
     });
 
     it("should use cached result within TTL and not install when up-to-date", async () => {

--- a/ts/versionChecker.spec.ts
+++ b/ts/versionChecker.spec.ts
@@ -221,6 +221,26 @@ describe("versionChecker", () => {
       );
     });
 
+    it("takes the right action on versions past 2^53, end to end", async () => {
+      // The comparator test pins the ordering; this pins the DECISION made on it.
+      // Through `Number` these two are the same float, the comparison answers
+      // "equal", and a real available upgrade is silently never installed.
+      const { readFile } = await import("fs/promises");
+      const { execaCommand } = await import("execa");
+      _setInstalledPackageForTesting({ name: "agent-yes", version: "1.2.9007199254740992" });
+      vi.mocked(readFile).mockResolvedValueOnce(
+        JSON.stringify({
+          checkedAt: Date.now(),
+          latestVersion: "1.2.9007199254740993",
+        }) as any,
+      );
+      await checkAndAutoUpdate();
+      expect(execaCommand).toHaveBeenCalledWith(
+        expect.stringContaining("agent-yes@1.2.9007199254740993"),
+        expect.anything(),
+      );
+    });
+
     it("should use cached result within TTL and not install when up-to-date", async () => {
       const { readFile } = await import("fs/promises");
       vi.mocked(readFile).mockResolvedValueOnce(

--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -218,9 +218,25 @@ export async function fetchLatestVersion(): Promise<string | null> {
 
 /** A version split into its numeric core and its prerelease identifiers. */
 interface ParsedVersion {
-  core: number[];
+  /** Kept as STRINGS — see `compareNumericStrings` for why, not `Number`. */
+  core: string[];
   /** Empty for a release; `["beta", "719", "1"]` for `-beta.719.1`. */
   pre: string[];
+}
+
+/**
+ * Compare two runs of digits as numbers, without going through `Number`.
+ *
+ * `Number` is exact only below 2^53, so a build counter past that compares EQUAL
+ * to its neighbour and the ordering silently collapses — the same class of
+ * mistake as the NaN this file is fixing, just further out. Digit strings have no
+ * such ceiling: strip leading zeros, then longer wins, then lexicographic.
+ */
+function compareNumericStrings(a: string, b: string): number {
+  const x = a.replace(/^0+(?=\d)/, "");
+  const y = b.replace(/^0+(?=\d)/, "");
+  if (x.length !== y.length) return x.length > y.length ? 1 : -1;
+  return x === y ? 0 : x > y ? 1 : -1;
 }
 
 /**
@@ -230,11 +246,17 @@ interface ParsedVersion {
  *
  * Build metadata is parsed and discarded: semver says it takes no part in
  * precedence.
+ *
+ * Deliberately more PERMISSIVE than strict semver about what it accepts — a
+ * leading zero in an identifier, a core shorter or longer than three fields.
+ * This is an ordering function, not a validator: the cost of rejecting a version
+ * npm actually published would be paid as a refused upgrade, and the cost of
+ * ordering an odd-but-real one is nothing.
  */
 export function parseVersion(v: string): ParsedVersion | null {
   const m = /^v?(\d+(?:\.\d+)*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(v.trim());
   if (!m) return null;
-  return { core: m[1]!.split(".").map(Number), pre: m[2] ? m[2].split(".") : [] };
+  return { core: m[1]!.split("."), pre: m[2] ? m[2].split(".") : [] };
 }
 
 /**
@@ -266,9 +288,8 @@ export function compareVersions(v1: string, v2: string): number {
   if (!a || !b) return 0;
 
   for (let i = 0; i < Math.max(a.core.length, b.core.length); i++) {
-    const x = a.core[i] ?? 0;
-    const y = b.core[i] ?? 0;
-    if (x !== y) return x > y ? 1 : -1;
+    const cmp = compareNumericStrings(a.core[i] ?? "0", b.core[i] ?? "0");
+    if (cmp !== 0) return cmp;
   }
 
   if (a.pre.length === 0 && b.pre.length === 0) return 0;
@@ -284,7 +305,8 @@ export function compareVersions(v1: string, v2: string): number {
     const xNum = /^\d+$/.test(x);
     const yNum = /^\d+$/.test(y);
     if (xNum && yNum) {
-      if (Number(x) !== Number(y)) return Number(x) > Number(y) ? 1 : -1;
+      const cmp = compareNumericStrings(x, y);
+      if (cmp !== 0) return cmp;
     } else if (xNum !== yNum) {
       return xNum ? -1 : 1; // numeric identifiers rank below alphanumeric ones
     } else if (x !== y) {

--- a/ts/versionChecker.ts
+++ b/ts/versionChecker.ts
@@ -216,22 +216,81 @@ export async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
+/** A version split into its numeric core and its prerelease identifiers. */
+interface ParsedVersion {
+  core: number[];
+  /** Empty for a release; `["beta", "719", "1"]` for `-beta.719.1`. */
+  pre: string[];
+}
+
 /**
- * Compare two semantic versions
- * Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
+ * Parse `1.2.3`, `v1.2.3`, `1.2.3-beta.4`, `1.2.3+build`. Returns null for
+ * anything else — including an empty string, a range, or a dist-tag name — so a
+ * caller can tell "older" from "I cannot read this".
+ *
+ * Build metadata is parsed and discarded: semver says it takes no part in
+ * precedence.
+ */
+export function parseVersion(v: string): ParsedVersion | null {
+  const m = /^v?(\d+(?:\.\d+)*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(v.trim());
+  if (!m) return null;
+  return { core: m[1]!.split(".").map(Number), pre: m[2] ? m[2].split(".") : [] };
+}
+
+/**
+ * Compare two versions. 1 if v1 > v2, -1 if v1 < v2, 0 if equal OR if either
+ * side cannot be read.
+ *
+ * That last clause is the whole point of this rewrite. The previous version was
+ * `v.split(".").map(Number)` with `parts[i] || 0`, which cannot see a
+ * prerelease: `"1.290.6-beta.719.1"` splits to `["1","290","6-beta","719","1"]`,
+ * `Number("6-beta")` is NaN, and `NaN || 0` is 0 — so the build compared as
+ * 1.290.0 and read as OLDER than 1.290.5. `checkAndAutoUpdate` acts on exactly
+ * that answer, so it installed the older release over the newer prerelease and
+ * re-execed. Measured on a live fleet: every machine on a prerelease reverted
+ * itself to the `latest` dist-tag on its next invocation, silently.
+ *
+ * So an unreadable version now answers 0, not -1. A comparison that cannot parse
+ * its input must never be the thing that says "downgrade" — the honest answer to
+ * "is this older?" when you cannot tell is "no", because the caller's action on
+ * a yes is destructive and its action on a no is nothing.
+ *
+ * Precedence, per semver: numeric core field by field, a version WITH a
+ * prerelease below the same core without one, prerelease identifiers compared
+ * numerically when both are numeric (numeric below alphanumeric otherwise), and
+ * a shorter run of identifiers below a longer one that shares its prefix.
  */
 export function compareVersions(v1: string, v2: string): number {
-  const parts1 = v1.split(".").map(Number);
-  const parts2 = v2.split(".").map(Number);
+  const a = parseVersion(v1);
+  const b = parseVersion(v2);
+  if (!a || !b) return 0;
 
-  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-    const part1 = parts1[i] || 0;
-    const part2 = parts2[i] || 0;
-
-    if (part1 > part2) return 1;
-    if (part1 < part2) return -1;
+  for (let i = 0; i < Math.max(a.core.length, b.core.length); i++) {
+    const x = a.core[i] ?? 0;
+    const y = b.core[i] ?? 0;
+    if (x !== y) return x > y ? 1 : -1;
   }
 
+  if (a.pre.length === 0 && b.pre.length === 0) return 0;
+  // A release outranks any prerelease of the same core: 1.2.3 > 1.2.3-beta.
+  if (a.pre.length === 0) return 1;
+  if (b.pre.length === 0) return -1;
+
+  for (let i = 0; i < Math.max(a.pre.length, b.pre.length); i++) {
+    const x = a.pre[i];
+    const y = b.pre[i];
+    if (x === undefined) return -1; // shorter prefix is lower
+    if (y === undefined) return 1;
+    const xNum = /^\d+$/.test(x);
+    const yNum = /^\d+$/.test(y);
+    if (xNum && yNum) {
+      if (Number(x) !== Number(y)) return Number(x) > Number(y) ? 1 : -1;
+    } else if (xNum !== yNum) {
+      return xNum ? -1 : 1; // numeric identifiers rank below alphanumeric ones
+    } else if (x !== y) {
+      return x > y ? 1 : -1;
+    }
+  }
   return 0;
 }
 


### PR DESCRIPTION
## What happened

`ay` auto-updates: on invocation it fetches npm's `latest` and, if the installed
build compares LESS than it, runs `bun add -g agent-yes@<latest>` and re-execs.
The comparison was `v.split(".").map(Number)` with `parts[i] || 0`, which cannot
see a prerelease:

```js
"1.290.6-beta.719.1".split(".").map(Number)   // [1, 290, NaN, 719, 1]
Number("6-beta")                              // NaN, and NaN || 0 === 0
compareVersions("1.290.6-beta.719.1", "1.290.5")  // -1  ← the update trigger
```

So the build compared as `1.290.0`, read as older than `1.290.5`, and the updater
did exactly what it is built to do: installed the older release over the newer
prerelease and re-execed.

**Measured, not reasoned.** A host was upgraded to a prerelease at 19:57 and had
reverted itself by 20:23 — the global `package.json`, `bun.lock` and the package
directory all rewritten within the same minute, on the first `ay` invocation after
the install. No error, no prompt. The fleet was silently back on the build the
prerelease had been installed to replace, and the mailbox and over-cap fixes that
came with it went with it.

Any prerelease install of `agent-yes` reverts itself on first use.

## The two changes, second one first

**A version it cannot read now answers `0`, never `-1`.** `latest`, `next`,
`^1.2.3`, an empty string — anything `parseVersion` refuses. The caller's action
on `-1` is a global install and its action on `0` is nothing, so "I cannot tell"
must arrive as "not older". A comparison that cannot parse its input must never be
the thing that says *downgrade*.

**`compareVersions` is now semver-correct.** Numeric core field by field; a version
WITH a prerelease below the same core without one; prerelease identifiers compared
numerically when both are numeric, numeric below alphanumeric otherwise, a shorter
run below a longer one sharing its prefix; build metadata parsed and discarded.

## Blast radius beyond the updater

The same function decides which cached Rust binaries to delete — `rustBinary.ts`
removes every cached version comparing older than the current one. The old parser
was one NaN away from deleting the wrong ones there too.

## Tests

Four new cases, **all four reddening when the previous implementation is restored**:
the downgrade itself, prerelease ordering (including numeric-vs-alphanumeric and
prefix length), the unparsable-answers-0 rule across six shapes, and build metadata
taking no part in precedence. The pre-existing comparison tests are unchanged and
still pass.

`bun run test:coverage` 1746 passed / 0 failed, branches 90.1% (gate 90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZdK7FnSwfZGWv7jn6UzEd

---

## Cross-vendor review (codex) — the same failure, further out, fixed in `a0d75c5`

**DEFECT: `Number` is exact only below 2^53.** A numeric identifier past that — a
build counter, a date-stamped patch — compares EQUAL to its neighbour, so the
ordering silently collapses exactly the way `NaN || 0` collapsed the prerelease.
Same shape: a comparison that cannot represent its input still answers
confidently, and a caller acts on the answer. The cached-Rust-binary GC is the
second victim: two versions that compare equal mean the older one is kept forever.

Nothing goes through `Number` any more. Digit runs compare as strings — strip
leading zeros, longer wins, then lexicographic — which has no ceiling.
`1.2.3-9007199254740992` now correctly precedes `…993`, and `1.02.3` still equals
`1.2.3`.

**Noted and made explicit:** this parser accepts things strict semver rejects (a
leading zero in an identifier, a core that is not exactly three fields). That is
deliberate and now says so — it is an ordering function, not a validator. The cost
of rejecting a version npm actually published would be paid as a refused upgrade;
the cost of ordering an odd-but-real one is nothing.

**The downgrade test pinned the answer, not the action.** Two tests now drive
`checkAndAutoUpdate` itself: installed `1.290.6-beta.719.1` against a `latest` of
`1.290.5` must not invoke the installer at all, and against a `latest` of `1.290.6`
it still must — so the fix cannot be "never update" in disguise.

**CONFIRMED-OK:** the unparsable→0 rule is safe for `rustBinary.ts` (both sides
there are filtered by a strict numeric-triple regex before they reach the
comparator); and the end-to-end walk with installed `1.290.6-beta.719.1` versus
`latest` `1.290.5` now returns 1 and skips the install branch entirely.

Seven tests redden when the previous comparator is restored, the end-to-end
downgrade test among them.

Final: `bun run test:coverage` 1750 passed / 0 failed, branches 90.1% (gate 90).

---

## Cross-vendor review, round 2 — three CONFIRMED-OK and one fair complaint (`b8be4e4`)

The two `checkAndAutoUpdate` tests added in `a0d75c5` both pass against its parent:
they exercise the prerelease fix, not the digit-string one. Fair. Nothing pinned
the **action** taken on a version past 2^53.

Added: installed `1.2.9007199254740992`, `latest` `1.2.9007199254740993`. Through
`Number` those are the same float, the comparison answers "equal", and a real
available upgrade is **silently never installed** — a refused update rather than a
downgrade, which is why it needed its own direction. The test asserts the installer
IS invoked, and it reddens against the previous commit.

**CONFIRMED-OK after the reviewer went looking:** `compareNumericStrings` cannot be
reached with an empty or sign-prefixed string (both call sites filter to digits
first) and handles all-zeros and 200k-digit runs without throwing; `parseVersion`
refuses nothing npm actually publishes — `0.0.0-dev`, hyphenated identifiers
including `--1`, and long prerelease chains all parse, and a dist-tag never reaches
it because the registry resolves `/latest` server-side; and the new tests leak no
module state between neighbours.

Final: `bun run test:coverage` 1751 passed / 0 failed, branches 90.1% (gate 90).
