### PR TITLE
test(subcommands): a homedir mock isolates agentYesHome only while the env is unset

### DIFF
--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -16,12 +16,24 @@ vi.mock("os", async () => {
   };
 });
 
+// The homedir mock covers the DEFAULT case completely: agentYesHome() falls back
+// to homedir() when $AGENT_YES_HOME is unset, so the fallback resolves into the
+// mock. It does NOT cover the case where the variable is set, because
+// agentYesHome() reads it first — and then the tests below write pids.jsonl rows
+// and IPC locks to whatever path it names, the operator's live store included.
+// Pin it at the same temp dir so both paths land there.
+let savedAyHome: string | undefined;
+
 beforeEach(async () => {
   testHome = await mkdtemp(path.join(tmpdir(), "ay-sub-test-"));
+  savedAyHome = process.env.AGENT_YES_HOME;
+  process.env.AGENT_YES_HOME = path.join(testHome, ".agent-yes");
   vi.resetModules();
 });
 
 afterEach(async () => {
+  if (savedAyHome === undefined) delete process.env.AGENT_YES_HOME;
+  else process.env.AGENT_YES_HOME = savedAyHome;
   await rm(testHome, { recursive: true, force: true }).catch(() => null);
 });
 


### PR DESCRIPTION
Re-lands a commit that was lost to a race: it was pushed to #455 while that PR's
auto-merge was already firing, so the squash took the state before it.

## The hole

`ts/subcommands.spec.ts` opens with `vi.mock(os.homedir)`, which reads as
sufficient isolation. It is not:

| `$AGENT_YES_HOME` | `agentYesHome()` returns | result |
|---|---|---|
| unset | `homedir()` → **the mock** | isolated, nothing escapes |
| set | **the variable**, read first | mock bypassed |

So the same suite either isolates cleanly or writes into the operator's live
store, decided by a variable no test declares. **CI has it unset, so CI can
never catch the second case** — it fails only on the machine of whoever exports
it, and it fails by corrupting real state rather than by going red.

## Measured both ways

With `AGENT_YES_HOME=/tmp/ay-hazard-probe` and this change stashed, one run of
the spec creates that directory containing `pids.jsonl`, `notes.jsonl`,
`reads.jsonl` and `locks/`. With the change applied, the same run leaves the
directory absent and the real home untouched. Unset, the real home is untouched
either way — which is why this has never fired here.

The FIFOs these tests create were always under `mkdtemp`; the exposure was the
pid index, the notes and read logs, and the IPC locks.

## How it was found

A reviewing lane raised the shape while trial-merging against #455, retracted it
after testing only the unset half (where it is genuinely safe), then re-confirmed
it once both halves were measured. Neither of our first claims was right on its
own — "it escapes" and "it never escapes" are both wrong; it depends on the
variable. That framing is theirs and is why the commit says so rather than just
pinning the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)