### PR TITLE
fix(mailbox): let the producer declare a terminal wire, and stop storing it

### DIFF
--- a/lab/ui/index.html
+++ b/lab/ui/index.html
@@ -5477,7 +5477,7 @@ my.translate = async (text, lang) => {
         if (!e || data == null) return;
         perfNote("in", typeof data === "string" ? data.length : (data?.byteLength ?? 0));
         txFor(e)
-          .post("/api/send", { keyword: String(e.pid), msg: data, code: "none" })
+          .post("/api/send", { keyword: String(e.pid), msg: data, code: "none", raw: true })
           .catch(() => {});
       }
       // Apply a pending sticky Ctrl/Alt to a typed character, then disarm. Only a
@@ -6768,6 +6768,10 @@ my.translate = async (text, lang) => {
         // tracking — click / drag-motion / wheel as SGR mouse reports. onBinary
         // covers the UTF-8 mouse encoding (DECSET 1005). Verified end-to-end:
         // a drag emits \x1b[<0;..M / \x1b[<32;..M / \x1b[<0;..m, wheel \x1b[<64/65..M.
+        // `raw: true` marks the whole wire as terminal forwarding so the host keeps
+        // it out of the agent's message log — mouse reports and keypresses have
+        // shapes no host-side predicate may claim, and stored as "messages" they
+        // evict real ones from a capped mailbox (ts/messageLog.ts shouldRecord).
         // keyword MUST be a string — ay serve's POST /api/send rejects a numeric
         // keyword with 400 (pid arrives as a number from /api/ls JSON).
         const kw = String(pid);
@@ -6779,7 +6783,7 @@ my.translate = async (text, lang) => {
         const input = createInputSender((msg) =>
           typeof tx.input === "function"
             ? tx.input(kw, msg)
-            : tx.post("/api/send", { keyword: kw, msg, code: "none" }),
+            : tx.post("/api/send", { keyword: kw, msg, code: "none", raw: true }),
         );
         const fwd = (d) => {
           if (sel !== e._key) return; // ignore a stale terminal mid-switch

--- a/lab/ui/rtc.js
+++ b/lab/ui/rtc.js
@@ -108,7 +108,7 @@ export async function sendRtcInput(rtc, pid, msg) {
   const r = await rtc.req(
     "POST",
     "/api/send",
-    JSON.stringify({ keyword: String(pid), msg, code: "none" }),
+    JSON.stringify({ keyword: String(pid), msg, code: "none", raw: true }),
   );
   if (r.status < 200 || r.status >= 300) throw new Error(r.text || `send failed (${r.status})`);
 }

--- a/tests/ui-logic/rtc-latency.spec.ts
+++ b/tests/ui-logic/rtc-latency.spec.ts
@@ -35,7 +35,13 @@ describe("RTC low-latency stdin", () => {
     await sendRtcInput(rtc, 42, "a");
 
     expect(calls).toEqual([
-      ["POST", "/api/send", JSON.stringify({ keyword: "42", msg: "a", code: "none" })],
+      [
+        "POST",
+        "/api/send",
+        // `raw` marks the wire as terminal forwarding — the host must not store
+        // these bytes in the agent's message log (ts/messageLog.ts shouldRecord).
+        JSON.stringify({ keyword: "42", msg: "a", code: "none", raw: true }),
+      ],
     ]);
   });
 

--- a/ts/messageLog.bun.spec.ts
+++ b/ts/messageLog.bun.spec.ts
@@ -324,3 +324,70 @@ describe("messageLog unprompted-reply filter", () => {
     expect(inbox.some((r) => r.body === "seed 1")).toBe(false);
   });
 });
+
+describe("messageLog declared terminal-forwarding filter", () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "msglog-raw-"));
+    prevCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // The families no byte-level predicate may claim, because a keypress can make
+  // the same shape. The producer declaring the wire is what settles them.
+  const FORWARDED = [
+    ["wheel — the second largest stored family", "\x1b[<64;24;25M"],
+    ["a click inside a TUI", "\x1b[<0;12;27m"],
+    ["plain CPR, shape-identical to modified F3", "\x1b[1;1R"],
+    ["focus in", "\x1b[I"],
+    ["an ordinary keystroke", "y"],
+    ["a pasted line", "run the tests\r"],
+  ] as const;
+
+  it("drops a write the producer declared terminal forwarding, whatever it looks like", () => {
+    for (const [name, body] of FORWARDED)
+      expect(shouldRecord(makeRecord({ from: null, kind: "terminal", body })), name).toBe(false);
+  });
+
+  it("keeps those same bodies when nothing declared them", () => {
+    // The regression this guards: inferring from the bytes would delete a
+    // keypress. Only the declaration may drop them.
+    for (const [name, body] of FORWARDED)
+      expect(shouldRecord(makeRecord({ from: null, body })), name).toBe(true);
+  });
+
+  it("lets the declaration outrank a sender", () => {
+    // `from` is a margin for reply SHAPES, not a licence to store a wire the
+    // producer already said carries no messages.
+    expect(
+      shouldRecord(
+        makeRecord({
+          from: { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" },
+          kind: "terminal",
+          body: "y",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("writes NO mailbox line for declared forwarding, end to end", async () => {
+    const to = path.join(dir, "recipient");
+    process.chdir(dir);
+    for (const [, body] of FORWARDED)
+      await recordMessage(
+        makeRecord({
+          from: null,
+          kind: "terminal",
+          body,
+          to: { pid: 2222, cli: "codex", cwd: to, agent_id: "agent-B" },
+        }),
+      );
+    expect(await readMailbox(to, "inbox")).toHaveLength(0);
+  });
+});

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -324,3 +324,70 @@ describe("messageLog unprompted-reply filter", () => {
     expect(inbox.some((r) => r.body === "seed 1")).toBe(false);
   });
 });
+
+describe("messageLog declared terminal-forwarding filter", () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "msglog-raw-"));
+    prevCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // The families no byte-level predicate may claim, because a keypress can make
+  // the same shape. The producer declaring the wire is what settles them.
+  const FORWARDED = [
+    ["wheel — the second largest stored family", "\x1b[<64;24;25M"],
+    ["a click inside a TUI", "\x1b[<0;12;27m"],
+    ["plain CPR, shape-identical to modified F3", "\x1b[1;1R"],
+    ["focus in", "\x1b[I"],
+    ["an ordinary keystroke", "y"],
+    ["a pasted line", "run the tests\r"],
+  ] as const;
+
+  it("drops a write the producer declared terminal forwarding, whatever it looks like", () => {
+    for (const [name, body] of FORWARDED)
+      expect(shouldRecord(makeRecord({ from: null, kind: "terminal", body })), name).toBe(false);
+  });
+
+  it("keeps those same bodies when nothing declared them", () => {
+    // The regression this guards: inferring from the bytes would delete a
+    // keypress. Only the declaration may drop them.
+    for (const [name, body] of FORWARDED)
+      expect(shouldRecord(makeRecord({ from: null, body })), name).toBe(true);
+  });
+
+  it("lets the declaration outrank a sender", () => {
+    // `from` is a margin for reply SHAPES, not a licence to store a wire the
+    // producer already said carries no messages.
+    expect(
+      shouldRecord(
+        makeRecord({
+          from: { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" },
+          kind: "terminal",
+          body: "y",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("writes NO mailbox line for declared forwarding, end to end", async () => {
+    const to = path.join(dir, "recipient");
+    process.chdir(dir);
+    for (const [, body] of FORWARDED)
+      await recordMessage(
+        makeRecord({
+          from: null,
+          kind: "terminal",
+          body,
+          to: { pid: 2222, cli: "codex", cwd: to, agent_id: "agent-B" },
+        }),
+      );
+    expect(await readMailbox(to, "inbox")).toHaveLength(0);
+  });
+});

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -41,8 +41,11 @@ export interface MessageRecord {
   /** What kind of stdin write this was. Omitted for a normal `ay send` text
    * message; "key" for raw keystrokes (`ay key`), "select" for a menu pick
    * (`ay select`), "auto-retry" for the wrapper's own recoverable-error nudge
-   * (from is null; `body` holds the paraphrased reason + backoff state). */
-  kind?: "key" | "select" | "auto-retry";
+   * (from is null; `body` holds the paraphrased reason + backoff state);
+   * "terminal" for a viewer forwarding its terminal's raw bytes — typing, mouse
+   * reports, the terminal's own answers — which the producer declares and
+   * {@link shouldRecord} never stores. */
+  kind?: "key" | "select" | "auto-retry" | "terminal";
   /** The message body (without the `[ay-msg …]` wrapper), or — for a key/select
    * record — the keystroke names / chosen option. */
   body: string;
@@ -73,7 +76,12 @@ export interface MessageRecord {
  * Raising MAILBOX_MAX_LINES cannot fix a rate; the rows have to stop being
  * recorded.
  *
- * TWO conditions, and only the first discriminates:
+ * THREE conditions. Condition 0 is the producer's own declaration; of the two
+ * that inspect the record, only the first discriminates:
+ *
+ *  0. The write was declared raw terminal forwarding (`kind: "terminal"`) — a
+ *     viewer pushing what its xterm emitted, which is never a message however
+ *     the bytes happen to look. See below for why shape could not do this.
  *
  *  1. The body is nothing but replies nobody asked for
  *     (`isUnpromptedTerminalReply`). That predicate is deliberately narrower
@@ -87,13 +95,23 @@ export interface MessageRecord {
  *     humans — an interactive human sender is also `from === null`, which is why
  *     every ambiguous shape has to be excluded by shape.
  *
- * NOT COVERED, named rather than silently missed: SGR mouse reports (36,616
- * rows) and plain CPR, both excluded because they collide with real input;
- * focus in/out (`ESC[I` / `ESC[O`, 215 rows), shape-identical to a two-byte CSI
- * key. What is left still drops 47,331 of 128,827 stored rows (36.7%) — and
- * 99.5% of the mailbox that was measured broken, whose noise was pure DECXCPR.
+ * NOT COVERED BY SHAPE, named rather than silently missed: SGR mouse reports
+ * (36,616 rows) and plain CPR, both excluded because they collide with real
+ * input; focus in/out (`ESC[I` / `ESC[O`, 215 rows), shape-identical to a
+ * two-byte CSI key. What shape alone drops is 47,331 of 128,827 stored rows
+ * (36.7%) — and 99.5% of the mailbox that was measured broken, whose noise was
+ * pure DECXCPR.
+ *
+ * Those families are what condition 0 is for. They are undecidable from the
+ * bytes BUT trivial at the source: a viewer forwarding its terminal's stdin
+ * knows none of it is a message. So the producer says so (`raw: true` on
+ * POST /api/send), serve tags the record `kind: "terminal"`, and this drops it
+ * without inferring anything from a shape a keypress could also make. A client
+ * that does not send the flag is unaffected — it falls through to conditions 1
+ * and 2 exactly as before.
  */
 export function shouldRecord(record: MessageRecord): boolean {
+  if (record.kind === "terminal") return false;
   if (record.from) return true;
   return !isUnpromptedTerminalReply(record.body ?? "");
 }

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -3739,13 +3739,16 @@ export async function cmdServe(rest: string[]): Promise<number> {
         msg: string;
         code?: string;
         from?: MailParty | null;
+        /** Set by a viewer forwarding its terminal's raw bytes — see the record
+         * below. Absent from every `ay send`, and from older consoles. */
+        raw?: boolean;
       };
       try {
         body = (await req.json()) as typeof body;
       } catch {
         return new Response("invalid JSON body", { status: 400 });
       }
-      const { keyword, msg = "", code = "enter", from = null } = body;
+      const { keyword, msg = "", code = "enter", from = null, raw = false } = body;
       if (!keyword || typeof keyword !== "string") {
         return new Response("missing keyword", { status: 400 });
       }
@@ -3789,6 +3792,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
         // outbox on its host). The sender crossed the wire, so `from.cwd` names a
         // path on another machine — mark it remote so the peer's cwd isn't misread
         // as local. Only real message bodies are logged. Best-effort.
+        //
+        // A console forwards its terminal's stdin over this same endpoint — every
+        // keystroke, xterm's own answers to the TUI's queries, and SGR mouse
+        // reports — and marks those writes `raw`. `shouldRecord` drops them: the
+        // mailbox is a message log, and mouse/keypress shapes are exactly the ones
+        // no byte-level predicate may claim (ts/messageLog.ts).
         if (msg) {
           const senderParty: MailParty | null =
             from && typeof from === "object" && typeof from.pid === "number"
@@ -3808,6 +3817,7 @@ export async function cmdServe(rest: string[]): Promise<number> {
               cwd: record.cwd,
               agent_id: record.agent_id,
             },
+            kind: raw === true ? "terminal" : undefined,
             body: msg,
             code: code.toLowerCase() === "enter" ? undefined : code.toLowerCase(),
             confirmed: true,


### PR DESCRIPTION
## What was measured

A lane reported its `ay msgs --in --json` window holding **50 of 50 rows of
terminal control noise** — bodies that were a bare `ESC[?45;3R` (a cursor
report) or `ESC[<64;24;25M` (an SGR wheel event), all with `from: null` — and a
real inter-agent message sent minutes earlier already pushed out of the window.
The harm is not the noise: it is that an evicted message is indistinguishable
from one that was never sent, and this log is the documented recovery path for
a message that arrived truncated.

## Why #447 could not finish this

#447 dropped the reply families no key can produce (`isUnpromptedTerminalReply`)
and deliberately named what it left behind: SGR mouse (36,616 of 128,827 stored
rows) and plain CPR, because `ESC[1;2R` is also xterm's modified F3 and a click
inside a TUI is byte-identical to the pointer drifting over it. Its conclusion:

> A discriminator has to come from the producer, which is the only place the
> intent is known.

## The change

The producer says so:

- `lab/ui/index.html` (terminal input, mobile key bar) and `lab/ui/rtc.js`
  (`sendRtcInput`) post `raw: true` on the wire that forwards the terminal's own
  bytes. Those are every path from a console to a TS daemon's `/api/send`.
- `ts/serve.ts` tags such a record `kind: "terminal"`.
- `ts/messageLog.ts` `shouldRecord` drops `kind: "terminal"` first, before any
  shape is inspected — so the two undecidable families stop being stored without
  a predicate ever having to claim a shape a keypress could make.

Not changed on purpose:

- **`noteStdinWrite` still uses the narrow `isTerminalReply`.** A click on a TUI
  menu *is* meaningful stdin; the console's stdin-flash is a different question
  from what belongs in a message log.
- **The console's `/exit` stop keeps its record.** It happens once per stop, so
  it evicts nothing, and "the console asked this agent to exit" is worth having.
- **ayrs** writes no recipient inbox at all today, so it has nothing to mark yet
  — worth knowing separately: on a Rust host, messages received over the wire do
  not appear in `ay msgs --in`.

Compatible in both directions: the flag is additive, and absent means "decide by
shape", i.e. conditions 1 and 2 exactly as they are today. An older console
against a new daemon and a new console against an older daemon both behave as
before.

## Verification

- `ts/messageLog.spec.ts` + `.bun.spec.ts`: a declared wire is dropped whatever
  the bytes look like (wheel, click, plain CPR, focus-in, a plain keystroke, a
  pasted line); **the same bodies with nothing declaring them are still kept** —
  that test is the guard against re-introducing shape inference; the declaration
  outranks a sender; and end-to-end no mailbox line is written.
- `tests/ui-logic/rtc-latency.spec.ts` pins the flag on the RTC fallback body.
- Full suite green locally: 1746 passed / 3 skipped, `tsgo --noEmit` clean.

One nuance for the report itself: `-n` defaults to 50, so those "50 of 50" rows
were the display window, not the 2000-line file — `ay msgs --in -n 500` could
still have recovered that message. The fix stops the window filling in the first
place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KswvYkUovXmBSuVUngkif