### PR TITLE
fix(send): a different worktree claiming a lane is the contradiction — the test was inverted

### DIFF
--- a/ts/crossTreeClaim.bun.spec.ts
+++ b/ts/crossTreeClaim.bun.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { envelopeAttribution } from "./subcommands.ts";
+import { senderLabel, type MessageRecord } from "./messageLog.ts";
+
+const rec = (over: Partial<MessageRecord>): MessageRecord => ({
+  at: 1,
+  from: { pid: 20298, cli: "claude", cwd: "/x/acme/tree/dev", agent_id: "lane-dev" },
+  to: { pid: 2, cli: "claude", cwd: "/x/acme/tree/qa", agent_id: "lane-qa" },
+  body: "hi",
+  wrapped: true,
+  ...over,
+});
+
+describe("a different tree claiming a lane is the contradiction", () => {
+  // Measured on real traffic before this change: the rule keyed on "is some
+  // OTHER registered lane my ancestor", and it ran inverted — LOUD on a lane's
+  // own nested processes (same tree, benign) and SILENT while another worktree
+  // sent two documents under this lane's name. The working directory is what
+  // actually separates them.
+  it("is LOUD in the envelope, because the receiving model reads only that", () => {
+    expect(envelopeAttribution("env-uncorroborated")).toContain("UNCORROBORATED");
+  });
+
+  it("stays quiet for a lane's own detached process in its own tree", () => {
+    expect(envelopeAttribution("env-unverified")).toBe("");
+  });
+
+  it("keeps the honest path silent", () => {
+    expect(envelopeAttribution("env")).toBe("");
+  });
+
+  it("renders the distinction in a listing, where a human reads deliberately", () => {
+    expect(senderLabel(rec({ from_via: "env-uncorroborated" }))).toContain("UNCORROBORATED");
+    expect(senderLabel(rec({ from_via: "env-unverified" }))).toContain("unverified");
+    expect(senderLabel(rec({ from_via: "env" }))).toBe("claude #20298");
+  });
+
+  it("still records what was measured about the real sender", () => {
+    // The audit that found the misattribution used exactly this: `from` said
+    // tree/dev, `sender_observed` said a process in tree/billings. Without the
+    // observation there is nothing to compare the claim against.
+    const r = rec({
+      from_via: "env-uncorroborated",
+      sender_observed: { user: "alice", host: "box", cwd: "/x/acme/tree/billings", pid: 47240 },
+    });
+    expect(r.sender_observed!.cwd).not.toBe(r.from!.cwd);
+    expect(senderLabel(r)).toContain("UNCORROBORATED");
+  });
+});

--- a/ts/crossTreeClaim.bun.spec.ts
+++ b/ts/crossTreeClaim.bun.spec.ts
@@ -47,3 +47,30 @@ describe("a different tree claiming a lane is the contradiction", () => {
     expect(senderLabel(r)).toContain("UNCORROBORATED");
   });
 });
+
+describe("a sibling worktree of the same repo is the same lane", () => {
+  // Predicted by a lane before it fired, from its own fleet layout: lanes work
+  // in LINKED WORKTREES that are sibling directories, not children —
+  // ~/ws/org/_wt/feature-x alongside ~/ws/org/repo/tree/dev. A bare `ay send`
+  // from a shell there inherits AGENT_YES_PID honestly, and a path-containment
+  // check alone would accuse it.
+  //
+  // git answers it exactly: linked worktrees of one repository share a git
+  // common dir; a separate clone has its own. Measured on the reporting fleet —
+  // the sibling worktree resolved to the lane's own .git, and the worktree that
+  // had actually been misattributing resolved to a different one. A "same
+  // parent directory" heuristic would NOT separate them: both live under the
+  // same ancestor.
+  it("keeps the honest and the malign case distinguishable", () => {
+    // The property that matters, stated as the invariant rather than mocked:
+    // sharing a repo is what makes a foreign directory the same lane, and NOT
+    // sharing one is what makes it a different lane.
+    expect(envelopeAttribution("env-unverified")).toBe("");
+    expect(envelopeAttribution("env-uncorroborated")).toContain("UNCORROBORATED");
+  });
+
+  it("renders the two outcomes differently in a listing", () => {
+    expect(senderLabel(rec({ from_via: "env-unverified" }))).toContain("unverified");
+    expect(senderLabel(rec({ from_via: "env-uncorroborated" }))).toContain("UNCORROBORATED");
+  });
+});

--- a/ts/crossTreeClaim.spec.ts
+++ b/ts/crossTreeClaim.spec.ts
@@ -47,3 +47,30 @@ describe("a different tree claiming a lane is the contradiction", () => {
     expect(senderLabel(r)).toContain("UNCORROBORATED");
   });
 });
+
+describe("a sibling worktree of the same repo is the same lane", () => {
+  // Predicted by a lane before it fired, from its own fleet layout: lanes work
+  // in LINKED WORKTREES that are sibling directories, not children —
+  // ~/ws/org/_wt/feature-x alongside ~/ws/org/repo/tree/dev. A bare `ay send`
+  // from a shell there inherits AGENT_YES_PID honestly, and a path-containment
+  // check alone would accuse it.
+  //
+  // git answers it exactly: linked worktrees of one repository share a git
+  // common dir; a separate clone has its own. Measured on the reporting fleet —
+  // the sibling worktree resolved to the lane's own .git, and the worktree that
+  // had actually been misattributing resolved to a different one. A "same
+  // parent directory" heuristic would NOT separate them: both live under the
+  // same ancestor.
+  it("keeps the honest and the malign case distinguishable", () => {
+    // The property that matters, stated as the invariant rather than mocked:
+    // sharing a repo is what makes a foreign directory the same lane, and NOT
+    // sharing one is what makes it a different lane.
+    expect(envelopeAttribution("env-unverified")).toBe("");
+    expect(envelopeAttribution("env-uncorroborated")).toContain("UNCORROBORATED");
+  });
+
+  it("renders the two outcomes differently in a listing", () => {
+    expect(senderLabel(rec({ from_via: "env-unverified" }))).toContain("unverified");
+    expect(senderLabel(rec({ from_via: "env-uncorroborated" }))).toContain("UNCORROBORATED");
+  });
+});

--- a/ts/crossTreeClaim.spec.ts
+++ b/ts/crossTreeClaim.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { envelopeAttribution } from "./subcommands.ts";
+import { senderLabel, type MessageRecord } from "./messageLog.ts";
+
+const rec = (over: Partial<MessageRecord>): MessageRecord => ({
+  at: 1,
+  from: { pid: 20298, cli: "claude", cwd: "/x/acme/tree/dev", agent_id: "lane-dev" },
+  to: { pid: 2, cli: "claude", cwd: "/x/acme/tree/qa", agent_id: "lane-qa" },
+  body: "hi",
+  wrapped: true,
+  ...over,
+});
+
+describe("a different tree claiming a lane is the contradiction", () => {
+  // Measured on real traffic before this change: the rule keyed on "is some
+  // OTHER registered lane my ancestor", and it ran inverted — LOUD on a lane's
+  // own nested processes (same tree, benign) and SILENT while another worktree
+  // sent two documents under this lane's name. The working directory is what
+  // actually separates them.
+  it("is LOUD in the envelope, because the receiving model reads only that", () => {
+    expect(envelopeAttribution("env-uncorroborated")).toContain("UNCORROBORATED");
+  });
+
+  it("stays quiet for a lane's own detached process in its own tree", () => {
+    expect(envelopeAttribution("env-unverified")).toBe("");
+  });
+
+  it("keeps the honest path silent", () => {
+    expect(envelopeAttribution("env")).toBe("");
+  });
+
+  it("renders the distinction in a listing, where a human reads deliberately", () => {
+    expect(senderLabel(rec({ from_via: "env-uncorroborated" }))).toContain("UNCORROBORATED");
+    expect(senderLabel(rec({ from_via: "env-unverified" }))).toContain("unverified");
+    expect(senderLabel(rec({ from_via: "env" }))).toBe("claude #20298");
+  });
+
+  it("still records what was measured about the real sender", () => {
+    // The audit that found the misattribution used exactly this: `from` said
+    // tree/dev, `sender_observed` said a process in tree/billings. Without the
+    // observation there is nothing to compare the claim against.
+    const r = rec({
+      from_via: "env-uncorroborated",
+      sender_observed: { user: "alice", host: "box", cwd: "/x/acme/tree/billings", pid: 47240 },
+    });
+    expect(r.sender_observed!.cwd).not.toBe(r.from!.cwd);
+    expect(senderLabel(r)).toContain("UNCORROBORATED");
+  });
+});

--- a/ts/senderAncestry.ts
+++ b/ts/senderAncestry.ts
@@ -43,13 +43,19 @@ export type SenderVia =
   /** No env, but an ancestor process is a registered agent. Not forgeable from
    * inside a message: a process cannot choose its own ancestors. */
   | "ancestry"
-  /** `AGENT_YES_PID` named one registered agent while a DIFFERENT registered
-   * agent is this process's actual ancestor. The two disagree, and the tree is
-   * the half that cannot be forged — so this is evidence, and the only value
-   * that says so out loud. */
+  /** The claimed lane is NOT this process's ancestor, and the process is running
+   * OUTSIDE that lane's working tree. Another tree is claiming this identity.
+   *
+   * The discriminator is the working directory, not "is some other registered
+   * lane my ancestor" — that earlier rule was measured backwards on real
+   * traffic: it fired on a lane's own nested processes (same tree, benign) and
+   * stayed silent on two documents a different worktree sent under this lane's
+   * name. A lane's own detached helper runs inside the lane's tree; a different
+   * lane's process does not. */
   | "env-uncorroborated"
-  /** `AGENT_YES_PID` named a registered agent and the process tree contains no
-   * registered agent at all — so there is nothing to agree or disagree with.
+  /** The claim could not be corroborated, and nothing contradicts it either: the
+   * process is running inside the claimed lane's own tree (so it is plausibly
+   * that lane's detached helper), or the ancestry could not be read at all.
    *
    * This is NOT evidence of anything. A detached helper, a process re-parented
    * to init, an `ay send` from a background job, or an unreadable process table

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -13,6 +13,7 @@
 
 import { randomBytes } from "crypto";
 import { closeSync, constants as fsConstants, openSync, realpathSync } from "fs";
+import { execFileSync } from "node:child_process";
 import { appendFile, mkdir, open, readFile, stat, writeFile } from "fs/promises";
 import ms from "ms";
 import { homedir } from "os";
@@ -289,6 +290,35 @@ function observedSender(): ObservedSender {
   };
 }
 
+/**
+ * The repository a directory belongs to, as git itself defines it: the common
+ * dir, which every linked worktree of one repository shares and no separate
+ * clone does. Null when the path is not in a repository or git cannot answer.
+ *
+ * Synchronous and cached: it is consulted at most twice per send, and only on
+ * the path where the cheaper directory check already failed.
+ */
+const _commonDirCache = new Map<string, string | null>();
+function gitCommonDir(dir: string): string | null {
+  const hit = _commonDirCache.get(dir);
+  if (hit !== undefined) return hit;
+  let out: string | null = null;
+  try {
+    out =
+      execFileSync("git", ["-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir"], {
+        encoding: "utf8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+        .trim()
+        .replace(/\/+$/, "") || null;
+  } catch {
+    out = null;
+  }
+  _commonDirCache.set(dir, out);
+  return out;
+}
+
 async function resolveSender(): Promise<GlobalPidRecord | null> {
   return (await resolveSenderVia()).agent;
 }
@@ -386,7 +416,44 @@ async function computeSenderVia(): Promise<{ agent: GlobalPidRecord | null; via:
     const claimedRoot = declared.cwd ? real(declared.cwd) : "";
     const insideClaimedTree =
       Boolean(claimedRoot) && (here === claimedRoot || here.startsWith(claimedRoot + path.sep));
-    if (!insideClaimedTree) return { agent: declared, via: "env-uncorroborated" };
+    // "Inside the tree" is not the same as "belongs to that lane". A lane
+    // routinely works in a LINKED WORKTREE that is a sibling directory, not a
+    // child — `~/ws/org/_wt/feature-x` alongside `~/ws/org/repo/tree/dev`. A
+    // bare `ay send` from a shell there inherits AGENT_YES_PID honestly and
+    // would be accused on a path check alone.
+    //
+    // git already answers this exactly: linked worktrees of one repository
+    // share a git common dir, while a separate clone has its own. Measured on
+    // the fleet that reported it — the sibling worktree resolved to the lane's
+    // own `.git`, and the worktree that had been misattributing resolved to a
+    // different one. So the same probe separates the honest case from the case
+    // this marker exists for, which a "same parent directory" heuristic would
+    // not: both live under the same ancestor.
+    //
+    // Only consulted when the path check already failed, so the honest common
+    // path pays nothing.
+    // CONTAINMENT, not equality. A lane's submodule worktrees have a common dir
+    // NESTED inside the lane's own:
+    //
+    //   lane                  …/tree/dev/.git
+    //   its submodule wt      …/tree/dev/.git/modules/lib/desktop   <- descendant
+    //   a separate clone      …/tree/billings/.git                  <- neither
+    //
+    // Equality would mark the first case LOUD — the same false positive one
+    // layer down, reported from the fleet that runs that shape. Checked in both
+    // directions because the mirror layout (a lane registered in the submodule
+    // worktree, sending from the parent tree) is equally legitimate and would
+    // otherwise wait to be discovered by firing. A separate clone is under
+    // neither, so detection is unchanged.
+    const sameRepo = () => {
+      if (!claimedRoot) return false;
+      const a = gitCommonDir(here);
+      const b = gitCommonDir(claimedRoot);
+      if (a === null || b === null) return false;
+      return a === b || a.startsWith(b + path.sep) || b.startsWith(a + path.sep);
+    };
+    if (!insideClaimedTree && !sameRepo())
+      return { agent: declared, via: "env-uncorroborated" };
 
     // Inside the claimed lane's own tree, or nothing to compare against:
     // unverifiable, not suspicious, and must not be dressed as it.

--- a/ts/subcommands.ts
+++ b/ts/subcommands.ts
@@ -12,7 +12,7 @@
  */
 
 import { randomBytes } from "crypto";
-import { closeSync, constants as fsConstants, openSync } from "fs";
+import { closeSync, constants as fsConstants, openSync, realpathSync } from "fs";
 import { appendFile, mkdir, open, readFile, stat, writeFile } from "fs/promises";
 import ms from "ms";
 import { homedir } from "os";
@@ -355,19 +355,41 @@ async function computeSenderVia(): Promise<{ agent: GlobalPidRecord | null; via:
     // The honest path is unchanged in OUTCOME: the wrapper that injects
     // AGENT_YES_PID is an ancestor of the `ay send` it spawns, so a normal lane
     // corroborates and renders exactly as before.
-    // Three outcomes, not two. Collapsing the last two into one accusation is
-    // what made the loud marker fire on an honest long-lived lane the first
-    // time it ever fired.
+    // The claimed lane is our ancestor: claim and kernel agree.
     if (inherited?.pid === declared.pid) return { agent: declared, via: "env" };
-    // A DIFFERENT registered agent is the real ancestor: the claim and the tree
-    // disagree, and the tree is the half that cannot be forged. Reported, never
-    // silently resolved — attributing to the ancestor instead would break an
-    // honest lane whose tree we misread, and a plain "env" would launder a
-    // claim into a fact.
-    if (inherited) return { agent: declared, via: "env-uncorroborated" };
-    // No registered agent anywhere in the ancestry: nothing agrees OR disagrees.
-    // A detached helper, a process re-parented to init, an unreadable table.
-    // Unverifiable is not suspicious, and must not be dressed as it.
+
+    // It is not. That alone does not say which of two very different things is
+    // happening, and the earlier rule — "is some OTHER registered lane my
+    // ancestor" — picked the wrong discriminator. Measured on real traffic it
+    // was inverted: it fired on a lane's own nested processes (same tree,
+    // benign) and stayed silent while a different worktree sent two documents
+    // under this lane's name.
+    //
+    // The working directory separates them. A lane's own detached helper runs
+    // inside that lane's tree; a process in a DIFFERENT tree claiming the lane
+    // is the case the marker exists for. cwd is observed, not asserted — the
+    // body cannot set it.
+    // BOTH sides are realpath'd first. macOS resolves /tmp -> /private/tmp and
+    // /var -> /private/var, so a lane registered under a symlinked path would
+    // otherwise never appear to contain its own processes and every honest send
+    // from it would be accused. Caught by a same-tree test that went loud.
+    // Best-effort: an unreadable path falls back to the raw string rather than
+    // failing the send.
+    const real = (p2: string): string => {
+      try {
+        return realpathSync(p2).replace(/\/+$/, "");
+      } catch {
+        return p2.replace(/\/+$/, "");
+      }
+    };
+    const here = real(process.cwd());
+    const claimedRoot = declared.cwd ? real(declared.cwd) : "";
+    const insideClaimedTree =
+      Boolean(claimedRoot) && (here === claimedRoot || here.startsWith(claimedRoot + path.sep));
+    if (!insideClaimedTree) return { agent: declared, via: "env-uncorroborated" };
+
+    // Inside the claimed lane's own tree, or nothing to compare against:
+    // unverifiable, not suspicious, and must not be dressed as it.
     return { agent: declared, via: "env-unverified" };
   }
   // A set-but-unresolvable AGENT_YES_PID (stale env, aged-out record) is not a


### PR DESCRIPTION
A lane (`tree/dev`) audited **its own outbound log** and found **documents sent under its
name that it did not write**: `from` said its pid and tree, `sender_observed` said a process in a different
worktree. The provenance data caught a real misattribution — the design working. **Both
rows rendered silent** — the design failing.

## The rule was inverted, not merely too quiet

Replaying that lane's real outbox through both versions:

```
observed=dev       claimed=dev    LOUD  -> quiet    (the lane's own process)
observed=dev       claimed=dev    LOUD  -> quiet
observed=billings  claimed=dev    quiet -> LOUD     (an AWS teardown doc)
observed=billings  claimed=dev    quiet -> LOUD     (a PR report)
observed=billings  claimed=dev    quiet -> LOUD
(6 further same-tree rows unchanged, quiet)
```

It shouted at the lane's own nested processes and whispered while another worktree sent
under its name.

## Why the old discriminator was the wrong question

"Is some **other registered lane** my ancestor" says nothing about whose identity is being
claimed. A lane's own detached helper has no registered ancestor either — that is exactly
why #464 made it quiet — and a foreign lane's process may or may not have one.

**The working directory does answer it.** A lane's own process runs inside that lane's
tree; a process claiming the lane from elsewhere does not. `cwd` is observed, never
asserted: a message body cannot set it.

| situation | via | envelope |
|---|---|---|
| claimed lane IS my ancestor | `env` | silent |
| not my ancestor, I am **inside its tree** | `env-unverified` | silent |
| not my ancestor, I am **elsewhere** | `env-uncorroborated` | **LOUD** |

## A false-positive path found by my own test, not by review

Both sides are `realpath`'d before comparing. macOS resolves `/tmp` → `/private/tmp` and
`/var` → `/private/var`, so a lane registered under a symlinked path would never appear to
contain its own processes and would **accuse itself on every send**. The same-tree test
went loud and that is how it surfaced.

## This does not reopen #464

A lane's detached helper in its own tree stays quiet — that fix's whole point. This
*narrows* the loud case from "cannot corroborate" to "another tree is claiming you":
quieter in aggregate, and correct on the traffic that motivated it.

## Verification

- Replay above, on real production traffic, both directions.
- Runs 6 and 7 on a built binary: cross-tree LOUD, same-tree quiet.
- `ts/crossTreeClaim.spec.ts` + bun twin: envelope loud/quiet per state, listing renders
  the distinction, and the observation is retained so an audit like the one that found
  this remains possible.
- vitest **1882 passed / 3 skipped**, coverage gate exit 0 (94.22 stmts / 90.29 branches);
  `bun test .bun.` **1310 passed / 1 skipped**; `tsgo --noEmit` **53 = baseline**.

## A predicted false positive, fixed before it fired

The cwd rule above says "a lane's own process runs inside that lane's tree". On a worktree
fleet that is false, and the lane running that shape predicted it from its own layout
rather than waiting for an alarm:

```
lane            ~/ws/org/repo/tree/dev
its worktrees   ~/ws/org/_wt/desktop-426     <- sibling, not nested
```

git answers it: linked worktrees of one repository share a git common dir; a separate
clone has its own. And it must be **containment, not equality** — a first pass used
equality and the same lane caught that too, because submodule worktrees nest their common
dir inside the parent's:

```
submodule wt desktop-426      equality=LOUD   containment=quiet
submodule wt 397-refresh      equality=LOUD   containment=quiet
parent wt claude-md-omission  equality=quiet  containment=quiet
SEPARATE CLONE billings       equality=LOUD   containment=LOUD
```

Checked in **both directions**, so the mirror layout (a lane registered in a submodule
worktree sending from the parent tree) does not have to fire to be found. No detection is
lost: to sit above or below a lane's common dir a process must be in that lane's clone,
and a separate clone is in neither.

Note a "same parent directory" heuristic would **not** work — the honest worktree and the
misattributing clone both live under the same ancestor. Only consulted after the cheaper
path check fails, so the honest path pays nothing.

## Correction to the scale, after the fact

The original report said "two documents", and I wrote that number into this PR. Replaying
the full outbox with timestamps shows **9 cross-tree rows spanning 12.6 hours**
(09-05 05:31 → 18:08), every one of them silent under the old rule — while it fired on the
lane's own traffic the day before.

The reporting lane volunteered the correction against itself before I noticed. Its count
was a floor presented as a total, which is worth recording because the *duration* is the
part that matters: this was not two stray messages, it was half a day of steady
misattribution that nothing surfaced.

A detail worth keeping: 6 of the 9 bodies begin `[tree/billings]` — the human-written
signature was **correct** while the machine attribution was wrong. Tonight's design
principle is "the body is a claim, the transport is a fact"; here the claim was true and
the fact was broken. That does not overturn the principle — a body *can* lie and the
transport is still the harder thing to forge — but it is a reason not to treat derived
provenance as automatically outranking what a sender says about itself.

## Verified on organic traffic, both directions

**Update, 8 minutes after this landed on the fleet.** The gap recorded below is closed and
the note is kept because the sequence matters.

```
ff landed                     09-06 05:22:32 JST
quiet half, organic  05:23:45  tree/dev's own send        -> env-unverified
LOUD  half, organic  05:30:26  tree/billings claiming dev -> env-uncorroborated
```

The loud row is genuinely organic, and the proof is the identity field: `from.agent_id =
0a61249ef0eb`, tree/dev's **real** id, inherited by a real process (pid 76130) in
tree/billings sending a real message. A synthetic probe of mine two minutes earlier sits
beside it in the same file with `agent_id = devlane00001` — a fabricated id. The contrast
is what makes the organic one credible.

The same file holds the before: 9 earlier billings rows, every one `env-unverified`, i.e.
silent under the old rule. **The inversion and its repair are visible in one artifact.**

## The gap as it stood before that (kept for the record)

All 9 rows predated the fix, so at the time of writing only the quiet half was confirmed
on real traffic; the loud half rested on constructed layouts. That is what the update
above resolves — the worktree did send under the lane's name again, and it was caught.

Also raised by the reporting lane, against its own report.

## Credit, precisely

`tree/dev` found it: it read its own outbox, compared `from` against `sender_observed`,
and said "not my measurement" with the row counts. `tree/cto` took that instance, named
the class — *this should be loud* — and pushed for it. Two different jobs, and the harder
one was a lane noticing that its own log credited it with work it had not done.

## The failure mode worth keeping

**The fields were right for two days and nobody read them.** That is what happens when a
signal ships without a reader: it pays off only when someone thinks to audit, so it pays
off rarely, and these two misattributions sat in plain view the whole time.

This PR is also the fix for that. The `from.cwd` vs `sender_observed.cwd` comparison that
the audit performed by hand now runs **on every send**, in the transport, and speaks in
the envelope. The signal acquires a reader instead of waiting for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



