### PR TITLE
test(config): pin the framing DECISION, the half that can rot without going red

### DIFF
--- a/ts/configShared.spec.ts
+++ b/ts/configShared.spec.ts
@@ -95,9 +95,11 @@ describe("configShared", () => {
     expect(clis.bash?.bracketedPaste).toBeFalsy();
   });
 
-  // The DECIDE half of paste framing: cmdSend composes a config lookup, the
-  // body, and isSlashCommand into shouldFramePaste. Each piece is tested on its
-  // own; this pins the JOIN, which is the part that rots SILENTLY. A renamed
+  // The DECIDE half of paste framing: BOTH send paths — cmdSend and serve.ts's
+  // POST /api/send — compose the same config lookup, the body, and
+  // isSlashCommand into shouldFramePaste. Each piece is tested on its own; this
+  // pins the JOIN, which is the part that rots SILENTLY, and it speaks for both
+  // sites because the composition is what it asserts, not one call site. A renamed
   // config key, a CLI added to default.config.yaml without the flag, or
   // isSlashCommand drifting would each leave `supported` false — nothing goes
   // red, messages just start losing their heads again (the failure #455 fixed).
@@ -105,7 +107,7 @@ describe("configShared", () => {
   // Needs no FIFO, so unlike the byte-level DELIVER assertions it runs on every
   // platform. It does NOT replace those: it cannot prove framed bytes reach the
   // pipe, only that the decision this config drives is still the right one.
-  it("decides framing from the real config, the way cmdSend composes it", async () => {
+  it("decides framing from the real config, the way both send paths compose it", async () => {
     const { isSlashCommand } = await import("./subcommands.ts");
     const { shouldFramePaste } = await import("./bracketedPaste.ts");
     const clis = await loadSharedCliDefaults(import.meta.url);

--- a/ts/configShared.spec.ts
+++ b/ts/configShared.spec.ts
@@ -95,6 +95,37 @@ describe("configShared", () => {
     expect(clis.bash?.bracketedPaste).toBeFalsy();
   });
 
+  // The DECIDE half of paste framing: cmdSend composes a config lookup, the
+  // body, and isSlashCommand into shouldFramePaste. Each piece is tested on its
+  // own; this pins the JOIN, which is the part that rots SILENTLY. A renamed
+  // config key, a CLI added to default.config.yaml without the flag, or
+  // isSlashCommand drifting would each leave `supported` false — nothing goes
+  // red, messages just start losing their heads again (the failure #455 fixed).
+  //
+  // Needs no FIFO, so unlike the byte-level DELIVER assertions it runs on every
+  // platform. It does NOT replace those: it cannot prove framed bytes reach the
+  // pipe, only that the decision this config drives is still the right one.
+  it("decides framing from the real config, the way cmdSend composes it", async () => {
+    const { isSlashCommand } = await import("./subcommands.ts");
+    const { shouldFramePaste } = await import("./bracketedPaste.ts");
+    const clis = await loadSharedCliDefaults(import.meta.url);
+    const decide = (cli: string, body: string) =>
+      shouldFramePaste({
+        supported: Boolean(clis[cli]?.bracketedPaste),
+        body,
+        isSlashCommand: isSlashCommand(body),
+      });
+
+    expect(decide("claude", "the deploy is green")).toBe(true);
+    expect(decide("codex", "the deploy is green")).toBe(true);
+    // A shell never enables the mode; the markers would land as literal text.
+    expect(decide("bash", "echo hi")).toBe(false);
+    // Recognized only when typed — pasted text is not typing.
+    expect(decide("claude", "/model opus")).toBe(false);
+    // An unknown CLI is unconfigured, so it must not be framed on a guess.
+    expect(decide("no-such-cli", "the deploy is green")).toBe(false);
+  });
+
   it("finds the shared defaults file by walking upward", async () => {
     const found = await findSharedCliDefaultsPath(import.meta.url);
     expect(found.endsWith("default.config.yaml")).toBe(true);

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -2853,9 +2853,19 @@ export async function extractTaskCounts(logPath: string): Promise<TaskCounts | n
 // heavy ts/index.ts module out of the `ay ls`/`ay status` startup path.
 let _cliDefaults: Promise<Record<string, AgentCliConfig>> | null = null;
 export function cliDefaults(): Promise<Record<string, AgentCliConfig>> {
-  return (_cliDefaults ??= loadSharedCliDefaults().catch(
-    () => ({}) as Record<string, AgentCliConfig>,
-  ));
+  return (_cliDefaults ??= loadSharedCliDefaults().catch((err) => {
+    // Fail-open is deliberate: `ay ls` / `ay status` must still work with a
+    // broken YAML. But an empty map is not neutral for every consumer — paste
+    // framing reads `bracketedPaste` from here, so a load failure turns framing
+    // OFF for every CLI at once and long messages start losing their heads
+    // again with nothing going red. Say so on stderr rather than degrading in
+    // silence; the caller still gets a usable (empty) map.
+    process.stderr.write(
+      `warning: could not load shared CLI defaults (${(err as Error)?.message ?? err}) — ` +
+        `falling back to none. Paste framing is off for every CLI until this is fixed.\n`,
+    );
+    return {} as Record<string, AgentCliConfig>;
+  }));
 }
 
 /**


### PR DESCRIPTION
Closes the coverage gap I named in #455 rather than leaving it named.

## The two halves

Paste framing has a **DECIDE** step and a **DELIVER** step:

```
DECIDE   shouldFramePaste({ supported: cliDefaults()[cli]?.bracketedPaste,
                            body, isSlashCommand: isSlashCommand(body) })
DELIVER  frameAsPaste(...) written down the FIFO
```

DELIVER needs a real pipe, so its byte-level assertions are unix-only. That is
the right boundary and this does not move it.

DECIDE is a pure function over **config**, and it is the half that rots
**silently**: a renamed config key, a CLI added to `default.config.yaml` without
the flag, or `isSlashCommand` drifting would each leave `supported` false.
Nothing goes red — messages just start losing their heads again, which is the
failure #455 exists to prevent.

## What this adds

Each piece was already covered alone (`shouldFramePaste` in
`bracketedPaste.spec.ts`, the flags in `configShared.spec.ts`). This pins the
**join**, against the real shared defaults.

There are **two** consumers of that join, not one — `cmdSend` and `serve.ts`'s
`POST /api/send` (the console and remote-send path) compose it identically. The
test asserts the composition rather than a call site, so it speaks for both; a
renamed key rots test and production together. Naming that here because a
reader who later changes only one site should not think the test covers it by
accident.

| cli | body | framed |
|---|---|---|
| claude | prose | ✅ |
| codex | prose | ✅ |
| bash | `echo hi` | ❌ never enables the mode |
| claude | `/model opus` | ❌ pasted text is not typing |
| unknown cli | prose | ❌ unconfigured, not a guess |

It needs no FIFO, so unlike the delivery assertions **it runs on Windows**.

## Mutation-tested

Not asserted — checked, on both realistic rots:

- flip `bracketedPaste: true` → `false` for claude → **2 failures**
- rename the YAML key so only the consumer uses the old name → **2 failures**

## Also in here

`cliDefaults()` swallowed its own load failure (`.catch(() => ({}))`). Fail-open
is deliberate — `ay ls` must still work with a broken YAML — but an empty map is
not neutral for every consumer: framing reads `bracketedPaste` from it, so a
load failure turns framing **off for every CLI at once** and long messages start
losing their heads again, with nothing going red. That is the same silent-rot
shape this PR exists to catch, one layer below where the test can see it. It now
warns on stderr and still returns the usable empty map.

## What it is not

It cannot prove framed bytes reach the pipe. It proves the decision this config
drives is still the right one. The gap is narrower now, not closed.

Gap named by a reviewing lane, which also verified the existing unix gates were
genuinely pipe-bound rather than describe-inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
