### PR TITLE
fix(send): deliver a message as one paste, not a burst the CLI must guess at

### DIFF
--- a/agent-yes.config.schema.json
+++ b/agent-yes.config.schema.json
@@ -140,6 +140,10 @@
           "type": "boolean",
           "description": "If true, don't split lines by newline (for CLIs using cursor movement like codex)"
         },
+        "bracketedPaste": {
+          "type": "boolean",
+          "description": "If true, `ay send` delivers the body as one bracketed paste (DECSET 2004) rather than a keystroke burst the CLI must segment by timing — which silently swallows the head of long bodies. Only set it for a CLI that enables the mode: its PTY .raw.log will contain ESC[?2004h."
+        },
         "enter": {
           "type": "array",
           "items": { "$ref": "#/definitions/RegexSource" },

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -1,6 +1,12 @@
 clis:
   claude:
     promptArg: last-arg
+    # `ay send` delivers the body as one bracketed paste (DECSET 2004) instead
+    # of a keystroke burst this CLI would have to segment by arrival timing.
+    # Without it the leading part of a long body is swallowed and the model sees
+    # only a tail — nondeterministically, so no length rule makes a sender safe.
+    # Measured before enabling: every claude agent log carries ESC[?2004h.
+    bracketedPaste: true
     systemPrompt: --append-system-prompt
     # yesArgs: appended when `-y` / --yes is passed. The per-CLI "yolo" flag.
     yesArgs:
@@ -288,6 +294,11 @@ clis:
 
   codex:
     promptArg: first-arg
+    # Verified the same way as claude's — codex's PTY log carries ESC[?2004h,
+    # so it honours a framed paste. That is the claim being made here; codex was
+    # NOT observed splitting an unframed burst the way claude does. Sending one
+    # message as one paste is right either way. See ts/bracketedPaste.ts.
+    bracketedPaste: true
     # yesArgs: `-y` / --yes maps to codex's own "yolo" flag. Codex rejects
     # claude's --dangerously-skip-permissions outright, and its bwrap sandbox
     # cannot initialize inside an already-sandboxed/containerized environment

--- a/ts/bracketedPaste.bun.spec.ts
+++ b/ts/bracketedPaste.bun.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import {
+  framePaste,
+  PASTE_END,
+  PASTE_START,
+  shouldFramePaste,
+  stripPasteMarkers,
+} from "./bracketedPaste.ts";
+
+describe("framePaste", () => {
+  it("wraps a payload in the paste markers", () => {
+    expect(framePaste("hello")).toBe(`${PASTE_START}hello${PASTE_END}`);
+  });
+
+  it("keeps the payload's own bytes, newlines included", () => {
+    // The whole point: the newlines must survive as text, not act as submits.
+    const body = "line one\nline two\nline three";
+    expect(framePaste(body)).toBe(`${PASTE_START}${body}${PASTE_END}`);
+  });
+
+  it("does not emit an empty paste", () => {
+    expect(framePaste("")).toBe("");
+  });
+});
+
+describe("stripPasteMarkers", () => {
+  // An embedded END marker would close our paste early and hand every following
+  // byte to the CLI as live keystrokes — a message that drives the receiving
+  // agent's TUI instead of being read by it.
+  it("removes an embedded END marker so a body cannot escape its own paste", () => {
+    const hostile = `innocent${PASTE_END}:q!\rrm -rf /`;
+    const framed = framePaste(hostile);
+    expect(framed.indexOf(PASTE_END)).toBe(framed.length - PASTE_END.length);
+    expect(framed.split(PASTE_END)).toHaveLength(2);
+  });
+
+  it("removes an embedded START marker too", () => {
+    expect(stripPasteMarkers(`a${PASTE_START}b`)).toBe("ab");
+    expect(framePaste(`a${PASTE_START}b`).split(PASTE_START)).toHaveLength(2);
+  });
+
+  it("leaves a body with no markers untouched", () => {
+    expect(stripPasteMarkers("plain \x1b[A text")).toBe("plain \x1b[A text");
+  });
+});
+
+describe("shouldFramePaste", () => {
+  it("frames for a supporting CLI", () => {
+    expect(shouldFramePaste({ supported: true, body: "hi", isSlashCommand: false })).toBe(true);
+  });
+
+  it("never frames for a CLI that does not enable the mode", () => {
+    // It would see ESC[200~ as literal text.
+    expect(shouldFramePaste({ supported: false, body: "hi", isSlashCommand: false })).toBe(false);
+  });
+
+  it("does not frame a slash command — pasted text is not typing", () => {
+    expect(shouldFramePaste({ supported: true, body: "/exit", isSlashCommand: true })).toBe(false);
+  });
+
+  it("frames regardless of length or line count", () => {
+    // Both rules were tried by the lanes hitting this bug and both gave false
+    // assurance: single-line 900-char bodies were lost, and the same body
+    // survived at a different terminal width. There is no safe size.
+    for (const body of ["x", "x".repeat(900), "a\nb", "a".repeat(900) + "\n" + "b".repeat(90)]) {
+      expect(shouldFramePaste({ supported: true, body, isSlashCommand: false })).toBe(true);
+    }
+  });
+
+  it("has nothing to frame for an empty body", () => {
+    expect(shouldFramePaste({ supported: true, body: "", isSlashCommand: false })).toBe(false);
+  });
+});

--- a/ts/bracketedPaste.spec.ts
+++ b/ts/bracketedPaste.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  framePaste,
+  PASTE_END,
+  PASTE_START,
+  shouldFramePaste,
+  stripPasteMarkers,
+} from "./bracketedPaste.ts";
+
+describe("framePaste", () => {
+  it("wraps a payload in the paste markers", () => {
+    expect(framePaste("hello")).toBe(`${PASTE_START}hello${PASTE_END}`);
+  });
+
+  it("keeps the payload's own bytes, newlines included", () => {
+    // The whole point: the newlines must survive as text, not act as submits.
+    const body = "line one\nline two\nline three";
+    expect(framePaste(body)).toBe(`${PASTE_START}${body}${PASTE_END}`);
+  });
+
+  it("does not emit an empty paste", () => {
+    expect(framePaste("")).toBe("");
+  });
+});
+
+describe("stripPasteMarkers", () => {
+  // An embedded END marker would close our paste early and hand every following
+  // byte to the CLI as live keystrokes — a message that drives the receiving
+  // agent's TUI instead of being read by it.
+  it("removes an embedded END marker so a body cannot escape its own paste", () => {
+    const hostile = `innocent${PASTE_END}:q!\rrm -rf /`;
+    const framed = framePaste(hostile);
+    expect(framed.indexOf(PASTE_END)).toBe(framed.length - PASTE_END.length);
+    expect(framed.split(PASTE_END)).toHaveLength(2);
+  });
+
+  it("removes an embedded START marker too", () => {
+    expect(stripPasteMarkers(`a${PASTE_START}b`)).toBe("ab");
+    expect(framePaste(`a${PASTE_START}b`).split(PASTE_START)).toHaveLength(2);
+  });
+
+  it("leaves a body with no markers untouched", () => {
+    expect(stripPasteMarkers("plain \x1b[A text")).toBe("plain \x1b[A text");
+  });
+});
+
+describe("shouldFramePaste", () => {
+  it("frames for a supporting CLI", () => {
+    expect(shouldFramePaste({ supported: true, body: "hi", isSlashCommand: false })).toBe(true);
+  });
+
+  it("never frames for a CLI that does not enable the mode", () => {
+    // It would see ESC[200~ as literal text.
+    expect(shouldFramePaste({ supported: false, body: "hi", isSlashCommand: false })).toBe(false);
+  });
+
+  it("does not frame a slash command — pasted text is not typing", () => {
+    expect(shouldFramePaste({ supported: true, body: "/exit", isSlashCommand: true })).toBe(false);
+  });
+
+  it("frames regardless of length or line count", () => {
+    // Both rules were tried by the lanes hitting this bug and both gave false
+    // assurance: single-line 900-char bodies were lost, and the same body
+    // survived at a different terminal width. There is no safe size.
+    for (const body of ["x", "x".repeat(900), "a\nb", "a".repeat(900) + "\n" + "b".repeat(90)]) {
+      expect(shouldFramePaste({ supported: true, body, isSlashCommand: false })).toBe(true);
+    }
+  });
+
+  it("has nothing to frame for an empty body", () => {
+    expect(shouldFramePaste({ supported: true, body: "", isSlashCommand: false })).toBe(false);
+  });
+});

--- a/ts/bracketedPaste.ts
+++ b/ts/bracketedPaste.ts
@@ -33,6 +33,16 @@
  *   grep -ac $'\\x1b\\[?2004h' <the agent's .raw.log>
  */
 
+/**
+ * The submit Enter must be written AFTER the framed payload, never inside it.
+ * Inside a paste a CR is content — it inserts a newline and submits nothing, so
+ * the message would sit unsent in the composer. Callers therefore write
+ * `framePaste(body)` first and the trailing code as a separate write; a refactor
+ * that folds the trailing byte into the framed string would break delivery
+ * silently, with no error at either end. Pinned by the byte-level FIFO test in
+ * ts/subcommands.spec.ts, which asserts the CR lands after the END marker.
+ */
+
 /** DECSET 2004 paste start — what a terminal emits before pasted content. */
 export const PASTE_START = "\x1b[200~";
 /** DECSET 2004 paste end. */

--- a/ts/bracketedPaste.ts
+++ b/ts/bracketedPaste.ts
@@ -1,0 +1,83 @@
+/**
+ * Deliver an `ay send` body as ONE paste instead of a burst of keystrokes.
+ *
+ * The bug this exists for: `ay send` writes the body into the agent's stdin as
+ * raw bytes, and a TUI that does not know a paste is happening has to GUESS
+ * from arrival timing where one ends. Claude's input does exactly that, and
+ * when the guess SPLITS the burst the leading part is lost — the model is
+ * handed only a tail, with no error at either end. Measured on a probe agent at
+ * COLUMNS=200: a 1061-char envelope+body arrived as its last 41 characters; the
+ * same payload at COLUMNS=80 arrived whole. Width is not the cause, it is a
+ * proxy for render cost, and render cost is what moves the timing — which is
+ * why the same body sometimes survives. That is the worst property of this bug:
+ * a sender who "stayed under the limit" is not safe, they were lucky.
+ *
+ * NOT the same thing as the CLI showing a `[Pasted text #N]` placeholder. That
+ * is COLLAPSING, it is normal, and the full text still reaches the model — a
+ * 777-char body was confirmed delivered whole while displayed as one. Only a
+ * split burst loses data. Reading the placeholder as the defect sends you
+ * looking for a rendering bug that isn't there.
+ *
+ * `ESC[200~ … ESC[201~` (DECSET 2004) removes the guess: the terminal is told
+ * where the paste begins and ends, so the receiving CLI keeps it as one unit.
+ * The markers are consumed by the receiver, not inserted as text.
+ *
+ * ONLY for CLIs that turn the mode on. A CLI that does not would show the
+ * markers as literal garbage, so this is opt-in per CLI (`bracketedPaste` in
+ * default.config.yaml). Whether a CLI ACCEPTS framing is measurable, not a
+ * guess — its PTY log contains the enable sequence. Note what that measurement
+ * does and does not say: it proves the CLI honours a paste, not that it
+ * segments an unframed burst the same way claude does. Enabling it for a CLI
+ * that never had the bug is still correct — one paste is what a message is.
+ *
+ *   grep -ac $'\\x1b\\[?2004h' <the agent's .raw.log>
+ */
+
+/** DECSET 2004 paste start — what a terminal emits before pasted content. */
+export const PASTE_START = "\x1b[200~";
+/** DECSET 2004 paste end. */
+export const PASTE_END = "\x1b[201~";
+
+/**
+ * Remove paste markers already present in a body.
+ *
+ * Not tidiness: an embedded `ESC[201~` would END our paste early, and every
+ * byte after it would reach the CLI as live keystrokes — a message that could
+ * drive the receiving agent's TUI instead of being read by it. A sender must
+ * not be able to reach past its own message, so the markers are stripped before
+ * the real ones are added.
+ */
+export function stripPasteMarkers(body: string): string {
+  return body.split(PASTE_START).join("").split(PASTE_END).join("");
+}
+
+/**
+ * Wrap `payload` as a single bracketed paste. Returns it unchanged when there
+ * is nothing to send — an empty paste is a no-op that only costs bytes.
+ */
+export function framePaste(payload: string): string {
+  if (!payload) return payload;
+  return PASTE_START + stripPasteMarkers(payload) + PASTE_END;
+}
+
+/**
+ * Whether this delivery should be framed.
+ *
+ * Deliberately NOT conditional on length or on the body being multi-line. Both
+ * were tried as rules by the lanes hitting this and both gave false assurance:
+ * single-line 900-char bodies were lost, and the same body survived at another
+ * terminal width. There is no size a sender can stay under, so the framing is
+ * unconditional for a supporting CLI.
+ *
+ * The one exclusion is a slash command. A CLI recognizes `/foo` only when it is
+ * typed at the start of the line, and pasted text is not typing — framing one
+ * would turn a command the sender meant to run into plain text. Those bodies
+ * are short and single-line, which is the shape that was never at risk anyway.
+ */
+export function shouldFramePaste(opts: {
+  supported: boolean;
+  body: string;
+  isSlashCommand: boolean;
+}): boolean {
+  return opts.supported && Boolean(opts.body) && !opts.isSlashCommand;
+}

--- a/ts/configShared.spec.ts
+++ b/ts/configShared.spec.ts
@@ -84,6 +84,17 @@ describe("configShared", () => {
     ).toBe(true);
   });
 
+  it("declares bracketed paste only for CLIs measured to enable the mode", async () => {
+    const clis = await loadSharedCliDefaults(import.meta.url);
+    // Enabled where the agents' PTY logs actually carry ESC[?2004h.
+    expect(clis.claude?.bracketedPaste).toBe(true);
+    expect(clis.codex?.bracketedPaste).toBe(true);
+    // A shell is not opted in: it never turns the mode on, so the markers would
+    // land as literal text — and a multi-line body there is several commands,
+    // which is what the sender meant.
+    expect(clis.bash?.bracketedPaste).toBeFalsy();
+  });
+
   it("finds the shared defaults file by walking upward", async () => {
     const found = await findSharedCliDefaultsPath(import.meta.url);
     expect(found.endsWith("default.config.yaml")).toBe(true);

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -142,6 +142,14 @@ export type AgentCliConfig = {
   promptArg?: (string & {}) | "first-arg" | "last-arg" | "typed"; // argument name to pass the prompt, e.g. --prompt, first-arg for positional arg, or "typed" to type it into an interactive session after ready (shells)
 
   // handle special format
+  /**
+   * The CLI turns bracketed-paste mode on (DECSET 2004), so `ay send` can
+   * deliver a body as ONE paste instead of a burst the CLI has to segment by
+   * timing — see ts/bracketedPaste.ts for the failure this prevents. Opt-in
+   * because a CLI without the mode would show the markers as literal text.
+   * Verify before setting it: the agent's `.raw.log` contains `ESC[?2004h`.
+   */
+  bracketedPaste?: boolean;
   noEOL?: boolean; // if true, do not split lines by \n when handling inputs, e.g. for codex, which uses cursor-move csi code instead of \n to move lines
 
   // auto responds

--- a/ts/serve.ts
+++ b/ts/serve.ts
@@ -29,11 +29,13 @@ import {
 import path from "path";
 import yargs from "yargs";
 import {
+  cliDefaults,
   controlCodeFromName,
   deriveLiveStatus,
   extractBadges,
   extractNeedsInput,
   extractTaskCounts,
+  isSlashCommand,
   isUserTyping,
   listRecords,
   readNotes,
@@ -58,6 +60,7 @@ import { isCallbackRevoked, loadCallbackSecretReadOnly } from "./callback.ts";
 import { CLAUDE_SESSION_PIN_ENV } from "./sessionEnv.ts";
 import { MAX_CALLBACK_MSG_BYTES, frameVisitorMessage, verifyCapability } from "./callbackCore.ts";
 import { isTerminalReply } from "./terminalReply.ts";
+import { framePaste, shouldFramePaste } from "./bracketedPaste.ts";
 import * as serveSampler from "./serveSampler.ts";
 import { withIpcLock } from "./ipcLock.ts";
 import { removeControlCharacters } from "./removeControlCharacters.ts";
@@ -3763,6 +3766,20 @@ export async function cmdServe(rest: string[]): Promise<number> {
           return new Response(`pid ${record.pid}: no fifo_file`, { status: 409 });
         const trailing = controlCodeFromName(code.toLowerCase());
         const fifo = record.fifo_file;
+        // Same one-paste delivery `ay send` uses locally (ts/bracketedPaste.ts):
+        // a remote send arrives here as a plain body and is written into a TUI
+        // that would otherwise have to segment the burst by timing. NOT for a
+        // `raw` write — that IS the viewer's terminal, already framing its own
+        // pastes, and re-framing would nest the markers.
+        const text =
+          !raw &&
+          shouldFramePaste({
+            supported: Boolean((await cliDefaults())[record.cli]?.bracketedPaste),
+            body: msg,
+            isSlashCommand: isSlashCommand(msg),
+          })
+            ? framePaste(msg)
+            : msg;
         // One transaction: the body and its Enter must reach the agent with
         // nothing spliced between them. The ~200ms settle gap below is a wide
         // window for another writer (a second viewer, an `ay send`) to land
@@ -3770,12 +3787,12 @@ export async function cmdServe(rest: string[]): Promise<number> {
         await withIpcLock(
           record.pid,
           async () => {
-            if (msg && trailing) {
-              await writeToIpc(fifo, msg);
+            if (text && trailing) {
+              await writeToIpc(fifo, text);
               await new Promise((r) => setTimeout(r, 200));
               await writeToIpc(fifo, trailing);
             } else {
-              await writeToIpc(fifo, msg + trailing);
+              await writeToIpc(fifo, text + trailing);
             }
           },
           (why) =>

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1027,8 +1027,12 @@ describe("subcommands.cmdSend writes bytes to FIFO", () => {
       const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
       const received = buf.subarray(0, n).toString();
       // Delivered as ONE bracketed paste (the target CLI declares the mode), so
-      // the receiving TUI never has to guess the burst's boundaries. The Enter
-      // is OUTSIDE the paste — inside, it would insert a newline, not submit.
+      // the receiving TUI never has to guess the burst's boundaries.
+      //
+      // The CR after the END marker is the load-bearing half: inside a paste a
+      // CR is content, so it would insert a newline and submit nothing, leaving
+      // the message unsent in the composer with no error anywhere. This is the
+      // guard against a refactor folding `trailing` into the framed string.
       expect(received).toBe(`${PASTE_START}hello-fifo${PASTE_END}\r`);
       fs.closeSync(rdwrFd);
     } finally {

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PASTE_END, PASTE_START } from "./bracketedPaste.ts";
 import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "fs/promises";
 import { appendFileSync } from "fs";
 import { tmpdir } from "os";
@@ -1025,11 +1026,69 @@ describe("subcommands.cmdSend writes bytes to FIFO", () => {
       const buf = Buffer.alloc(4096);
       const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
       const received = buf.subarray(0, n).toString();
-      expect(received).toBe("hello-fifo\r");
+      // Delivered as ONE bracketed paste (the target CLI declares the mode), so
+      // the receiving TUI never has to guess the burst's boundaries. The Enter
+      // is OUTSIDE the paste — inside, it would insert a newline, not submit.
+      expect(received).toBe(`${PASTE_START}hello-fifo${PASTE_END}\r`);
       fs.closeSync(rdwrFd);
     } finally {
       await rm(tmp, { recursive: true, force: true }).catch(() => null);
     }
+  });
+
+  // The two ways framing must NOT happen, checked on the wire rather than on the
+  // predicate — a wiring mistake here is invisible to a unit test.
+  const fifoCase = async (cli: string, body: string) => {
+    const { runSubcommand } = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const { spawnSync } = await import("child_process");
+    const tmp = await mkdtemp(path.join(tmpdir(), "ay-fifo-"));
+    const fifo = path.join(tmp, "test.fifo");
+    if (spawnSync("mkfifo", [fifo]).status !== 0) return null;
+    const fs = await import("fs");
+    const rdwrFd = fs.openSync(fifo, fs.constants.O_RDWR);
+    await appendGlobalPid({
+      pid: process.pid,
+      cli,
+      prompt: null,
+      cwd: process.cwd(),
+      log_file: null,
+      fifo_file: fifo,
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+    });
+    const orig = process.stdout.write.bind(process.stdout);
+    (process.stdout as any).write = () => true;
+    const savedAyPid = process.env.AGENT_YES_PID;
+    delete process.env.AGENT_YES_PID;
+    try {
+      await runSubcommand(["bun", "cli.js", "send", String(process.pid), body, "--force"]);
+    } finally {
+      process.stdout.write = orig;
+      if (savedAyPid !== undefined) process.env.AGENT_YES_PID = savedAyPid;
+    }
+    const buf = Buffer.alloc(4096);
+    const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
+    fs.closeSync(rdwrFd);
+    await rm(tmp, { recursive: true, force: true }).catch(() => null);
+    return buf.subarray(0, n).toString();
+  };
+
+  it.skipIf(!itUnix)("never frames a CLI that does not enable the mode", async () => {
+    // bash would receive ESC[200~ as literal text on its command line.
+    const received = await fifoCase("bash", "echo hi");
+    if (received === null) return;
+    expect(received).toBe("echo hi\r");
+  });
+
+  it.skipIf(!itUnix)("never frames a slash command — pasted text is not typing", async () => {
+    // A CLI recognizes /exit only when typed; framing it would deliver the text
+    // of a command the sender meant to run.
+    const received = await fifoCase("claude", "/model opus");
+    if (received === null) return;
+    expect(received).toBe("/model opus\r");
   });
 
   it("--code=none skips the trailing CR", async () => {
@@ -2977,8 +3036,9 @@ describe("subcommands.cmdSend double-envelope warning", () => {
         const buf = Buffer.alloc(8192);
         const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
         const received = buf.subarray(0, n).toString();
+        expect(received.startsWith(PASTE_START)).toBe(true);
         expect(received).toMatch(
-          /^<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/repo\/beta#900001 — /,
+          /<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:\/repo\/beta#900001 — /,
         );
         expect(received).toContain("<ay-msg deadbeef");
         fs.closeSync(rdwrFd);
@@ -3114,9 +3174,12 @@ describe("subcommands.cmdSend double-envelope warning", () => {
       const buf = Buffer.alloc(4096);
       const n = fs.readSync(rdwrFd, buf, 0, buf.length, null);
       const received = buf.subarray(0, n).toString();
-      // <user>@<host>:<path>:<branch>#<pid> — reply targets the agent_id.
+      // <user>@<host>:<path>:<branch>#<pid> — reply targets the agent_id. The
+      // envelope now opens just inside the paste marker, so the anchor moves
+      // from start-of-payload to start-of-paste.
+      expect(received.startsWith(PASTE_START)).toBe(true);
       expect(received).toMatch(
-        /^<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:.+:crm-lane#900001 — reply: ay send cccc0000dddd "\.\.\.">/,
+        /<ay-msg [0-9a-f]{8} from claude [A-Za-z0-9._-]+@[A-Za-z0-9._-]+:.+:crm-lane#900001 — reply: ay send cccc0000dddd "\.\.\.">/,
       );
       fs.closeSync(rdwrFd);
     } finally {

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -65,6 +65,7 @@ import {
 import { loadSharedCliDefaults } from "./configShared.ts";
 import { invokedCliName } from "./invokedCli.ts";
 import type { AgentCliConfig } from "./index.ts";
+import { framePaste as frameAsPaste, shouldFramePaste } from "./bracketedPaste.ts";
 import yargs from "yargs";
 import { type ResolvedRemote, readRemotes, resolveRemoteSpec } from "./remotes.ts";
 import { isWebrtcSpec } from "./webrtcLink.ts";
@@ -2851,7 +2852,7 @@ export async function extractTaskCounts(logPath: string): Promise<TaskCounts | n
 // process from default.config.yaml. Type-only import of AgentCliConfig keeps the
 // heavy ts/index.ts module out of the `ay ls`/`ay status` startup path.
 let _cliDefaults: Promise<Record<string, AgentCliConfig>> | null = null;
-function cliDefaults(): Promise<Record<string, AgentCliConfig>> {
+export function cliDefaults(): Promise<Record<string, AgentCliConfig>> {
   return (_cliDefaults ??= loadSharedCliDefaults().catch(
     () => ({}) as Record<string, AgentCliConfig>,
   ));
@@ -3530,7 +3531,18 @@ async function cmdSend(rest: string[]): Promise<number> {
     }
   }
 
-  const fullBody = prefix + body + suffix;
+  // Deliver as ONE paste when the target CLI supports it, instead of a burst it
+  // has to segment by arrival timing — which silently eats the head of a long
+  // body. See ts/bracketedPaste.ts for the measurement and why no length or
+  // single-line rule can replace this.
+  const framePaste = shouldFramePaste({
+    supported: Boolean((await cliDefaults())[record.cli]?.bracketedPaste),
+    body,
+    isSlashCommand: isSlashCommand(body),
+  });
+  const fullBody = framePaste
+    ? frameAsPaste(prefix + body + suffix)
+    : prefix + body + suffix;
   const noWait = Boolean(argv.noWait) || process.env.AGENT_YES_SEND_NO_WAIT === "1";
 
   // Back off while the user is typing at the target's terminal — injecting our


### PR DESCRIPTION
## The failure

`ay send` writes the body into the agent's stdin as raw bytes. A TUI that is not
told a paste is happening has to infer where it ends from arrival timing, and
when that inference **splits** the burst, the leading part is lost. The model
receives a tail; neither end reports anything.

Two lanes hit this independently. One had messages arriving as nothing but the
closing `</ay-msg …>` tag; the other lost 875–922 chars off the front of five
consecutive messages.

## Reproduction

Fresh claude probes at controlled `COLUMNS`, measured from the receiving
**session transcript** (what the model got, not what the terminal drew):

| width | payload | arrived | |
|---|---|---|---|
| 80 | 900 | 900 | no envelope |
| 200 | 900 | 900 | no envelope |
| 80 | 1061 | 1061 | with `<ay-msg>` envelope |
| **200** | **1061** | **41** | with envelope — **reproduction** |

Width changes the outcome, but **backwards for a wrapping explanation**: the
*wide* terminal lost it. Width is a proxy for render cost, and render cost moves
the timing that decides where the split lands. The receiving PTY log names the
mechanism directly — `Pasted text #1`.

**One distinction worth keeping** (it cost a lane an hour): a `[Pasted text #N]`
placeholder by itself is **collapsing**, which is normal and lossless — a
777-char body was confirmed delivered whole while displayed as one. Only a
**split** burst loses data. Read the placeholder as the defect and you go looking
for a rendering bug that isn't there.

## Why the fix is unconditional

Both interim rules the lanes adopted gave false assurance:

- **"≤250 chars"** — the surviving bodies were short *and* single-line; length
  was not what saved them.
- **"single line"** — my own first conclusion, and **wrong**. A lane's five lost
  messages had zero newlines. Their data disproved it before I shipped it.

There is no size, line count, or width a sender can stay under, because the
trigger is timing on the *receiver's* side, which the sender cannot see. So the
framing is not conditional on length or on the body being multi-line.

## What changed

- `ts/bracketedPaste.ts` (new, pure): `framePaste` / `stripPasteMarkers` /
  `shouldFramePaste`.
- `cmdSend` and `POST /api/send` frame the payload for a CLI that declares the
  mode. `/api/send` skips it for a `raw` write — that is the viewer's own
  terminal, which already frames its own pastes (#453).
- `bracketedPaste` per-CLI config + JSON-schema property. Set for **claude** and
  **codex**, both verified: `ESC[?2004h` appears in 24/24 and 1/1 of their PTY
  logs. Shells are excluded — they never enable it, and a multi-line body there
  is several commands, which is what the sender meant.

**Not framed**, both guarded on the wire rather than only in the predicate:

- a **slash command** — a CLI recognizes `/foo` only when typed, and pasted text
  is not typing;
- any CLI that does not declare the mode.

A body carrying its own `ESC[201~` is stripped before framing. Otherwise a
sender could close our paste early and have the remainder run as **live
keystrokes** in the receiving TUI.

The submit CR is written **after** the framed payload, never inside it — inside
a paste a CR is content, so it would insert a newline and submit nothing,
leaving the message unsent in the composer with no error anywhere. That
invariant is now stated in the module doc and pinned by the byte-level FIFO
test, so a refactor folding `trailing` into the framed string fails loudly.

## Verification

- At the reproduction cell (COLUMNS=200): framed sends arrived whole **3/3**,
  and the 12 marker bytes were *consumed*, not inserted (1016 sent → 1004
  received) — independent proof the receiver honours DECSET 2004.
- A lane confirmed from its own receiving log that `ESC[200~` had been written to
  it **zero times ever**: the receiver's door was already open and no sender had
  used it.
- Negative result, reported because it is **predicted**, not despite being
  awkward: a later paired A/B that waited for the agent to go **idle** before
  each send reproduced nothing at all (3/3 both arms). "An unhurried receiver
  does not split" is what the timing mechanism says should happen, so that null
  is confirmation of the mechanism, not evidence against it — read as a bare
  3/3-nothing-reproduced it would look like the opposite. It is also why the
  claim here rests on the reproduction cell plus the structural argument
  (framing removes the inference entirely) rather than on an N-of-N win.
- Suites green: vitest 1766 passed / 3 skipped; `bun test .bun.` 1230 passed / 1
  skipped. `tsgo --noEmit` error count unchanged at 49 vs the same baseline.

## Scope note

`ay send` enforces its 1023-char limit on the **body**, then transmits
body + ~134 bytes of envelope — so the enforced number was never the transmitted
number. That is a real defect of the same family, but it is not this one, and it
deserves its own commit and test rather than riding along here.

Also unchanged: the Rust runtime has no `send` implementation (it delegates to
this CLI), so there is no mirror to keep in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
