### PR TITLE
fix(remote): name the likely cause of a signaling failure, and wrap remote sends

### DIFF
--- a/ts/buildEnvelope.bun.spec.ts
+++ b/ts/buildEnvelope.bun.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { buildEnvelope } from "./subcommands.ts";
+
+const base = {
+  nonce: "deadbeef",
+  cli: "claude" as const,
+  identity: "alice@box:/repo/alpha:main#1111",
+  replyTarget: "24db968a3ab1",
+  via: "env" as const,
+};
+
+describe("buildEnvelope", () => {
+  it("wraps a local send with a reply route that works locally", () => {
+    const { prefix, suffix } = buildEnvelope(base);
+    expect(prefix).toContain("<ay-msg deadbeef from claude alice@box:/repo/alpha:main#1111");
+    expect(prefix).toContain(`reply: ay send 24db968a3ab1 "..."`);
+    expect(suffix).toBe("\n</ay-msg deadbeef>");
+  });
+
+  it("marks a message that crossed a host boundary", () => {
+    // The receiver has to know the sender is not on its own host, because that
+    // changes how it can answer.
+    const { prefix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    expect(prefix).toContain("via remote");
+  });
+
+  it("does NOT hand a remote receiver a bare local reply command", () => {
+    // The regression that matters: the sender's agent id resolves on the
+    // SENDER's host. A bare `ay send <id>` on the receiving side addresses
+    // nothing there — or, worse, a local agent whose id shares the prefix.
+    const { prefix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    expect(prefix).not.toMatch(/reply: ay send 24db968a3ab1 "/);
+    expect(prefix).toContain("24db968a3ab1"); // the id is still there to route to
+    expect(prefix).toContain("box"); // and the host to route through
+  });
+
+  it("never puts a capability token in the envelope", () => {
+    // The receiver's route back is its own to hold; the sender's token for the
+    // far side would be a credential leak into a message body.
+    const { prefix, suffix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    for (const secret of ["tok", "Bearer", "token", "webrtc://"]) {
+      expect(prefix + suffix).not.toContain(secret);
+    }
+  });
+
+  it("carries the attribution strength through, remote or not", () => {
+    // A weakly-attributed sender must not be laundered into a strong one by
+    // crossing a host boundary.
+    expect(buildEnvelope({ ...base, via: "ancestry" }).prefix).toContain("via process-tree");
+    expect(
+      buildEnvelope({ ...base, via: "env-uncorroborated", remote: { senderHost: "box" } }).prefix,
+    ).toContain("UNCORROBORATED-SENDER");
+  });
+
+  it("closes with the same nonce it opened with", () => {
+    // Nonce match, not tag syntax, is what makes the block's boundaries
+    // unforgeable by text inside the body.
+    const { prefix, suffix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    expect(prefix).toContain("deadbeef");
+    expect(suffix).toContain("deadbeef");
+  });
+});

--- a/ts/buildEnvelope.spec.ts
+++ b/ts/buildEnvelope.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildEnvelope } from "./subcommands.ts";
+
+const base = {
+  nonce: "deadbeef",
+  cli: "claude" as const,
+  identity: "alice@box:/repo/alpha:main#1111",
+  replyTarget: "24db968a3ab1",
+  via: "env" as const,
+};
+
+describe("buildEnvelope", () => {
+  it("wraps a local send with a reply route that works locally", () => {
+    const { prefix, suffix } = buildEnvelope(base);
+    expect(prefix).toContain("<ay-msg deadbeef from claude alice@box:/repo/alpha:main#1111");
+    expect(prefix).toContain(`reply: ay send 24db968a3ab1 "..."`);
+    expect(suffix).toBe("\n</ay-msg deadbeef>");
+  });
+
+  it("marks a message that crossed a host boundary", () => {
+    // The receiver has to know the sender is not on its own host, because that
+    // changes how it can answer.
+    const { prefix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    expect(prefix).toContain("via remote");
+  });
+
+  it("does NOT hand a remote receiver a bare local reply command", () => {
+    // The regression that matters: the sender's agent id resolves on the
+    // SENDER's host. A bare `ay send <id>` on the receiving side addresses
+    // nothing there — or, worse, a local agent whose id shares the prefix.
+    const { prefix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    expect(prefix).not.toMatch(/reply: ay send 24db968a3ab1 "/);
+    expect(prefix).toContain("24db968a3ab1"); // the id is still there to route to
+    expect(prefix).toContain("box"); // and the host to route through
+  });
+
+  it("never puts a capability token in the envelope", () => {
+    // The receiver's route back is its own to hold; the sender's token for the
+    // far side would be a credential leak into a message body.
+    const { prefix, suffix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    for (const secret of ["tok", "Bearer", "token", "webrtc://"]) {
+      expect(prefix + suffix).not.toContain(secret);
+    }
+  });
+
+  it("carries the attribution strength through, remote or not", () => {
+    // A weakly-attributed sender must not be laundered into a strong one by
+    // crossing a host boundary.
+    expect(buildEnvelope({ ...base, via: "ancestry" }).prefix).toContain("via process-tree");
+    expect(
+      buildEnvelope({ ...base, via: "env-uncorroborated", remote: { senderHost: "box" } }).prefix,
+    ).toContain("UNCORROBORATED-SENDER");
+  });
+
+  it("closes with the same nonce it opened with", () => {
+    // Nonce match, not tag syntax, is what makes the block's boundaries
+    // unforgeable by text inside the body.
+    const { prefix, suffix } = buildEnvelope({ ...base, remote: { senderHost: "box" } });
+    expect(prefix).toContain("deadbeef");
+    expect(suffix).toContain("deadbeef");
+  });
+});

--- a/ts/signalingHint.bun.spec.ts
+++ b/ts/signalingHint.bun.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { probeSignalingHost, signalingFailureHint } from "./signalingHint.ts";
+
+const CAUSE = "WebSocket connection to 'wss://s.agent-yes.com/rc19085' failed: Failed to connect";
+const HOST = "s.agent-yes.com";
+
+describe("signalingFailureHint", () => {
+  it("always keeps the original error — the one part known to be true", () => {
+    for (const probe of ["https-ok", "https-failed", "unknown"] as const) {
+      expect(signalingFailureHint(CAUSE, probe, HOST)).toContain(CAUSE);
+      expect(signalingFailureHint(CAUSE, probe, HOST)).toContain(HOST);
+    }
+  });
+
+  it("blames the local environment ONLY when HTTPS to the same host works", () => {
+    // The reported case: alias, token and server were all healthy, and the same
+    // command succeeded with escalated sandbox permission. HTTPS reaching the
+    // host is what makes "something is refusing the upgrade" a deduction rather
+    // than a guess.
+    const hint = signalingFailureHint(CAUSE, "https-ok", HOST);
+    expect(hint).toMatch(/sandbox/i);
+    expect(hint).toMatch(/escalated|external-network/i);
+    expect(hint).toMatch(/proxy/i);
+    // It must NOT tell the operator to go looking at the server.
+    expect(hint).toMatch(/the\s+server is up/i);
+  });
+
+  it("does not misdiagnose a genuine outage as a sandbox problem", () => {
+    // When HTTPS fails too, a blocked sandbox and a down host are BOTH live
+    // possibilities. Naming only the sandbox would send someone chasing their
+    // own permissions while the service is actually down.
+    const hint = signalingFailureHint(CAUSE, "https-failed", HOST);
+    expect(hint).toMatch(/not specific to\s*\n?\s*WebSockets/);
+    expect(hint).toMatch(/genuinely unreachable|check connectivity/i);
+    expect(hint).toMatch(/sandbox/i); // still offered, as one cause among two
+    // And it must not claim the server is fine, which the probe did not show.
+    expect(hint).not.toMatch(/the\s+server is up/i);
+  });
+
+  it("claims nothing from a probe that could not run", () => {
+    const hint = signalingFailureHint(CAUSE, "unknown", HOST);
+    expect(hint).toMatch(/sandbox/i);
+    expect(hint).not.toMatch(/HTTPS to .* works/);
+    expect(hint).not.toMatch(/does not work from here either/);
+  });
+
+  it("is a multi-line note, not a wall of text", () => {
+    // It prints on every failed remote command; if it reads as noise it gets
+    // skipped, which is how a real hint stops working.
+    for (const probe of ["https-ok", "https-failed", "unknown"] as const) {
+      const [first, ...rest] = signalingFailureHint(CAUSE, probe, HOST).split("\n");
+      expect(rest.length + 1).toBeLessThanOrEqual(9);
+      // The first line carries the original error verbatim and is as long as
+      // that error is; the added guidance is what must stay scannable.
+      expect(first).toContain(CAUSE);
+      for (const l of rest) expect(l.length).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe("probeSignalingHost", () => {
+  it("treats ANY http response as reachable, including an error status", async () => {
+    // A 404 still proves DNS, TLS and egress all worked, which is the only
+    // question being asked.
+    const notFound = async () => new Response("nope", { status: 404 });
+    expect(await probeSignalingHost(HOST, 1000, notFound as typeof fetch)).toBe("https-ok");
+  });
+
+  it("answers instead of throwing when the host cannot be reached", async () => {
+    // A failure here IS the answer — it must never replace the original error
+    // with an error from the diagnosis itself.
+    const boom = async () => {
+      throw new TypeError("fetch failed");
+    };
+    await expect(probeSignalingHost(HOST, 1000, boom as typeof fetch)).resolves.toBe(
+      "https-failed",
+    );
+  });
+
+  it("does not hang a failing command waiting on the probe", async () => {
+    const never = (_u: any, init: any) =>
+      new Promise<Response>((_res, rej) =>
+        init.signal.addEventListener("abort", () => rej(new Error("aborted"))),
+      );
+    const t0 = Date.now();
+    expect(await probeSignalingHost(HOST, 150, never as unknown as typeof fetch)).toBe(
+      "https-failed",
+    );
+    expect(Date.now() - t0).toBeLessThan(2000);
+  });
+});

--- a/ts/signalingHint.spec.ts
+++ b/ts/signalingHint.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { probeSignalingHost, signalingFailureHint } from "./signalingHint.ts";
+
+const CAUSE = "WebSocket connection to 'wss://s.agent-yes.com/rc19085' failed: Failed to connect";
+const HOST = "s.agent-yes.com";
+
+describe("signalingFailureHint", () => {
+  it("always keeps the original error — the one part known to be true", () => {
+    for (const probe of ["https-ok", "https-failed", "unknown"] as const) {
+      expect(signalingFailureHint(CAUSE, probe, HOST)).toContain(CAUSE);
+      expect(signalingFailureHint(CAUSE, probe, HOST)).toContain(HOST);
+    }
+  });
+
+  it("blames the local environment ONLY when HTTPS to the same host works", () => {
+    // The reported case: alias, token and server were all healthy, and the same
+    // command succeeded with escalated sandbox permission. HTTPS reaching the
+    // host is what makes "something is refusing the upgrade" a deduction rather
+    // than a guess.
+    const hint = signalingFailureHint(CAUSE, "https-ok", HOST);
+    expect(hint).toMatch(/sandbox/i);
+    expect(hint).toMatch(/escalated|external-network/i);
+    expect(hint).toMatch(/proxy/i);
+    // It must NOT tell the operator to go looking at the server.
+    expect(hint).toMatch(/the\s+server is up/i);
+  });
+
+  it("does not misdiagnose a genuine outage as a sandbox problem", () => {
+    // When HTTPS fails too, a blocked sandbox and a down host are BOTH live
+    // possibilities. Naming only the sandbox would send someone chasing their
+    // own permissions while the service is actually down.
+    const hint = signalingFailureHint(CAUSE, "https-failed", HOST);
+    expect(hint).toMatch(/not specific to\s*\n?\s*WebSockets/);
+    expect(hint).toMatch(/genuinely unreachable|check connectivity/i);
+    expect(hint).toMatch(/sandbox/i); // still offered, as one cause among two
+    // And it must not claim the server is fine, which the probe did not show.
+    expect(hint).not.toMatch(/the\s+server is up/i);
+  });
+
+  it("claims nothing from a probe that could not run", () => {
+    const hint = signalingFailureHint(CAUSE, "unknown", HOST);
+    expect(hint).toMatch(/sandbox/i);
+    expect(hint).not.toMatch(/HTTPS to .* works/);
+    expect(hint).not.toMatch(/does not work from here either/);
+  });
+
+  it("is a multi-line note, not a wall of text", () => {
+    // It prints on every failed remote command; if it reads as noise it gets
+    // skipped, which is how a real hint stops working.
+    for (const probe of ["https-ok", "https-failed", "unknown"] as const) {
+      const [first, ...rest] = signalingFailureHint(CAUSE, probe, HOST).split("\n");
+      expect(rest.length + 1).toBeLessThanOrEqual(9);
+      // The first line carries the original error verbatim and is as long as
+      // that error is; the added guidance is what must stay scannable.
+      expect(first).toContain(CAUSE);
+      for (const l of rest) expect(l.length).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe("probeSignalingHost", () => {
+  it("treats ANY http response as reachable, including an error status", async () => {
+    // A 404 still proves DNS, TLS and egress all worked, which is the only
+    // question being asked.
+    const notFound = async () => new Response("nope", { status: 404 });
+    expect(await probeSignalingHost(HOST, 1000, notFound as typeof fetch)).toBe("https-ok");
+  });
+
+  it("answers instead of throwing when the host cannot be reached", async () => {
+    // A failure here IS the answer — it must never replace the original error
+    // with an error from the diagnosis itself.
+    const boom = async () => {
+      throw new TypeError("fetch failed");
+    };
+    await expect(probeSignalingHost(HOST, 1000, boom as typeof fetch)).resolves.toBe(
+      "https-failed",
+    );
+  });
+
+  it("does not hang a failing command waiting on the probe", async () => {
+    const never = (_u: any, init: any) =>
+      new Promise<Response>((_res, rej) =>
+        init.signal.addEventListener("abort", () => rej(new Error("aborted"))),
+      );
+    const t0 = Date.now();
+    expect(await probeSignalingHost(HOST, 150, never as unknown as typeof fetch)).toBe(
+      "https-failed",
+    );
+    expect(Date.now() - t0).toBeLessThan(2000);
+  });
+});

--- a/ts/signalingHint.ts
+++ b/ts/signalingHint.ts
@@ -1,0 +1,98 @@
+/**
+ * Why a WebRTC signaling connection failed, said in a way the operator can act
+ * on — without pretending to know more than was measured.
+ *
+ * The report this exists for: `ay ls <alias>` inside a coding-agent sandbox
+ * printed only
+ *
+ *   WebSocket connection to wss://s.agent-yes.com/rc19085 failed: Failed to connect
+ *
+ * while the identical command succeeded immediately with escalated sandbox
+ * permission (29 agents returned). Alias, token and server were all healthy, so
+ * every fact in that message was true and none of them pointed at the cause.
+ *
+ * The temptation is to append "you may be sandboxed" to the failure. That would
+ * misdiagnose every genuine outage, and an error that cries wolf is one people
+ * learn to skip. So the hint is DERIVED instead: on failure, probe plain HTTPS
+ * to the same host. The two outcomes are different problems with different
+ * fixes, and the probe distinguishes them:
+ *
+ *   HTTPS reachable, WSS not  -> something permits ordinary HTTPS and refuses a
+ *                                WebSocket upgrade. A sandbox or an intercepting
+ *                                proxy does this; an outage does not.
+ *   neither reachable         -> no egress at all, or the host really is down.
+ *                                Both are named; neither is asserted.
+ */
+
+/** What a probe of the signaling host over plain HTTPS established. */
+export type HostProbe =
+  /** The host answered — anything at all, including an error status. */
+  | "https-ok"
+  /** HTTPS did not get through either. */
+  | "https-failed"
+  /** The probe could not be run (no fetch, no time). Nothing is claimed from it. */
+  | "unknown";
+
+/**
+ * Reach the signaling host over ordinary HTTPS. ANY HTTP response counts as
+ * reachable — a 404 or a 400 still proves egress, TLS and DNS all worked, which
+ * is the whole question. Never throws; a failure IS the answer.
+ */
+export async function probeSignalingHost(
+  host: string,
+  timeoutMs = 4000,
+  // Injected so the outcome mapping is testable without a network, and so a
+  // test can never depend on the real host being up.
+  doFetch: typeof fetch = fetch,
+): Promise<HostProbe> {
+  try {
+    await doFetch(`https://${host}/`, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: "manual",
+    });
+    return "https-ok";
+  } catch {
+    return "https-failed";
+  }
+}
+
+/**
+ * The operator-facing explanation, given the original error and what the probe
+ * found. Pure, so the wording is testable without a network.
+ *
+ * Every branch keeps the original error text: it is the only part that is
+ * certainly true, and a hint that replaces evidence is worse than no hint.
+ */
+export function signalingFailureHint(cause: string, probe: HostProbe, host: string): string {
+  const head = `cannot reach the signaling host ${host}: ${cause}`;
+  switch (probe) {
+    case "https-ok":
+      return (
+        `${head}\n` +
+        `  HTTPS to ${host} works from here, so DNS, TLS and egress are fine and the\n` +
+        `  server is up — only the WebSocket did not connect. Something in between is\n` +
+        `  allowing HTTPS and refusing the upgrade, which is what a coding-agent\n` +
+        `  sandbox or an intercepting proxy does.\n` +
+        `  If you are running inside a sandbox (Codex and similar): re-run with\n` +
+        `  escalated / external-network permission. If you are behind a corporate\n` +
+        `  proxy: it must allow WebSocket upgrades to ${host}.`
+      );
+    case "https-failed":
+      return (
+        `${head}\n` +
+        `  HTTPS to ${host} does not work from here either, so this is not specific to\n` +
+        `  WebSockets — either this environment has no outbound network, or the host\n` +
+        `  is genuinely unreachable.\n` +
+        `  If you are running inside a sandbox (Codex and similar): re-run with\n` +
+        `  escalated / external-network permission. Otherwise check connectivity and\n` +
+        `  whether ${host} is up.`
+      );
+    default:
+      return (
+        `${head}\n` +
+        `  If you are running inside a coding-agent sandbox, outbound WebSockets are\n` +
+        `  often blocked — re-run with escalated / external-network permission.`
+      );
+  }
+}

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -643,6 +643,44 @@ export const SEND_BODY_MAX_CHARS = 1024;
  * Shared by the real construction and by `envelopeCostFor` so the two cannot
  * drift — a marker in one and not the other would under-count the cap.
  */
+/**
+ * Build the `<ay-msg …>` envelope for one send.
+ *
+ * ONE builder, because there are now three callers — `cmdSend`, the remote send
+ * path, and `envelopeCostFor` (which must size exactly what is transmitted).
+ * Two of them were already hand-copied templates whose own comment warned that a
+ * divergence would under-count the cap; the third was missing entirely, which is
+ * the bug this exists to close.
+ *
+ * `remote` names the transport when the message crosses a host boundary. The
+ * reply route has to change with it: the sender's agent id resolves on the
+ * SENDER's host, so a bare `ay send <id>` on the receiving side would address
+ * nothing, or — worse — a local agent that happens to share the prefix. The
+ * receiver is told what it actually needs: the sender's stable id, the host to
+ * route to, and that its own alias for that host goes in front. No capability
+ * token appears here; the receiver's route back is its own to hold.
+ */
+export function buildEnvelope(opts: {
+  nonce: string;
+  cli: string;
+  identity: string;
+  replyTarget: string | number;
+  via: SenderVia;
+  /** Set when the message crossed a host boundary; the sender's own label for
+   * the far side is deliberately NOT used — it is meaningless to the receiver. */
+  remote?: { senderHost: string } | null;
+}): { prefix: string; suffix: string } {
+  const attrib = envelopeAttribution(opts.via);
+  const via = opts.remote ? " via remote" : "";
+  const reply = opts.remote
+    ? `reply: ay send <your-remote-alias-for-${opts.remote.senderHost}>:${opts.replyTarget} "..."`
+    : `reply: ay send ${opts.replyTarget} "..."`;
+  return {
+    prefix: `<ay-msg ${opts.nonce} from ${opts.cli}${attrib}${via} ${opts.identity} — ${reply}>\n`,
+    suffix: `\n</ay-msg ${opts.nonce}>`,
+  };
+}
+
 export function envelopeAttribution(via: SenderVia): string {
   switch (via) {
     case "ancestry":
@@ -665,9 +703,13 @@ export async function envelopeCostFor(body: string, raw: boolean): Promise<numbe
   const nonce = "00000000"; // 4 random bytes as hex — fixed width, so any value sizes alike
   const identity = formatIdentity({ cwd: sender.agent.cwd, pid: sender.agent.pid });
   const replyTarget = sender.agent.agent_id || sender.agent.pid;
-  const attrib = envelopeAttribution(sender.via);
-  const prefix = `<ay-msg ${nonce} from ${sender.agent.cli}${attrib} ${identity} — reply: ay send ${replyTarget} "...">\n`;
-  const suffix = `\n</ay-msg ${nonce}>`;
+  const { prefix, suffix } = buildEnvelope({
+    nonce,
+    cli: sender.agent.cli,
+    identity,
+    replyTarget,
+    via: sender.via,
+  });
   return prefix.length + suffix.length;
 }
 
@@ -1555,7 +1597,12 @@ async function runRemoteRead(
   return 0;
 }
 
-async function runRemoteSend(remote: ResolvedRemote, msg: string, code: string): Promise<number> {
+async function runRemoteSend(
+  remote: ResolvedRemote,
+  msg: string,
+  code: string,
+  raw = false,
+): Promise<number> {
   const keyword = remote.keyword ?? "";
   if (!keyword) {
     process.stderr.write("remote send requires a keyword (e.g. token@host:port:keyword)\n");
@@ -1572,7 +1619,33 @@ async function runRemoteSend(remote: ResolvedRemote, msg: string, code: string):
         agent_id: sender.agent.agent_id,
       }
     : null;
-  const res = await remotePost(remote, "/api/send", { keyword, msg, code, from });
+  // Wrap it, exactly as a local send does. This path used to post the bare body:
+  // `cmdSend` returns here BEFORE the envelope is built, so a message that
+  // crossed a host boundary arrived with no header, no nonce and no reply route
+  // — the receiving model saw an unattributed string. The provenance existed
+  // only in `from`, which the host records in its mailbox file and which the
+  // model asked to act on never reads. Same shape as #461: a provenance signal
+  // is only real for the reader it actually reaches.
+  //
+  // Skipped for a slash command (recognized only when it starts the line) and
+  // for --raw, matching cmdSend, and for a human shell with no agent identity to
+  // put in the header.
+  let wire = msg;
+  let nonce: string | undefined;
+  if (sender.agent && msg && msg !== "-" && !isSlashCommand(msg) && !raw) {
+    nonce = randomBytes(4).toString("hex");
+    const { prefix, suffix } = buildEnvelope({
+      nonce,
+      cli: sender.agent.cli,
+      identity: formatIdentity({ cwd: sender.agent.cwd, pid: sender.agent.pid }),
+      replyTarget: sender.agent.agent_id || sender.agent.pid,
+      via: sender.via,
+      // The receiver needs a route back to OUR host, not our label for theirs.
+      remote: { senderHost: localHost() },
+    });
+    wire = prefix + msg + suffix;
+  }
+  const res = await remotePost(remote, "/api/send", { keyword, msg: wire, code, from });
   if (!res.ok) {
     process.stderr.write(`remote error ${res.status}: ${await res.text()}\n`);
     return 1;
@@ -1589,6 +1662,8 @@ async function runRemoteSend(remote: ResolvedRemote, msg: string, code: string):
   if (msg && msg !== "-") {
     await recordOutbox({
       at: Date.now(),
+      nonce,
+      wrapped: Boolean(nonce),
       origin: from ? undefined : "shell",
       from_via: sender.via,
       sender_observed: observedSender(),
@@ -1599,10 +1674,11 @@ async function runRemoteSend(remote: ResolvedRemote, msg: string, code: string):
         cwd: data.cwd ?? "",
         agent_id: data.agentId,
       },
+      // The BODY as authored, not the wire form — the envelope is transport
+      // framing, and storing it would double-wrap on any later re-send.
       body: msg,
       code: code.toLowerCase() === "enter" ? undefined : code.toLowerCase(),
       confirmed: true,
-      wrapped: false,
       remote: remote.label,
     });
   }
@@ -3804,7 +3880,15 @@ async function cmdSend(rest: string[]): Promise<number> {
   const codeName = argv.code.toLowerCase();
   {
     const remote = await resolveRemoteSpec(keyword);
-    if (remote) return runRemoteSend(remote, rawMessage, codeName);
+    // --raw / AGENT_YES_SEND_RAW means "deliver verbatim"; it has to be honoured
+    // on this path too, now that the remote path wraps at all.
+    if (remote)
+      return runRemoteSend(
+        remote,
+        rawMessage,
+        codeName,
+        Boolean(argv.raw) || process.env.AGENT_YES_SEND_RAW === "1",
+      );
   }
   const trailing = controlCodeFromName(codeName);
 
@@ -3951,9 +4035,13 @@ async function cmdSend(rest: string[]): Promise<number> {
     const identity = formatIdentity({ cwd: sender.agent.cwd, pid: sender.agent.pid });
     // How strong this attribution is, stated IN the envelope — see
     // envelopeAttribution for why the mailbox file is not enough.
-    const attrib = envelopeAttribution(sender.via);
-    prefix = `<ay-msg ${nonce} from ${sender.agent.cli}${attrib} ${identity} — reply: ay send ${replyTarget} "...">\n`;
-    suffix = `\n</ay-msg ${nonce}>`;
+    ({ prefix, suffix } = buildEnvelope({
+      nonce,
+      cli: sender.agent.cli,
+      identity,
+      replyTarget: replyTarget!,
+      via: sender.via,
+    }));
     // A body that itself starts with an <ay-msg …> header is usually an agent
     // hand-wrapping what this send is about to wrap again — the recipient then
     // sees a double envelope with two (possibly conflicting) reply targets.

--- a/ts/webrtcRemote.ts
+++ b/ts/webrtcRemote.ts
@@ -9,6 +9,7 @@
 // so the AES-GCM / transcript-hash handshake is byte-identical to the browser
 // console and the host.
 import { RTCPeerConnection } from "node-datachannel/polyfill";
+import { probeSignalingHost, signalingFailureHint } from "./signalingHint.ts";
 import {
   deriveAuthToken,
   deriveDirKeys,
@@ -253,7 +254,19 @@ export async function startWebrtcBridge(link: string): Promise<WebrtcBridge> {
   const parsed = parseWebrtcLink(link);
   if (!parsed) throw new Error(`not a WebRTC share link: ${link}`);
   const conn = new WebRtcConn(parsed);
-  await conn.ready;
+  try {
+    await conn.ready;
+  } catch (e) {
+    // Every remote command routes through here, so this is the one place a
+    // signaling failure has to become actionable. The raw error names the URL
+    // and says "failed to connect" — all true, none of it pointing at the cause
+    // when the cause is the local environment rather than the network. Probe
+    // and say which; see ts/signalingHint.ts for why it is derived rather than
+    // guessed.
+    const cause = String((e as Error)?.message ?? e);
+    const probe = await probeSignalingHost(parsed.host);
+    throw new Error(signalingFailureHint(cause, probe, parsed.host));
+  }
 
   const server = Bun.serve({
     port: 0,


### PR DESCRIPTION
Two reports from the same day, both a remote command telling the operator less than
it knew.

---

## 1. `ay ls <alias>` in a Codex sandbox

Reported output:

```
WebSocket connection to wss://s.agent-yes.com/rc19085 failed: Failed to connect
```

Every word true, none of it pointing at the cause. The identical command succeeded
immediately with `sandbox_permissions=require_escalated` (29 agents returned), and the
alias, token and server were healthy throughout.

### Why not just append "you may be sandboxed"

That misdiagnoses every genuine outage, and an error that cries wolf is one people learn
to skip. So the hint is **derived**: on failure, probe plain HTTPS to the same host — the
two outcomes are different problems with different fixes.

| probe | what it proves | what the hint says |
|---|---|---|
| **HTTPS reachable, WSS not** | DNS, TLS, egress and the server are all fine; only the upgrade failed | that pattern is a sandbox or an intercepting proxy — retry with escalated / external-network permission |
| **neither reachable** | not WebSocket-specific | names **both** "no outbound network here" **and** "the host is genuinely unreachable"; does **not** claim the server is up |
| probe couldn't run | nothing | the generic sandbox note only |

What the operator now sees in the reported case:

```
cannot reach the signaling host s.agent-yes.com: WebSocket connection to
'wss://s.agent-yes.com/rc19085' failed: Failed to connect
  HTTPS to s.agent-yes.com works from here, so DNS, TLS and egress are fine and the
  server is up — only the WebSocket did not connect. Something in between is
  allowing HTTPS and refusing the upgrade, which is what a coding-agent
  sandbox or an intercepting proxy does.
  If you are running inside a sandbox (Codex and similar): re-run with
  escalated / external-network permission. If you are behind a corporate
  proxy: it must allow WebSocket upgrades to s.agent-yes.com.
```

Wired at `startWebrtcBridge`, which **every** remote command routes through, so `ls`,
`send`, `read`, `status` and streaming `tail` gain it at once. The original error text is
preserved in every branch — it is the part known to be true, and a hint that replaces
evidence is worse than no hint. The probe is bounded and injectable, so a failing command
cannot be made slower or hang by the diagnosis itself.

---

## 2. `ay send <alias>:<kw>` delivered a bare, unattributed body

Reported independently: a remote-delivered message reached the receiving agent with no
`<ay-msg …>` wrapper. Confirmed in the code — `cmdSend` returns into the remote path at
line 3882, and the envelope is built at 3955. Remote sends never reached it.

The provenance did exist, in the `from` field the receiving host writes to its **mailbox
file** — which the model asked to act on never reads. Exactly the shape recorded in #461:
**a provenance signal is only real for the reader it actually reaches.**

Reproduced against a stub host, before and after. The wire now carries:

```
<ay-msg 84e9ee17 from claude via remote sno@Mac:/repo/near#59291 —
 reply: ay send <your-remote-alias-for-Mac>:24db968a3ab1 "...">
the deploy is green
</ay-msg 84e9ee17>
```

**The reply route had to change with the transport.** The sender's agent id resolves on
the *sender's* host, so a bare `ay send <id>` on the receiving side addresses nothing
there — or, worse, a local agent whose id shares the prefix. The receiver gets the stable
id, the host to route through, and the fact that its own alias goes in front. **No
capability token appears in the envelope**; the receiver's route back is its own to hold.

Reused `<ay-msg>` rather than introducing `<ay-remote-msg>`: receivers already
pattern-match the existing tag, and `via remote` composes with the attribution markers
that are already there (`via process-tree`, `UNCORROBORATED-SENDER`) instead of forking
the grammar.

Three call sites now share one `buildEnvelope` — two of them were hand-copied templates
whose own comment warned a divergence would under-count the send cap, and the third was
missing entirely, which is this bug. `--raw` is honoured on the remote path too, and a
slash command still goes unwrapped, both matching local behaviour.

---

## Coverage

- `ts/signalingHint.spec.ts` (+ bun twin): the original error survives every branch; the
  local environment is blamed **only** when HTTPS works; the outage case names both
  possibilities and does **not** claim the server is up; a probe that could not run claims
  nothing; the note stays scannable; the probe answers rather than throws, and cannot hang.
- `ts/buildEnvelope.spec.ts` (+ bun twin): a remote envelope is marked; it does **not**
  hand a remote receiver a bare local reply command; **no token appears**; attribution
  strength is not laundered by crossing a host boundary; the nonce matches.
- Suites green: vitest **1861 passed / 3 skipped**, coverage gate exit 0 (94.20 stmts /
  90.22 branches); `bun test .bun.` **1289 passed / 1 skipped**; `tsgo --noEmit` unchanged.

## Not done

The receiving host does not rewrite anything — the envelope is composed sender-side,
where the identity is known. A receiver still cannot *automatically* reply to a remote
sender without its own alias for that host; it is now told exactly what it needs, which
is the honest limit of what the sender can supply without handing over a credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)