### PR TITLE
fix(send): unverifiable is not contradicted — the loud marker cried wolf first

### DIFF
--- a/ts/messageLog.bun.spec.ts
+++ b/ts/messageLog.bun.spec.ts
@@ -14,6 +14,7 @@ import {
   shouldRecord,
   type MessageRecord,
 } from "./messageLog.ts";
+import { envelopeAttribution } from "./subcommands.ts";
 
 function makeRecord(over: Partial<MessageRecord> = {}): MessageRecord {
   return {
@@ -538,5 +539,37 @@ describe("messageLog sender provenance — derived vs asserted", () => {
     expect(
       shouldRecord(makeRecord({ from: null, from_via: "observed", sender_observed: observed })),
     ).toBe(true);
+  });
+});
+
+describe("unverifiable is not contradicted", () => {
+  // The direction matters more than the fact. Collapsing UNKNOWN into SUSPICIOUS
+  // trains every reader to dismiss the marker on legitimate traffic, so when a
+  // real contradiction arrives it reads as more of the same — the alarm is spent
+  // before its first true positive. The reverse error would merely miss one.
+  it("stays SILENT in the envelope when there is nothing to disagree with", () => {
+    expect(envelopeAttribution("env-unverified")).toBe("");
+  });
+
+  it("keeps the loud marker for a genuine contradiction only", () => {
+    expect(envelopeAttribution("env-uncorroborated")).toContain("UNCORROBORATED");
+  });
+
+  it("still records the distinction for a reader who wants it", () => {
+    // Silent in the body is not the same as thrown away: `ay msgs` shows it,
+    // and from_via carries it for anything that wants to weigh it.
+    const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
+    expect(senderLabel(makeRecord({ from, from_via: "env-unverified" }))).toBe(
+      "claude #1111 (unverified)",
+    );
+    expect(senderLabel(makeRecord({ from, from_via: "env-uncorroborated" }))).toBe(
+      "claude #1111 (UNCORROBORATED)",
+    );
+  });
+
+  it("does not weaken the honest path", () => {
+    const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
+    expect(senderLabel(makeRecord({ from, from_via: "env" }))).toBe("claude #1111");
+    expect(envelopeAttribution("env")).toBe("");
   });
 });

--- a/ts/messageLog.spec.ts
+++ b/ts/messageLog.spec.ts
@@ -14,6 +14,7 @@ import {
   shouldRecord,
   type MessageRecord,
 } from "./messageLog.ts";
+import { envelopeAttribution } from "./subcommands.ts";
 
 function makeRecord(over: Partial<MessageRecord> = {}): MessageRecord {
   return {
@@ -538,5 +539,37 @@ describe("messageLog sender provenance — derived vs asserted", () => {
     expect(
       shouldRecord(makeRecord({ from: null, from_via: "observed", sender_observed: observed })),
     ).toBe(true);
+  });
+});
+
+describe("unverifiable is not contradicted", () => {
+  // The direction matters more than the fact. Collapsing UNKNOWN into SUSPICIOUS
+  // trains every reader to dismiss the marker on legitimate traffic, so when a
+  // real contradiction arrives it reads as more of the same — the alarm is spent
+  // before its first true positive. The reverse error would merely miss one.
+  it("stays SILENT in the envelope when there is nothing to disagree with", () => {
+    expect(envelopeAttribution("env-unverified")).toBe("");
+  });
+
+  it("keeps the loud marker for a genuine contradiction only", () => {
+    expect(envelopeAttribution("env-uncorroborated")).toContain("UNCORROBORATED");
+  });
+
+  it("still records the distinction for a reader who wants it", () => {
+    // Silent in the body is not the same as thrown away: `ay msgs` shows it,
+    // and from_via carries it for anything that wants to weigh it.
+    const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
+    expect(senderLabel(makeRecord({ from, from_via: "env-unverified" }))).toBe(
+      "claude #1111 (unverified)",
+    );
+    expect(senderLabel(makeRecord({ from, from_via: "env-uncorroborated" }))).toBe(
+      "claude #1111 (UNCORROBORATED)",
+    );
+  });
+
+  it("does not weaken the honest path", () => {
+    const from = { pid: 1111, cli: "claude", cwd: "/repo/alpha", agent_id: "agent-A" };
+    expect(senderLabel(makeRecord({ from, from_via: "env" }))).toBe("claude #1111");
+    expect(envelopeAttribution("env")).toBe("");
   });
 });

--- a/ts/messageLog.ts
+++ b/ts/messageLog.ts
@@ -183,6 +183,9 @@ export function senderLabel(record: MessageRecord): string {
     // The one attributed value that is only a claim — say so, since a receiver
     // weighing whether to act on it cannot otherwise tell it from a fact.
     if (record.from_via === "env-uncorroborated") return `${name} (UNCORROBORATED)`;
+    // Visible in a listing, where a human is reading deliberately, but never in
+    // the envelope — see envelopeAttribution.
+    if (record.from_via === "env-unverified") return `${name} (unverified)`;
     return name;
   }
   // No agent identified. Say what WAS measured rather than "unattributed" —

--- a/ts/senderAncestry.ts
+++ b/ts/senderAncestry.ts
@@ -43,14 +43,22 @@ export type SenderVia =
   /** No env, but an ancestor process is a registered agent. Not forgeable from
    * inside a message: a process cannot choose its own ancestors. */
   | "ancestry"
-  /** `AGENT_YES_PID` named a registered agent that is NOT among this process's
-   * ancestors, or ancestry could not be read to check. The attribution is the
-   * caller's own claim and nothing corroborates it. Any process can export that
-   * variable, so this is the one attributed value a receiver should not trust
-   * on its own. Kept attributed rather than discarded: a stale env on an honest
-   * lane lands here too, and dropping it would be the starvation this exists to
-   * end. */
+  /** `AGENT_YES_PID` named one registered agent while a DIFFERENT registered
+   * agent is this process's actual ancestor. The two disagree, and the tree is
+   * the half that cannot be forged — so this is evidence, and the only value
+   * that says so out loud. */
   | "env-uncorroborated"
+  /** `AGENT_YES_PID` named a registered agent and the process tree contains no
+   * registered agent at all — so there is nothing to agree or disagree with.
+   *
+   * This is NOT evidence of anything. A detached helper, a process re-parented
+   * to init, an `ay send` from a background job, or an unreadable process table
+   * all land here, and every one of them is honest. Distinguishing it from a
+   * real contradiction is the whole point: the first live firing of the loud
+   * marker was a legitimate long-lived lane, and a warning that fires on honest
+   * traffic is one people learn to skip — which destroys the signal for the
+   * case it was built for. Unknown has to stay expressible AS unknown. */
+  | "env-unverified"
   /** Nothing identified the caller; only its observable facts are recorded. */
   | "observed";
 

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -355,12 +355,20 @@ async function computeSenderVia(): Promise<{ agent: GlobalPidRecord | null; via:
     // The honest path is unchanged in OUTCOME: the wrapper that injects
     // AGENT_YES_PID is an ancestor of the `ay send` it spawns, so a normal lane
     // corroborates and renders exactly as before.
-    const corroborated = inherited?.pid === declared.pid;
-    // A disagreement is REPORTED, never silently resolved. Attributing to the
-    // ancestor instead would break an honest lane whose tree we misread; giving
-    // it a plain "env" would launder a claim into a fact. So the claim stands
-    // and the receiver is told it stands alone.
-    return { agent: declared, via: corroborated ? "env" : "env-uncorroborated" };
+    // Three outcomes, not two. Collapsing the last two into one accusation is
+    // what made the loud marker fire on an honest long-lived lane the first
+    // time it ever fired.
+    if (inherited?.pid === declared.pid) return { agent: declared, via: "env" };
+    // A DIFFERENT registered agent is the real ancestor: the claim and the tree
+    // disagree, and the tree is the half that cannot be forged. Reported, never
+    // silently resolved — attributing to the ancestor instead would break an
+    // honest lane whose tree we misread, and a plain "env" would launder a
+    // claim into a fact.
+    if (inherited) return { agent: declared, via: "env-uncorroborated" };
+    // No registered agent anywhere in the ancestry: nothing agrees OR disagrees.
+    // A detached helper, a process re-parented to init, an unreadable table.
+    // Unverifiable is not suspicious, and must not be dressed as it.
+    return { agent: declared, via: "env-unverified" };
   }
   // A set-but-unresolvable AGENT_YES_PID (stale env, aged-out record) is not a
   // reason to stop: the process tree can still say who this is.
@@ -687,10 +695,16 @@ export function envelopeAttribution(via: SenderVia): string {
       // Derived from the process tree because the wrapper's env was absent.
       return " via process-tree";
     case "env-uncorroborated":
-      // The caller's own claim, and nothing corroborates it: any process can
-      // export another lane's pid (#461). Loud, because a receiver that acts on
-      // a message weighted by its sender must not be handed this as a fact.
+      // The claim and the process tree name DIFFERENT lanes. Loud, because this
+      // is the case a receiver acting on sender weight must not be handed as a
+      // fact — and loud only here, so it keeps meaning something.
       return " UNCORROBORATED-SENDER";
+    case "env-unverified":
+      // Nothing to disagree with. Silent in the envelope: the receiver gains
+      // nothing actionable from "we could not check", and a marker on honest
+      // traffic is how the loud one stops being read. It is still recorded in
+      // from_via for anyone who wants to weigh it.
+      return "";
     default:
       return "";
   }


### PR DESCRIPTION
The first time `UNCORROBORATED-SENDER` (#460) ever fired in production, it fired on an
**honest, long-lived lane** — reported from the receiving side within hours of shipping.

## Ruled out the pid-reuse guard first

Using the reporter's own numbers:

```
lstart      Thu Sep  3 10:09:38 2026
started_at  Thu Sep  3 10:09:38 2026     (identical)
etime 36.65h  vs  now-started 36.65h     skew -0.2 min  ->  guard PASSES
```

So corroboration failed for the only other reason it can: the declared lane was not in
that send's ancestor chain. **The guard was right; the wording was wrong.**

## The defect

Two different situations were collapsed into one accusation:

| situation | what it means |
|---|---|
| a **different** registered lane is my ancestor | the claim and the tree disagree, and the tree cannot be forged → **evidence** |
| **no** registered lane in my ancestry at all | nothing agrees or disagrees → **not evidence** |

A detached helper, a process re-parented to init, a background job, or an unreadable
process table all produce the second — and every one of them is honest. Marking them
accused breaks the property the change was built to satisfy: **unknown must stay
expressible as unknown.**

### The direction is what decides the damage

Collapsing unknown into *suspicious* spends the alarm on legitimate traffic **before its
first true positive**, so when a real contradiction arrives it reads as more of the same.
The reverse error would merely miss one. The asymmetry was backwards.

## Three outcomes where there were two

```
declared pid IS the ancestor        env                  silent
a DIFFERENT registered lane is      env-uncorroborated   LOUD
no registered lane in the ancestry  env-unverified       silent in the body
```

**Silent is not discarded.** `from_via` still records it and `ay msgs` still renders
`(unverified)`, where a human is reading deliberately and a quiet qualification costs
nothing. The envelope stays clean because that is what the receiving model reads.

## Runs 4 and 5 — the two halves that were one

```
########## 4 — env CONTRADICTED by the tree ##########
envelope : <ay-msg b6e3efd8 from claude UNCORROBORATED-SENDER sno@Mac:/repo/claimed#987654 — …>
from_via : env-uncorroborated
RENDERS  : claude #987654 (UNCORROBORATED)

########## 5 — env UNVERIFIABLE, no registered ancestor ##########
envelope : <ay-msg 19623dfd from claude sno@Mac:/repo/claimed#987654 — …>
from_via : env-unverified
RENDERS  : claude #987654 (unverified)
```

Identical env claim in both; the only difference is whether some *other* registered lane
is the real ancestor. Run 5 is the state the live firing was in.

## Why the acceptance runs missed it

Runs 1–3 covered env-corroborated, ancestry-derived and fully-unattributed — three states
that each have an internally **consistent** story. The untested fourth is the one where
two sources **disagree** and the code must choose what to say, which is exactly where the
bug was.

> Coherence is what a passing case looks like; it is not what coverage looks like.

Generalised, and worth more than this diff: **test the states where sources conflict or
one is missing, not the ones where the answer is clean.**

## Verification

vitest **1875 passed / 3 skipped**, coverage gate exit 0 (94.24 stmts / 90.29 branches);
`bun test .bun.` **1303 passed / 1 skipped**; `tsgo --noEmit` error multiset **identical**
to the branch baseline (53 = 53, the three diffs are line-number shifts of pre-existing
errors).

Also measured separately while investigating: 2 of 29 live agents on this host carry
registry rows whose `started_at` predates the process at that pid by 96h and 2045h. Those
trip the age guard correctly — genuine stale registrations, not clock drift — and now
render `(unverified)` rather than an accusation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)