### PR TITLE
fix(setup): refuse to onboard from inside a snap sandbox

### DIFF
--- a/default.config.yaml
+++ b/default.config.yaml
@@ -399,7 +399,6 @@ clis:
       - "Error: The cursor position could not be read within"
     noEOL: true
 
-
   # codex-ds-direct — same idea as codex-ds, but pointed straight at DeepSeek's
   # own endpoint instead of going through OpenRouter. DeepSeek gained native
   # Responses API support in the 2026-08-13 V4 Pro update
@@ -449,7 +448,6 @@ clis:
     fatal:
       - "Error: The cursor position could not be read within"
     noEOL: true
-
 
   qwen:
     install:

--- a/docs/deepseek-codex.md
+++ b/docs/deepseek-codex.md
@@ -6,12 +6,12 @@ configuration — `binary: codex` plus a few `-c` overrides in
 `CODEX_HOME`, a helper script, or a config file of your own: a stock `codex`
 install is enough.
 
-| | `ay codex-ds` | `ay codex-ds-direct` |
-|---|---|---|
-| Route | OpenRouter | DeepSeek's own endpoint |
-| Model | `deepseek/deepseek-v4-pro-0813` | `deepseek-v4-pro` |
-| Requires | `OPENROUTER_API_KEY` | `DEEPSEEK_API_KEY` |
-| Billing | OpenRouter credits | DeepSeek account |
+|          | `ay codex-ds`                   | `ay codex-ds-direct`    |
+| -------- | ------------------------------- | ----------------------- |
+| Route    | OpenRouter                      | DeepSeek's own endpoint |
+| Model    | `deepseek/deepseek-v4-pro-0813` | `deepseek-v4-pro`       |
+| Requires | `OPENROUTER_API_KEY`            | `DEEPSEEK_API_KEY`      |
+| Billing  | OpenRouter credits              | DeepSeek account        |
 
 Pick `codex-ds` to keep one key across many providers, or `codex-ds-direct` to
 bill DeepSeek straight and drop a network hop plus the reseller margin.

--- a/docs/kernel-resource-limits.md
+++ b/docs/kernel-resource-limits.md
@@ -7,11 +7,11 @@
 
 ## 1. Overview: the two failure modes
 
-| Symptom | Actual cause | Errno | Fix |
-|---|---|---|---|
-| `openpty failed: out of pty devices` (Python) | **Sandbox blocks `/dev/ptmx`** (EPERM), NOT pty exhaustion | `errno=1 Operation not permitted` | Escalate sandbox: `danger-full-access` or remove Seatbelt profile |
-| `openpty failed: …` (real exhaustion) | Actual pty count exceeds `kern.tty.ptmx_max` | `errno=34 Result too large` / `ENOSPC` | Raise `ptmx_max` or kill idle agents |
-| `forkpty failed` (C/rs) | Same — sandbox (EPERM) or pool exhaustion (ENOSPC) | EPERM vs ENOSPC | Diagnose with `posix_openpt()` test, then appropriate fix |
+| Symptom                                       | Actual cause                                               | Errno                                  | Fix                                                               |
+| --------------------------------------------- | ---------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------- |
+| `openpty failed: out of pty devices` (Python) | **Sandbox blocks `/dev/ptmx`** (EPERM), NOT pty exhaustion | `errno=1 Operation not permitted`      | Escalate sandbox: `danger-full-access` or remove Seatbelt profile |
+| `openpty failed: …` (real exhaustion)         | Actual pty count exceeds `kern.tty.ptmx_max`               | `errno=34 Result too large` / `ENOSPC` | Raise `ptmx_max` or kill idle agents                              |
+| `forkpty failed` (C/rs)                       | Same — sandbox (EPERM) or pool exhaustion (ENOSPC)         | EPERM vs ENOSPC                        | Diagnose with `posix_openpt()` test, then appropriate fix         |
 
 **Key diagnostic**: run `open("/dev/ptmx", O_RDWR)` from a C test binary; if it returns
 **EPERM**, it's the sandbox. If it returns **ENOSPC**, it's actual pty depletion.
@@ -22,8 +22,8 @@
 
 ### 2.1 What they are and why agent-yes needs them
 
-Every `ay <cli>` spawns the target CLI under a **pseudoterminal pair** (master
-+ slave). The master end is opened via `open("/dev/ptmx")` (or the
+Every `ay <cli>` spawns the target CLI under a **pseudoterminal pair**
+(master + slave). The master end is opened via `open("/dev/ptmx")` (or the
 `posix_openpt(3)` wrapper). The slave end appears as `/dev/ttysXXX` on macOS
 or `/dev/pts/N` on Linux.
 
@@ -37,6 +37,7 @@ it's talking to a real terminal even in headless/CI contexts.
 default 511).
 
 **Is it adjustable?** **Yes** — but with constraints:
+
 ```bash
 # Check current
 sysctl kern.tty.ptmx_max    # default: 511
@@ -53,11 +54,12 @@ echo 'kern.tty.ptmx_max=999' | sudo tee -a /etc/sysctl.conf
 
 **Sandbox caveat**: on macOS, agent-yes may run under a **Seatbelt sandbox**
 that blocks `open("/dev/ptmx")` with `EPERM` (Operation not permitted),
-*regardless* of whether the pty pool has free slots. The sandbox policy must
-explicitly allow `/dev/ptmx` access (`(allow sysctl-read kern.tty.ptmx_max)`
-+ `(allow file-read* file-write* (char-device "/dev/ptmx"))`). See §4 below.
+_regardless_ of whether the pty pool has free slots. The sandbox policy must
+explicitly allow `/dev/ptmx` access (`(allow sysctl-read kern.tty.ptmx_max)` +
+`(allow file-read* file-write* (char-device "/dev/ptmx"))`). See §4 below.
 
 **Diagnosis**:
+
 ```bash
 # Count active pty opens
 lsof /dev/ptmx | tail -n +2 | wc -l
@@ -110,6 +112,7 @@ sudo sysctl kern.tty.ptmx_max=512 # raise
 ### 3.1 File descriptors
 
 **macOS**:
+
 ```bash
 kern.maxfiles: 276480         # system-wide
 kern.maxfilesperproc: 138240  # per-process
@@ -117,6 +120,7 @@ ulimit -n: unlimited          # soft limit (may be lower)
 ```
 
 **Linux**:
+
 ```bash
 ulimit -n                    # soft limit (often 1024)
 ulimit -n 65536              # raise (session only)
@@ -130,6 +134,7 @@ per-process soft limit.
 ### 3.2 Process count
 
 **macOS**:
+
 ```bash
 kern.maxproc: 9000            # system-wide ceiling
 kern.maxprocperuid: 6000      # per-user ceiling
@@ -137,6 +142,7 @@ ulimit -u: 6000               # soft limit
 ```
 
 **Linux**:
+
 ```bash
 ulimit -u                    # per-user (often 4096 or "unlimited")
 # /etc/security/limits.conf  # nproc

--- a/docs/orchestrator-observability.md
+++ b/docs/orchestrator-observability.md
@@ -118,10 +118,10 @@ Each left out with a one-line reason; none is required to fix the reported pain.
   `feat/state-events`) — see "What shipped next" above.
 - **Join-wait — `ay ls --wait` (block until the whole batch is settled).** The
   blocking counterpart to `ay ls --watch`: exit once _every_ matched agent is in
-  a terminal-for-the-operator state (`needs_input | idle | stuck | unreachable |
-  stopped`), so a
-  fan-out parent can `ay ls <scope> --wait` and get control back the moment the
-  batch collectively needs it. _Why not now:_ `--watch` already delivers the
+  a terminal-for-the-operator state
+  (`needs_input | idle | stuck | unreachable | stopped`), so a fan-out parent can
+  `ay ls <scope> --wait` and get control back the moment the batch collectively
+  needs it. _Why not now:_ `--watch` already delivers the
   events; the parent can implement the join itself by consuming the stream. This
   overlaps with P5 (`ay wait --until`) and is best designed together with it
   (target-state set + multi-pid in one flag) rather than bolted onto `ls`.

--- a/docs/perf-hud-archive.md
+++ b/docs/perf-hud-archive.md
@@ -23,12 +23,12 @@
 
 ## 4. 服务端 perf 分支（已全部合并，无遗留）
 
-| 分支 | 内容 | main 落点 |
-|---|---|---|
-| `perf/edges-backscan` | エッジ走査時刻窓打ち切り + `/api/ls` メタ収集並列化 | `ee6917a #422` |
-| `perf/raw-log-gc` | 旧版書き手の raw ログ daemon 回収 + log_tasks 再計算間引き | `9ad6aed #425` |
-| `perf/raw-log-read-cap` | cap raw PTY log reads/size + compact-in-place | `18b100e/ad58931` → `a672f91 #264` |
-| `perf-w-startup` | web console 启动加速 | 已合并 |
+| 分支                    | 内容                                                       | main 落点                          |
+| ----------------------- | ---------------------------------------------------------- | ---------------------------------- |
+| `perf/edges-backscan`   | エッジ走査時刻窓打ち切り + `/api/ls` メタ収集並列化        | `ee6917a #422`                     |
+| `perf/raw-log-gc`       | 旧版書き手の raw ログ daemon 回収 + log_tasks 再計算間引き | `9ad6aed #425`                     |
+| `perf/raw-log-read-cap` | cap raw PTY log reads/size + compact-in-place              | `18b100e/ad58931` → `a672f91 #264` |
+| `perf-w-startup`        | web console 启动加速                                       | 已合并                             |
 
 > 这些本地分支与 worktree 已于 2026-08-17 清理（内容已全在 main）。远程 `origin/perf/*` 分支是 PR 来源，保留即可。
 

--- a/lab/ui/rtc.js
+++ b/lab/ui/rtc.js
@@ -479,7 +479,8 @@ export class RTCClient {
   // The host still returns cumulative acknowledgements for observability and
   // rejection reporting; callers only await admission to the wire.
   sendInput(pid, msg) {
-    if (typeof msg !== "string") return Promise.reject(new TypeError("terminal input must be text"));
+    if (typeof msg !== "string")
+      return Promise.reject(new TypeError("terminal input must be text"));
     const seq = ++this._inputSeq;
     return this._dcSend(0, { t: "stdin", pid: String(pid), seq, msg });
   }

--- a/ts/cmdDsh.bun.spec.ts
+++ b/ts/cmdDsh.bun.spec.ts
@@ -80,9 +80,7 @@ describe("cmdDsh", () => {
     const spawn: DshSpawn = (cmd) => {
       calls.push(cmd);
       return {
-        exited: Promise.resolve(
-          cmd[1] === "--version" ? 0 : (undefined as unknown as number),
-        ),
+        exited: Promise.resolve(cmd[1] === "--version" ? 0 : (undefined as unknown as number)),
       };
     };
     expect(await cmdDsh(["alpha"], spawn)).toBe(0);

--- a/ts/cmdDsh.spec.ts
+++ b/ts/cmdDsh.spec.ts
@@ -80,9 +80,7 @@ describe("cmdDsh", () => {
     const spawn: DshSpawn = (cmd) => {
       calls.push(cmd);
       return {
-        exited: Promise.resolve(
-          cmd[1] === "--version" ? 0 : (undefined as unknown as number),
-        ),
+        exited: Promise.resolve(cmd[1] === "--version" ? 0 : (undefined as unknown as number)),
       };
     };
     expect(await cmdDsh(["alpha"], spawn)).toBe(0);

--- a/ts/cmdPs.spec.ts
+++ b/ts/cmdPs.spec.ts
@@ -435,7 +435,10 @@ describe("subtreeTotals", () => {
   });
 
   it("treats a missing depth as a root", () => {
-    const out = subtreeTotals([{ stats: { pid: 1, rss: 1, cpuPercent: 0, procs: 1 } }, n(1, 2, 0, 1)]);
+    const out = subtreeTotals([
+      { stats: { pid: 1, rss: 1, cpuPercent: 0, procs: 1 } },
+      n(1, 2, 0, 1),
+    ]);
     expect(out[0]).toMatchObject({ rss: 3 });
   });
 });
@@ -512,7 +515,12 @@ describe("renderTable --tree", () => {
 
   it("adds the Σ columns and renders forest rails on the PID cell", () => {
     const withTree = [
-      { ...treeRows[0]!, depth: 0, prefix: "", subtree: stats({ rss: 150, cpuPercent: 3, procs: 3 }) },
+      {
+        ...treeRows[0]!,
+        depth: 0,
+        prefix: "",
+        subtree: stats({ rss: 150, cpuPercent: 3, procs: 3 }),
+      },
       { ...treeRows[1]!, depth: 1, prefix: "└─ ", subtree: null },
     ];
     const out = renderTable(withTree, null, { tree: true });

--- a/ts/core/responders.ts
+++ b/ts/core/responders.ts
@@ -4,7 +4,11 @@ import { sendEnter, sendMessage } from "./messaging.ts";
 import type { AgentContext } from "./context.ts";
 import type { AgentCliConfig } from "../index.ts";
 import type { SUPPORTED_CLIS } from "../SUPPORTED_CLIS.ts";
-import { extractSessionId, isCodexFamily, storeSessionForCwd } from "../resume/codexSessionManager.ts";
+import {
+  extractSessionId,
+  isCodexFamily,
+  storeSessionForCwd,
+} from "../resume/codexSessionManager.ts";
 
 /**
  * Auto-response handlers for CLI-specific patterns

--- a/ts/messageLog.bun.spec.ts
+++ b/ts/messageLog.bun.spec.ts
@@ -491,8 +491,9 @@ describe("messageLog sender provenance — derived vs asserted", () => {
   it("describes an unidentified sender by what was MEASURED, not as a blank", () => {
     // The failure this fixes: an honest sender outside the wrapper rendered
     // identically to an anonymous stranger, so receiving lanes refused it.
-    expect(senderLabel(makeRecord({ from: null, from_via: "observed", sender_observed: observed })))
-      .toBe("unattributed (alice@box:/repo/alpha#4242)");
+    expect(
+      senderLabel(makeRecord({ from: null, from_via: "observed", sender_observed: observed })),
+    ).toBe("unattributed (alice@box:/repo/alpha#4242)");
   });
 
   it("still says unattributed when even the observation is missing", () => {
@@ -534,7 +535,8 @@ describe("messageLog sender provenance — derived vs asserted", () => {
 
   it("keeps an unattributed message DELIVERABLE, just visibly unattributed", () => {
     // Dropping them would recreate the same starvation from the other side.
-    expect(shouldRecord(makeRecord({ from: null, from_via: "observed", sender_observed: observed })))
-      .toBe(true);
+    expect(
+      shouldRecord(makeRecord({ from: null, from_via: "observed", sender_observed: observed })),
+    ).toBe(true);
   });
 });

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -491,8 +491,9 @@ describe("messageLog sender provenance — derived vs asserted", () => {
   it("describes an unidentified sender by what was MEASURED, not as a blank", () => {
     // The failure this fixes: an honest sender outside the wrapper rendered
     // identically to an anonymous stranger, so receiving lanes refused it.
-    expect(senderLabel(makeRecord({ from: null, from_via: "observed", sender_observed: observed })))
-      .toBe("unattributed (alice@box:/repo/alpha#4242)");
+    expect(
+      senderLabel(makeRecord({ from: null, from_via: "observed", sender_observed: observed })),
+    ).toBe("unattributed (alice@box:/repo/alpha#4242)");
   });
 
   it("still says unattributed when even the observation is missing", () => {
@@ -534,7 +535,8 @@ describe("messageLog sender provenance — derived vs asserted", () => {
 
   it("keeps an unattributed message DELIVERABLE, just visibly unattributed", () => {
     // Dropping them would recreate the same starvation from the other side.
-    expect(shouldRecord(makeRecord({ from: null, from_via: "observed", sender_observed: observed })))
-      .toBe(true);
+    expect(
+      shouldRecord(makeRecord({ from: null, from_via: "observed", sender_observed: observed })),
+    ).toBe(true);
   });
 });

--- a/ts/procStats.ts
+++ b/ts/procStats.ts
@@ -355,7 +355,11 @@ function memberRows(
     out.push({
       pid,
       ppid: now.ppid,
-      comm: (now.comm || "").split(/[\\/]+/).filter(Boolean).pop() ?? "",
+      comm:
+        (now.comm || "")
+          .split(/[\\/]+/)
+          .filter(Boolean)
+          .pop() ?? "",
       rss: now.rss,
       cpuPercent: elapsedSeconds > 0 ? (delta / elapsedSeconds) * 100 : 0,
       state: now.state,

--- a/ts/senderAncestry.bun.spec.ts
+++ b/ts/senderAncestry.bun.spec.ts
@@ -29,7 +29,14 @@ describe("parseProcessTable", () => {
 describe("ancestorPids", () => {
   it("walks parents nearest-first", async () => {
     expect(
-      await ancestorPids(400, { readTable: table([[400, 300], [300, 200], [200, 100], [100, 1]]) }),
+      await ancestorPids(400, {
+        readTable: table([
+          [400, 300],
+          [300, 200],
+          [200, 100],
+          [100, 1],
+        ]),
+      }),
     ).toEqual([300, 200, 100]);
   });
 
@@ -39,9 +46,15 @@ describe("ancestorPids", () => {
 
   it("terminates on a cycle instead of spinning", async () => {
     // pid reuse can produce a table that loops; a spin here hangs every send.
-    expect(await ancestorPids(10, { readTable: table([[10, 20], [20, 30], [30, 10]]) })).toEqual([
-      20, 30,
-    ]);
+    expect(
+      await ancestorPids(10, {
+        readTable: table([
+          [10, 20],
+          [20, 30],
+          [30, 10],
+        ]),
+      }),
+    ).toEqual([20, 30]);
   });
 
   it("respects the hop bound", async () => {
@@ -64,11 +77,17 @@ describe("ancestorPids", () => {
 });
 
 describe("findAgentAncestor", () => {
-  const chain = table([[400, 300], [300, 200], [200, 100], [100, 1]]);
+  const chain = table([
+    [400, 300],
+    [300, 200],
+    [200, 100],
+    [100, 1],
+  ]);
 
   it("finds a registered ancestor however many hops up", async () => {
-    expect(await findAgentAncestor(400, (p) => (p === 100 ? "lane-A" : null), { readTable: chain }))
-      .toBe("lane-A");
+    expect(
+      await findAgentAncestor(400, (p) => (p === 100 ? "lane-A" : null), { readTable: chain }),
+    ).toBe("lane-A");
   });
 
   it("prefers the NEAREST enclosing agent", async () => {
@@ -89,8 +108,9 @@ describe("findAgentAncestor", () => {
 
   it("does not attribute the caller to ITSELF", async () => {
     // The walk starts at the parent: a bare `ay send` is not its own sender.
-    expect(await findAgentAncestor(400, (p) => (p === 400 ? "self" : null), { readTable: chain }))
-      .toBeNull();
+    expect(
+      await findAgentAncestor(400, (p) => (p === 400 ? "self" : null), { readTable: chain }),
+    ).toBeNull();
   });
 });
 

--- a/ts/senderAncestry.spec.ts
+++ b/ts/senderAncestry.spec.ts
@@ -29,7 +29,14 @@ describe("parseProcessTable", () => {
 describe("ancestorPids", () => {
   it("walks parents nearest-first", async () => {
     expect(
-      await ancestorPids(400, { readTable: table([[400, 300], [300, 200], [200, 100], [100, 1]]) }),
+      await ancestorPids(400, {
+        readTable: table([
+          [400, 300],
+          [300, 200],
+          [200, 100],
+          [100, 1],
+        ]),
+      }),
     ).toEqual([300, 200, 100]);
   });
 
@@ -39,9 +46,15 @@ describe("ancestorPids", () => {
 
   it("terminates on a cycle instead of spinning", async () => {
     // pid reuse can produce a table that loops; a spin here hangs every send.
-    expect(await ancestorPids(10, { readTable: table([[10, 20], [20, 30], [30, 10]]) })).toEqual([
-      20, 30,
-    ]);
+    expect(
+      await ancestorPids(10, {
+        readTable: table([
+          [10, 20],
+          [20, 30],
+          [30, 10],
+        ]),
+      }),
+    ).toEqual([20, 30]);
   });
 
   it("respects the hop bound", async () => {
@@ -64,11 +77,17 @@ describe("ancestorPids", () => {
 });
 
 describe("findAgentAncestor", () => {
-  const chain = table([[400, 300], [300, 200], [200, 100], [100, 1]]);
+  const chain = table([
+    [400, 300],
+    [300, 200],
+    [200, 100],
+    [100, 1],
+  ]);
 
   it("finds a registered ancestor however many hops up", async () => {
-    expect(await findAgentAncestor(400, (p) => (p === 100 ? "lane-A" : null), { readTable: chain }))
-      .toBe("lane-A");
+    expect(
+      await findAgentAncestor(400, (p) => (p === 100 ? "lane-A" : null), { readTable: chain }),
+    ).toBe("lane-A");
   });
 
   it("prefers the NEAREST enclosing agent", async () => {
@@ -89,8 +108,9 @@ describe("findAgentAncestor", () => {
 
   it("does not attribute the caller to ITSELF", async () => {
     // The walk starts at the parent: a bare `ay send` is not its own sender.
-    expect(await findAgentAncestor(400, (p) => (p === 400 ? "self" : null), { readTable: chain }))
-      .toBeNull();
+    expect(
+      await findAgentAncestor(400, (p) => (p === 400 ? "self" : null), { readTable: chain }),
+    ).toBeNull();
   });
 });
 

--- a/ts/serveSampler.spec.ts
+++ b/ts/serveSampler.spec.ts
@@ -25,10 +25,7 @@ function tree(pid: number, rss: number, cpuPercent: number, procs: number) {
 }
 
 /** A whole sampleTrees result: the given trees plus an unattributed rollup. */
-function result(
-  trees: Array<ReturnType<typeof tree>>,
-  unattributed = tree(0, 0, 0, 0),
-) {
+function result(trees: Array<ReturnType<typeof tree>>, unattributed = tree(0, 0, 0, 0)) {
   return {
     trees: new Map(trees.map((t) => [t.pid, t])),
     unattributed,
@@ -331,12 +328,13 @@ describe("startSampler", () => {
     // Node hands back a Timeout carrying .unref(); a bare numeric handle (jsdom,
     // some bundlers) has none, and the optional call must simply skip it.
     const raw = globalThis.setTimeout;
-    const stub = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation(((fn: () => void, ms?: number) => {
-        const h = raw(fn, ms);
-        return { ...(h as object), unref: undefined } as unknown as ReturnType<typeof raw>;
-      }) as typeof raw);
+    const stub = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: () => void,
+      ms?: number,
+    ) => {
+      const h = raw(fn, ms);
+      return { ...(h as object), unref: undefined } as unknown as ReturnType<typeof raw>;
+    }) as typeof raw);
 
     try {
       startSampler(async () => [100]);

--- a/ts/serveSampler.ts
+++ b/ts/serveSampler.ts
@@ -215,4 +215,13 @@ function stopSampler(): void {
   timer = null;
 }
 
-export { getSnapshot, getBucketSecs, resField, resourcesField, startSampler, stopSampler, sweep, windowLen };
+export {
+  getSnapshot,
+  getBucketSecs,
+  resField,
+  resourcesField,
+  startSampler,
+  stopSampler,
+  sweep,
+  windowLen,
+};

--- a/ts/setup.bun.spec.ts
+++ b/ts/setup.bun.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import { cmdSetup } from "./setup.ts";
 import { getWorkspaceRoot } from "./workspaceConfig.ts";
@@ -41,6 +41,32 @@ describe("cmdSetup", () => {
     const code = await cmdSetup([dir, "--no-share"]);
     expect(code).toBe(0);
     expect(getWorkspaceRoot()).toBe(path.resolve(dir));
+  });
+
+  // The snap guard: piped (no TTY) it must warn and carry on, never block.
+  it("warns but proceeds when running inside a snap sandbox", async () => {
+    // Point SNAP_USER_DATA at the real homedir() rather than mutating $HOME:
+    // Bun resolves os.homedir() without re-reading the env, so an env-only
+    // remap wouldn't be seen. Matching the actual home is what the guard checks.
+    const snapEnv = { SNAP_NAME: "bun-js", SNAP_REVISION: "87", SNAP_USER_DATA: homedir() };
+    const restore = Object.entries(snapEnv).map(([k, v]) => {
+      const prev = process.env[k];
+      process.env[k] = v;
+      return () => (prev === undefined ? delete process.env[k] : (process.env[k] = prev));
+    });
+    const write = process.stderr.write.bind(process.stderr);
+    let err = "";
+    process.stderr.write = ((s: string) => ((err += s), true)) as typeof process.stderr.write;
+    try {
+      expect(await cmdSetup([path.join(tmp, "snap-ws"), "--no-share"])).toBe(0);
+      expect(err).toContain("snap sandbox");
+      err = "";
+      expect(await cmdSetup([path.join(tmp, "snap-ws"), "--no-share", "--allow-snap"])).toBe(0);
+      expect(err).not.toContain("snap sandbox");
+    } finally {
+      process.stderr.write = write;
+      for (const undo of restore) undo();
+    }
   });
 
   it("--no-share with a --port flag still treats the path as the workspace", async () => {

--- a/ts/setup.bun.spec.ts
+++ b/ts/setup.bun.spec.ts
@@ -33,6 +33,16 @@ describe("cmdSetup", () => {
     expect(getWorkspaceRoot()).toBe(path.resolve(dir));
   });
 
+  // Regression: with no --port, `rest.indexOf("--port")` is -1, so the old
+  // `i !== portIdx + 1` filter excluded index 0 — the documented
+  // `ay setup <workspace-dir>` form silently ignored its argument.
+  it("takes the workspace dir as the FIRST argument", async () => {
+    const dir = path.join(tmp, "first-arg");
+    const code = await cmdSetup([dir, "--no-share"]);
+    expect(code).toBe(0);
+    expect(getWorkspaceRoot()).toBe(path.resolve(dir));
+  });
+
   it("--no-share with a --port flag still treats the path as the workspace", async () => {
     const dir = path.join(tmp, "ws");
     const code = await cmdSetup(["--no-share", "--port", "7440", dir]);

--- a/ts/setup.spec.ts
+++ b/ts/setup.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import { cmdSetup } from "./setup.ts";
 import { getWorkspaceRoot } from "./workspaceConfig.ts";
@@ -41,6 +41,32 @@ describe("cmdSetup", () => {
     const code = await cmdSetup([dir, "--no-share"]);
     expect(code).toBe(0);
     expect(getWorkspaceRoot()).toBe(path.resolve(dir));
+  });
+
+  // The snap guard: piped (no TTY) it must warn and carry on, never block.
+  it("warns but proceeds when running inside a snap sandbox", async () => {
+    // Point SNAP_USER_DATA at the real homedir() rather than mutating $HOME:
+    // Bun resolves os.homedir() without re-reading the env, so an env-only
+    // remap wouldn't be seen. Matching the actual home is what the guard checks.
+    const snapEnv = { SNAP_NAME: "bun-js", SNAP_REVISION: "87", SNAP_USER_DATA: homedir() };
+    const restore = Object.entries(snapEnv).map(([k, v]) => {
+      const prev = process.env[k];
+      process.env[k] = v;
+      return () => (prev === undefined ? delete process.env[k] : (process.env[k] = prev));
+    });
+    const write = process.stderr.write.bind(process.stderr);
+    let err = "";
+    process.stderr.write = ((s: string) => ((err += s), true)) as typeof process.stderr.write;
+    try {
+      expect(await cmdSetup([path.join(tmp, "snap-ws"), "--no-share"])).toBe(0);
+      expect(err).toContain("snap sandbox");
+      err = "";
+      expect(await cmdSetup([path.join(tmp, "snap-ws"), "--no-share", "--allow-snap"])).toBe(0);
+      expect(err).not.toContain("snap sandbox");
+    } finally {
+      process.stderr.write = write;
+      for (const undo of restore) undo();
+    }
   });
 
   it("--no-share with a --port flag still treats the path as the workspace", async () => {

--- a/ts/setup.spec.ts
+++ b/ts/setup.spec.ts
@@ -33,6 +33,16 @@ describe("cmdSetup", () => {
     expect(getWorkspaceRoot()).toBe(path.resolve(dir));
   });
 
+  // Regression: with no --port, `rest.indexOf("--port")` is -1, so the old
+  // `i !== portIdx + 1` filter excluded index 0 — the documented
+  // `ay setup <workspace-dir>` form silently ignored its argument.
+  it("takes the workspace dir as the FIRST argument", async () => {
+    const dir = path.join(tmp, "first-arg");
+    const code = await cmdSetup([dir, "--no-share"]);
+    expect(code).toBe(0);
+    expect(getWorkspaceRoot()).toBe(path.resolve(dir));
+  });
+
   it("--no-share with a --port flag still treats the path as the workspace", async () => {
     const dir = path.join(tmp, "ws");
     const code = await cmdSetup(["--no-share", "--port", "7440", dir]);

--- a/ts/setup.ts
+++ b/ts/setup.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
+import { detectSnapConfinement, snapConfinementMessage } from "./snapGuard.ts";
 import { getWorkspaceRoot, setWorkspaceRoot } from "./workspaceConfig.ts";
 
 // `ay setup` — guided onboarding. Two steps:
@@ -22,16 +23,41 @@ export async function cmdSetup(rest: string[]): Promise<number> {
         `Options:\n` +
         `  workspace-dir   default directory for new agents (skips the prompt)\n` +
         `  --no-share      set the workspace only; don't install the share daemon\n` +
-        `  --port N        HTTP API port for the share daemon (default: 7432)\n`,
+        `  --port N        HTTP API port for the share daemon (default: 7432)\n` +
+        `  --allow-snap    proceed even when running inside a snap sandbox\n`,
     );
     return 0;
+  }
+
+  // 0. Snap sandbox check. A strictly confined snap runtime remaps $HOME into a
+  //    per-revision sandbox dir and confines every agent we spawn — see
+  //    snapGuard for why no path rewrite can fix it. Warn before we write any
+  //    state; in a TTY make continuing the deliberate choice.
+  if (!rest.includes("--allow-snap")) {
+    const snap = detectSnapConfinement();
+    if (snap) {
+      process.stderr.write(snapConfinementMessage(snap));
+      if (stdin.isTTY && stdout.isTTY) {
+        const rl = createInterface({ input: stdin, output: stdout });
+        try {
+          const ans = (await rl.question("continue anyway? [y/N]: ")).trim();
+          if (!/^y(es)?$/i.test(ans)) return 1;
+        } finally {
+          rl.close();
+        }
+      }
+      // Non-interactive: the warning stands, but setup never blocks on input.
+    }
   }
 
   const noShare = rest.includes("--no-share");
   const portIdx = rest.indexOf("--port");
   const port = portIdx >= 0 ? rest[portIdx + 1] : undefined;
   // The workspace is the first non-flag token (and not the value of --port).
-  const positional = rest.filter((a, i) => !a.startsWith("-") && i !== portIdx + 1);
+  // Guard on portIdx >= 0: without --port, indexOf returns -1 and a bare
+  // `portIdx + 1` is 0, which would silently drop the dir in `ay setup <dir>`.
+  const portValueIdx = portIdx >= 0 ? portIdx + 1 : -1;
+  const positional = rest.filter((a, i) => !a.startsWith("-") && i !== portValueIdx);
 
   // 1. Workspace root.
   let ws = positional[0];

--- a/ts/snapGuard.bun.spec.ts
+++ b/ts/snapGuard.bun.spec.ts
@@ -29,6 +29,18 @@ describe("detectSnapConfinement", () => {
     const snap = detectSnapConfinement({ SNAP: "/snap/bun-js/87" }, SANDBOX_HOME);
     expect(snap).toMatchObject({ name: "bun-js", revision: "87" });
   });
+
+  it("returns null when SNAP is set but neither HOME nor SNAP_USER_DATA says so", () => {
+    expect(detectSnapConfinement({ SNAP: "/snap/bun-js/87" }, "/home/u")).toBeNull();
+  });
+
+  it("degrades to a nameless snap when the sandbox HOME is not the usual shape", () => {
+    const snap = detectSnapConfinement(
+      { SNAP: "/snap/x", SNAP_USER_DATA: "/var/sandbox" },
+      "/var/sandbox",
+    );
+    expect(snap).toEqual({ name: "snap", revision: undefined, home: "/var/sandbox" });
+  });
 });
 
 describe("snapConfinementMessage", () => {
@@ -38,5 +50,14 @@ describe("snapConfinementMessage", () => {
     expect(msg).toContain(SANDBOX_HOME);
     expect(msg).toContain("sudo snap remove bun-js");
     expect(msg).toContain("https://bun.sh/install");
+  });
+
+  it("omits the revision when it is unknown, and adapts the install line", () => {
+    const node = snapConfinementMessage({ name: "node", home: "/home/u/snap/node/1" });
+    expect(node).toContain("the 'node' snap sandbox\n");
+    expect(node).toContain("fnm.vercel.app");
+
+    const other = snapConfinementMessage({ name: "zellij", home: "/home/u/snap/zellij/1" });
+    expect(other).toContain("reinstall zellij from its official installer");
   });
 });

--- a/ts/snapGuard.bun.spec.ts
+++ b/ts/snapGuard.bun.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { detectSnapConfinement, snapConfinementMessage } from "./snapGuard.ts";
+
+const SANDBOX_HOME = "/home/u/snap/bun-js/87";
+
+describe("detectSnapConfinement", () => {
+  it("returns null outside a snap", () => {
+    expect(detectSnapConfinement({}, "/home/u")).toBeNull();
+  });
+
+  it("detects strict confinement when HOME is the snap user-data dir", () => {
+    const snap = detectSnapConfinement(
+      { SNAP_NAME: "bun-js", SNAP_REVISION: "87", SNAP_USER_DATA: SANDBOX_HOME },
+      SANDBOX_HOME,
+    );
+    expect(snap).toMatchObject({ name: "bun-js", revision: "87" });
+  });
+
+  it("ignores classic confinement — SNAP_* is set but HOME is untouched", () => {
+    expect(
+      detectSnapConfinement(
+        { SNAP_NAME: "bun-js", SNAP_USER_DATA: SANDBOX_HOME, SNAP: "/snap/bun-js/87" },
+        "/home/u",
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to the HOME path shape when SNAP_USER_DATA is absent", () => {
+    const snap = detectSnapConfinement({ SNAP: "/snap/bun-js/87" }, SANDBOX_HOME);
+    expect(snap).toMatchObject({ name: "bun-js", revision: "87" });
+  });
+});
+
+describe("snapConfinementMessage", () => {
+  it("names the snap, the sandbox HOME, and the native install", () => {
+    const msg = snapConfinementMessage({ name: "bun-js", revision: "87", home: SANDBOX_HOME });
+    expect(msg).toContain("'bun-js' snap sandbox (revision 87)");
+    expect(msg).toContain(SANDBOX_HOME);
+    expect(msg).toContain("sudo snap remove bun-js");
+    expect(msg).toContain("https://bun.sh/install");
+  });
+});

--- a/ts/snapGuard.bun.spec.ts
+++ b/ts/snapGuard.bun.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import path from "path";
 import { detectSnapConfinement, snapConfinementMessage } from "./snapGuard.ts";
 
 const SANDBOX_HOME = "/home/u/snap/bun-js/87";
@@ -35,11 +36,11 @@ describe("detectSnapConfinement", () => {
   });
 
   it("degrades to a nameless snap when the sandbox HOME is not the usual shape", () => {
-    const snap = detectSnapConfinement(
-      { SNAP: "/snap/x", SNAP_USER_DATA: "/var/sandbox" },
-      "/var/sandbox",
-    );
-    expect(snap).toEqual({ name: "snap", revision: undefined, home: "/var/sandbox" });
+    const sandbox = "/var/sandbox";
+    const snap = detectSnapConfinement({ SNAP: "/snap/x", SNAP_USER_DATA: sandbox }, sandbox);
+    // home comes back resolved, so compare resolved — a literal POSIX path
+    // fails on Windows, where path.resolve prefixes the current drive.
+    expect(snap).toEqual({ name: "snap", revision: undefined, home: path.resolve(sandbox) });
   });
 });
 

--- a/ts/snapGuard.spec.ts
+++ b/ts/snapGuard.spec.ts
@@ -29,6 +29,18 @@ describe("detectSnapConfinement", () => {
     const snap = detectSnapConfinement({ SNAP: "/snap/bun-js/87" }, SANDBOX_HOME);
     expect(snap).toMatchObject({ name: "bun-js", revision: "87" });
   });
+
+  it("returns null when SNAP is set but neither HOME nor SNAP_USER_DATA says so", () => {
+    expect(detectSnapConfinement({ SNAP: "/snap/bun-js/87" }, "/home/u")).toBeNull();
+  });
+
+  it("degrades to a nameless snap when the sandbox HOME is not the usual shape", () => {
+    const snap = detectSnapConfinement(
+      { SNAP: "/snap/x", SNAP_USER_DATA: "/var/sandbox" },
+      "/var/sandbox",
+    );
+    expect(snap).toEqual({ name: "snap", revision: undefined, home: "/var/sandbox" });
+  });
 });
 
 describe("snapConfinementMessage", () => {
@@ -38,5 +50,14 @@ describe("snapConfinementMessage", () => {
     expect(msg).toContain(SANDBOX_HOME);
     expect(msg).toContain("sudo snap remove bun-js");
     expect(msg).toContain("https://bun.sh/install");
+  });
+
+  it("omits the revision when it is unknown, and adapts the install line", () => {
+    const node = snapConfinementMessage({ name: "node", home: "/home/u/snap/node/1" });
+    expect(node).toContain("the 'node' snap sandbox\n");
+    expect(node).toContain("fnm.vercel.app");
+
+    const other = snapConfinementMessage({ name: "zellij", home: "/home/u/snap/zellij/1" });
+    expect(other).toContain("reinstall zellij from its official installer");
   });
 });

--- a/ts/snapGuard.spec.ts
+++ b/ts/snapGuard.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { detectSnapConfinement, snapConfinementMessage } from "./snapGuard.ts";
+
+const SANDBOX_HOME = "/home/u/snap/bun-js/87";
+
+describe("detectSnapConfinement", () => {
+  it("returns null outside a snap", () => {
+    expect(detectSnapConfinement({}, "/home/u")).toBeNull();
+  });
+
+  it("detects strict confinement when HOME is the snap user-data dir", () => {
+    const snap = detectSnapConfinement(
+      { SNAP_NAME: "bun-js", SNAP_REVISION: "87", SNAP_USER_DATA: SANDBOX_HOME },
+      SANDBOX_HOME,
+    );
+    expect(snap).toMatchObject({ name: "bun-js", revision: "87" });
+  });
+
+  it("ignores classic confinement — SNAP_* is set but HOME is untouched", () => {
+    expect(
+      detectSnapConfinement(
+        { SNAP_NAME: "bun-js", SNAP_USER_DATA: SANDBOX_HOME, SNAP: "/snap/bun-js/87" },
+        "/home/u",
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to the HOME path shape when SNAP_USER_DATA is absent", () => {
+    const snap = detectSnapConfinement({ SNAP: "/snap/bun-js/87" }, SANDBOX_HOME);
+    expect(snap).toMatchObject({ name: "bun-js", revision: "87" });
+  });
+});
+
+describe("snapConfinementMessage", () => {
+  it("names the snap, the sandbox HOME, and the native install", () => {
+    const msg = snapConfinementMessage({ name: "bun-js", revision: "87", home: SANDBOX_HOME });
+    expect(msg).toContain("'bun-js' snap sandbox (revision 87)");
+    expect(msg).toContain(SANDBOX_HOME);
+    expect(msg).toContain("sudo snap remove bun-js");
+    expect(msg).toContain("https://bun.sh/install");
+  });
+});

--- a/ts/snapGuard.spec.ts
+++ b/ts/snapGuard.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import path from "path";
 import { detectSnapConfinement, snapConfinementMessage } from "./snapGuard.ts";
 
 const SANDBOX_HOME = "/home/u/snap/bun-js/87";
@@ -35,11 +36,11 @@ describe("detectSnapConfinement", () => {
   });
 
   it("degrades to a nameless snap when the sandbox HOME is not the usual shape", () => {
-    const snap = detectSnapConfinement(
-      { SNAP: "/snap/x", SNAP_USER_DATA: "/var/sandbox" },
-      "/var/sandbox",
-    );
-    expect(snap).toEqual({ name: "snap", revision: undefined, home: "/var/sandbox" });
+    const sandbox = "/var/sandbox";
+    const snap = detectSnapConfinement({ SNAP: "/snap/x", SNAP_USER_DATA: sandbox }, sandbox);
+    // home comes back resolved, so compare resolved — a literal POSIX path
+    // fails on Windows, where path.resolve prefixes the current drive.
+    expect(snap).toEqual({ name: "snap", revision: undefined, home: path.resolve(sandbox) });
   });
 });
 

--- a/ts/snapGuard.ts
+++ b/ts/snapGuard.ts
@@ -1,0 +1,84 @@
+import { homedir } from "os";
+import path from "path";
+
+/**
+ * Detects that we're running inside a *strictly confined* snap (snapd's default
+ * sandbox), which quietly breaks agent-yes in three ways:
+ *
+ *  1. snapd remaps `$HOME` to the snap's per-revision data dir
+ *     (`~/snap/<name>/<revision>`), so `homedir()` — and therefore
+ *     {@link agentYesHome}, the workspace root, the pid index, the FIFO IPC
+ *     endpoints and the serve token — all land inside the sandbox.
+ *  2. That path is keyed to the snap *revision*: after a `snap refresh` a fresh
+ *     CLI invocation resolves to the new revision's dir while an already-running
+ *     daemon keeps writing to the old one. Split-brain, with no error either side.
+ *  3. Every agent we spawn inherits the snap's AppArmor profile and mount
+ *     namespace — fatal for a tool whose whole job is launching agents into
+ *     arbitrary worktrees.
+ *
+ * There is no path rewrite that fixes this: the sandbox HOME is the only
+ * reliably writable location (the `home` interface grants *non-hidden* files
+ * only, so a "corrected" `~/.agent-yes` would just be denied). The only real fix
+ * is to install the runtime natively, so we detect and say so.
+ */
+export interface SnapConfinement {
+  /** Snap package name, e.g. `bun-js`. */
+  name: string;
+  /** Snap revision — the trailing number of the sandbox HOME. */
+  revision?: string;
+  /** The remapped HOME (`$SNAP_USER_DATA`), e.g. `/root/snap/bun-js/87`. */
+  home: string;
+}
+
+/** Matches a snap user-data HOME: `…/snap/<name>/<revision>`. */
+const SNAP_HOME_RE = /(?:^|[\\/])snap[\\/]([^\\/]+)[\\/]([^\\/]+)$/;
+
+/**
+ * Returns the confinement details when the current process is a strictly
+ * confined snap, else null.
+ *
+ * *Classic* confinement is deliberately NOT reported: classic snaps export the
+ * same `SNAP_*` env but are not sandboxed and leave `$HOME` alone, so they need
+ * no warning. The remapped HOME is both the symptom and the discriminator.
+ */
+export function detectSnapConfinement(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): SnapConfinement | null {
+  if (!env.SNAP_NAME?.trim() && !env.SNAP?.trim()) return null;
+  const abs = path.resolve(home);
+  const userData = env.SNAP_USER_DATA?.trim();
+  // HOME still pointing at the real home => classic confinement => not our problem.
+  const remapped = userData ? path.resolve(userData) === abs : SNAP_HOME_RE.test(abs);
+  if (!remapped) return null;
+  const m = SNAP_HOME_RE.exec(abs);
+  return {
+    name: env.SNAP_NAME?.trim() || m?.[1] || "snap",
+    revision: env.SNAP_REVISION?.trim() || m?.[2],
+    home: abs,
+  };
+}
+
+/** The native (non-snap) install command for a runtime, when we recognize it. */
+function nativeInstall(name: string): string {
+  if (/bun/i.test(name)) return `curl -fsSL https://bun.sh/install | bash`;
+  if (/^node/i.test(name)) return `curl -fsSL https://fnm.vercel.app/install | bash`;
+  return `# reinstall ${name} from its official installer (not snap)`;
+}
+
+/** Operator-facing explanation + the exact commands to get out of the sandbox. */
+export function snapConfinementMessage(snap: SnapConfinement): string {
+  const rev = snap.revision ? ` (revision ${snap.revision})` : "";
+  return (
+    `\n!  running inside the '${snap.name}' snap sandbox${rev}\n\n` +
+    `   snap remapped HOME to ${snap.home}, so agent-yes would keep its fleet\n` +
+    `   state — config, pid index, FIFO IPC, serve token — inside the sandbox, and\n` +
+    `   every agent it spawns would inherit the snap's AppArmor profile and mount\n` +
+    `   namespace. Agents need to reach your real worktrees; confined ones can't.\n\n` +
+    `   Install ${snap.name} natively instead:\n\n` +
+    `     sudo snap remove ${snap.name}\n` +
+    `     ${nativeInstall(snap.name)}\n` +
+    `     exec $SHELL -l\n` +
+    `     ay setup\n\n`
+  );
+}

--- a/ts/subcommands.spec.ts
+++ b/ts/subcommands.spec.ts
@@ -3190,14 +3190,14 @@ describe("subcommands.cmdSend double-envelope warning", () => {
           exit_reason: null,
           started_at: Date.now(),
           // A wrapper that is a REAL ancestor of this test process. Two reasons it
-        // is `ppid` and not `pid`: a pid that never existed cannot be
-        // corroborated by the process tree, so the envelope would carry an
-        // UNCORROBORATED marker and this fixture would stop testing the shape it
-        // is named for; and the ancestry walk deliberately starts at the parent,
-        // because a bare `ay send` is not its own sender. In production the
-        // wrapper really is an ancestor — measured 26/26 on the live fleet — so
-        // this is the production shape, not a workaround.
-        wrapper_pid: process.ppid,
+          // is `ppid` and not `pid`: a pid that never existed cannot be
+          // corroborated by the process tree, so the envelope would carry an
+          // UNCORROBORATED marker and this fixture would stop testing the shape it
+          // is named for; and the ancestry walk deliberately starts at the parent,
+          // because a bare `ay send` is not its own sender. In production the
+          // wrapper really is an ancestor — measured 26/26 on the live fleet — so
+          // this is the production shape, not a workaround.
+          wrapper_pid: process.ppid,
           agent_id: "cccc0000dddd",
         });
         const savedAyPid = process.env.AGENT_YES_PID;


### PR DESCRIPTION
## Why

`bun x agent-yes setup` under a snap-installed bun prompts with a workspace root of `~/snap/bun-js/<rev>` — snapd's per-revision sandbox data dir, not a workspace.

`os.homedir()` returns `$HOME`, and a strictly confined snap remaps `$HOME` into its sandbox. So the workspace root, `agentYesHome()`, the pid index, the FIFO IPC endpoints and the serve token all resolve inside the sandbox.

There is no path rewrite that fixes this:

- The snapd `home` interface grants **non-hidden** files only, so a "corrected" `~/.agent-yes` would just be denied. The sandbox HOME is the only reliably writable location.
- State is keyed to the snap **revision**: a daemon started under rev N keeps writing there while fresh CLI invocations resolve to rev N+1. Split-brain, no error either side.
- Every agent we spawn inherits the snap's AppArmor profile and mount namespace — fatal for a tool whose job is launching agents into arbitrary worktrees.

So: detect and say so, rather than guess at paths we can't reach anyway.

## What

**`ts/snapGuard.ts`** (new) — `detectSnapConfinement()` returns the snap name/revision/sandbox-HOME or null; `snapConfinementMessage()` explains the failure modes and prints the native reinstall. Classic-confinement snaps export the same `SNAP_*` env but aren't sandboxed and leave `$HOME` alone, so the remapped HOME is the discriminator and they get no warning.

**`ts/setup.ts`** — the check runs before anything writes state. In a TTY it prompts `continue anyway? [y/N]`; piped it warns and proceeds, keeping the file's existing "never blocks on input" contract. `--allow-snap` skips it.

```
!  running inside the 'bun-js' snap sandbox (revision 87)

   snap remapped HOME to /home/u/snap/bun-js/87, so agent-yes would keep its fleet
   state — config, pid index, FIFO IPC, serve token — inside the sandbox, and
   every agent it spawns would inherit the snap's AppArmor profile and mount
   namespace. Agents need to reach your real worktrees; confined ones can't.

   Install bun-js natively instead:

     sudo snap remove bun-js
     curl -fsSL https://bun.sh/install | bash
     exec $SHELL -l
     ay setup
```

## Drive-by fix

`ay setup <dir>` silently ignored its argument. The positional filter was `i !== portIdx + 1`, and with no `--port` present `indexOf` returns `-1`, so it excluded index 0 — the workspace dir itself. Every existing test happened to pass a flag first (`["--no-share", dir]`), so the documented `ay setup [workspace-dir]` form was never covered. Regression test added.

## Formatting commit

`bun run fmt` had drifted out of sync with the checked-in sources, so any touched file dragged unrelated reformatting into its diff. Ran it once tree-wide as a separate commit — pure formatting, no semantic edits.

Two docs needed a prose fix first: oxfmt read a line-leading `+` (a sentence continuing across a wrap, `"(master\n+ slave)"`) as a list bullet and reflowed the paragraph into a broken list. Rewrapped so the `+` isn't line-leading, which also makes the formatter idempotent there.

## Verification

- vitest: 1867 passed / 3 skipped
- `bun test`: 1295 passed / 0 fail
- branch coverage back over the 90% pre-push gate (`snapGuard.ts` at 100%)
- typecheck: identical to the HEAD baseline (61 pre-existing errors, none in touched files)
- end-to-end against `dist/agent-yes.js`: warns under a simulated strict-snap env, silent with `--allow-snap`, silent under a classic-snap env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rg2z5K7xS1H6GosmrZsKu