### PR TITLE
fix(mailbox): record where a write came from, and stop calling it human

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -994,6 +994,7 @@ export default async function agentYes({
             // runtime's record_auto_retry_inbox) — best-effort, never blocks.
             void recordInbox({
               at: now,
+              origin: "wrapper",
               from: null,
               to: { pid: process.pid, cli, cwd: workingDir },
               kind: "auto-retry",

--- a/ts/messageLog.bun.spec.ts
+++ b/ts/messageLog.bun.spec.ts
@@ -10,6 +10,7 @@ import {
   recordInbox,
   recordMessage,
   recordOutbox,
+  senderLabel,
   shouldRecord,
   type MessageRecord,
 } from "./messageLog.ts";
@@ -389,5 +390,64 @@ describe("messageLog declared terminal-forwarding filter", () => {
         }),
       );
     expect(await readMailbox(to, "inbox")).toHaveLength(0);
+  });
+});
+
+describe("messageLog sender provenance", () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "msglog-prov-"));
+    prevCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // The failure this guards: a lane saw 50 rows of a terminal's own cursor
+  // reports listed as "human". An agent that weighs a human's instruction above
+  // an agent's was being handed control bytes wearing the one label it obeys.
+  it("names a human ONLY for a local shell invocation", () => {
+    expect(senderLabel(makeRecord({ from: null, origin: "shell" }))).toBe("human");
+  });
+
+  it("never calls an unattributed wire write, or a public visitor, human", () => {
+    expect(senderLabel(makeRecord({ from: null, origin: "wire" }))).toBe("wire");
+    expect(senderLabel(makeRecord({ from: null, origin: "visitor" }))).toBe("visitor");
+  });
+
+  it("says unattributed when nothing recorded an origin", () => {
+    // Rows written before `origin` existed. "human" was the old default here,
+    // and it is exactly the claim the record cannot support.
+    expect(senderLabel(makeRecord({ from: null }))).toBe("unattributed");
+  });
+
+  it("still names the wrapper's own nudge, by origin or by legacy kind", () => {
+    expect(senderLabel(makeRecord({ from: null, origin: "wrapper" }))).toBe("agent-yes");
+    expect(senderLabel(makeRecord({ from: null, kind: "auto-retry" }))).toBe("agent-yes");
+  });
+
+  it("names an attributed sender by its agent, whatever the origin says", () => {
+    const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
+    expect(senderLabel(makeRecord({ from }))).toBe("claude #1111");
+    expect(senderLabel(makeRecord({ from, origin: "wire" }))).toBe("claude #1111");
+  });
+
+  it("round-trips origin through a mailbox so a reader can check it itself", async () => {
+    const to = path.join(dir, "recipient");
+    process.chdir(dir);
+    await recordMessage(
+      makeRecord({
+        from: null,
+        origin: "wire",
+        body: "deploy is green",
+        to: { pid: 2222, cli: "codex", cwd: to, agent_id: "agent-B" },
+      }),
+    );
+    const [rec] = await readMailbox(to, "inbox");
+    expect(rec?.origin).toBe("wire");
   });
 });

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -10,6 +10,7 @@ import {
   recordInbox,
   recordMessage,
   recordOutbox,
+  senderLabel,
   shouldRecord,
   type MessageRecord,
 } from "./messageLog.ts";
@@ -389,5 +390,64 @@ describe("messageLog declared terminal-forwarding filter", () => {
         }),
       );
     expect(await readMailbox(to, "inbox")).toHaveLength(0);
+  });
+});
+
+describe("messageLog sender provenance", () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "msglog-prov-"));
+    prevCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // The failure this guards: a lane saw 50 rows of a terminal's own cursor
+  // reports listed as "human". An agent that weighs a human's instruction above
+  // an agent's was being handed control bytes wearing the one label it obeys.
+  it("names a human ONLY for a local shell invocation", () => {
+    expect(senderLabel(makeRecord({ from: null, origin: "shell" }))).toBe("human");
+  });
+
+  it("never calls an unattributed wire write, or a public visitor, human", () => {
+    expect(senderLabel(makeRecord({ from: null, origin: "wire" }))).toBe("wire");
+    expect(senderLabel(makeRecord({ from: null, origin: "visitor" }))).toBe("visitor");
+  });
+
+  it("says unattributed when nothing recorded an origin", () => {
+    // Rows written before `origin` existed. "human" was the old default here,
+    // and it is exactly the claim the record cannot support.
+    expect(senderLabel(makeRecord({ from: null }))).toBe("unattributed");
+  });
+
+  it("still names the wrapper's own nudge, by origin or by legacy kind", () => {
+    expect(senderLabel(makeRecord({ from: null, origin: "wrapper" }))).toBe("agent-yes");
+    expect(senderLabel(makeRecord({ from: null, kind: "auto-retry" }))).toBe("agent-yes");
+  });
+
+  it("names an attributed sender by its agent, whatever the origin says", () => {
+    const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
+    expect(senderLabel(makeRecord({ from }))).toBe("claude #1111");
+    expect(senderLabel(makeRecord({ from, origin: "wire" }))).toBe("claude #1111");
+  });
+
+  it("round-trips origin through a mailbox so a reader can check it itself", async () => {
+    const to = path.join(dir, "recipient");
+    process.chdir(dir);
+    await recordMessage(
+      makeRecord({
+        from: null,
+        origin: "wire",
+        body: "deploy is green",
+        to: { pid: 2222, cli: "codex", cwd: to, agent_id: "agent-B" },
+      }),
+    );
+    const [rec] = await readMailbox(to, "inbox");
+    expect(rec?.origin).toBe("wire");
   });
 });

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -20,6 +20,27 @@ import path from "path";
 import { logger } from "./logger.ts";
 import { isUnpromptedTerminalReply } from "./terminalReply.ts";
 
+/**
+ * Where a write entered this host — its provenance, as known at the door.
+ *
+ * `from === null` used to be read as "a human typed this", because the one
+ * producer that left it null was an interactive `ay send`. It is now four
+ * producers, and only one of them is a person's shell. A console forwarding a
+ * terminal's own bytes and a public callback visitor also arrive unattributed,
+ * so inferring a human from an absent sender hands the operator's label to a
+ * wire artefact — and an agent that weighs a human's instruction above another
+ * agent's is exactly the reader that must not be told that.
+ *
+ *  - `shell`   — a local `ay send` / `key` / `select` with no agent context.
+ *                The only origin a person is behind, and even then only
+ *                probably: a script invoking the CLI looks the same.
+ *  - `wire`    — an unattributed `POST /api/send`: the web console, a remote
+ *                `ay send` from a host that sent no `from`, any HTTP client.
+ *  - `visitor` — the public callback widget. A stranger on the internet.
+ *  - `wrapper` — the agent's own supervisor (the auto-retry nudge).
+ */
+export type MessageOrigin = "shell" | "wire" | "visitor" | "wrapper";
+
 /** One end of a message: enough to attribute and to route a reply. */
 export interface MailParty {
   pid: number;
@@ -34,8 +55,14 @@ export interface MessageRecord {
   at: number;
   /** The per-send nonce from the `[ay-msg …]` wrapper, when the body was wrapped. */
   nonce?: string;
-  /** Sender; `null` when an interactive human shell sent it (no agent context). */
+  /** Sender; `null` when no agent context was attributed to the write. `null`
+   * is NOT evidence of a human — see {@link MessageOrigin}. */
   from: MailParty | null;
+  /** WHERE the write entered this host, recorded by the entry point rather than
+   * inferred later from `from`. Absent on rows written before this field
+   * existed, which is why a missing value renders as unattributed and never as
+   * a human. See {@link MessageOrigin}. */
+  origin?: MessageOrigin;
   /** Recipient agent. */
   to: MailParty;
   /** What kind of stdin write this was. Omitted for a normal `ay send` text
@@ -110,6 +137,34 @@ export interface MessageRecord {
  * that does not send the flag is unaffected — it falls through to conditions 1
  * and 2 exactly as before.
  */
+/**
+ * How to name the sender of a record in a listing.
+ *
+ * Never claims a human on the strength of an absent sender: an unattributed
+ * write whose origin was not recorded is `unattributed`, because that is all
+ * that is known about it. Only `origin: "shell"` — a local CLI invocation with
+ * a terminal behind it — is called human, and a caller that must not be fooled
+ * should read `origin` itself rather than this label.
+ */
+export function senderLabel(record: MessageRecord): string {
+  if (record.from) return `${record.from.cli} #${record.from.pid}`;
+  switch (record.origin) {
+    case "shell":
+      return "human";
+    case "wire":
+      return "wire";
+    case "visitor":
+      return "visitor";
+    case "wrapper":
+      return "agent-yes";
+  }
+  // No origin recorded. Written before the field existed, or by a producer that
+  // did not declare one — either way the sender is unknown, and "human" is a
+  // claim nothing here supports. The auto-retry nudge predates `origin` and is
+  // still identifiable by its kind.
+  return record.kind === "auto-retry" ? "agent-yes" : "unattributed";
+}
+
 export function shouldRecord(record: MessageRecord): boolean {
   if (record.kind === "terminal") return false;
   if (record.from) return true;

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -3810,6 +3810,10 @@ export async function cmdServe(rest: string[]): Promise<number> {
               : null;
           await recordInbox({
             at: Date.now(),
+            // Unattributed HTTP, not a person: the console, a remote `ay send`
+            // that sent no `from`, any client at all. Recorded so a listing can
+            // never mistake it for the operator.
+            origin: senderParty ? undefined : "wire",
             from: senderParty,
             to: {
               pid: record.pid,
@@ -4834,6 +4838,9 @@ export async function cmdServe(rest: string[]): Promise<number> {
       await noteStdinWrite(record.pid, record.fifo_file, true);
       await recordInbox({
         at: Date.now(),
+        // A stranger on the public callback page. The framing in `body` says so
+        // to a reader; `origin` says so to the listing.
+        origin: "visitor",
         from: null,
         to: { pid: record.pid, cli: record.cli, cwd: record.cwd, agent_id: record.agent_id },
         body: framed,

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -28,6 +28,7 @@ import {
   readMailbox,
   recordMessage,
   recordOutbox,
+  senderLabel,
 } from "./messageLog.ts";
 import { badgeLabel, matchBadges, TYPING_BADGE } from "./badges.ts";
 import {
@@ -220,7 +221,9 @@ export interface MessageEdge {
   by: number;
   target: number;
   at: number;
-  kind?: "key" | "select" | "auto-retry";
+  /** Derived, not re-listed: a hand-copied union here silently broke when
+   * `MessageRecord["kind"]` grew a member (#453 added "terminal"). */
+  kind?: MessageRecord["kind"];
 }
 
 /**
@@ -1352,6 +1355,7 @@ async function runRemoteSend(remote: ResolvedRemote, msg: string, code: string):
   if (msg && msg !== "-") {
     await recordOutbox({
       at: Date.now(),
+      origin: from ? undefined : "shell",
       from,
       to: {
         pid: data.pid,
@@ -3597,6 +3601,9 @@ async function cmdSend(rest: string[]): Promise<number> {
     await recordMessage({
       at: Date.now(),
       nonce,
+      // A local CLI invocation. When there is no agent behind it, a terminal
+      // is — the one unattributed origin a person is plausibly at.
+      origin: sender.agent ? undefined : "shell",
       from: sender.agent
         ? {
             pid: sender.agent.pid,
@@ -3764,13 +3771,10 @@ async function cmdMsgs(rest: string[]): Promise<number> {
 
   for (const { dir, rec } of shown) {
     const when = new Date(rec.at).toLocaleTimeString();
-    // auto-retry nudges are written by the agent's own wrapper (from is null
-    // there too) — label them as agent-yes, not a human send.
-    const fromLabel = rec.from
-      ? `${rec.from.cli} #${rec.from.pid}`
-      : rec.kind === "auto-retry"
-        ? "agent-yes"
-        : "human";
+    // Names the sender from the RECORDED origin, never from `from` being null —
+    // a console's wire write and a public visitor are unattributed too, and
+    // calling either of them "human" is the claim a reader must not be handed.
+    const fromLabel = senderLabel(rec);
     const peer = dir === "out" ? `→ ${rec.to.cli} #${rec.to.pid}` : `← ${fromLabel}`;
     const via = rec.remote ? ` (via ${rec.remote})` : "";
     const flag = rec.confirmed === false ? " (unconfirmed)" : "";
@@ -3807,6 +3811,7 @@ async function recordKeyEvent(
 ): Promise<void> {
   await recordMessage({
     at: Date.now(),
+    origin: sender.agent ? undefined : "shell",
     from: sender.agent
       ? {
           pid: sender.agent.pid,


### PR DESCRIPTION
## What was reported

A lane found 50 mailbox rows whose bodies were a terminal's own cursor reports
(`ESC[?45;3R`) listed as `← human`. Their point, and it is the right one:

> An agent that trusts sender identity — mine does, a human message outranks an
> agent's — is being handed control sequences wearing the one label it is built
> to obey. So the bug is not only eviction pressure, it is a provenance failure.

#453 stopped storing those rows. It did not touch the label, and the label is
wrong independently of what gets stored.

## Why the label was wrong

`ts/subcommands.ts` rendered any `from === null` record as `human`. That was
true when `ay send` from an interactive shell was the only producer that left
`from` null. It has four producers now, and only one is a person:

| producer | `from` | rendered before |
|---|---|---|
| local `ay send` / `key` / `select`, no agent context | null | `human` ✓ |
| unattributed `POST /api/send` (console, remote send with no `from`) | null | `human` ✗ |
| the public callback widget — **a stranger on the internet** | null | `human` ✗ |
| the wrapper's auto-retry nudge | null | `agent-yes` ✓ (by `kind`) |

The callback-visitor row is the sharpest case: anyone who can open a shared
callback page could put text in an agent's mailbox under the operator's label.

## The change

Record provenance at the door instead of inferring it later. `MessageRecord`
gains `origin?: "shell" | "wire" | "visitor" | "wrapper"`, each producer stamps
its own, and `senderLabel()` names the sender from that.

A row with **no** origin — every row written before this field — renders
`unattributed`, not `human`. An absent sender is absence of evidence, and
defaulting it to the most-trusted label is the bug itself.

`origin` rides through `ay msgs --json` unchanged, so a reader that must not be
fooled can check provenance programmatically rather than trusting a rendered
string.

## Also in here

`MessageEdge.kind` re-listed `MessageRecord["kind"]`'s union by hand and did not
grow the `"terminal"` member #453 added — a real type break from that PR, caught
by `tsgo` here. Now derived from `MessageRecord`, so it cannot drift again.
(`recentMessageEdges` filters to `from.pid`-bearing rows, so no `"terminal"`
record could actually reach it — the break was type-level only.)

## Verification

- `ts/messageLog.spec.ts` + `.bun.spec.ts`: human only for `shell`; `wire` and
  `visitor` never render as human; **a missing origin renders `unattributed`** —
  that test is the guard against the old default coming back; the wrapper is
  still named via `origin` or legacy `kind`; an attributed sender always wins;
  and `origin` round-trips through a real mailbox file.
- Full suites green: vitest 1752 passed / 3 skipped; `bun test .bun.` 1219
  passed / 1 skipped.
- `tsgo --noEmit` error count 50 → 49 against the same baseline: no new errors,
  one removed (the MessageEdge drift above).

Reported by a lane running stable 1.290.5, which carries neither #447 nor #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)