### PR TITLE
fix(send): count the envelope ay send adds, so the enforced cap is the sent size

### DIFF
--- a/ts/sendCap.bun.spec.ts
+++ b/ts/sendCap.bun.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { SEND_BODY_MAX_CHARS, sendPayloadCapError } from "./subcommands.ts";
+
+describe("sendPayloadCapError", () => {
+  it("measures the cap on the TRANSMITTED payload, not the body alone", () => {
+    // The defect: a body under the cap was accepted and then transmitted with a
+    // ~134-char envelope on top, so the enforced number was never the sent one.
+    const body = SEND_BODY_MAX_CHARS - 50;
+    expect(sendPayloadCapError(body, 0)).toBeNull();
+    expect(sendPayloadCapError(body, 134)).toContain("would transmit");
+  });
+
+  it("passes a send that fits once the envelope is counted", () => {
+    expect(sendPayloadCapError(SEND_BODY_MAX_CHARS - 134, 134)).toBeNull();
+    expect(sendPayloadCapError(SEND_BODY_MAX_CHARS, 0)).toBeNull();
+  });
+
+  it("names the sender's real budget, which depends on their own envelope", () => {
+    // The envelope carries the sender's cwd, branch and pid, so no constant
+    // body budget can be quoted — it has to be computed per send.
+    const short = sendPayloadCapError(SEND_BODY_MAX_CHARS, 100)!;
+    const long = sendPayloadCapError(SEND_BODY_MAX_CHARS, 200)!;
+    expect(short).toContain(`${SEND_BODY_MAX_CHARS - 100} chars of body`);
+    expect(long).toContain(`${SEND_BODY_MAX_CHARS - 200} chars of body`);
+  });
+
+  it("reports the split so the sender can see where the overflow came from", () => {
+    const err = sendPayloadCapError(1000, 134)!;
+    expect(err).toContain("1134");
+    expect(err).toContain("1000 of body");
+    expect(err).toContain("134 of <ay-msg");
+  });
+
+  it("says nothing about an envelope when there is none", () => {
+    // --raw and slash commands go out unwrapped; the whole cap is theirs.
+    const err = sendPayloadCapError(SEND_BODY_MAX_CHARS + 1, 0)!;
+    expect(err).not.toContain("envelope");
+    expect(err).toContain(`≤${SEND_BODY_MAX_CHARS} chars`);
+  });
+
+  it("still points at the remedy that works — a path, not `-`", () => {
+    const err = sendPayloadCapError(5000, 0)!;
+    expect(err).toContain("the PATH");
+    expect(err).toMatch(/'-' hits this same/);
+  });
+
+  it("never quotes a negative budget for an envelope larger than the cap", () => {
+    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS + 500)!;
+    expect(err).toContain("≤0 chars");
+  });
+});

--- a/ts/sendCap.bun.spec.ts
+++ b/ts/sendCap.bun.spec.ts
@@ -44,8 +44,26 @@ describe("sendPayloadCapError", () => {
     expect(err).toMatch(/'-' hits this same/);
   });
 
-  it("never quotes a negative budget for an envelope larger than the cap", () => {
-    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS + 500)!;
-    expect(err).toContain("≤0 chars");
+  it("refuses to quote a budget when the envelope alone exceeds the cap", () => {
+    // Reachable by construction: nothing bounds a cwd's depth or a branch name's
+    // length. Quoting a budget here printed "-76 chars of body" and then
+    // "shorten to <=0" — contradictory, and impossible advice, since no body
+    // length works. Caught in review by a lane that probed the boundary.
+    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS + 76)!;
+    expect(err).not.toMatch(/-\d+ chars/);
+    expect(err).not.toContain("budget");
+    expect(err).toContain("no body length can fit");
+    expect(err).toContain("--raw");
+  });
+
+  it("treats an envelope exactly at the cap as leaving no room", () => {
+    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS)!;
+    expect(err).toContain("no body length can fit");
+  });
+
+  it("still quotes a real budget one char below that boundary", () => {
+    const err = sendPayloadCapError(500, SEND_BODY_MAX_CHARS - 1)!;
+    expect(err).toContain("1 chars of body");
+    expect(err).not.toContain("no body length can fit");
   });
 });

--- a/ts/sendCap.spec.ts
+++ b/ts/sendCap.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { SEND_BODY_MAX_CHARS, sendPayloadCapError } from "./subcommands.ts";
+
+describe("sendPayloadCapError", () => {
+  it("measures the cap on the TRANSMITTED payload, not the body alone", () => {
+    // The defect: a body under the cap was accepted and then transmitted with a
+    // ~134-char envelope on top, so the enforced number was never the sent one.
+    const body = SEND_BODY_MAX_CHARS - 50;
+    expect(sendPayloadCapError(body, 0)).toBeNull();
+    expect(sendPayloadCapError(body, 134)).toContain("would transmit");
+  });
+
+  it("passes a send that fits once the envelope is counted", () => {
+    expect(sendPayloadCapError(SEND_BODY_MAX_CHARS - 134, 134)).toBeNull();
+    expect(sendPayloadCapError(SEND_BODY_MAX_CHARS, 0)).toBeNull();
+  });
+
+  it("names the sender's real budget, which depends on their own envelope", () => {
+    // The envelope carries the sender's cwd, branch and pid, so no constant
+    // body budget can be quoted — it has to be computed per send.
+    const short = sendPayloadCapError(SEND_BODY_MAX_CHARS, 100)!;
+    const long = sendPayloadCapError(SEND_BODY_MAX_CHARS, 200)!;
+    expect(short).toContain(`${SEND_BODY_MAX_CHARS - 100} chars of body`);
+    expect(long).toContain(`${SEND_BODY_MAX_CHARS - 200} chars of body`);
+  });
+
+  it("reports the split so the sender can see where the overflow came from", () => {
+    const err = sendPayloadCapError(1000, 134)!;
+    expect(err).toContain("1134");
+    expect(err).toContain("1000 of body");
+    expect(err).toContain("134 of <ay-msg");
+  });
+
+  it("says nothing about an envelope when there is none", () => {
+    // --raw and slash commands go out unwrapped; the whole cap is theirs.
+    const err = sendPayloadCapError(SEND_BODY_MAX_CHARS + 1, 0)!;
+    expect(err).not.toContain("envelope");
+    expect(err).toContain(`≤${SEND_BODY_MAX_CHARS} chars`);
+  });
+
+  it("still points at the remedy that works — a path, not `-`", () => {
+    const err = sendPayloadCapError(5000, 0)!;
+    expect(err).toContain("the PATH");
+    expect(err).toMatch(/'-' hits this same/);
+  });
+
+  it("never quotes a negative budget for an envelope larger than the cap", () => {
+    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS + 500)!;
+    expect(err).toContain("≤0 chars");
+  });
+});

--- a/ts/sendCap.spec.ts
+++ b/ts/sendCap.spec.ts
@@ -44,8 +44,26 @@ describe("sendPayloadCapError", () => {
     expect(err).toMatch(/'-' hits this same/);
   });
 
-  it("never quotes a negative budget for an envelope larger than the cap", () => {
-    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS + 500)!;
-    expect(err).toContain("≤0 chars");
+  it("refuses to quote a budget when the envelope alone exceeds the cap", () => {
+    // Reachable by construction: nothing bounds a cwd's depth or a branch name's
+    // length. Quoting a budget here printed "-76 chars of body" and then
+    // "shorten to <=0" — contradictory, and impossible advice, since no body
+    // length works. Caught in review by a lane that probed the boundary.
+    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS + 76)!;
+    expect(err).not.toMatch(/-\d+ chars/);
+    expect(err).not.toContain("budget");
+    expect(err).toContain("no body length can fit");
+    expect(err).toContain("--raw");
+  });
+
+  it("treats an envelope exactly at the cap as leaving no room", () => {
+    const err = sendPayloadCapError(1, SEND_BODY_MAX_CHARS)!;
+    expect(err).toContain("no body length can fit");
+  });
+
+  it("still quotes a real budget one char below that boundary", () => {
+    const err = sendPayloadCapError(500, SEND_BODY_MAX_CHARS - 1)!;
+    expect(err).toContain("1 chars of body");
+    expect(err).not.toContain("no body length can fit");
   });
 });

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -1783,6 +1783,70 @@ describe("subcommands.cmdSend safety guards", () => {
     }
   });
 
+  it("counts the envelope it adds — a body UNDER the cap that would transmit over it", async () => {
+    // The defect: the cap was checked on the body, then ~134 chars of
+    // <ay-msg …> envelope were added and the whole thing written. A body of
+    // 1000 was accepted and ~1134 went down the pipe. The enforced number was
+    // never the transmitted number.
+    const { runSubcommand } = await loadModule();
+    const { appendGlobalPid } = await import("./globalPidIndex.ts");
+    const sender = {
+      pid: 900001,
+      cli: "claude" as const,
+      prompt: null,
+      cwd: "/repo/beta",
+      log_file: null,
+      fifo_file: null,
+      status: "active" as const,
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+      agent_id: "cccc0000dddd",
+      wrapper_pid: 900001,
+    };
+    await appendGlobalPid(sender);
+    await appendGlobalPid({
+      pid: process.pid,
+      cli: "claude",
+      prompt: null,
+      cwd: process.cwd(),
+      log_file: null,
+      fifo_file: "/tmp/ay-envelope-cap-test.fifo",
+      status: "active",
+      exit_code: null,
+      exit_reason: null,
+      started_at: Date.now(),
+    });
+    const stderr: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (x: any) => {
+      stderr.push(String(x));
+      return true;
+    };
+    const savedAyPid = process.env.AGENT_YES_PID;
+    process.env.AGENT_YES_PID = "900001"; // an AGENT sender, so the envelope is added
+    try {
+      const body = "x".repeat(1000); // comfortably under the 1024 body cap
+      const code = await runSubcommand([
+        "bun",
+        "cli.js",
+        "send",
+        String(process.pid),
+        body,
+        "--force",
+      ]);
+      expect(code).toBe(1);
+      const out = stderr.join("");
+      expect(out).toMatch(/would transmit/);
+      expect(out).toMatch(/1000 of body/);
+      expect(out).toMatch(/envelope/);
+    } finally {
+      process.stderr.write = orig;
+      if (savedAyPid === undefined) delete process.env.AGENT_YES_PID;
+      else process.env.AGENT_YES_PID = savedAyPid;
+    }
+  });
+
   it("applies the same cap to the `-` (stdin) body — the form the old hint recommended", async () => {
     const { runSubcommand } = await loadModule();
     const { appendGlobalPid } = await import("./globalPidIndex.ts");

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -502,9 +502,9 @@ export const SEND_BODY_MAX_CHARS = 1024;
  *
  * `ay send` checked the BODY against the cap and then transmitted the body plus
  * an `<ay-msg …>` envelope — a header naming the sender's identity and a closing
- * tag, together a bit over 130 characters. So the number the sender was told was
- * safe was never the number that went down the pipe, and a body accepted at 1000
- * arrived as ~1140. The envelope is not a fixed surcharge either: it carries the
+ * tag, together ~160 characters on real traffic. So the number the sender was
+ * told was safe was never the number that went down the pipe, and a body
+ * accepted at 1000 arrived as ~1160. The envelope is not a fixed surcharge either: it carries the
  * sender's cwd, branch and pid, so its length differs per sender and no constant
  * body budget can be quoted. Hence a check on the sum rather than a smaller
  * hard-coded limit.
@@ -523,6 +523,21 @@ export function sendPayloadCapError(bodyLen: number, envelopeLen: number): strin
   const transmitted = bodyLen + envelopeLen;
   if (transmitted <= SEND_BODY_MAX_CHARS) return null;
   const budget = SEND_BODY_MAX_CHARS - envelopeLen;
+  const remedy =
+    `Write it to a file and send the PATH instead, e.g. ` +
+    `'ay send <keyword> "details: /path/to/notes.md"'`;
+  // Nothing bounds a cwd's depth or a branch name's length, so an envelope can
+  // in principle reach the cap on its own. Then NO body length works, and
+  // quoting a budget would print a negative number and tell the sender to
+  // shorten to ≤0 — an error naming a remedy that cannot work, which is the
+  // very defect this function exists to remove. Say what is actually true.
+  if (budget <= 0) {
+    return (
+      `the <ay-msg …> envelope alone is ${envelopeLen} chars, at or over the ` +
+      `${SEND_BODY_MAX_CHARS}-char limit, so no body length can fit. ${remedy} — ` +
+      `and send it with --raw, which omits the envelope.`
+    );
+  }
   return (
     `message would transmit ${transmitted} chars, over the ${SEND_BODY_MAX_CHARS}-char limit` +
     (envelopeLen > 0
@@ -530,9 +545,8 @@ export function sendPayloadCapError(bodyLen: number, envelopeLen: number): strin
         `ay send adds for you. Your budget for this send is ${budget} chars of body`
       : "") +
     `. Longer text isn't a terminal prompt. Piping it in with '-' hits this same ` +
-    `cap — the payload is capped however it arrives. Write it to a file and send ` +
-    `the PATH instead, e.g. 'ay send <keyword> "details: /path/to/notes.md"', ` +
-    `or shorten the body to ≤${Math.max(0, budget)} chars.`
+    `cap — the payload is capped however it arrives. ${remedy}, ` +
+    `or shorten the body to ≤${budget} chars.`
   );
 }
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -495,7 +495,46 @@ const SEND_TYPING_MAX_WAIT_MS = 10_000;
 // Lowered 4096 → 1024 (operator 2026-08-20): past ~1KB the bracketed paste keeps
 // re-rendering long enough that the trailing Enter lands mid-paste and is
 // swallowed, so the body sits unsent in the target's input line.
-const SEND_BODY_MAX_CHARS = 1024;
+export const SEND_BODY_MAX_CHARS = 1024;
+
+/**
+ * The cap, measured on what is actually WRITTEN to the agent's stdin.
+ *
+ * `ay send` checked the BODY against the cap and then transmitted the body plus
+ * an `<ay-msg …>` envelope — a header naming the sender's identity and a closing
+ * tag, together a bit over 130 characters. So the number the sender was told was
+ * safe was never the number that went down the pipe, and a body accepted at 1000
+ * arrived as ~1140. The envelope is not a fixed surcharge either: it carries the
+ * sender's cwd, branch and pid, so its length differs per sender and no constant
+ * body budget can be quoted. Hence a check on the sum rather than a smaller
+ * hard-coded limit.
+ *
+ * Returns the error text, or null when the send fits. `envelopeLen` is 0 for a
+ * `--raw` send and for a slash command, both of which go out unwrapped — the
+ * budget is then the whole cap, which is why this is computed per send and not
+ * once.
+ *
+ * Paste framing (ts/bracketedPaste.ts) is deliberately NOT counted: those 12
+ * bytes are consumed by the receiving terminal as delimiters, never inserted as
+ * text, so charging the sender for them would be charging for something that
+ * does not arrive.
+ */
+export function sendPayloadCapError(bodyLen: number, envelopeLen: number): string | null {
+  const transmitted = bodyLen + envelopeLen;
+  if (transmitted <= SEND_BODY_MAX_CHARS) return null;
+  const budget = SEND_BODY_MAX_CHARS - envelopeLen;
+  return (
+    `message would transmit ${transmitted} chars, over the ${SEND_BODY_MAX_CHARS}-char limit` +
+    (envelopeLen > 0
+      ? ` — ${bodyLen} of body plus ${envelopeLen} of <ay-msg …> envelope, which ` +
+        `ay send adds for you. Your budget for this send is ${budget} chars of body`
+      : "") +
+    `. Longer text isn't a terminal prompt. Piping it in with '-' hits this same ` +
+    `cap — the payload is capped however it arrives. Write it to a file and send ` +
+    `the PATH instead, e.g. 'ay send <keyword> "details: /path/to/notes.md"', ` +
+    `or shorten the body to ≤${Math.max(0, budget)} chars.`
+  );
+}
 
 /**
  * Whether `name` is a subcommand. `managerCommands` (default true, for the
@@ -3453,14 +3492,14 @@ async function cmdSend(rest: string[]): Promise<number> {
   // What works is not sending the text at all: send the PATH and let the reader
   // open it. That also survives a truncated delivery, since the tail is what
   // arrives and a path is short enough to sit in it.
-  if (body.length > SEND_BODY_MAX_CHARS) {
-    throw new Error(
-      `message is ${body.length} chars, over the ${SEND_BODY_MAX_CHARS}-char limit. ` +
-        `Longer text isn't a terminal prompt. Piping it in with '-' hits this same ` +
-        `cap — the body is capped however it arrives. Write it to a file and send ` +
-        `the PATH instead, e.g. 'ay send <keyword> "details: /path/to/notes.md"', ` +
-        `or shorten to ≤${SEND_BODY_MAX_CHARS} chars.`,
-    );
+  //
+  // This is the cheap pre-check: a body that is already over the cap on its own
+  // cannot fit once the envelope is added either, so it fails here before the
+  // send guards run. The AUTHORITATIVE check is on the transmitted payload,
+  // below, once the envelope's length is known — see sendPayloadCapError.
+  {
+    const err = sendPayloadCapError(body.length, 0);
+    if (err) throw new Error(err);
   }
 
   // Who's sending, and have they actually looked at this target recently?
@@ -3540,6 +3579,14 @@ async function cmdSend(rest: string[]): Promise<number> {
     body,
     isSlashCommand: isSlashCommand(body),
   });
+  // The cap applies to what is WRITTEN, and the envelope is part of that. The
+  // pre-check above saw only the body, so a body just under the limit reaches
+  // here and is over it once wrapped — which is exactly the case that used to
+  // transmit silently. Framing markers are excluded: the terminal consumes them.
+  {
+    const err = sendPayloadCapError(body.length, prefix.length + suffix.length);
+    if (err) throw new Error(err);
+  }
   const fullBody = framePaste
     ? frameAsPaste(prefix + body + suffix)
     : prefix + body + suffix;


### PR DESCRIPTION
## The defect

`ay send` checked the **body** against the 1024-char cap, then added an
`<ay-msg …>` envelope — a header naming the sender's identity plus a closing tag,
a bit over 130 characters — and wrote the whole thing. **The number the sender
was told was safe was never the number transmitted.** A body accepted at 1000
went down the pipe at ~1134.

That is its own family of bug, distinct from the truncation in #455: a tool
reporting a limit it does not apply. Even with framing landed, a sender told
"1024 is safe" is being told something untrue.

## Why not just lower the constant

The envelope is not a fixed surcharge. It carries the **sender's** cwd, branch
and pid:

```
<ay-msg 29f34faf from claude sno@tak:~/ws/…/tree/main:fix/send-bracketed-paste#73119 — reply: ay send cae497d3424d "...">
```

Its length differs per sender, so no constant body budget can be quoted. The
check has to be on the sum, per send.

## What changed

`sendPayloadCapError(bodyLen, envelopeLen)` — pure, exported, unit-tested — is
called twice:

1. **Pre-guard**, with `envelopeLen: 0`, where the old check was. A body already
   over the cap cannot fit once wrapped either, so it still fails early, before
   the send guards run. Behaviour for that case is unchanged.
2. **Authoritative**, once `prefix`/`suffix` exist, just before the write.

The message now names arithmetic the sender can act on rather than a number they
cannot: what would transmit, how it splits between body and envelope, and **this
sender's** actual body budget. A `--raw` send and a slash command go out
unwrapped, get the whole cap, and are told nothing about an envelope they do not
have.

Paste framing is deliberately **not** counted — those 12 bytes are consumed by
the receiving terminal as delimiters and never inserted as text, so charging for
them would charge for something that does not arrive.

## Verification

- `ts/sendCap.spec.ts` + `.bun.spec.ts` (7 cases): the cap measured on the
  transmitted payload; a send that fits once the envelope is counted still
  passes; the quoted budget tracks the envelope length rather than being
  constant; the split is reported; no envelope is mentioned when there is none;
  the working remedy (a path, not `-`) survives; and no negative budget is
  quoted when the envelope alone exceeds the cap.
- An integration case in `ts/subcommands.spec.ts`: an **agent** sender with a
  1000-char body — comfortably under the old body cap — is now refused, with the
  split named. That is the exact case that used to transmit silently. It is
  **not** platform-gated: it fails before any write, so it needs no FIFO and runs
  on Windows too.
- Suites green: vitest 1774 passed / 3 skipped, coverage gate exit 0 at
  94.18 stmts / 90.15 branches; `bun test .bun.` 1237 passed / 1 skipped.

## Provenance

Found by hitting it — ten replies in one session were rejected at a limit their
bodies were under. Kept out of #455 on a reviewer's advice, since riding along
inside the framing PR would have read as incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)